### PR TITLE
add `published-at` to move.toml

### DIFF
--- a/packages/deepbook/Move.lock
+++ b/packages/deepbook/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "77450CAF5CB6CF95D38E61C7F44F5C35EF483F5B232C93A8039C28ECA9AC8BA1"
+manifest_digest = "BB0F8FF334D5ABA31DB08E4C54E5FA466528C0CB751419F121E86513103E0DD3"
 deps_digest = "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -30,7 +30,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.43.1"
+compiler-version = "1.46.0"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/packages/deepbook/Move.toml
+++ b/packages/deepbook/Move.toml
@@ -9,4 +9,4 @@ Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-fram
 token = { local = "../token"}
 
 [addresses]
-deepbook = "0x0"
+deepbook = "0x2c8d603bc51326b8c13cef9dd07031a408a48dddb541963357661df5d3204809"

--- a/packages/deepbook/Move.toml
+++ b/packages/deepbook/Move.toml
@@ -2,6 +2,7 @@
 name = "deepbook"
 edition = "2024.beta"
 version = "0.0.1"
+published-at = "0x2c8d603bc51326b8c13cef9dd07031a408a48dddb541963357661df5d3204809"
 
 [dependencies]
 Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }

--- a/packages/deepbook/sources/state/governance.move
+++ b/packages/deepbook/sources/state/governance.move
@@ -302,7 +302,7 @@ public fun proposals(self: &Governance): VecMap<ID, Proposal> {
     self.proposals
 }
 
-#[test_only]
+// #[test_only]
 public fun next_trade_params(self: &Governance): TradeParams {
     self.next_trade_params
 }


### PR DESCRIPTION
`published-at` field currently not in `packages/deepbook/move.toml`
which causing other packages's refer error.

appoint it out the fix other's refer error.