### PR TITLE
Lower taker fee bound

### DIFF
--- a/packages/deepbook/Move.lock
+++ b/packages/deepbook/Move.lock
@@ -30,7 +30,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.35.0"
+compiler-version = "1.40.2"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/packages/deepbook/sources/state/governance.move
+++ b/packages/deepbook/sources/state/governance.move
@@ -22,14 +22,14 @@ const EWhitelistedPoolCannotChange: u64 = 5;
 
 // === Constants ===
 const FEE_MULTIPLE: u64 = 1000; // 0.01 basis points
-const MIN_TAKER_STABLE: u64 = 50000; // 0.5 basis points
-const MAX_TAKER_STABLE: u64 = 100000;
-const MIN_MAKER_STABLE: u64 = 20000;
-const MAX_MAKER_STABLE: u64 = 50000;
-const MIN_TAKER_VOLATILE: u64 = 500000;
-const MAX_TAKER_VOLATILE: u64 = 1000000;
-const MIN_MAKER_VOLATILE: u64 = 200000;
-const MAX_MAKER_VOLATILE: u64 = 500000;
+const MIN_TAKER_STABLE: u64 = 10000; // 0.1 basis points
+const MAX_TAKER_STABLE: u64 = 100000; // 1 basis points
+const MIN_MAKER_STABLE: u64 = 0;
+const MAX_MAKER_STABLE: u64 = 50000; // 0.5 basis points
+const MIN_TAKER_VOLATILE: u64 = 100000; // 1 basis points
+const MAX_TAKER_VOLATILE: u64 = 1000000; // 10 basis points
+const MIN_MAKER_VOLATILE: u64 = 0;
+const MAX_MAKER_VOLATILE: u64 = 500000; // 5 basis points
 const MAX_PROPOSALS: u64 = 100;
 const VOTING_POWER_THRESHOLD: u64 = 100_000_000_000; // 100k deep
 

--- a/packages/deepbook/tests/state/governance_tests.move
+++ b/packages/deepbook/tests/state/governance_tests.move
@@ -59,7 +59,7 @@ fun add_proposal_volatile_low_taker_e() {
     test.next_tx(alice);
     let stable_pool = false;
     let mut gov = governance::empty(stable_pool, test.ctx());
-    gov.add_proposal(490000, 200000, 10000, 1000, id_from_address(alice));
+    gov.add_proposal(99000, 200000, 10000, 1000, id_from_address(alice));
     abort 0
 }
 
@@ -72,18 +72,6 @@ fun add_proposal_volatile_high_taker_e() {
     let stable_pool = false;
     let mut gov = governance::empty(stable_pool, test.ctx());
     gov.add_proposal(1010000, 200000, 10000, 1000, id_from_address(alice));
-    abort 0
-}
-
-#[test, expected_failure(abort_code = governance::EInvalidMakerFee)]
-fun add_proposal_volatile_low_maker_e() {
-    let mut test = begin(OWNER);
-    let alice = ALICE;
-
-    test.next_tx(alice);
-    let stable_pool = false;
-    let mut gov = governance::empty(stable_pool, test.ctx());
-    gov.add_proposal(500000, 190000, 10000, 1000, id_from_address(alice));
     abort 0
 }
 
@@ -127,6 +115,34 @@ fun add_proposal_stable_taker_e() {
 
     test.next_tx(alice);
     gov.add_proposal(500000, 20000, 10000, 1000, id_from_address(alice));
+    abort 0
+}
+
+#[test, expected_failure(abort_code = governance::EInvalidTakerFee)]
+fun add_proposal_stable_low_taker_e() {
+    let mut test = begin(OWNER);
+    let alice = ALICE;
+
+    test.next_tx(OWNER);
+    let stable_pool = true;
+    let mut gov = governance::empty(stable_pool, test.ctx());
+
+    test.next_tx(alice);
+    gov.add_proposal(9000, 20000, 10000, 10000, id_from_address(alice));
+    abort 0
+}
+
+#[test, expected_failure(abort_code = governance::EInvalidTakerFee)]
+fun add_proposal_stable_high_taker_e() {
+    let mut test = begin(OWNER);
+    let alice = ALICE;
+
+    test.next_tx(OWNER);
+    let stable_pool = true;
+    let mut gov = governance::empty(stable_pool, test.ctx());
+
+    test.next_tx(alice);
+    gov.add_proposal(110000, 20000, 10000, 10000, id_from_address(alice));
     abort 0
 }
 
