### PR TITLE
Fill Limit and Open Orders Limit (Audit)

### DIFF
--- a/packages/deepbook/sources/helper/constants.move
+++ b/packages/deepbook/sources/helper/constants.move
@@ -39,7 +39,10 @@ module deepbook::constants {
     const EXPIRED: u8 = 4;
 
     // Maximum number of fills per transaction
-    const MAX_FILLS: u64 = 200;
+    const MAX_FILLS: u64 = 100;
+
+    // Maximum number of open orders per balance manager
+    const MAX_OPEN_ORDERS: u64 = 100;
 
     // Big vector params
     const MAX_SLICE_SIZE: u64 = 64;
@@ -191,6 +194,10 @@ module deepbook::constants {
 
     public fun max_fills(): u64 {
         MAX_FILLS
+    }
+
+    public fun max_open_orders(): u64 {
+        MAX_OPEN_ORDERS
     }
 
     public fun max_slice_size(): u64 {

--- a/packages/deepbook/sources/state/state.move
+++ b/packages/deepbook/sources/state/state.move
@@ -21,6 +21,7 @@ module deepbook::state {
 
     // === Errors ===
     const ENoStake: u64 = 1;
+    const EMaxOpenOrders: u64 = 2;
 
     // === Structs ===
     public struct State has store {
@@ -82,6 +83,7 @@ module deepbook::state {
         let maker_fee = self.governance.trade_params().maker_fee();
 
         if (order_info.remaining_quantity() > 0 && order_info.order_type() != constants::immediate_or_cancel()) {
+            assert!(account.open_orders().size() < constants::max_open_orders(), EMaxOpenOrders);
             account.add_order(order_info.order_id());
         };
         account.add_taker_volume(order_info.executed_quantity());

--- a/packages/deepbook/tests/pool_tests.move
+++ b/packages/deepbook/tests/pool_tests.move
@@ -542,6 +542,16 @@ module deepbook::pool_tests {
         test_place_order_edge_price(constants::lot_size(), constants::tick_size())
     }
 
+    #[test]
+    fun test_order_limit_bid_ok(){
+        test_order_limit(true);
+    }
+
+    #[test]
+    fun test_order_limit_ask_ok(){
+        test_order_limit(false);
+    }
+
     #[test_only]
     public(package) fun setup_test(
         owner: address,
@@ -1191,22 +1201,13 @@ module deepbook::pool_tests {
         end(test);
     }
 
-    #[test]
-    fun test_order_limit_bid_ok(){
-        test_order_limit(true);
-    }
-
-    #[test]
-    fun test_order_limit_ask_ok(){
-        test_order_limit(false);
-    }
-
     fun test_order_limit(
         is_bid: bool,
     ){
         let mut test = begin(OWNER);
         let registry_id = setup_test(OWNER, &mut test);
         let balance_manager_id_alice = create_acct_and_share_with_funds(ALICE, 1000000 * constants::float_scaling(), &mut test);
+        let balance_manager_id_bob = create_acct_and_share_with_funds(BOB, 1000000 * constants::float_scaling(), &mut test);
         let pool_id = setup_pool_with_default_fees_and_reference_pool<SUI, USDC, SUI, DEEP>(ALICE, registry_id, balance_manager_id_alice, &mut test);
 
         let client_order_id = 1;
@@ -1214,13 +1215,32 @@ module deepbook::pool_tests {
         let quantity = 1 * constants::float_scaling();
         let expire_timestamp = constants::max_u64();
         let pay_with_deep = true;
-        let mut num_orders = 300;
+        let mut num_orders = 150;
 
-        while (num_orders > 0) {
+        while (num_orders > 100) {
             place_limit_order<SUI, USDC>(
             ALICE,
             pool_id,
             balance_manager_id_alice,
+            client_order_id,
+            constants::no_restriction(),
+            constants::self_matching_allowed(),
+            price,
+            quantity,
+            is_bid,
+            pay_with_deep,
+            expire_timestamp,
+            &mut test,
+            );
+
+            num_orders = num_orders - 1;
+        };
+
+        while (num_orders > 0) {
+            place_limit_order<SUI, USDC>(
+            BOB,
+            pool_id,
+            balance_manager_id_bob,
             client_order_id,
             constants::no_restriction(),
             constants::self_matching_allowed(),
@@ -1287,15 +1307,16 @@ module deepbook::pool_tests {
         );
 
         let expected_status = constants::partially_filled();
-        let expected_cumulative_quote_quantity = 100 * price;
-        let paid_fees = 100 * math::mul(constants::taker_fee(), constants::deep_multiplier());
+        let expected_cumulative_quote_quantity = 50 * price;
+        let expected_executed_quantity = 50 * quantity;
+        let paid_fees = 50 * math::mul(constants::taker_fee(), constants::deep_multiplier());
 
         verify_order_info(
             &order_info,
             client_order_id,
             price,
             match_quantity,
-            100 * quantity,
+            expected_executed_quantity,
             expected_cumulative_quote_quantity,
             paid_fees,
             true,
@@ -2978,7 +2999,7 @@ module deepbook::pool_tests {
             &mut test,
         );
         validate_open_orders<SUI, USDC>(ALICE, pool_id, balance_manager_id_alice, 1, &mut test);
-        
+
         end(test);
     }
 


### PR DESCRIPTION
1. Fill Limit changed from 200 to 100
2. Open order limit per balance manager per pool is 100