### PR TITLE
update volume to hold u128 instead of u64

### DIFF
--- a/packages/deepbook/sources/helper/constants.move
+++ b/packages/deepbook/sources/helper/constants.move
@@ -2,7 +2,9 @@ module deepbook::constants {
     const CURRENT_VERSION: u64 = 1; // Update version during upgrades
     const POOL_CREATION_FEE: u64 = 10000 * 1_000_000; // 10000 DEEP
     const FLOAT_SCALING: u64 = 1_000_000_000;
+    const FLOAT_SCALING_U128: u128 = 1_000_000_000;
     const MAX_U64: u64 = ((1u128 << 64) - 1) as u64;
+    const MAX_U128: u128 = ((1u256 << 128) - 1) as u128;
     const MIN_PRICE: u64 = 1;
     const MAX_PRICE: u64 = ((1u128 << 63) - 1) as u64;
     const DEFAULT_STAKE_REQUIRED: u64 = 100_000_000; // 100 DEEP
@@ -88,8 +90,16 @@ module deepbook::constants {
         FLOAT_SCALING
     }
 
+    public fun float_scaling_u128(): u128 {
+        FLOAT_SCALING_U128
+    }
+
     public fun max_u64(): u64 {
         MAX_U64
+    }
+
+    public fun max_u128(): u128 {
+        MAX_U128
     }
 
     public fun no_restriction(): u8 {

--- a/packages/deepbook/sources/helper/math.move
+++ b/packages/deepbook/sources/helper/math.move
@@ -7,6 +7,7 @@ module deepbook::math {
     /// scaling setting for float
     const FLOAT_SCALING: u64 = 1_000_000_000;
     const FLOAT_SCALING_U128: u128 = 1_000_000_000;
+    const FLOAT_SCALING_U256: u256 = 1_000_000_000;
 
     /// Error codes
     const EInvalidPrecision: u64 = 0;
@@ -15,6 +16,12 @@ module deepbook::math {
     /// This function will round down the result.
     public(package) fun mul(x: u64, y: u64): u64 {
         let (_, result) = mul_internal(x, y);
+
+        result
+    }
+
+    public(package) fun mul_u128(x: u128, y: u128): u128 {
+        let (_, result) = mul_internal_u128(x, y);
 
         result
     }
@@ -35,6 +42,12 @@ module deepbook::math {
         result
     }
 
+    public(package) fun div_u128(x: u128, y: u128): u128 {
+        let (_, result) = div_internal_u128(x, y);
+
+        result
+    }
+
     /// Divide two floating numbers.
     /// This function will round up the result.
     public(package) fun div_round_up(x: u64, y: u64): u64 {
@@ -51,6 +64,14 @@ module deepbook::math {
         }
     }
 
+    public(package) fun min_u128(x: u128, y: u128): u128 {
+        if (x <= y) {
+            x
+        } else {
+            y
+        }
+    }
+
     public(package) fun max(x: u64, y: u64): u64 {
         if (x > y) {
             x
@@ -60,7 +81,7 @@ module deepbook::math {
     }
 
     /// given a vector of u64, return the median
-    public(package) fun median(v: vector<u64>): u64 {
+    public(package) fun median(v: vector<u128>): u128 {
         let n = v.length();
         if (n == 0) {
             return 0
@@ -68,7 +89,7 @@ module deepbook::math {
 
         let sorted_v = quick_sort(v);
         if (n % 2 == 0) {
-            mul((sorted_v[n / 2 - 1] + sorted_v[n / 2]), FLOAT_SCALING / 2)
+            mul_u128((sorted_v[n / 2 - 1] + sorted_v[n / 2]), FLOAT_SCALING_U128 / 2)
         } else {
             sorted_v[n / 2]
         }
@@ -85,15 +106,15 @@ module deepbook::math {
         (sqrt_scaled_x / multiplier) as u64
     }
 
-    fun quick_sort(mut data: vector<u64>): vector<u64> {
+    fun quick_sort(mut data: vector<u128>): vector<u128> {
         if (data.length() <= 1) {
             return data
         };
 
         let pivot = data[0];
-        let mut less = vector<u64>[];
-        let mut equal = vector<u64>[];
-        let mut greater = vector<u64>[];
+        let mut less = vector<u128>[];
+        let mut equal = vector<u128>[];
+        let mut greater = vector<u128>[];
 
         while (data.length() > 0) {
             let value = data.remove(0);
@@ -106,7 +127,7 @@ module deepbook::math {
             };
         };
 
-        let mut sortedData = vector<u64>[];
+        let mut sortedData = vector<u128>[];
         sortedData.append(quick_sort(less));
         sortedData.append(equal);
         sortedData.append(quick_sort(greater));
@@ -121,6 +142,14 @@ module deepbook::math {
         (round, (x * y / FLOAT_SCALING_U128) as u64)
     }
 
+    fun mul_internal_u128(x: u128, y: u128): (u128, u128) {
+        let x = x as u256;
+        let y = y as u256;
+        let round = if ((x * y) % FLOAT_SCALING_U256 == 0) 0 else 1;
+
+        (round, (x * y / FLOAT_SCALING_U256) as u128)
+    }
+
     fun div_internal(x: u64, y: u64): (u64, u64) {
         let x = x as u128;
         let y = y as u128;
@@ -129,34 +158,42 @@ module deepbook::math {
         (round, (x * FLOAT_SCALING_U128 / y) as u64)
     }
 
+    fun div_internal_u128(x: u128, y: u128): (u128, u128) {
+        let x = x as u256;
+        let y = y as u256;
+        let round = if ((x * FLOAT_SCALING_U256 % y) == 0) 0 else 1;
+
+        (round, (x * FLOAT_SCALING_U256 / y) as u128)
+    }
+
     #[test]
     /// Test median function
     fun test_median() {
-        let v = vector<u64>[
-            1 * FLOAT_SCALING,
-            2 * FLOAT_SCALING,
-            3 * FLOAT_SCALING,
-            4 * FLOAT_SCALING,
-            5 * FLOAT_SCALING,
+        let v = vector<u128>[
+            1 * FLOAT_SCALING_U128,
+            2 * FLOAT_SCALING_U128,
+            3 * FLOAT_SCALING_U128,
+            4 * FLOAT_SCALING_U128,
+            5 * FLOAT_SCALING_U128,
         ];
-        assert!(median(v) == 3 * FLOAT_SCALING, 0);
+        assert!(median(v) == 3 * FLOAT_SCALING_U128, 0);
 
-        let v = vector<u64>[
-            10 * FLOAT_SCALING,
-            15 * FLOAT_SCALING,
-            2 * FLOAT_SCALING,
-            3 * FLOAT_SCALING,
-            5 * FLOAT_SCALING,
+        let v = vector<u128>[
+            10 * FLOAT_SCALING_U128,
+            15 * FLOAT_SCALING_U128,
+            2 * FLOAT_SCALING_U128,
+            3 * FLOAT_SCALING_U128,
+            5 * FLOAT_SCALING_U128,
         ];
-        assert!(median(v) == 5 * FLOAT_SCALING, 0);
+        assert!(median(v) == 5 * FLOAT_SCALING_U128, 0);
 
-        let v = vector<u64>[
-            10 * FLOAT_SCALING,
-            9 * FLOAT_SCALING,
-            23 * FLOAT_SCALING,
-            4 * FLOAT_SCALING,
-            5 * FLOAT_SCALING,
-            28 * FLOAT_SCALING,
+        let v = vector<u128>[
+            10 * FLOAT_SCALING_U128,
+            9 * FLOAT_SCALING_U128,
+            23 * FLOAT_SCALING_U128,
+            4 * FLOAT_SCALING_U128,
+            5 * FLOAT_SCALING_U128,
+            28 * FLOAT_SCALING_U128,
         ];
         assert!(median(v) == 9_500_000_000, 0);
     }


### PR DESCRIPTION
Since whitelisted pools have zero trading fees, users can take flashloans and trade and force an overflow of the u64