### PR TITLE
Get open orders on new account

### DIFF
--- a/packages/deepbook/sources/pool.move
+++ b/packages/deepbook/sources/pool.move
@@ -642,7 +642,12 @@ module deepbook::pool {
         self: &Pool<BaseAsset, QuoteAsset>,
         balance_manager: ID,
     ): VecSet<u128> {
-        self.load_inner().state.account(balance_manager).open_orders()
+        let self = self.load_inner();
+        if (!self.state.account_exists(balance_manager)) {
+            return vec_set::empty()
+        };
+
+        self.state.account(balance_manager).open_orders()
     }
 
     /// Returns the (price_vec, quantity_vec) for the level2 order book.

--- a/packages/deepbook/sources/state/state.move
+++ b/packages/deepbook/sources/state/state.move
@@ -259,6 +259,10 @@ module deepbook::state {
         &mut self.governance
     }
 
+    public(package) fun account_exists(self: &State, account_id: ID): bool {
+        self.accounts.contains(account_id)
+    }
+
     public(package) fun account(self: &State, account_id: ID): &Account {
         &self.accounts[account_id]
     }

--- a/packages/deepbook/tests/pool_tests.move
+++ b/packages/deepbook/tests/pool_tests.move
@@ -869,6 +869,24 @@ module deepbook::pool_tests {
         }
     }
 
+    #[test_only]
+    public(package) fun validate_open_orders<BaseAsset, QuoteAsset>(
+        sender: address,
+        pool_id: ID,
+        balance_manager_id: ID,
+        expected_open_orders: u64,
+        test: &mut Scenario,
+    ){
+        test.next_tx(sender);
+        {
+            let pool = test.take_shared_by_id<Pool<BaseAsset, QuoteAsset>>(pool_id);
+
+            assert!(pool.account_open_orders(balance_manager_id).size() == expected_open_orders, 1);
+
+            return_shared(pool);
+        }
+    }
+
     /// Alice places a worse order
     /// Alice places 3 bid/ask orders with at price 1
     /// Alice matches the order with an ask/bid order at price 1
@@ -2721,6 +2739,7 @@ module deepbook::pool_tests {
         let balance_manager_id_alice = create_acct_and_share_with_funds(ALICE, 1000000 * constants::float_scaling(), &mut test);
         let pool_id = setup_pool_with_default_fees_and_reference_pool<SUI, USDC, SUI, DEEP>(ALICE, registry_id, balance_manager_id_alice, &mut test);
 
+        validate_open_orders<SUI, USDC>(ALICE, pool_id, balance_manager_id_alice, 0, &mut test);
         // variables to input into order
         let client_order_id = 1;
         let order_type = constants::no_restriction();
@@ -2777,6 +2796,8 @@ module deepbook::pool_tests {
             expire_timestamp,
             &mut test,
         );
+        validate_open_orders<SUI, USDC>(ALICE, pool_id, balance_manager_id_alice, 1, &mut test);
+        
         end(test);
     }
 


### PR DESCRIPTION
When checking for open orders on an account that has not interacted with DeepBook yet, we will return an empty vector. 