### PR TITLE
Margin Manager

### DIFF
--- a/packages/margin_trading/sources/margin_manager.move
+++ b/packages/margin_trading/sources/margin_manager.move
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// TODO: update comments
 module margin_trading::margin_manager;
 
 use deepbook::{

--- a/packages/margin_trading/sources/margin_manager.move
+++ b/packages/margin_trading/sources/margin_manager.move
@@ -1,0 +1,722 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// TODO: update comments
+module margin_trading::margin_manager;
+
+use deepbook::{
+    balance_manager::{
+        Self,
+        mint_deposit_cap,
+        mint_trade_cap,
+        mint_withdraw_cap,
+        BalanceManager,
+        TradeCap,
+        DepositCap,
+        WithdrawCap
+    },
+    constants,
+    math,
+    pool::Pool
+};
+use margin_trading::{
+    margin_pool::MarginPool,
+    margin_registry::MarginRegistry,
+    oracle::{calculate_usd_price, calculate_target_amount}
+};
+use pyth::price_info::PriceInfoObject;
+use std::type_name;
+use sui::{clock::Clock, coin::Coin, event};
+use token::deep::DEEP;
+
+// === Errors ===
+const EInvalidDeposit: u64 = 0;
+const EMarginPairNotAllowed: u64 = 1;
+const EInvalidMarginManager: u64 = 4;
+const EBorrowRiskRatioExceeded: u64 = 5;
+const EWithdrawRiskRatioExceeded: u64 = 6;
+const ECannotLiquidate: u64 = 8;
+const EInvalidMarginManagerOwner: u64 = 9;
+
+// === Constants ===
+const WITHDRAW: u8 = 0;
+const BORROW: u8 = 1;
+
+// === Structs ===
+/// A shared object that wraps a `BalanceManager` and provides the necessary capabilities to deposit, withdraw, and trade.
+public struct MarginManager<phantom BaseAsset, phantom QuoteAsset> has key, store {
+    id: UID,
+    owner: address,
+    balance_manager: BalanceManager,
+    deposit_cap: DepositCap,
+    withdraw_cap: WithdrawCap,
+    trade_cap: TradeCap,
+}
+
+/// Event emitted when a new margin_manager is created.
+public struct MarginManagerEvent has copy, drop {
+    margin_manager_id: ID,
+    balance_manager_id: ID,
+    owner: address,
+}
+
+/// Event emitted when a new margin_manager is created.
+public struct LiquidationEvent has copy, drop {
+    margin_manager_id: ID,
+    base_amount: u64,
+    quote_amount: u64,
+    liquidator: address,
+}
+
+/// Request_type: 0 for withdraw, 1 for borrow
+public struct Request {
+    margin_manager_id: ID,
+    request_type: u8,
+}
+
+// === Public Functions - Margin Manager ===
+public fun new<BaseAsset, QuoteAsset>(margin_registry: &MarginRegistry, ctx: &mut TxContext) {
+    assert!(margin_registry.margin_pair_allowed<BaseAsset, QuoteAsset>(), EMarginPairNotAllowed);
+
+    let id = object::new(ctx);
+
+    let mut balance_manager = balance_manager::new_with_custom_owner(id.to_address(), ctx);
+    let deposit_cap = mint_deposit_cap(&mut balance_manager, ctx);
+    let withdraw_cap = mint_withdraw_cap(&mut balance_manager, ctx);
+    let trade_cap = mint_trade_cap(&mut balance_manager, ctx);
+
+    event::emit(MarginManagerEvent {
+        margin_manager_id: id.to_inner(),
+        balance_manager_id: object::id(&balance_manager),
+        owner: ctx.sender(),
+    });
+
+    let margin_manager = MarginManager<BaseAsset, QuoteAsset> {
+        id,
+        owner: ctx.sender(),
+        balance_manager,
+        deposit_cap,
+        withdraw_cap,
+        trade_cap,
+    };
+
+    transfer::share_object(margin_manager)
+}
+
+/// Deposit a coin into the margin manager. The coin must be of the same type as either the base, quote, or DEEP.
+public fun deposit<BaseAsset, QuoteAsset, DepositAsset>(
+    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    coin: Coin<DepositAsset>,
+    ctx: &mut TxContext,
+) {
+    assert!(ctx.sender() == margin_manager.owner, EInvalidMarginManagerOwner);
+
+    let deposit_asset_type = type_name::get<DepositAsset>();
+    let base_asset_type = type_name::get<BaseAsset>();
+    let quote_asset_type = type_name::get<QuoteAsset>();
+    let deep_asset_type = type_name::get<DEEP>();
+    assert!(
+        deposit_asset_type == base_asset_type || deposit_asset_type == quote_asset_type || deposit_asset_type == deep_asset_type,
+        EInvalidDeposit,
+    );
+
+    let balance_manager = &mut margin_manager.balance_manager;
+    let deposit_cap = &margin_manager.deposit_cap;
+
+    balance_manager.deposit_with_cap<DepositAsset>(deposit_cap, coin, ctx);
+}
+
+/// Withdraw a specified amount of an asset from the margin manager. The asset must be of the same type as either the base, quote, or DEEP.
+/// The withdrawal is subject to the risk ratio limit. This is restricted through the Request.
+public fun withdraw<BaseAsset, QuoteAsset, WithdrawAsset>(
+    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    withdraw_amount: u64,
+    ctx: &mut TxContext,
+): (Coin<WithdrawAsset>, Request) {
+    assert!(ctx.sender() == margin_manager.owner, EInvalidMarginManagerOwner);
+
+    let balance_manager = &mut margin_manager.balance_manager;
+    let withdraw_cap = &margin_manager.withdraw_cap;
+
+    let coin = balance_manager.withdraw_with_cap<WithdrawAsset>(
+        withdraw_cap,
+        withdraw_amount,
+        ctx,
+    );
+
+    let withdrawal_request = Request {
+        margin_manager_id: margin_manager.id(),
+        request_type: WITHDRAW,
+    };
+
+    (coin, withdrawal_request)
+}
+
+/// Borrow the base asset using the margin manager.
+public fun borrow_base<BaseAsset, QuoteAsset>(
+    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    margin_pool: &mut MarginPool<BaseAsset>,
+    loan_amount: u64,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): Request {
+    margin_manager.borrow<BaseAsset, QuoteAsset, BaseAsset>(margin_pool, loan_amount, clock, ctx)
+}
+
+/// Borrow the quote asset using the margin manager.
+public fun borrow_quote<BaseAsset, QuoteAsset>(
+    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    margin_pool: &mut MarginPool<QuoteAsset>,
+    loan_amount: u64,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): Request {
+    margin_manager.borrow<BaseAsset, QuoteAsset, QuoteAsset>(margin_pool, loan_amount, clock, ctx)
+}
+
+/// Repay the base asset loan using the margin manager.
+public fun repay_base<BaseAsset, QuoteAsset>(
+    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    margin_pool: &mut MarginPool<BaseAsset>,
+    repay_amount: Option<u64>, // if None, repay all
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    margin_manager.repay<BaseAsset, QuoteAsset, BaseAsset>(
+        margin_pool,
+        repay_amount,
+        false,
+        clock,
+        ctx,
+    );
+}
+
+/// Repay the quote asset loan using the margin manager.
+public fun repay_quote<BaseAsset, QuoteAsset>(
+    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    margin_pool: &mut MarginPool<QuoteAsset>,
+    repay_amount: Option<u64>, // if None, repay all
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    margin_manager.repay<BaseAsset, QuoteAsset, QuoteAsset>(
+        margin_pool,
+        repay_amount,
+        false,
+        clock,
+        ctx,
+    );
+}
+
+/// Destroys the request to borrow or withdraw if risk ratio conditions are met.
+/// This function is called after the borrow or withdraw request is created.
+public fun risk_ratio_proof<BaseAsset, QuoteAsset>(
+    registry: &MarginRegistry,
+    margin_manager: &MarginManager<BaseAsset, QuoteAsset>,
+    base_margin_pool: &mut MarginPool<BaseAsset>,
+    quote_margin_pool: &mut MarginPool<QuoteAsset>,
+    pool: &Pool<BaseAsset, QuoteAsset>,
+    base_price_info_object: &PriceInfoObject,
+    quote_price_info_object: &PriceInfoObject,
+    clock: &Clock,
+    request: Request,
+) {
+    assert!(request.margin_manager_id == margin_manager.id(), EInvalidMarginManager);
+
+    let risk_ratio = risk_ratio<BaseAsset, QuoteAsset>(
+        registry,
+        margin_manager,
+        base_margin_pool,
+        quote_margin_pool,
+        pool,
+        base_price_info_object,
+        quote_price_info_object,
+        clock,
+    );
+    if (request.request_type == BORROW) {
+        assert!(registry.can_borrow<BaseAsset, QuoteAsset>(risk_ratio), EBorrowRiskRatioExceeded);
+    } else if (request.request_type == WITHDRAW) {
+        assert!(
+            registry.can_withdraw<BaseAsset, QuoteAsset>(risk_ratio),
+            EWithdrawRiskRatioExceeded,
+        );
+    };
+
+    let Request {
+        margin_manager_id: _,
+        request_type: _,
+    } = request;
+}
+
+/// Risk ratio = total asset in USD / (total debt and interest in USD)
+/// Risk ratio above 2.0 allows for withdrawal from balance manager, borrowing, and trading
+/// Risk ratio between 1.25 and 2.0 allows for borrowing and trading
+/// Risk ratio between 1.1 and 1.25 allows for trading only
+/// Risk ratio below 1.1 allows for liquidation
+/// These numbers can be updated by the admin. 1.25 is the default borrow risk ratio, this is equivalent to 5x leverage.
+public fun risk_ratio<BaseAsset, QuoteAsset>(
+    registry: &MarginRegistry,
+    margin_manager: &MarginManager<BaseAsset, QuoteAsset>,
+    base_margin_pool: &mut MarginPool<BaseAsset>,
+    quote_margin_pool: &mut MarginPool<QuoteAsset>,
+    pool: &Pool<BaseAsset, QuoteAsset>,
+    base_price_info_object: &PriceInfoObject,
+    quote_price_info_object: &PriceInfoObject,
+    clock: &Clock,
+): u64 {
+    let (base_debt, quote_debt) = margin_manager_debt<BaseAsset, QuoteAsset>(
+        base_margin_pool,
+        quote_margin_pool,
+        margin_manager,
+        clock,
+    );
+    let (base_asset, quote_asset) = margin_manager_asset<BaseAsset, QuoteAsset>(
+        pool,
+        margin_manager,
+    );
+
+    let base_usd_debt = calculate_usd_price<BaseAsset>(
+        registry,
+        base_debt,
+        clock,
+        base_price_info_object,
+    );
+    let base_usd_asset = calculate_usd_price<BaseAsset>(
+        registry,
+        base_asset,
+        clock,
+        base_price_info_object,
+    );
+    let quote_usd_debt = calculate_usd_price<QuoteAsset>(
+        registry,
+        quote_debt,
+        clock,
+        quote_price_info_object,
+    );
+    let quote_usd_asset = calculate_usd_price<QuoteAsset>(
+        registry,
+        quote_asset,
+        clock,
+        quote_price_info_object,
+    );
+    let total_usd_debt = base_usd_debt + quote_usd_debt; // 6 decimals
+    let total_usd_asset = base_usd_asset + quote_usd_asset; // 6 decimals
+
+    if (total_usd_debt == 0 || total_usd_asset > 1000 * total_usd_debt) {
+        1000 * constants::float_scaling() // 9 decimals, risk ratio above 1000 will be considered as 1000
+    } else {
+        math::div(total_usd_asset, total_usd_debt) // 9 decimals
+    }
+}
+
+/// Liquidates a margin manager
+public fun liquidate<BaseAsset, QuoteAsset>(
+    registry: &MarginRegistry,
+    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    base_margin_pool: &mut MarginPool<BaseAsset>,
+    quote_margin_pool: &mut MarginPool<QuoteAsset>,
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    base_price_info_object: &PriceInfoObject,
+    quote_price_info_object: &PriceInfoObject,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    let (base_debt, quote_debt) = margin_manager_debt<BaseAsset, QuoteAsset>(
+        base_margin_pool,
+        quote_margin_pool,
+        margin_manager,
+        clock,
+    );
+    let (base_asset, quote_asset) = margin_manager_asset<BaseAsset, QuoteAsset>(
+        pool,
+        margin_manager,
+    );
+
+    let base_usd_debt = calculate_usd_price<BaseAsset>(
+        registry,
+        base_debt,
+        clock,
+        base_price_info_object,
+    );
+    let base_usd_asset = calculate_usd_price<BaseAsset>(
+        registry,
+        base_asset,
+        clock,
+        base_price_info_object,
+    );
+    let quote_usd_debt = calculate_usd_price<QuoteAsset>(
+        registry,
+        quote_debt,
+        clock,
+        quote_price_info_object,
+    );
+    let quote_usd_asset = calculate_usd_price<QuoteAsset>(
+        registry,
+        quote_asset,
+        clock,
+        quote_price_info_object,
+    );
+
+    let total_usd_asset = base_usd_asset + quote_usd_asset; // 9 decimals
+    let total_usd_debt = base_usd_debt + quote_usd_debt; // 9 decimals
+
+    let risk_ratio = risk_ratio<BaseAsset, QuoteAsset>(
+        registry,
+        margin_manager,
+        base_margin_pool,
+        quote_margin_pool,
+        pool,
+        base_price_info_object,
+        quote_price_info_object,
+        clock,
+    );
+
+    assert!(registry.can_liquidate<BaseAsset, QuoteAsset>(risk_ratio), ECannotLiquidate);
+
+    let target_ratio = registry.target_liquidation_risk_ratio<BaseAsset, QuoteAsset>();
+
+    // Now we check whether we have base or quote loan that needs to be covered. Only one of them can be net negative.
+    // TODO: some edge cases here during defaults?
+    let net_debt_is_base = base_debt > base_asset; // If true, we have to swap quote to base
+    let net_debt_is_quote = quote_debt > quote_asset; // If true, we have to swap base to quote
+
+    // Amount in USD (9 decimals) to repay to bring risk_ratio to target_ratio
+    // amount_to_liquidate = (target_ratio × debt_value - asset) / (target_ratio - 1)
+    let usd_amount_to_repay = math::div(
+        (math::mul(total_usd_debt, target_ratio) - total_usd_asset),
+        (target_ratio - constants::float_scaling()),
+    );
+
+    let base_same_asset_repay = base_asset.min(base_debt);
+    let quote_same_asset_repay = quote_asset.min(quote_debt);
+
+    let base_usd_repay = calculate_usd_price<BaseAsset>(
+        registry,
+        base_same_asset_repay,
+        clock,
+        base_price_info_object,
+    );
+    let quote_usd_repay = calculate_usd_price<QuoteAsset>(
+        registry,
+        quote_same_asset_repay,
+        clock,
+        quote_price_info_object,
+    );
+
+    // Simply repaying the loan using same assets will be enough to cover the liquidation.
+    let same_asset_usd_repay = base_usd_repay + quote_usd_repay;
+    if (same_asset_usd_repay < usd_amount_to_repay) {
+        let remaining_usd_repay = usd_amount_to_repay - same_asset_usd_repay;
+
+        let quote_amount_liquidate = if (net_debt_is_base) {
+            calculate_target_amount<QuoteAsset>(
+                registry,
+                remaining_usd_repay,
+                clock,
+                quote_price_info_object,
+            )
+        } else {
+            0
+        };
+        let base_amount_liquidate = if (net_debt_is_quote) {
+            calculate_target_amount<BaseAsset>(
+                registry,
+                remaining_usd_repay,
+                clock,
+                base_price_info_object,
+            )
+        } else {
+            0
+        };
+
+        let trade_proof = margin_manager
+            .balance_manager
+            .generate_proof_as_trader(&margin_manager.trade_cap, ctx);
+
+        let balance_manager = margin_manager.balance_manager_mut();
+        pool.cancel_all_orders(balance_manager, &trade_proof, clock, ctx);
+        pool.withdraw_settled_amounts(balance_manager, &trade_proof);
+
+        if (base_amount_liquidate > 0) {
+            let client_order_id = 0;
+            let is_bid = false;
+            let pay_with_deep = false; // TODO: Should this be customizable? No guarantee to be DEEP in manager however
+            // We have to use input token as fee during, in case there is not enough DEEP in the balance manager.
+            // Alternatively, we can utilize DEEP flash loan.
+
+            let (_, lot_size, _) = pool.pool_book_params<BaseAsset, QuoteAsset>();
+            let base_quantity = base_amount_liquidate - base_amount_liquidate % lot_size;
+
+            pool.place_market_order(
+                margin_manager.balance_manager_mut(),
+                &trade_proof,
+                client_order_id,
+                constants::self_matching_allowed(),
+                base_quantity,
+                is_bid,
+                pay_with_deep,
+                clock,
+                ctx,
+            );
+        };
+
+        if (quote_amount_liquidate > 0) {
+            let client_order_id = 0;
+            let is_bid = true;
+            let pay_with_deep = false; // TODO: Should this be customizable? No guarantee to be DEEP in manager however
+            // We have to use input token as fee during, in case there is not enough DEEP in the balance manager.
+            // Alternatively, we can utilize DEEP flash loan.
+            let (base_out, _, _) = pool.get_base_quantity_out_input_fee(
+                quote_amount_liquidate,
+                clock,
+            );
+
+            pool.place_market_order(
+                margin_manager.balance_manager_mut(),
+                &trade_proof,
+                client_order_id,
+                constants::self_matching_allowed(),
+                base_out,
+                is_bid,
+                pay_with_deep,
+                clock,
+                ctx,
+            );
+        };
+
+        event::emit(LiquidationEvent {
+            margin_manager_id: margin_manager.id(),
+            base_amount: base_amount_liquidate,
+            quote_amount: quote_amount_liquidate,
+            liquidator: ctx.sender(),
+        });
+    } else {
+        event::emit(LiquidationEvent {
+            margin_manager_id: margin_manager.id(),
+            base_amount: 0,
+            quote_amount: 0,
+            liquidator: ctx.sender(),
+        });
+    };
+
+    // We repay the same loans using the same assets.
+    margin_manager.repay_all_liquidation(base_margin_pool, quote_margin_pool, clock, ctx);
+}
+
+/// Unwraps balance manager for trading in deepbook.
+public fun balance_manager_trading_mut<BaseAsset, QuoteAsset>(
+    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    ctx: &mut TxContext,
+): &mut BalanceManager {
+    assert!(margin_manager.owner == ctx.sender(), EInvalidMarginManagerOwner);
+
+    &mut margin_manager.balance_manager
+}
+
+/// Unwraps TradeCap reference for trading in deepbook.
+public fun trade_cap<BaseAsset, QuoteAsset>(
+    margin_manager: &MarginManager<BaseAsset, QuoteAsset>,
+    ctx: &mut TxContext,
+): &TradeCap {
+    assert!(margin_manager.owner == ctx.sender(), EInvalidMarginManagerOwner);
+
+    &margin_manager.trade_cap
+}
+
+// === Public-Package Functions ===
+public(package) fun balance_manager<BaseAsset, QuoteAsset>(
+    margin_manager: &MarginManager<BaseAsset, QuoteAsset>,
+): &BalanceManager {
+    &margin_manager.balance_manager
+}
+
+public(package) fun balance_manager_mut<BaseAsset, QuoteAsset>(
+    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+): &mut BalanceManager {
+    &mut margin_manager.balance_manager
+}
+
+public(package) fun id<BaseAsset, QuoteAsset>(
+    margin_manager: &MarginManager<BaseAsset, QuoteAsset>,
+): ID {
+    object::id(margin_manager)
+}
+
+// === Private Functions ===
+fun borrow<BaseAsset, QuoteAsset, BorrowAsset>(
+    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    margin_pool: &mut MarginPool<BorrowAsset>,
+    loan_amount: u64,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): Request {
+    let manager_id = margin_manager.id();
+    let coin = margin_pool.borrow(manager_id, loan_amount, clock, ctx);
+
+    margin_manager.deposit<BaseAsset, QuoteAsset, BorrowAsset>(coin, ctx);
+
+    Request {
+        margin_manager_id: manager_id,
+        request_type: BORROW,
+    }
+}
+
+fun repay<BaseAsset, QuoteAsset, RepayAsset>(
+    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    margin_pool: &mut MarginPool<RepayAsset>,
+    repay_amount: Option<u64>,
+    is_liquidation: bool,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    margin_pool.update_state(clock);
+    let manager_id = margin_manager.id();
+
+    margin_pool.update_user_loan(manager_id);
+    let user_loan = margin_pool.user_loan(manager_id);
+
+    let repay_amount = repay_amount.get_with_default(user_loan);
+    let available_balance = margin_manager.balance_manager().balance<RepayAsset>();
+
+    // if user tries to repay more than owed, just repay the loan amount
+    let repayment = if (repay_amount >= user_loan) {
+        user_loan
+    } else {
+        repay_amount
+    };
+
+    // if user tries to repay more than available balance, just repay the available balance
+    let repayment = if (repayment >= available_balance) {
+        available_balance
+    } else {
+        repayment
+    };
+
+    // Owner check is skipped if this is liquidation
+    let coin = if (is_liquidation) {
+        margin_manager.liquidation_withdraw<BaseAsset, QuoteAsset, RepayAsset>(
+            repayment,
+            ctx,
+        )
+    } else {
+        margin_manager.repay_withdraw<BaseAsset, QuoteAsset, RepayAsset>(
+            repayment,
+            ctx,
+        )
+    };
+
+    margin_pool.repay(
+        manager_id,
+        coin,
+        clock,
+    );
+}
+
+/// Returns the (base_debt, quote_debt) for the margin manager
+fun margin_manager_debt<BaseAsset, QuoteAsset>(
+    base_margin_pool: &mut MarginPool<BaseAsset>,
+    quote_margin_pool: &mut MarginPool<QuoteAsset>,
+    margin_manager: &MarginManager<BaseAsset, QuoteAsset>,
+    clock: &Clock,
+): (u64, u64) {
+    let base_debt = margin_manager.manager_debt(base_margin_pool, clock);
+    let quote_debt = margin_manager.manager_debt(quote_margin_pool, clock);
+
+    (base_debt, quote_debt)
+}
+
+fun manager_debt<BaseAsset, QuoteAsset, Asset>(
+    margin_manager: &MarginManager<BaseAsset, QuoteAsset>,
+    margin_pool: &mut MarginPool<Asset>,
+    clock: &Clock,
+): u64 {
+    margin_pool.update_state(clock);
+    margin_pool.update_user_loan(margin_manager.id());
+
+    margin_pool.user_loan(margin_manager.id())
+}
+
+fun liquidation_withdraw<BaseAsset, QuoteAsset, WithdrawAsset>(
+    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    withdraw_amount: u64,
+    ctx: &mut TxContext,
+): Coin<WithdrawAsset> {
+    let balance_manager = &mut margin_manager.balance_manager;
+
+    balance_manager.withdraw_with_cap<WithdrawAsset>(
+        &margin_manager.withdraw_cap,
+        withdraw_amount,
+        ctx,
+    )
+}
+
+/// This can only be called by the manager owner
+fun repay_withdraw<BaseAsset, QuoteAsset, WithdrawAsset>(
+    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    withdraw_amount: u64,
+    ctx: &mut TxContext,
+): Coin<WithdrawAsset> {
+    let balance_manager = &mut margin_manager.balance_manager;
+
+    let coin = balance_manager.withdraw<WithdrawAsset>(
+        withdraw_amount,
+        ctx,
+    );
+
+    coin
+}
+
+/// Returns (base_asset, quote_asset) for margin manager.
+fun margin_manager_asset<BaseAsset, QuoteAsset>(
+    pool: &Pool<BaseAsset, QuoteAsset>,
+    margin_manager: &MarginManager<BaseAsset, QuoteAsset>,
+): (u64, u64) {
+    let balance_manager = margin_manager.balance_manager();
+    let (mut base, mut quote, _) = pool.locked_balance(balance_manager);
+    base = base + balance_manager.balance<BaseAsset>();
+    quote = quote + balance_manager.balance<QuoteAsset>();
+
+    (base, quote)
+}
+
+fun repay_all_liquidation<BaseAsset, QuoteAsset>(
+    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    base_margin_pool: &mut MarginPool<BaseAsset>,
+    quote_margin_pool: &mut MarginPool<QuoteAsset>,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    repay_base_liquidate(margin_manager, base_margin_pool, clock, ctx);
+    repay_quote_liquidate(margin_manager, quote_margin_pool, clock, ctx);
+}
+
+fun repay_base_liquidate<BaseAsset, QuoteAsset>(
+    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    margin_pool: &mut MarginPool<BaseAsset>,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    margin_manager.repay<BaseAsset, QuoteAsset, BaseAsset>(
+        margin_pool,
+        option::none(),
+        true,
+        clock,
+        ctx,
+    );
+}
+
+/// Repay the quote asset loan using the margin manager.
+fun repay_quote_liquidate<BaseAsset, QuoteAsset>(
+    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    margin_pool: &mut MarginPool<QuoteAsset>,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    margin_manager.repay<BaseAsset, QuoteAsset, QuoteAsset>(
+        margin_pool,
+        option::none(),
+        true,
+        clock,
+        ctx,
+    );
+}

--- a/packages/margin_trading/sources/margin_pool/margin_pool.move
+++ b/packages/margin_trading/sources/margin_pool/margin_pool.move
@@ -279,7 +279,3 @@ fun add_user_loan_entry<Asset>(self: &mut MarginPool<Asset>, manager_id: ID) {
     };
     self.loans.add(manager_id, loan);
 }
