### PR TITLE
Consider Using Testnet Sui Instead of Mainnet Sui on Testnet Branch

### DIFF
--- a/packages/deepbook/Move.toml
+++ b/packages/deepbook/Move.toml
@@ -4,7 +4,7 @@ edition = "2024.beta"
 version = "0.0.1"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/testnet" }
 token = { local = "../token"}
 
 [addresses]


### PR DESCRIPTION
Motivation
I am currently testing my Sui contract on Testnet with the deepbook dependency. However, I encounter the error "conflicting versions of package MoveStdlib." This issue arises from using incompatible versions of MoveStdlib across different dependencies, which complicates testing and development.

Proposed Change
Update the Testnet branch to import Testnet Sui Dep.
