### PR TITLE
Check account exists in vault.state before accessing it.

### DIFF
--- a/packages/deepbook/sources/pool.move
+++ b/packages/deepbook/sources/pool.move
@@ -985,13 +985,13 @@ public fun locked_balance<BaseAsset, QuoteAsset>(
         deep_quantity = deep_quantity + deep;
     });
 
-    let settled_balances = self
-        .state
-        .account(balance_manager.id())
-        .settled_balances();
-    base_quantity = base_quantity + settled_balances.base();
-    quote_quantity = quote_quantity + settled_balances.quote();
-    deep_quantity = deep_quantity + settled_balances.deep();
+    if (self.state.account_exists(balance_manager.id())) {
+        let settled_balances = self.state.account(balance_manager.id()).settled_balances();
+        base_quantity = base_quantity + settled_balances.base();
+        quote_quantity = quote_quantity + settled_balances.quote();
+        deep_quantity = deep_quantity + settled_balances.deep();
+    };
+    
 
     (base_quantity, quote_quantity, deep_quantity)
 }

--- a/packages/deepbook/sources/pool.move
+++ b/packages/deepbook/sources/pool.move
@@ -973,6 +973,10 @@ public fun locked_balance<BaseAsset, QuoteAsset>(
 ): (u64, u64, u64) {
     let account_orders = self.get_account_order_details(balance_manager);
     let self = self.load_inner();
+    if (!self.state.account_exists(balance_manager.id())) {
+        return (0, 0, 0)
+    };
+
     let mut base_quantity = 0;
     let mut quote_quantity = 0;
     let mut deep_quantity = 0;
@@ -985,13 +989,13 @@ public fun locked_balance<BaseAsset, QuoteAsset>(
         deep_quantity = deep_quantity + deep;
     });
 
-    if (self.state.account_exists(balance_manager.id())) {
-        let settled_balances = self.state.account(balance_manager.id()).settled_balances();
-        base_quantity = base_quantity + settled_balances.base();
-        quote_quantity = quote_quantity + settled_balances.quote();
-        deep_quantity = deep_quantity + settled_balances.deep();
-    };
-    
+    let settled_balances = self
+        .state
+        .account(balance_manager.id())
+        .settled_balances();
+    base_quantity = base_quantity + settled_balances.base();
+    quote_quantity = quote_quantity + settled_balances.quote();
+    deep_quantity = deep_quantity + settled_balances.deep();
 
     (base_quantity, quote_quantity, deep_quantity)
 }

--- a/packages/deepbook/tests/master_tests.move
+++ b/packages/deepbook/tests/master_tests.move
@@ -254,6 +254,8 @@ module deepbook::master_tests {
         // Epoch 0
         assert!(test.ctx().epoch() == 0, 0);
 
+        check_locked_balance<SUI, USDC>(ALICE, pool1_id, alice_balance_manager_id, &alice_locked_balance, &mut test);
+
         // Alice places an order in pool 1
         pool_tests::place_limit_order<SUI, USDC>(
             ALICE,


### PR DESCRIPTION
Fixed #303 

**Description**:  
This pull request addresses the issue where the `locked_balance` function aborts when called on a fresh `balance_manager` that has not interacted with the pool. The solution involves adding a check for `locked_balance` before placing an order.

**Changes Made**:
- Updated `pool::locked_balance`, check account exists before accessing.
- Updated `deepbook::master_tests::test_locked_balance` to include `check_locked_balance<SUI, USDC>(ALICE, pool1_id, alice_balance_manager_id, &alice_locked_balance, &mut test);` before placing an order.

**Testing**:
- The updated test case now passes, confirming the fix.
- Verified that the computational load increase is minimal and acceptable.