### PR TITLE
Deep required getter, math lib update

### DIFF
--- a/packages/deepbook/sources/book/order_info.move
+++ b/packages/deepbook/sources/book/order_info.move
@@ -64,8 +64,10 @@ module deepbook::order_info {
         fills: vector<Fill>,
         // Whether the fee is in DEEP terms
         fee_is_deep: bool,
-        // Fees paid so far in base/quote/DEEP terms
+        // Fees paid so far in base/quote/DEEP terms for taker orders
         paid_fees: u64,
+        // Fees transferred to pool vault but not yet paid for maker order
+        maker_fees: u64,
         // Epoch this order was placed
         epoch: u64,
         // Status of the order
@@ -251,6 +253,7 @@ module deepbook::order_info {
             fee_is_deep,
             epoch,
             paid_fees: 0,
+            maker_fees: 0,
             status: constants::live(),
             market_order,
             fill_limit_reached: false,
@@ -317,6 +320,7 @@ module deepbook::order_info {
                         math::mul(remaining_quantity, self.price()),
                     ),
             );
+            self.maker_fees = maker_deep_in;
             owed_balances.add_deep(maker_deep_in);
             if (self.is_bid) {
                 owed_balances.add_quote(math::mul(remaining_quantity, self.price()));

--- a/packages/deepbook/sources/helper/math.move
+++ b/packages/deepbook/sources/helper/math.move
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module deepbook::math {
-    use sui::math as sui_math;
-
     /// scaling setting for float
     const FLOAT_SCALING: u64 = 1_000_000_000;
     const FLOAT_SCALING_U128: u128 = 1_000_000_000;
@@ -101,7 +99,7 @@ module deepbook::math {
         assert!(precision <= FLOAT_SCALING, EInvalidPrecision);
         let multiplier = (FLOAT_SCALING / precision) as u128;
         let scaled_x: u128 = (x as u128) * multiplier * FLOAT_SCALING_U128;
-        let sqrt_scaled_x: u128 = sui_math::sqrt_u128(scaled_x);
+        let sqrt_scaled_x: u128 = std::u128::sqrt(scaled_x);
 
         (sqrt_scaled_x / multiplier) as u64
     }


### PR DESCRIPTION
1. Taker and Maker order deep required
2. Read only access for OrderDeep Price
3. Update math to use std::u instead of deprecated sui_math