### PR TITLE
Allow admin to change pool book params

### DIFF
--- a/packages/deepbook/sources/book/book.move
+++ b/packages/deepbook/sources/book/book.move
@@ -343,6 +343,18 @@ public(package) fun get_order(self: &Book, order_id: u128): Order {
     order.copy_order()
 }
 
+public(package) fun set_tick_size(self: &mut Book, new_tick_size: u64) {
+    self.tick_size = new_tick_size;
+}
+
+public(package) fun set_lot_size(self: &mut Book, new_lot_size: u64) {
+    self.lot_size = new_lot_size;
+}
+
+public(package) fun set_min_size(self: &mut Book, new_min_size: u64) {
+    self.min_size = new_min_size;
+}
+
 // === Private Functions ===
 // Access side of book where order_id belongs
 fun book_side_mut(self: &mut Book, order_id: u128): &mut BigVector<Order> {

--- a/packages/deepbook/sources/helper/math.move
+++ b/packages/deepbook/sources/helper/math.move
@@ -73,8 +73,10 @@ public(package) fun median(v: vector<u128>): u128 {
     }
 }
 
-/// Computes the integer square root of a scaled u64 value, assuming the original value
-/// is scaled by precision. The result will be in the same floating-point representation.
+/// Computes the integer square root of a scaled u64 value, assuming the
+/// original value
+/// is scaled by precision. The result will be in the same floating-point
+/// representation.
 public(package) fun sqrt(x: u64, precision: u64): u64 {
     assert!(precision <= FLOAT_SCALING, EInvalidPrecision);
     let multiplier = (FLOAT_SCALING / precision) as u128;
@@ -82,6 +84,20 @@ public(package) fun sqrt(x: u64, precision: u64): u64 {
     let sqrt_scaled_x: u128 = std::u128::sqrt(scaled_x);
 
     (sqrt_scaled_x / multiplier) as u64
+}
+
+public(package) fun is_power_of_ten(n: u64): bool {
+    let mut num = n;
+
+    if (num < 1) {
+        false
+    } else {
+        while (num % 10 == 0) {
+            num = num / 10;
+        };
+
+        num == 1
+    }
 }
 
 fun quick_sort(data: vector<u128>): vector<u128> {
@@ -200,4 +216,20 @@ fun test_sqrt() {
     assert!(sqrt(100_000_000 * scaling, precision_9) == 316_227_766_016, 0);
     assert!(sqrt(300_000_000 * scaling, precision_9) == 547_722_557_505, 0);
     assert!(sqrt(100_000_000_000, precision_9) == 10_000_000_000, 0);
+}
+
+#[test]
+/// Test is_power_of_ten function
+fun test_is_power_of_ten() {
+    assert!(is_power_of_ten(1), 0);
+    assert!(is_power_of_ten(10), 0);
+    assert!(is_power_of_ten(100), 0);
+    assert!(is_power_of_ten(1000), 0);
+    assert!(is_power_of_ten(10000), 0);
+    assert!(is_power_of_ten(100000), 0);
+    assert!(!is_power_of_ten(0), 0);
+    assert!(!is_power_of_ten(2), 0);
+    assert!(!is_power_of_ten(3), 0);
+    assert!(!is_power_of_ten(20), 0);
+    assert!(!is_power_of_ten(1001), 0);
 }

--- a/packages/deepbook/sources/pool.move
+++ b/packages/deepbook/sources/pool.move
@@ -707,6 +707,7 @@ public fun adjust_tick_size_admin<BaseAsset, QuoteAsset>(
 ) {
     let self = self.load_inner_mut();
     assert!(new_tick_size > 0, EInvalidTickSize);
+    assert!(math::is_power_of_ten(new_tick_size), EInvalidTickSize);
     self.book.set_tick_size(new_tick_size);
 
     event::emit(BookParamsUpdated<BaseAsset, QuoteAsset> {
@@ -1048,6 +1049,7 @@ public(package) fun create_pool<BaseAsset, QuoteAsset>(
         EInvalidFee,
     );
     assert!(tick_size > 0, EInvalidTickSize);
+    assert!(math::is_power_of_ten(tick_size), EInvalidTickSize);
     assert!(lot_size > 0, EInvalidLotSize);
     assert!(min_size > 0, EInvalidMinSize);
     assert!(min_size % lot_size == 0, EInvalidMinSize);

--- a/packages/deepbook/sources/pool.move
+++ b/packages/deepbook/sources/pool.move
@@ -85,11 +85,13 @@ public struct BookParamsUpdated<
     tick_size: u64,
     lot_size: u64,
     min_size: u64,
+    timestamp: u64,
 }
 
 // === Public-Mutative Functions * EXCHANGE * ===
 /// Place a limit order. Quantity is in base asset terms.
-/// For current version pay_with_deep must be true, so the fee will be paid with DEEP tokens.
+/// For current version pay_with_deep must be true, so the fee will be paid with
+/// DEEP tokens.
 public fun place_limit_order<BaseAsset, QuoteAsset>(
     self: &mut Pool<BaseAsset, QuoteAsset>,
     balance_manager: &mut BalanceManager,
@@ -122,8 +124,10 @@ public fun place_limit_order<BaseAsset, QuoteAsset>(
     )
 }
 
-/// Place a market order. Quantity is in base asset terms. Calls place_limit_order with
-/// a price of MAX_PRICE for bids and MIN_PRICE for asks. Any quantity not filled is cancelled.
+/// Place a market order. Quantity is in base asset terms. Calls
+/// place_limit_order with
+/// a price of MAX_PRICE for bids and MIN_PRICE for asks. Any quantity not
+/// filled is cancelled.
 public fun place_market_order<BaseAsset, QuoteAsset>(
     self: &mut Pool<BaseAsset, QuoteAsset>,
     balance_manager: &mut BalanceManager,
@@ -298,7 +302,8 @@ public fun modify_order<BaseAsset, QuoteAsset>(
 
 /// Cancel an order. The order must be owned by the balance_manager.
 /// The order is removed from the book and the balance_manager's open orders.
-/// The balance_manager's balance is updated with the order's remaining quantity.
+/// The balance_manager's balance is updated with the order's remaining
+/// quantity.
 /// Order canceled event is emitted.
 public fun cancel_order<BaseAsset, QuoteAsset>(
     self: &mut Pool<BaseAsset, QuoteAsset>,
@@ -328,7 +333,8 @@ public fun cancel_order<BaseAsset, QuoteAsset>(
     );
 }
 
-/// Cancel multiple orders within a vector. The orders must be owned by the balance_manager.
+/// Cancel multiple orders within a vector. The orders must be owned by the
+/// balance_manager.
 /// The orders are removed from the book and the balance_manager's open orders.
 /// Order canceled events are emitted.
 /// If any order fails to cancel, no orders will be cancelled.
@@ -387,7 +393,8 @@ public fun withdraw_settled_amounts<BaseAsset, QuoteAsset>(
 }
 
 // === Public-Mutative Functions * GOVERNANCE * ===
-/// Stake DEEP tokens to the pool. The balance_manager must have enough DEEP tokens.
+/// Stake DEEP tokens to the pool. The balance_manager must have enough DEEP
+/// tokens.
 /// The balance_manager's data is updated with the staked amount.
 public fun stake<BaseAsset, QuoteAsset>(
     self: &mut Pool<BaseAsset, QuoteAsset>,
@@ -406,7 +413,8 @@ public fun stake<BaseAsset, QuoteAsset>(
         .settle_balance_manager(settled, owed, balance_manager, trade_proof);
 }
 
-/// Unstake DEEP tokens from the pool. The balance_manager must have enough staked DEEP tokens.
+/// Unstake DEEP tokens from the pool. The balance_manager must have enough
+/// staked DEEP tokens.
 /// The balance_manager's data is updated with the unstaked amount.
 /// Balance is transferred to the balance_manager immediately.
 public fun unstake<BaseAsset, QuoteAsset>(
@@ -427,8 +435,10 @@ public fun unstake<BaseAsset, QuoteAsset>(
 /// Submit a proposal to change the taker fee, maker fee, and stake required.
 /// The balance_manager must have enough staked DEEP tokens to participate.
 /// Each balance_manager can only submit one proposal per epoch.
-/// If the maximum proposal is reached, the proposal with the lowest vote is removed.
-/// If the balance_manager has less voting power than the lowest voted proposal, the proposal is not added.
+/// If the maximum proposal is reached, the proposal with the lowest vote is
+/// removed.
+/// If the balance_manager has less voting power than the lowest voted proposal,
+/// the proposal is not added.
 public fun submit_proposal<BaseAsset, QuoteAsset>(
     self: &mut Pool<BaseAsset, QuoteAsset>,
     balance_manager: &mut BalanceManager,
@@ -452,7 +462,8 @@ public fun submit_proposal<BaseAsset, QuoteAsset>(
         );
 }
 
-/// Vote on a proposal. The balance_manager must have enough staked DEEP tokens to participate.
+/// Vote on a proposal. The balance_manager must have enough staked DEEP tokens
+/// to participate.
 /// Full voting power of the balance_manager is used.
 /// Voting for a new proposal will remove the vote from the previous proposal.
 public fun vote<BaseAsset, QuoteAsset>(
@@ -469,7 +480,8 @@ public fun vote<BaseAsset, QuoteAsset>(
         .process_vote(self.pool_id, balance_manager.id(), proposal_id, ctx);
 }
 
-/// Claim the rewards for the balance_manager. The balance_manager must have rewards to claim.
+/// Claim the rewards for the balance_manager. The balance_manager must have
+/// rewards to claim.
 /// The balance_manager's data is updated with the claimed rewards.
 public fun claim_rebates<BaseAsset, QuoteAsset>(
     self: &mut Pool<BaseAsset, QuoteAsset>,
@@ -581,16 +593,20 @@ public fun add_deep_price_point<
         EIneligibleTargetPool,
     );
 
-    // For DEEP/USDC pool, reference_deep_is_base is true, DEEP per USDC is reference_pool_price
-    // For USDC/DEEP pool, reference_deep_is_base is false, USDC per DEEP is reference_pool_price
+    // For DEEP/USDC pool, reference_deep_is_base is true, DEEP per USDC is
+    // reference_pool_price
+    // For USDC/DEEP pool, reference_deep_is_base is false, USDC per DEEP is
+    // reference_pool_price
     let deep_per_reference_other_price = if (reference_deep_is_base) {
         math::div(1_000_000_000, reference_pool_price)
     } else {
         reference_pool_price
     };
 
-    // For USDC/SUI pool, reference_other_is_target_base is true, add price point to deep per base
-    // For SUI/USDC pool, reference_other_is_target_base is false, add price point to deep per quote
+    // For USDC/SUI pool, reference_other_is_target_base is true, add price
+    // point to deep per base
+    // For SUI/USDC pool, reference_other_is_target_base is false, add price
+    // point to deep per quote
     target_pool
         .deep_price
         .add_price_point(
@@ -628,7 +644,8 @@ public fun burn_deep<BaseAsset, QuoteAsset>(
 
 // === Public-Mutative Functions * ADMIN * ===
 /// Create a new pool. The pool is registered in the registry.
-/// Checks are performed to ensure the tick size, lot size, and min size are valid.
+/// Checks are performed to ensure the tick size, lot size, and min size are
+/// valid.
 /// The creation fee is transferred to the treasury address.
 /// Returns the id of the pool created
 public fun create_pool_admin<BaseAsset, QuoteAsset>(
@@ -686,6 +703,7 @@ public fun adjust_tick_size_admin<BaseAsset, QuoteAsset>(
     self: &mut Pool<BaseAsset, QuoteAsset>,
     new_tick_size: u64,
     _cap: &DeepbookAdminCap,
+    clock: &Clock,
 ) {
     let self = self.load_inner_mut();
     assert!(new_tick_size > 0, EInvalidTickSize);
@@ -696,15 +714,18 @@ public fun adjust_tick_size_admin<BaseAsset, QuoteAsset>(
         tick_size: self.book.tick_size(),
         lot_size: self.book.lot_size(),
         min_size: self.book.min_size(),
+        timestamp: clock.timestamp_ms(),
     });
 }
 
-/// Adjust and lot size and min size of the pool. New lot size must be smaller than current lot size. Only admin can adjust the min size and lot size.
+/// Adjust and lot size and min size of the pool. New lot size must be smaller
+/// than current lot size. Only admin can adjust the min size and lot size.
 public fun adjust_min_lot_size_admin<BaseAsset, QuoteAsset>(
     self: &mut Pool<BaseAsset, QuoteAsset>,
     new_lot_size: u64,
     new_min_size: u64,
     _cap: &DeepbookAdminCap,
+    clock: &Clock,
 ) {
     let self = self.load_inner_mut();
     let lot_size = self.book.lot_size();
@@ -720,6 +741,7 @@ public fun adjust_min_lot_size_admin<BaseAsset, QuoteAsset>(
         tick_size: self.book.tick_size(),
         lot_size: self.book.lot_size(),
         min_size: self.book.min_size(),
+        timestamp: clock.timestamp_ms(),
     });
 }
 
@@ -804,7 +826,8 @@ public fun account_open_orders<BaseAsset, QuoteAsset>(
 }
 
 /// Returns the (price_vec, quantity_vec) for the level2 order book.
-/// The price_low and price_high are inclusive, all orders within the range are returned.
+/// The price_low and price_high are inclusive, all orders within the range are
+/// returned.
 /// is_bid is true for bids and false for asks.
 public fun get_level2_range<BaseAsset, QuoteAsset>(
     self: &Pool<BaseAsset, QuoteAsset>,
@@ -826,9 +849,12 @@ public fun get_level2_range<BaseAsset, QuoteAsset>(
 }
 
 /// Returns the (price_vec, quantity_vec) for the level2 order book.
-/// Ticks are the maximum number of ticks to return starting from best bid and best ask.
-/// (bid_price, bid_quantity, ask_price, ask_quantity) are returned as 4 vectors.
-/// The price vectors are sorted in descending order for bids and ascending order for asks.
+/// Ticks are the maximum number of ticks to return starting from best bid and
+/// best ask.
+/// (bid_price, bid_quantity, ask_price, ask_quantity) are returned as 4
+/// vectors.
+/// The price vectors are sorted in descending order for bids and ascending
+/// order for asks.
 public fun get_level2_ticks_from_mid<BaseAsset, QuoteAsset>(
     self: &Pool<BaseAsset, QuoteAsset>,
     ticks: u64,
@@ -917,7 +943,8 @@ public fun get_order_deep_price<BaseAsset, QuoteAsset>(
     self.deep_price.get_order_deep_price(whitelist)
 }
 
-/// Returns the deep required for an order if it's taker or maker given quantity and price
+/// Returns the deep required for an order if it's taker or maker given quantity
+/// and price
 /// Does not account for discounted taker fees
 /// Returns (deep_required_taker, deep_required_maker)
 public fun get_order_deep_required<BaseAsset, QuoteAsset>(
@@ -957,7 +984,10 @@ public fun locked_balance<BaseAsset, QuoteAsset>(
         deep_quantity = deep_quantity + deep;
     });
 
-    let settled_balances = self.state.account(balance_manager.id()).settled_balances();
+    let settled_balances = self
+        .state
+        .account(balance_manager.id())
+        .settled_balances();
     base_quantity = base_quantity + settled_balances.base();
     quote_quantity = quote_quantity + settled_balances.quote();
     deep_quantity = deep_quantity + settled_balances.deep();
@@ -1111,7 +1141,8 @@ public(package) fun load_inner_mut<BaseAsset, QuoteAsset>(
 }
 
 // === Private Functions ===
-/// Set a pool as a whitelist pool at pool creation. Whitelist pools have zero fees.
+/// Set a pool as a whitelist pool at pool creation. Whitelist pools have zero
+/// fees.
 fun set_whitelist<BaseAsset, QuoteAsset>(
     self: &mut PoolInner<BaseAsset, QuoteAsset>,
     ctx: &TxContext,

--- a/packages/deepbook/sources/pool.move
+++ b/packages/deepbook/sources/pool.move
@@ -77,6 +77,16 @@ public struct PoolCreated<
     treasury_address: address,
 }
 
+public struct BookParamsUpdated<
+    phantom BaseAsset,
+    phantom QuoteAsset,
+> has copy, store, drop {
+    pool_id: ID,
+    tick_size: u64,
+    lot_size: u64,
+    min_size: u64,
+}
+
 // === Public-Mutative Functions * EXCHANGE * ===
 /// Place a limit order. Quantity is in base asset terms.
 /// For current version pay_with_deep must be true, so the fee will be paid with DEEP tokens.
@@ -680,6 +690,13 @@ public fun adjust_tick_size_admin<BaseAsset, QuoteAsset>(
     let self = self.load_inner_mut();
     assert!(new_tick_size > 0, EInvalidTickSize);
     self.book.set_tick_size(new_tick_size);
+
+    event::emit(BookParamsUpdated<BaseAsset, QuoteAsset> {
+        pool_id: self.pool_id,
+        tick_size: self.book.tick_size(),
+        lot_size: self.book.lot_size(),
+        min_size: self.book.min_size(),
+    });
 }
 
 /// Adjust and lot size and min size of the pool. New lot size must be smaller than current lot size. Only admin can adjust the min size and lot size.
@@ -697,6 +714,13 @@ public fun adjust_min_lot_size_admin<BaseAsset, QuoteAsset>(
     assert!(new_min_size % new_lot_size == 0, EInvalidMinSize);
     self.book.set_lot_size(new_lot_size);
     self.book.set_min_size(new_min_size);
+
+    event::emit(BookParamsUpdated<BaseAsset, QuoteAsset> {
+        pool_id: self.pool_id,
+        tick_size: self.book.tick_size(),
+        lot_size: self.book.lot_size(),
+        min_size: self.book.min_size(),
+    });
 }
 
 // === Public-View Functions ===

--- a/packages/deepbook/sources/pool.move
+++ b/packages/deepbook/sources/pool.move
@@ -671,6 +671,34 @@ public fun update_allowed_versions<BaseAsset, QuoteAsset>(
     inner.allowed_versions = allowed_versions;
 }
 
+/// Adjust the tick size of the pool. Only admin can adjust the tick size.
+public fun adjust_tick_size_admin<BaseAsset, QuoteAsset>(
+    self: &mut Pool<BaseAsset, QuoteAsset>,
+    new_tick_size: u64,
+    _cap: &DeepbookAdminCap,
+) {
+    let self = self.load_inner_mut();
+    assert!(new_tick_size > 0, EInvalidTickSize);
+    self.book.set_tick_size(new_tick_size);
+}
+
+/// Adjust and lot size and min size of the pool. New lot size must be smaller than current lot size. Only admin can adjust the min size and lot size.
+public fun adjust_min_lot_size_admin<BaseAsset, QuoteAsset>(
+    self: &mut Pool<BaseAsset, QuoteAsset>,
+    new_lot_size: u64,
+    new_min_size: u64,
+    _cap: &DeepbookAdminCap,
+) {
+    let self = self.load_inner_mut();
+    let lot_size = self.book.lot_size();
+    assert!(lot_size % new_lot_size == 0, EInvalidLotSize);
+    assert!(new_lot_size > 0, EInvalidLotSize);
+    assert!(new_min_size > 0, EInvalidMinSize);
+    assert!(new_min_size % new_lot_size == 0, EInvalidMinSize);
+    self.book.set_lot_size(new_lot_size);
+    self.book.set_min_size(new_min_size);
+}
+
 // === Public-View Functions ===
 /// Accessor to check if the pool is whitelisted.
 public fun whitelisted<BaseAsset, QuoteAsset>(

--- a/packages/deepbook/tests/pool_tests.move
+++ b/packages/deepbook/tests/pool_tests.move
@@ -105,12 +105,17 @@ fun test_place_order_bid() {
 
 #[test]
 fun test_update_pool_book_params_ok() {
-    test_update_pool_book_params(true);
+    test_update_pool_book_params(0);
 }
 
 #[test, expected_failure(abort_code = ::deepbook::order_info::EOrderInvalidLotSize)]
-fun test_update_pool_book_params_e() {
-    test_update_pool_book_params(false);
+fun test_update_pool_book_params_trade_e() {
+    test_update_pool_book_params(1);
+}
+
+#[test, expected_failure(abort_code = ::deepbook::pool::EInvalidLotSize)]
+fun test_update_pool_book_params_update_e() {
+    test_update_pool_book_params(2);
 }
 
 #[test]
@@ -4908,7 +4913,7 @@ fun test_cancel_orders(is_bid: bool) {
 }
 
 fun test_update_pool_book_params(
-    is_ok: bool,
+    error: u8,
 ){
     let mut test = begin(OWNER);
     let registry_id = setup_test(OWNER, &mut test);
@@ -4946,12 +4951,23 @@ fun test_update_pool_book_params(
         expire_timestamp,
         &mut test,
     );
-    if (is_ok) {
+
+    if (error == 0) {
         adjust_min_lot_size_admin<SUI, USDC>(
             OWNER,
             pool_id,
             100,
             500,
+            &mut test,
+        );
+    };
+
+    if (error == 2){
+        adjust_min_lot_size_admin<SUI, USDC>(
+            OWNER,
+            pool_id,
+            600,
+            6000,
             &mut test,
         );
     };

--- a/packages/deepbook/tests/pool_tests.move
+++ b/packages/deepbook/tests/pool_tests.move
@@ -108,7 +108,12 @@ fun test_update_pool_book_params_ok() {
     test_update_pool_book_params(0);
 }
 
-#[test, expected_failure(abort_code = ::deepbook::order_info::EOrderInvalidLotSize)]
+#[
+    test,
+    expected_failure(
+        abort_code = ::deepbook::order_info::EOrderInvalidLotSize,
+    ),
+]
 fun test_update_pool_book_params_trade_e() {
     test_update_pool_book_params(1);
 }
@@ -2518,7 +2523,8 @@ fun test_mid_price() {
 }
 
 /// Places 3 orders at price 1, 2, 3 with quantity 1
-/// Market order of quantity 1.5 should fill one order completely, one partially, and one not at all
+/// Market order of quantity 1.5 should fill one order completely, one
+/// partially, and one not at all
 /// Order 3 is fully filled for bid orders then ask market order
 /// Order 1 is fully filled for ask orders then bid market order
 /// Order 2 is partially filled for both
@@ -2657,7 +2663,8 @@ fun test_market_order(is_bid: bool) {
 
 /// Test crossing num_orders orders with a single order
 /// Should be filled with the num_orders orders, with correct quantities
-/// Quantity of 1 for the first num_orders orders, quantity of num_orders for the last order
+/// Quantity of 1 for the first num_orders orders, quantity of num_orders for
+/// the last order
 fun test_crossing_multiple(is_bid: bool, num_orders: u64) {
     let mut test = begin(OWNER);
     let registry_id = setup_test(OWNER, &mut test);
@@ -2737,8 +2744,10 @@ fun test_crossing_multiple(is_bid: bool, num_orders: u64) {
     end(test);
 }
 
-/// Test fill or kill order that crosses with an order that's smaller in quantity
-/// Should error with EFOKOrderCannotBeFullyFilled if order cannot be fully filled
+/// Test fill or kill order that crosses with an order that's smaller in
+/// quantity
+/// Should error with EFOKOrderCannotBeFullyFilled if order cannot be fully
+/// filled
 /// Should fill correctly if order can be fully filled
 /// First order has quantity 1, second order has quantity 2 for incorrect fill
 /// First two orders have quantity 1, third order is quantity 2 for correct fill
@@ -3289,7 +3298,8 @@ fun test_swap_exact_amount(is_bid: bool) {
 }
 
 /// Alice places a bid/ask order
-/// Alice then places an ask/bid order that crosses with that order with cancel_taker option
+/// Alice then places an ask/bid order that crosses with that order with
+/// cancel_taker option
 /// Order should be rejected.
 fun test_self_matching_cancel_taker(is_bid: bool) {
     let mut test = begin(OWNER);
@@ -3367,7 +3377,8 @@ fun test_self_matching_cancel_taker(is_bid: bool) {
 }
 
 /// Alice places a bid/ask order
-/// Alice then places an ask/bid order that crosses with that order with cancel_maker option
+/// Alice then places an ask/bid order that crosses with that order with
+/// cancel_maker option
 /// Maker order should be removed, with the new order placed successfully.
 fun test_self_matching_cancel_maker(is_bid: bool) {
     let mut test = begin(OWNER);
@@ -3500,9 +3511,7 @@ fun place_with_price_quantity(price: u64, quantity: u64) {
     end(test);
 }
 
-fun partially_filled_order_taken(
-    is_bid: bool,
-) {
+fun partially_filled_order_taken(is_bid: bool) {
     let mut test = begin(OWNER);
     let registry_id = setup_test(OWNER, &mut test);
     let balance_manager_id_alice = create_acct_and_share_with_funds(
@@ -3550,7 +3559,8 @@ fun partially_filled_order_taken(
         &mut test,
     );
 
-    // Alice places a crossing order of quantity 10, 2 is filled and 8 is placed on book
+    // Alice places a crossing order of quantity 10, 2 is filled and 8 is placed
+    // on book
     let alice_order_info_2 = place_limit_order<SUI, USDC>(
         ALICE,
         pool_id,
@@ -3573,7 +3583,10 @@ fun partially_filled_order_taken(
         alice_quantity_2,
         alice_quantity_1,
         math::mul(alice_quantity_1, alice_price_1),
-        math::mul(alice_quantity_1, math::mul(constants::taker_fee(), constants::deep_multiplier())),
+        math::mul(
+            alice_quantity_1,
+            math::mul(constants::taker_fee(), constants::deep_multiplier()),
+        ),
         pay_with_deep,
         constants::partially_filled(),
         expire_timestamp,
@@ -3583,7 +3596,8 @@ fun partially_filled_order_taken(
     let bob_price = 3 * constants::float_scaling();
     let bob_quantity = 10 * constants::float_scaling();
 
-    // Bob places another crossing order of quantity 10, 8 is filled and 2 is placed on book
+    // Bob places another crossing order of quantity 10, 8 is filled and 2 is
+    // placed on book
     let bob_order_info = place_limit_order<SUI, USDC>(
         BOB,
         pool_id,
@@ -3607,7 +3621,10 @@ fun partially_filled_order_taken(
         bob_quantity,
         8 * constants::float_scaling(),
         8 * alice_price_2,
-        math::mul(8 * constants::float_scaling(), math::mul(constants::taker_fee(), constants::deep_multiplier())),
+        math::mul(
+            8 * constants::float_scaling(),
+            math::mul(constants::taker_fee(), constants::deep_multiplier()),
+        ),
         pay_with_deep,
         constants::partially_filled(),
         expire_timestamp,
@@ -4912,9 +4929,7 @@ fun test_cancel_orders(is_bid: bool) {
     end(test);
 }
 
-fun test_update_pool_book_params(
-    error: u8,
-){
+fun test_update_pool_book_params(error: u8) {
     let mut test = begin(OWNER);
     let registry_id = setup_test(OWNER, &mut test);
     let balance_manager_id_alice = create_acct_and_share_with_funds(
@@ -4962,7 +4977,7 @@ fun test_update_pool_book_params(
         );
     };
 
-    if (error == 2){
+    if (error == 2) {
         adjust_min_lot_size_admin<SUI, USDC>(
             OWNER,
             pool_id,
@@ -5019,14 +5034,17 @@ fun adjust_min_lot_size_admin<BaseAsset, QuoteAsset>(
     test.next_tx(sender);
     let mut pool = test.take_shared_by_id<Pool<BaseAsset, QuoteAsset>>(pool_id);
     let admin_cap = registry::get_admin_cap_for_testing(test.ctx());
+    let clock = test.take_shared<Clock>();
     pool::adjust_min_lot_size_admin<BaseAsset, QuoteAsset>(
         &mut pool,
         new_lot_size,
         new_min_size,
         &admin_cap,
+        &clock,
     );
     test_utils::destroy(admin_cap);
     return_shared(pool);
+    return_shared(clock);
 }
 
 fun adjust_tick_size_admin<BaseAsset, QuoteAsset>(
@@ -5038,11 +5056,14 @@ fun adjust_tick_size_admin<BaseAsset, QuoteAsset>(
     test.next_tx(sender);
     let mut pool = test.take_shared_by_id<Pool<BaseAsset, QuoteAsset>>(pool_id);
     let admin_cap = registry::get_admin_cap_for_testing(test.ctx());
+    let clock = test.take_shared<Clock>();
     pool::adjust_tick_size_admin<BaseAsset, QuoteAsset>(
         &mut pool,
         new_tick_size,
         &admin_cap,
+        &clock,
     );
     test_utils::destroy(admin_cap);
     return_shared(pool);
+    return_shared(clock);
 }

--- a/packages/deepbook/tests/pool_tests.move
+++ b/packages/deepbook/tests/pool_tests.move
@@ -123,6 +123,11 @@ fun test_update_pool_book_params_update_e() {
     test_update_pool_book_params(2);
 }
 
+#[test, expected_failure(abort_code = ::deepbook::pool::EInvalidTickSize)]
+fun test_update_pool_book_params_tick_e() {
+    test_update_pool_book_params(3);
+}
+
 #[test]
 fun test_place_order_ask() {
     place_order_ok(false);
@@ -4966,6 +4971,15 @@ fun test_update_pool_book_params(error: u8) {
         expire_timestamp,
         &mut test,
     );
+
+    if (error == 3) {
+        adjust_tick_size_admin<SUI, USDC>(
+            OWNER,
+            pool_id,
+            50,
+            &mut test,
+        );
+    };
 
     if (error == 0) {
         adjust_min_lot_size_admin<SUI, USDC>(


### PR DESCRIPTION
Tick size: Can be changed to any value >0
Lot size: Must be able to divide previous lot size (and therefore smaller), >0
Min size: Any value, as long as min size % lot size = 0, >0