### PR TITLE
Allow burning 0 DEEP tokens

### DIFF
--- a/packages/deepbook/sources/pool.move
+++ b/packages/deepbook/sources/pool.move
@@ -40,12 +40,11 @@ const EIneligibleReferencePool: u64 = 7;
 const EFeeTypeNotSupported: u64 = 8;
 const EInvalidOrderBalanceManager: u64 = 9;
 const EIneligibleTargetPool: u64 = 10;
-const ENoAmountToBurn: u64 = 11;
-const EPackageVersionDisabled: u64 = 12;
-const EMinimumQuantityOutNotMet: u64 = 13;
-const EInvalidStake: u64 = 14;
-const EPoolNotRegistered: u64 = 15;
-const EPoolCannotBeBothWhitelistedAndStable: u64 = 16;
+const EPackageVersionDisabled: u64 = 11;
+const EMinimumQuantityOutNotMet: u64 = 12;
+const EInvalidStake: u64 = 13;
+const EPoolNotRegistered: u64 = 14;
+const EPoolCannotBeBothWhitelistedAndStable: u64 = 15;
 
 // === Structs ===
 public struct Pool<phantom BaseAsset, phantom QuoteAsset> has key {
@@ -631,7 +630,6 @@ public fun burn_deep<BaseAsset, QuoteAsset>(
 ): u64 {
     let self = self.load_inner_mut();
     let balance_to_burn = self.state.history_mut().reset_balance_to_burn();
-    assert!(balance_to_burn > 0, ENoAmountToBurn);
     let deep_to_burn = self
         .vault
         .withdraw_deep_to_burn(balance_to_burn)

--- a/packages/deepbook/sources/pool.move
+++ b/packages/deepbook/sources/pool.move
@@ -87,6 +87,14 @@ public struct BookParamsUpdated<
     timestamp: u64,
 }
 
+public struct DeepBurned<
+    phantom BaseAsset,
+    phantom QuoteAsset,
+> has copy, store, drop {
+    pool_id: ID,
+    deep_burned: u64,
+}
+
 // === Public-Mutative Functions * EXCHANGE * ===
 /// Place a limit order. Quantity is in base asset terms.
 /// For current version pay_with_deep must be true, so the fee will be paid with
@@ -636,6 +644,11 @@ public fun burn_deep<BaseAsset, QuoteAsset>(
         .into_coin(ctx);
     let amount_burned = deep_to_burn.value();
     token::deep::burn(treasury_cap, deep_to_burn);
+
+    event::emit(DeepBurned<BaseAsset, QuoteAsset> {
+        pool_id: self.pool_id,
+        deep_burned: amount_burned,
+    });
 
     amount_burned
 }

--- a/packages/deepbook/tests/master_tests.move
+++ b/packages/deepbook/tests/master_tests.move
@@ -45,20 +45,18 @@ module deepbook::master_tests {
     const ECannotPropose: u64 = 5;
     const EIncorrectRebateClaimer: u64 = 6;
     const EDataRecentlyAdded: u64 = 7;
-    const ENoAmountToBurn: u64 = 8;
-    const ENoAmountToBurn2: u64 = 9;
-    const ENotEnoughBaseForLoan: u64 = 10;
-    const ENotEnoughQuoteForLoan: u64 = 11;
-    const EIncorrectLoanPool: u64 = 12;
-    const EIncorrectTypeReturned: u64 = 13;
-    const EInvalidOwner: u64 = 14;
-    const ETradeCapNotInList: u64 = 15;
-    const EInvalidTrader: u64 = 16;
-    const EIncorrectLevel2Price: u64 = 17;
-    const EIncorrectLevel2Quantity: u64 = 18;
-    const EInvalidStake: u64 = 19;
-    const EAddPricePointUnregisteredPool: u64 = 20;
-    const EIncorrectLevel2Length: u64 = 21;
+    const ENotEnoughBaseForLoan: u64 = 8;
+    const ENotEnoughQuoteForLoan: u64 = 9;
+    const EIncorrectLoanPool: u64 = 10;
+    const EIncorrectTypeReturned: u64 = 11;
+    const EInvalidOwner: u64 = 12;
+    const ETradeCapNotInList: u64 = 13;
+    const EInvalidTrader: u64 = 14;
+    const EIncorrectLevel2Price: u64 = 15;
+    const EIncorrectLevel2Quantity: u64 = 16;
+    const EInvalidStake: u64 = 17;
+    const EAddPricePointUnregisteredPool: u64 = 18;
+    const EIncorrectLevel2Length: u64 = 19;
 
     #[test]
     fun test_master_ok() {
@@ -93,16 +91,6 @@ module deepbook::master_tests {
     #[test, expected_failure(abort_code = ::deepbook::balance_manager::EInvalidTrader)]
     fun test_master_incorrect_rebate_claimer_e() {
         test_master(EIncorrectRebateClaimer)
-    }
-
-    #[test, expected_failure(abort_code = ::deepbook::pool::ENoAmountToBurn)]
-    fun test_no_amount_to_burn_e() {
-        test_master(ENoAmountToBurn)
-    }
-
-    #[test, expected_failure(abort_code = ::deepbook::pool::ENoAmountToBurn)]
-    fun test_no_amount_to_burn_2_e() {
-        test_master(ENoAmountToBurn2)
     }
 
     #[test, expected_failure(abort_code = ::deepbook::pool::EIneligibleReferencePool)]
@@ -901,16 +889,6 @@ module deepbook::master_tests {
             &mut test
         );
 
-        // Since all rebates are to be claimed, there are no amounts to burn
-        if (error_code == ENoAmountToBurn) {
-            burn_deep<SUI, USDC>(
-                ALICE,
-                pool1_id,
-                0,
-                &mut test
-            );
-        };
-
         // Same cross trading happens during epoch 28
         // quantity being traded is halved, each person will make 0.5 quantity and take 0.5 quantity
         let quantity = 500_000_000;
@@ -1002,16 +980,6 @@ module deepbook::master_tests {
             expected_amount_burned,
             &mut test
         );
-
-        // Trying to burn again will fail
-        if (error_code == ENoAmountToBurn2) {
-            burn_deep<SUI, USDC>(
-                ALICE,
-                pool1_id,
-                0,
-                &mut test
-            );
-        };
 
         end(test);
     }


### PR DESCRIPTION
1. Allow burning 0 DEEP tokens to enable batch burning across pools
2. Deep burned event