### PR TITLE
Return deep fee quantity if OrderDeepPrice has deep per asset

### DIFF
--- a/packages/deepbook/sources/vault/deep_price.move
+++ b/packages/deepbook/sources/vault/deep_price.move
@@ -99,7 +99,7 @@ public(package) fun fee_quantity(
         math::mul(quote_quantity, self.deep_per_asset)
     };
 
-    if (deep_quantity > 0) {
+    if (self.deep_per_asset > 0) {
         balances::new(0, 0, deep_quantity)
     } else if (is_bid) {
         balances::new(

--- a/packages/deepbook/tests/pool_tests.move
+++ b/packages/deepbook/tests/pool_tests.move
@@ -1280,7 +1280,7 @@ public(package) fun setup_default_permissionless_pool<BaseAsset, QuoteAsset>(
     registry_id: ID,
     test: &mut Scenario,
 ): ID {
-    setup_permissionsless_pool<BaseAsset, QuoteAsset>(
+    setup_permissionless_pool<BaseAsset, QuoteAsset>(
         sender,
         constants::tick_size(), // tick size
         constants::lot_size(), // lot size
@@ -4918,7 +4918,7 @@ fun setup_pool<BaseAsset, QuoteAsset>(
     pool_id
 }
 
-fun setup_permissionsless_pool<BaseAsset, QuoteAsset>(
+fun setup_permissionless_pool<BaseAsset, QuoteAsset>(
     sender: address,
     tick_size: u64,
     lot_size: u64,


### PR DESCRIPTION
1. Return deep fee quantity if OrderDeepPrice has deep per asset, which means the order is paying in DEEP
2. Additional test coverage