### PR TITLE
Fix Abort in `pool::withdraw_settled_amounts` for Fresh `balance_manager`

### DIFF
--- a/packages/deepbook/sources/state/state.move
+++ b/packages/deepbook/sources/state/state.move
@@ -145,9 +145,14 @@ public(package) fun withdraw_settled_amounts(
     self: &mut State,
     balance_manager_id: ID,
 ): (Balances, Balances) {
-    let account = &mut self.accounts[balance_manager_id];
+    if (self.accounts.contains(balance_manager_id)) {
+        let account = &mut self.accounts[balance_manager_id];
 
-    account.settle()
+        account.settle()    
+    } else {
+        (balances::empty(), balances::empty())
+    }
+    
 }
 
 /// Update account settled balances and volumes.

--- a/packages/deepbook/tests/master_tests.move
+++ b/packages/deepbook/tests/master_tests.move
@@ -451,6 +451,13 @@ module deepbook::master_tests {
             );
         };
 
+        withdraw_settled_amounts<SUI, USDC>(
+            ALICE,
+            pool1_id,
+            alice_balance_manager_id,
+            &mut test
+        );
+
         // Alice places bid order in pool 1
         let order_info_1 = pool_tests::place_limit_order<SUI, USDC>(
             ALICE,


### PR DESCRIPTION
Fix #305 

**Description**:  
This pull request addresses the issue where the `pool::withdraw_settled_amounts` function aborts when called on a fresh `balance_manager` that has not interacted with the pool. The solution involves adding a check for `state.withdraw_settled_amounts`.

**Testing**:
- The updated test case now passes, confirming the fix.
- Original code failed several cases.
- Verified that the computational load increase is minimal and acceptable.