@@ -355,7 +371,8 @@ fun adjust_vote_ok() {
     assert!(gov.next_trade_params().taker_fee() == 500000, 0);
     assert!(gov.next_trade_params().maker_fee() == 200000, 0);
 
-    // bob removes his votes completely, making the default trade params the next trade params
+    // bob removes his votes completely, making the default trade params the
+    // next trade params
     test.next_tx(bob);
     gov.adjust_vote(option::some(id_from_address(alice)), option::none(), 300);
     assert!(gov.proposals().get(&id_from_address(alice)).votes() == 0, 0);
@@ -424,7 +441,8 @@ fun adjust_vote_from_removed_proposal_ok() {
 /// A with less voting power than B (A had 100000, B had 200000, C had 150000)
 /// C votes on A's proposal and pushes it over quorum
 /// C then makes a new proposal. The proposal that's removed should be A
-/// Check to make sure A's removed by voting on proposal A, which will error (EProposalDoesNotExist)
+/// Check to make sure A's removed by voting on proposal A, which will error
+/// (EProposalDoesNotExist)
 fun remove_proposal_vote_e() {
     let mut test = begin(OWNER);
     let alice = ALICE;
@@ -456,7 +474,8 @@ fun remove_proposal_vote_e() {
         i = i + 1;
     };
 
-    // Alice proposes and votes with 100000 stake, not enough to push proposal ALICE over quorum
+    // Alice proposes and votes with 100000 stake, not enough to push proposal
+    // ALICE over quorum
     gov.add_proposal(500000, 200000, 10000, 100000, id_from_address(alice));
     gov.adjust_vote(
         option::none(),
@@ -464,12 +483,14 @@ fun remove_proposal_vote_e() {
         100000,
     );
     assert_eq(gov.trade_params(), gov.next_trade_params());
-    // Bob proposes and votes with 200000 stake, not enough to push proposal Bob over quorum
+    // Bob proposes and votes with 200000 stake, not enough to push proposal Bob
+    // over quorum
     gov.add_proposal(600000, 300000, 20000, 200000, id_from_address(bob));
     gov.adjust_vote(option::none(), option::some(id_from_address(bob)), 200000);
     assert_eq(gov.trade_params(), gov.next_trade_params());
 
-    // Charlie votes with 150000 stake, enough to push proposal ALICE over quorum
+    // Charlie votes with 150000 stake, enough to push proposal ALICE over
+    // quorum
     gov.adjust_vote(
         option::none(),
         option::some(id_from_address(alice)),
@@ -597,11 +618,13 @@ fun adjust_voting_power_over_threshold_ok() {
     );
     test.next_epoch(OWNER);
     gov.update(test.ctx());
-    // The additional power is calculated as sqrt(total_stake = 150k) - sqrt(threshold = 100k)
+    // The additional power is calculated as sqrt(total_stake = 150k) -
+    // sqrt(threshold = 100k)
     // 387.298334620 - 316.227766016 = 71.070568604
     // total voting power = 100000 + 71.070568604 = 100071.070568604
     // quorum = 50035.535284302
-    // The total voting power is therefore 52.928, with quorum being half of that = 26.464.
+    // The total voting power is therefore 52.928, with quorum being half of
+    // that = 26.464.
     assert!(gov.voting_power() == 100_071_070_568, 0);
 
     assert!(gov.quorum() == 50_035_535_284, 0);
@@ -611,7 +634,8 @@ fun adjust_voting_power_over_threshold_ok() {
     );
     test.next_epoch(OWNER);
     gov.update(test.ctx());
-    // The additional power is calculated as sqrt(total_stake = 200k) - sqrt(threshold = 100k)
+    // The additional power is calculated as sqrt(total_stake = 200k) -
+    // sqrt(threshold = 100k)
     // 447.213595499 - 316.227766016 = 130.985829483
     // total voting power = 100000 + 130.985829484 = 100130.985829483
     // quorum = 50065.492914741


### PR DESCRIPTION
1. Lower bound for maker fee is 0 for both stable and volatile pools
2. Lower bound for taker fee is 0.1 bps for stable pool and 1 bps for volatile pool