-
-fun user_loan<Asset>(self: &MarginPool<Asset>, manager_id: ID): u64 {
-    self.loans.borrow(manager_id).loan_amount
-}

--- a/packages/margin_trading/sources/margin_pool/margin_pool.move
+++ b/packages/margin_trading/sources/margin_pool/margin_pool.move
@@ -11,9 +11,9 @@ use sui::{balance::{Self, Balance}, clock::Clock, coin::Coin, table::{Self, Tabl
 const ENotEnoughAssetInPool: u64 = 1;
 const ESupplyCapExceeded: u64 = 2;
 const ECannotWithdrawMoreThanSupply: u64 = 3;
+const ECannotRepayMoreThanLoan: u64 = 4;
 
 // === Structs ===
-#[allow(unused_field)]
 public struct Loan has drop, store {
     loan_amount: u64, // total loan remaining, including interest
     last_index: u64, // 9 decimals
@@ -104,13 +104,47 @@ public fun withdraw<Asset>(
     self.vault.split(withdrawal_amount).into_coin(ctx)
 }
 
-/// Borrow a loan from the margin pool.
-public fun borrow<Asset>(_self: &mut MarginPool<Asset>) {}
-
-/// Repay a loan.
-public fun repay<Asset>(_self: &mut MarginPool<Asset>) {}
-
 // === Public-Package Functions ===
+/// Allows borrowing from the margin pool. Returns the borrowed coin.
+public(package) fun borrow<Asset>(
+    self: &mut MarginPool<Asset>,
+    manager_id: ID,
+    amount: u64,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): Coin<Asset> {
+    self.state.update(clock);
+
+    self.update_user_loan(manager_id);
+    self.increase_user_loan(manager_id, amount);
+
+    assert!(amount <= self.vault.value(), ENotEnoughAssetInPool);
+    self.state.increase_total_borrow(amount);
+
+    let balance = self.vault.split(amount);
+    balance.into_coin(ctx)
+}
+
+/// Allows repaying the loan.
+public(package) fun repay<Asset>(
+    self: &mut MarginPool<Asset>,
+    manager_id: ID,
+    coin: Coin<Asset>,
+    clock: &Clock,
+) {
+    self.state.update(clock);
+
+    let repay_amount = coin.value();
+    self.update_user_loan(manager_id);
+    let user_loan = self.user_loan(manager_id);
+    assert!(repay_amount <= user_loan, ECannotRepayMoreThanLoan);
+    self.decrease_user_loan(manager_id, repay_amount);
+    self.state.decrease_total_borrow(repay_amount);
+
+    let balance = coin.into_balance();
+    self.vault.join(balance);
+}
+
 /// Returns the loans table.
 public(package) fun loans<Asset>(self: &MarginPool<Asset>): &Table<ID, Loan> {
     &self.loans
@@ -174,4 +208,47 @@ fun add_user_supply_entry<Asset>(self: &mut MarginPool<Asset>, supplier: address
 
 fun user_supply<Asset>(self: &MarginPool<Asset>, supplier: address): u64 {
     self.supplies.borrow(supplier).supplied_amount
+}
+
+fun update_user_loan<Asset>(self: &mut MarginPool<Asset>, manager_id: ID) {
+    self.add_user_loan_entry(manager_id);
+
+    let loan = self.loans.borrow_mut(manager_id);
+    let current_index = self.state.borrow_index();
+    let interest_multiplier = math::div(
+        current_index,
+        loan.last_index,
+    );
+    let new_loan_amount = math::mul(
+        loan.loan_amount,
+        interest_multiplier,
+    );
+    loan.loan_amount = new_loan_amount;
+    loan.last_index = current_index;
+}
+
+fun increase_user_loan<Asset>(self: &mut MarginPool<Asset>, manager_id: ID, amount: u64) {
+    let loan = self.loans.borrow_mut(manager_id);
+    loan.loan_amount = loan.loan_amount + amount;
+}
+
+fun decrease_user_loan<Asset>(self: &mut MarginPool<Asset>, manager_id: ID, amount: u64) {
+    let loan = self.loans.borrow_mut(manager_id);
+    loan.loan_amount = loan.loan_amount - amount;
+}
+
+fun add_user_loan_entry<Asset>(self: &mut MarginPool<Asset>, manager_id: ID) {
+    if (self.loans.contains(manager_id)) {
+        return
+    };
+    let current_index = self.state.borrow_index();
+    let loan = Loan {
+        loan_amount: 0,
+        last_index: current_index,
+    };
+    self.loans.add(manager_id, loan);
+}
+
+fun user_loan<Asset>(self: &MarginPool<Asset>, manager_id: ID): u64 {
+    self.loans.borrow(manager_id).loan_amount
 }

--- a/packages/margin_trading/sources/margin_pool/state.move
+++ b/packages/margin_trading/sources/margin_pool/state.move
@@ -88,6 +88,10 @@ public(package) fun increase_total_borrow(self: &mut State, amount: u64) {
     self.total_borrow = self.total_borrow + amount;
 }
 
+public(package) fun decrease_total_borrow(self: &mut State, amount: u64) {
+    self.total_borrow = self.total_borrow - amount;
+}
+
 public(package) fun total_supply(self: &State): u64 {
     self.total_supply
 }

--- a/packages/margin_trading/sources/margin_registry.move
+++ b/packages/margin_trading/sources/margin_registry.move
@@ -4,10 +4,19 @@
 /// Registry holds all margin pools.
 module margin_trading::margin_registry;
 
-use std::type_name::TypeName;
+use std::type_name::{Self, TypeName};
 use sui::{bag::{Self, Bag}, dynamic_field as df, table::{Self, Table}};
 
+use fun df::add as UID.add;
 use fun df::borrow as UID.borrow;
+use fun df::remove as UID.remove;
+
+// === Errors ===
+const EPairAlreadyAllowed: u64 = 1;
+const EPairNotAllowed: u64 = 2;
+const EMarginPoolAlreadyExists: u64 = 3;
+const EMarginPoolDoesNotExists: u64 = 4;
+const EInvalidRiskParam: u64 = 5;
 
 public struct MARGIN_REGISTRY has drop {}
 
@@ -16,16 +25,14 @@ public struct MarginAdminCap has key, store {
     id: UID,
 }
 
-#[allow(unused_field)]
 public struct RiskParams has drop, store {
     min_withdraw_risk_ratio: u64, // 9 decimals, minimum risk ratio to allow transfer
     min_borrow_risk_ratio: u64, // 9 decimals, minimum risk ratio to allow borrow
     liquidation_risk_ratio: u64, // 9 decimals, risk ratio below which liquidation is allowed
     target_liquidation_risk_ratio: u64, // 9 decimals, target risk ratio after liquidation
-    liquidation_reward_perc: u64, // reward for liquidating a position, in 9 decimals
+    liquidation_reward: u64, // fractional reward for liquidating a position, in 9 decimals
 }
 
-#[allow(unused_field)]
 public struct MarginPair has copy, drop, store {
     base: TypeName,
     quote: TypeName,
@@ -48,6 +55,177 @@ fun init(_: MARGIN_REGISTRY, ctx: &mut TxContext) {
     transfer::share_object(registry);
     let margin_admin_cap = MarginAdminCap { id: object::new(ctx) };
     transfer::public_transfer(margin_admin_cap, ctx.sender())
+}
+
+// === Public Functions * ADMIN * ===
+public fun new_risk_params(
+    min_withdraw_risk_ratio: u64,
+    min_borrow_risk_ratio: u64,
+    liquidation_risk_ratio: u64,
+    target_liquidation_risk_ratio: u64,
+    liquidation_reward: u64,
+): RiskParams {
+    assert!(min_borrow_risk_ratio < min_withdraw_risk_ratio, EInvalidRiskParam);
+    assert!(liquidation_risk_ratio < min_borrow_risk_ratio, EInvalidRiskParam);
+    assert!(liquidation_risk_ratio < target_liquidation_risk_ratio, EInvalidRiskParam);
+    assert!(liquidation_risk_ratio >= 1_000_000_000, EInvalidRiskParam);
+    assert!(liquidation_reward <= 1_000_000_000, EInvalidRiskParam);
+
+    RiskParams {
+        min_withdraw_risk_ratio,
+        min_borrow_risk_ratio,
+        liquidation_risk_ratio,
+        target_liquidation_risk_ratio,
+        liquidation_reward,
+    }
+}
+
+/// Updates risk params for the margin pool as the admin.
+/// TODO: maybe liquidation risk ratio can only decrease?
+public fun update_risk_params<BaseAsset, QuoteAsset>(
+    self: &mut MarginRegistry,
+    risk_params: RiskParams,
+    _cap: &MarginAdminCap,
+) {
+    let pair = MarginPair {
+        base: type_name::get<BaseAsset>(),
+        quote: type_name::get<QuoteAsset>(),
+    };
+    assert!(self.risk_params.contains(pair), EPairNotAllowed);
+    self.risk_params.remove(pair);
+    self.risk_params.add(pair, risk_params);
+}
+
+/// Allow a margin trading pair
+public fun add_margin_pair<BaseAsset, QuoteAsset>(
+    self: &mut MarginRegistry,
+    risk_params: RiskParams,
+    _cap: &MarginAdminCap,
+) {
+    let pair = MarginPair {
+        base: type_name::get<BaseAsset>(),
+        quote: type_name::get<QuoteAsset>(),
+    };
+    assert!(!self.risk_params.contains(pair), EPairAlreadyAllowed);
+    self.risk_params.add(pair, risk_params);
+}
+
+/// Disallow a margin trading pair
+public fun remove_margin_pair<BaseAsset, QuoteAsset>(
+    self: &mut MarginRegistry,
+    _cap: &MarginAdminCap,
+) {
+    let pair = MarginPair {
+        base: type_name::get<BaseAsset>(),
+        quote: type_name::get<QuoteAsset>(),
+    };
+    assert!(self.risk_params.contains(pair), EPairNotAllowed);
+    self.risk_params.remove(pair);
+}
+
+/// Add Pyth Config to the MarginRegistry.
+public fun add_config<Config: store + drop>(
+    self: &mut MarginRegistry,
+    _cap: &MarginAdminCap,
+    config: Config,
+) {
+    self.id.add(ConfigKey<Config> {}, config);
+}
+
+/// Remove Pyth Config from the MarginRegistry.
+public fun remove_config<Config: store + drop>(
+    self: &mut MarginRegistry,
+    _cap: &MarginAdminCap,
+): Config {
+    self.id.remove(ConfigKey<Config> {})
+}
+
+// === Public Helper Functions ===
+/// Check if a margin trading pair is allowed
+public fun margin_pair_allowed<BaseAsset, QuoteAsset>(self: &MarginRegistry): bool {
+    let pair = MarginPair {
+        base: type_name::get<BaseAsset>(),
+        quote: type_name::get<QuoteAsset>(),
+    };
+
+    self.risk_params.contains(pair)
+}
+
+/// Get the ID of the pool given the asset types.
+public fun get_margin_pool_id_by_asset<Asset>(registry: &MarginRegistry): ID {
+    registry.get_margin_pool_id<Asset>()
+}
+
+// === Public-Package Functions ===
+/// Register a new margin pool. If a same asset pool already exists, abort.
+public(package) fun register_margin_pool<Asset>(self: &mut MarginRegistry, pool_id: ID) {
+    let key = type_name::get<Asset>();
+    assert!(!self.margin_pools.contains(key), EMarginPoolAlreadyExists);
+    self.margin_pools.add(key, pool_id);
+}
+
+/// Get the margin pool id for the given asset.
+public(package) fun get_margin_pool_id<Asset>(self: &MarginRegistry): ID {
+    let key = type_name::get<Asset>();
+    assert!(self.margin_pools.contains(key), EMarginPoolDoesNotExists);
+
+    *self.margin_pools.borrow<TypeName, ID>(key)
+}
+
+public(package) fun can_withdraw<BaseAsset, QuoteAsset>(
+    self: &MarginRegistry,
+    risk_ratio: u64,
+): bool {
+    let pair = MarginPair {
+        base: type_name::get<BaseAsset>(),
+        quote: type_name::get<QuoteAsset>(),
+    };
+
+    risk_ratio >= self.risk_params.borrow(pair).min_withdraw_risk_ratio
+}
+
+public(package) fun can_borrow<BaseAsset, QuoteAsset>(
+    self: &MarginRegistry,
+    risk_ratio: u64,
+): bool {
+    let pair = MarginPair {
+        base: type_name::get<BaseAsset>(),
+        quote: type_name::get<QuoteAsset>(),
+    };
+
+    risk_ratio >= self.risk_params.borrow(pair).min_borrow_risk_ratio
+}
+
+public(package) fun can_liquidate<BaseAsset, QuoteAsset>(
+    self: &MarginRegistry,
+    risk_ratio: u64,
+): bool {
+    let pair = MarginPair {
+        base: type_name::get<BaseAsset>(),
+        quote: type_name::get<QuoteAsset>(),
+    };
+
+    risk_ratio < self.risk_params.borrow(pair).liquidation_risk_ratio
+}
+
+public(package) fun target_liquidation_risk_ratio<BaseAsset, QuoteAsset>(
+    self: &MarginRegistry,
+): u64 {
+    let pair = MarginPair {
+        base: type_name::get<BaseAsset>(),
+        quote: type_name::get<QuoteAsset>(),
+    };
+
+    self.risk_params.borrow(pair).target_liquidation_risk_ratio
+}
+
+public(package) fun liquidation_reward<BaseAsset, QuoteAsset>(self: &MarginRegistry): u64 {
+    let pair = MarginPair {
+        base: type_name::get<BaseAsset>(),
+        quote: type_name::get<QuoteAsset>(),
+    };
+
+    self.risk_params.borrow(pair).liquidation_reward
 }
 
 public(package) fun get_config<Config: store + drop>(self: &MarginRegistry): &Config {

--- a/packages/margin_trading/sources/margin_registry.move
+++ b/packages/margin_trading/sources/margin_registry.move
@@ -4,7 +4,6 @@
 /// Registry holds all margin pools.
 module margin_trading::margin_registry;
 
-
 use deepbook::{constants, math};
 use std::type_name::{Self, TypeName};
 use sui::{bag::{Self, Bag}, dynamic_field as df, table::{Self, Table}};


### PR DESCRIPTION
- Basic margin manager functions, including borrow/repay for managers
- `max_borrow_percentage` added for margin pools
- Ignore logic around liquidations for now. Will be finalized in another PR
- Emitting events are not the main focus in this PR. Will do a final check later on and add in all events we think will be useful. Comments still welcome!