### PR TITLE
Margin manager has a specific deepbook pool

### DIFF
--- a/packages/deepbook/sources/pool.move
+++ b/packages/deepbook/sources/pool.move
@@ -4,30 +4,26 @@
 /// Public-facing interface for the package.
 module deepbook::pool;
 
-use deepbook::{
-    account::Account,
-    balance_manager::{Self, BalanceManager, TradeProof},
-    big_vector::BigVector,
-    book::{Self, Book},
-    constants,
-    deep_price::{Self, DeepPrice, OrderDeepPrice, emit_deep_price_added},
-    ewma::{init_ewma_state, EWMAState},
-    math,
-    order::Order,
-    order_info::{Self, OrderInfo},
-    registry::{DeepbookAdminCap, Registry},
-    state::{Self, State},
-    vault::{Self, Vault, FlashLoan}
-};
+use deepbook::account::Account;
+use deepbook::balance_manager::{Self, BalanceManager, TradeProof};
+use deepbook::big_vector::BigVector;
+use deepbook::book::{Self, Book};
+use deepbook::constants;
+use deepbook::deep_price::{Self, DeepPrice, OrderDeepPrice, emit_deep_price_added};
+use deepbook::ewma::{init_ewma_state, EWMAState};
+use deepbook::math;
+use deepbook::order::Order;
+use deepbook::order_info::{Self, OrderInfo};
+use deepbook::registry::{DeepbookAdminCap, Registry};
+use deepbook::state::{Self, State};
+use deepbook::vault::{Self, Vault, FlashLoan};
 use std::type_name;
-use sui::{
-    clock::Clock,
-    coin::{Self, Coin},
-    dynamic_field as df,
-    event,
-    vec_set::{Self, VecSet},
-    versioned::{Self, Versioned}
-};
+use sui::clock::Clock;
+use sui::coin::{Self, Coin};
+use sui::dynamic_field as df;
+use sui::event;
+use sui::vec_set::{Self, VecSet};
+use sui::versioned::{Self, Versioned};
 use token::deep::{DEEP, ProtectedTreasury};
 
 use fun df::add as UID.add;
@@ -273,10 +269,10 @@ public fun swap_exact_quantity<BaseAsset, QuoteAsset>(
     let is_bid = quote_quantity > 0;
     if (is_bid) {
         (base_quantity, _, _) = if (pay_with_deep) {
-            self.get_quantity_out(0, quote_quantity, clock)
-        } else {
-            self.get_quantity_out_input_fee(0, quote_quantity, clock)
-        }
+                self.get_quantity_out(0, quote_quantity, clock)
+            } else {
+                self.get_quantity_out_input_fee(0, quote_quantity, clock)
+            }
     } else {
         if (!pay_with_deep) {
             base_quantity =
@@ -1226,7 +1222,7 @@ public fun quorum<BaseAsset, QuoteAsset>(self: &Pool<BaseAsset, QuoteAsset>): u6
     self.load_inner().state.governance().quorum()
 }
 
-public fun pool_id<BaseAsset, QuoteAsset>(self: &Pool<BaseAsset, QuoteAsset>): ID {
+public fun id<BaseAsset, QuoteAsset>(self: &Pool<BaseAsset, QuoteAsset>): ID {
     self.load_inner().pool_id
 }
 

--- a/packages/deepbook/sources/pool.move
+++ b/packages/deepbook/sources/pool.move
@@ -1226,6 +1226,10 @@ public fun quorum<BaseAsset, QuoteAsset>(self: &Pool<BaseAsset, QuoteAsset>): u6
     self.load_inner().state.governance().quorum()
 }
 
+public fun pool_id<BaseAsset, QuoteAsset>(self: &Pool<BaseAsset, QuoteAsset>): ID {
+    self.load_inner().pool_id
+}
+
 public fun margin_trading_enabled<BaseAsset, QuoteAsset>(self: &Pool<BaseAsset, QuoteAsset>): bool {
     if (!self.id.exists_(MarginTradingKey {})) {
         return false

--- a/packages/deepbook/sources/pool.move
+++ b/packages/deepbook/sources/pool.move
@@ -1227,6 +1227,10 @@ public fun quorum<BaseAsset, QuoteAsset>(self: &Pool<BaseAsset, QuoteAsset>): u6
 }
 
 public fun margin_trading_enabled<BaseAsset, QuoteAsset>(self: &Pool<BaseAsset, QuoteAsset>): bool {
+    if (!self.id.exists_(MarginTradingKey {})) {
+        return false
+    };
+
     *self.id.borrow<_, bool>(MarginTradingKey {})
 }
 

--- a/packages/deepbook/sources/pool.move
+++ b/packages/deepbook/sources/pool.move
@@ -4,26 +4,30 @@
 /// Public-facing interface for the package.
 module deepbook::pool;
 
-use deepbook::account::Account;
-use deepbook::balance_manager::{Self, BalanceManager, TradeProof};
-use deepbook::big_vector::BigVector;
-use deepbook::book::{Self, Book};
-use deepbook::constants;
-use deepbook::deep_price::{Self, DeepPrice, OrderDeepPrice, emit_deep_price_added};
-use deepbook::ewma::{init_ewma_state, EWMAState};
-use deepbook::math;
-use deepbook::order::Order;
-use deepbook::order_info::{Self, OrderInfo};
-use deepbook::registry::{DeepbookAdminCap, Registry};
-use deepbook::state::{Self, State};
-use deepbook::vault::{Self, Vault, FlashLoan};
+use deepbook::{
+    account::Account,
+    balance_manager::{Self, BalanceManager, TradeProof},
+    big_vector::BigVector,
+    book::{Self, Book},
+    constants,
+    deep_price::{Self, DeepPrice, OrderDeepPrice, emit_deep_price_added},
+    ewma::{init_ewma_state, EWMAState},
+    math,
+    order::Order,
+    order_info::{Self, OrderInfo},
+    registry::{DeepbookAdminCap, Registry},
+    state::{Self, State},
+    vault::{Self, Vault, FlashLoan}
+};
 use std::type_name;
-use sui::clock::Clock;
-use sui::coin::{Self, Coin};
-use sui::dynamic_field as df;
-use sui::event;
-use sui::vec_set::{Self, VecSet};
-use sui::versioned::{Self, Versioned};
+use sui::{
+    clock::Clock,
+    coin::{Self, Coin},
+    dynamic_field as df,
+    event,
+    vec_set::{Self, VecSet},
+    versioned::{Self, Versioned}
+};
 use token::deep::{DEEP, ProtectedTreasury};
 
 use fun df::add as UID.add;
@@ -269,10 +273,10 @@ public fun swap_exact_quantity<BaseAsset, QuoteAsset>(
     let is_bid = quote_quantity > 0;
     if (is_bid) {
         (base_quantity, _, _) = if (pay_with_deep) {
-                self.get_quantity_out(0, quote_quantity, clock)
-            } else {
-                self.get_quantity_out_input_fee(0, quote_quantity, clock)
-            }
+            self.get_quantity_out(0, quote_quantity, clock)
+        } else {
+            self.get_quantity_out_input_fee(0, quote_quantity, clock)
+        }
     } else {
         if (!pay_with_deep) {
             base_quantity =

--- a/packages/margin_trading/sources/margin_manager.move
+++ b/packages/margin_trading/sources/margin_manager.move
@@ -112,7 +112,7 @@ public fun new<BaseAsset, QuoteAsset>(pool: &Pool<BaseAsset, QuoteAsset>, ctx: &
     let margin_manager = MarginManager<BaseAsset, QuoteAsset> {
         id,
         owner: ctx.sender(),
-        deepbook_pool: pool.pool_id(),
+        deepbook_pool: pool.id(),
         balance_manager,
         deposit_cap,
         withdraw_cap,
@@ -261,7 +261,7 @@ public fun prove_and_destroy_request<BaseAsset, QuoteAsset>(
     request: Request,
 ) {
     assert!(request.margin_manager_id == margin_manager.id(), EInvalidMarginManager);
-    assert!(margin_manager.deepbook_pool == pool.pool_id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool == pool.id(), EIncorrectDeepbookPool);
 
     let risk_ratio = margin_manager
         .manager_info<BaseAsset, QuoteAsset>(
@@ -274,7 +274,7 @@ public fun prove_and_destroy_request<BaseAsset, QuoteAsset>(
             clock,
         )
         .risk_ratio;
-    let pool_id = pool.pool_id();
+    let pool_id = pool.id();
     if (request.request_type == BORROW) {
         assert!(registry.can_borrow(pool_id, risk_ratio), EBorrowRiskRatioExceeded);
     } else if (request.request_type == WITHDRAW) {
@@ -303,7 +303,7 @@ public fun manager_info<BaseAsset, QuoteAsset>(
     quote_price_info_object: &PriceInfoObject,
     clock: &Clock,
 ): ManagerInfo {
-    assert!(margin_manager.deepbook_pool == pool.pool_id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool == pool.id(), EIncorrectDeepbookPool);
 
     let (base_debt, quote_debt) = margin_manager.total_debt<BaseAsset, QuoteAsset>(
         base_margin_pool,
@@ -390,7 +390,7 @@ public fun liquidate_custom<BaseAsset, QuoteAsset>(
     Option<RepaymentProof<BaseAsset>>,
     Option<RepaymentProof<QuoteAsset>>,
 ) {
-    assert!(margin_manager.deepbook_pool == pool.pool_id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool == pool.id(), EIncorrectDeepbookPool);
 
     // Step 1: We retrieve the manager info and check if liquidation is possible.
     let manager_info = margin_manager.manager_info<BaseAsset, QuoteAsset>(
@@ -402,7 +402,7 @@ public fun liquidate_custom<BaseAsset, QuoteAsset>(
         quote_price_info_object,
         clock,
     );
-    let pool_id = pool.pool_id();
+    let pool_id = pool.id();
 
     assert!(registry.can_liquidate(pool_id, manager_info.risk_ratio), ECannotLiquidate);
 
@@ -681,7 +681,7 @@ public fun liquidate_with_deepbook<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ): (Coin<BaseAsset>, Coin<QuoteAsset>) {
-    assert!(margin_manager.deepbook_pool == pool.pool_id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool == pool.id(), EIncorrectDeepbookPool);
 
     // Step 1: We retrieve the manager info and check if liquidation is possible.
     let manager_info = margin_manager.manager_info<BaseAsset, QuoteAsset>(
@@ -693,7 +693,7 @@ public fun liquidate_with_deepbook<BaseAsset, QuoteAsset>(
         quote_price_info_object,
         clock,
     );
-    let pool_id = pool.pool_id();
+    let pool_id = pool.id();
 
     assert!(registry.can_liquidate(pool_id, manager_info.risk_ratio), ECannotLiquidate);
 

--- a/packages/margin_trading/sources/margin_manager.move
+++ b/packages/margin_trading/sources/margin_manager.move
@@ -32,7 +32,7 @@ use token::deep::DEEP;
 
 // === Errors ===
 const EInvalidDeposit: u64 = 0;
-const EMarginTradingNotAllowedOnPool: u64 = 1;
+const EMarginTradingNotAllowedInPool: u64 = 1;
 const EInvalidMarginManager: u64 = 2;
 const EBorrowRiskRatioExceeded: u64 = 3;
 const EWithdrawRiskRatioExceeded: u64 = 4;
@@ -40,7 +40,7 @@ const ECannotLiquidate: u64 = 5;
 const EInvalidMarginManagerOwner: u64 = 6;
 const ECannotHaveLoanInBothMarginPools: u64 = 7;
 const ELiquidationSlippageExceeded: u64 = 8;
-const EIncorrectDeepbookPool: u64 = 9;
+const EIncorrectDeepBookPool: u64 = 9;
 
 // === Constants ===
 const WITHDRAW: u8 = 0;
@@ -94,7 +94,7 @@ public struct LiquidationEvent has copy, drop {
 
 // === Public Functions - Margin Manager ===
 public fun new<BaseAsset, QuoteAsset>(pool: &Pool<BaseAsset, QuoteAsset>, ctx: &mut TxContext) {
-    assert!(pool.margin_trading_enabled(), EMarginTradingNotAllowedOnPool);
+    assert!(pool.margin_trading_enabled(), EMarginTradingNotAllowedInPool);
 
     let id = object::new(ctx);
 
@@ -261,7 +261,7 @@ public fun prove_and_destroy_request<BaseAsset, QuoteAsset>(
     request: Request,
 ) {
     assert!(request.margin_manager_id == margin_manager.id(), EInvalidMarginManager);
-    assert!(margin_manager.deepbook_pool == pool.id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool == pool.id(), EIncorrectDeepBookPool);
 
     let risk_ratio = margin_manager
         .manager_info<BaseAsset, QuoteAsset>(
@@ -303,7 +303,7 @@ public fun manager_info<BaseAsset, QuoteAsset>(
     quote_price_info_object: &PriceInfoObject,
     clock: &Clock,
 ): ManagerInfo {
-    assert!(margin_manager.deepbook_pool == pool.id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool == pool.id(), EIncorrectDeepBookPool);
 
     let (base_debt, quote_debt) = margin_manager.total_debt<BaseAsset, QuoteAsset>(
         base_margin_pool,
@@ -390,7 +390,7 @@ public fun liquidate_custom<BaseAsset, QuoteAsset>(
     Option<RepaymentProof<BaseAsset>>,
     Option<RepaymentProof<QuoteAsset>>,
 ) {
-    assert!(margin_manager.deepbook_pool == pool.id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool == pool.id(), EIncorrectDeepBookPool);
 
     // Step 1: We retrieve the manager info and check if liquidation is possible.
     let manager_info = margin_manager.manager_info<BaseAsset, QuoteAsset>(
@@ -681,7 +681,7 @@ public fun liquidate_with_deepbook<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ): (Coin<BaseAsset>, Coin<QuoteAsset>) {
-    assert!(margin_manager.deepbook_pool == pool.id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool == pool.id(), EIncorrectDeepBookPool);
 
     // Step 1: We retrieve the manager info and check if liquidation is possible.
     let manager_info = margin_manager.manager_info<BaseAsset, QuoteAsset>(

--- a/packages/margin_trading/sources/margin_manager.move
+++ b/packages/margin_trading/sources/margin_manager.move
@@ -40,7 +40,7 @@ const ECannotLiquidate: u64 = 5;
 const EInvalidMarginManagerOwner: u64 = 6;
 const ECannotHaveLoanInBothMarginPools: u64 = 7;
 const ELiquidationSlippageExceeded: u64 = 8;
-const EInvalidDeepbookPool: u64 = 9;
+const EIncorrectDeepbookPool: u64 = 9;
 
 // === Constants ===
 const WITHDRAW: u8 = 0;
@@ -112,7 +112,7 @@ public fun new<BaseAsset, QuoteAsset>(pool: &Pool<BaseAsset, QuoteAsset>, ctx: &
     let margin_manager = MarginManager<BaseAsset, QuoteAsset> {
         id,
         owner: ctx.sender(),
-        deepbook_pool: object::id(pool),
+        deepbook_pool: pool.pool_id(),
         balance_manager,
         deposit_cap,
         withdraw_cap,
@@ -261,7 +261,7 @@ public fun prove_and_destroy_request<BaseAsset, QuoteAsset>(
     request: Request,
 ) {
     assert!(request.margin_manager_id == margin_manager.id(), EInvalidMarginManager);
-    assert!(margin_manager.deepbook_pool == object::id(pool), EInvalidDeepbookPool);
+    assert!(margin_manager.deepbook_pool == pool.pool_id(), EIncorrectDeepbookPool);
 
     let risk_ratio = margin_manager
         .manager_info<BaseAsset, QuoteAsset>(
@@ -274,7 +274,7 @@ public fun prove_and_destroy_request<BaseAsset, QuoteAsset>(
             clock,
         )
         .risk_ratio;
-    let pool_id = object::id(pool);
+    let pool_id = pool.pool_id();
     if (request.request_type == BORROW) {
         assert!(registry.can_borrow(pool_id, risk_ratio), EBorrowRiskRatioExceeded);
     } else if (request.request_type == WITHDRAW) {
@@ -303,7 +303,7 @@ public fun manager_info<BaseAsset, QuoteAsset>(
     quote_price_info_object: &PriceInfoObject,
     clock: &Clock,
 ): ManagerInfo {
-    assert!(margin_manager.deepbook_pool == object::id(pool), EInvalidDeepbookPool);
+    assert!(margin_manager.deepbook_pool == pool.pool_id(), EIncorrectDeepbookPool);
 
     let (base_debt, quote_debt) = margin_manager.total_debt<BaseAsset, QuoteAsset>(
         base_margin_pool,
@@ -390,7 +390,7 @@ public fun liquidate_custom<BaseAsset, QuoteAsset>(
     Option<RepaymentProof<BaseAsset>>,
     Option<RepaymentProof<QuoteAsset>>,
 ) {
-    assert!(margin_manager.deepbook_pool == object::id(pool), EInvalidDeepbookPool);
+    assert!(margin_manager.deepbook_pool == pool.pool_id(), EIncorrectDeepbookPool);
 
     // Step 1: We retrieve the manager info and check if liquidation is possible.
     let manager_info = margin_manager.manager_info<BaseAsset, QuoteAsset>(
@@ -402,7 +402,7 @@ public fun liquidate_custom<BaseAsset, QuoteAsset>(
         quote_price_info_object,
         clock,
     );
-    let pool_id = object::id(pool);
+    let pool_id = pool.pool_id();
 
     assert!(registry.can_liquidate(pool_id, manager_info.risk_ratio), ECannotLiquidate);
 
@@ -681,7 +681,7 @@ public fun liquidate_with_deepbook<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ): (Coin<BaseAsset>, Coin<QuoteAsset>) {
-    assert!(margin_manager.deepbook_pool == object::id(pool), EInvalidDeepbookPool);
+    assert!(margin_manager.deepbook_pool == pool.pool_id(), EIncorrectDeepbookPool);
 
     // Step 1: We retrieve the manager info and check if liquidation is possible.
     let manager_info = margin_manager.manager_info<BaseAsset, QuoteAsset>(
@@ -693,7 +693,7 @@ public fun liquidate_with_deepbook<BaseAsset, QuoteAsset>(
         quote_price_info_object,
         clock,
     );
-    let pool_id = object::id(pool);
+    let pool_id = pool.pool_id();
 
     assert!(registry.can_liquidate(pool_id, manager_info.risk_ratio), ECannotLiquidate);
 
@@ -1027,6 +1027,12 @@ public fun liquidate_with_deepbook<BaseAsset, QuoteAsset>(
     };
 
     (user_base_coin, user_quote_coin)
+}
+
+public fun deepbook_pool<BaseAsset, QuoteAsset>(
+    margin_manager: &MarginManager<BaseAsset, QuoteAsset>,
+): ID {
+    margin_manager.deepbook_pool
 }
 
 // === Public-Package Functions ===

--- a/packages/margin_trading/sources/margin_registry.move
+++ b/packages/margin_trading/sources/margin_registry.move
@@ -181,7 +181,7 @@ public fun register_deepbook_pool<BaseAsset, QuoteAsset>(
     pool_config: PoolConfig,
     _cap: &MarginAdminCap,
 ) {
-    let pool_id = pool.pool_id();
+    let pool_id = pool.id();
     assert!(!self.pool_registry.contains(pool_id), EPoolAlreadyRegistered);
 
     self.pool_registry.add(pool_id, pool_config);
@@ -260,7 +260,7 @@ public fun update_risk_params<BaseAsset, QuoteAsset>(
     pool_config: PoolConfig,
     _cap: &MarginAdminCap,
 ) {
-    let pool_id = pool.pool_id();
+    let pool_id = pool.id();
     assert!(self.pool_registry.contains(pool_id), EPoolNotRegistered);
 
     let prev_config = self.pool_registry.remove(pool_id);
@@ -297,7 +297,7 @@ public fun enable_deepbook_pool<BaseAsset, QuoteAsset>(
     pool: &mut Pool<BaseAsset, QuoteAsset>,
     _cap: &MarginAdminCap,
 ) {
-    let pool_id = pool.pool_id();
+    let pool_id = pool.id();
     assert!(self.pool_registry.contains(pool_id), EPoolNotRegistered);
 
     let config = self.pool_registry.borrow_mut(pool_id);
@@ -313,7 +313,7 @@ public fun disable_deepbook_pool<BaseAsset, QuoteAsset>(
     pool: &mut Pool<BaseAsset, QuoteAsset>,
     _cap: &MarginAdminCap,
 ) {
-    let pool_id = pool.pool_id();
+    let pool_id = pool.id();
     assert!(self.pool_registry.contains(pool_id), EPoolNotRegistered);
 
     let config = self.pool_registry.borrow_mut(pool_id);
@@ -346,7 +346,7 @@ public fun pool_enabled<BaseAsset, QuoteAsset>(
     self: &MarginRegistry,
     pool: &Pool<BaseAsset, QuoteAsset>,
 ): bool {
-    let pool_id = pool.pool_id();
+    let pool_id = pool.id();
     if (self.pool_registry.contains(pool_id)) {
         let config = self.pool_registry.borrow(pool_id);
 

--- a/packages/margin_trading/sources/margin_registry.move
+++ b/packages/margin_trading/sources/margin_registry.move
@@ -181,7 +181,7 @@ public fun register_deepbook_pool<BaseAsset, QuoteAsset>(
     pool_config: PoolConfig,
     _cap: &MarginAdminCap,
 ) {
-    let pool_id = object::id(pool);
+    let pool_id = pool.pool_id();
     assert!(!self.pool_registry.contains(pool_id), EPoolAlreadyRegistered);
 
     self.pool_registry.add(pool_id, pool_config);
@@ -260,7 +260,7 @@ public fun update_risk_params<BaseAsset, QuoteAsset>(
     pool_config: PoolConfig,
     _cap: &MarginAdminCap,
 ) {
-    let pool_id = object::id(pool);
+    let pool_id = pool.pool_id();
     assert!(self.pool_registry.contains(pool_id), EPoolNotRegistered);
 
     let prev_config = self.pool_registry.remove(pool_id);
@@ -297,7 +297,7 @@ public fun enable_deepbook_pool<BaseAsset, QuoteAsset>(
     pool: &mut Pool<BaseAsset, QuoteAsset>,
     _cap: &MarginAdminCap,
 ) {
-    let pool_id = object::id(pool);
+    let pool_id = pool.pool_id();
     assert!(self.pool_registry.contains(pool_id), EPoolNotRegistered);
 
     let config = self.pool_registry.borrow_mut(pool_id);
@@ -313,7 +313,7 @@ public fun disable_deepbook_pool<BaseAsset, QuoteAsset>(
     pool: &mut Pool<BaseAsset, QuoteAsset>,
     _cap: &MarginAdminCap,
 ) {
-    let pool_id = object::id(pool);
+    let pool_id = pool.pool_id();
     assert!(self.pool_registry.contains(pool_id), EPoolNotRegistered);
 
     let config = self.pool_registry.borrow_mut(pool_id);
@@ -346,7 +346,7 @@ public fun pool_enabled<BaseAsset, QuoteAsset>(
     self: &MarginRegistry,
     pool: &Pool<BaseAsset, QuoteAsset>,
 ): bool {
-    let pool_id = object::id(pool);
+    let pool_id = pool.pool_id();
     if (self.pool_registry.contains(pool_id)) {
         let config = self.pool_registry.borrow(pool_id);
 

--- a/packages/margin_trading/sources/pool_proxy.move
+++ b/packages/margin_trading/sources/pool_proxy.move
@@ -13,7 +13,7 @@ use token::deep::DEEP;
 const ECannotStakeWithDeepMarginManager: u64 = 1;
 const EPoolNotEnabledForMarginTrading: u64 = 2;
 const ENotReduceOnlyOrder: u64 = 3;
-const EIncorrectDeepbookPool: u64 = 4;
+const EIncorrectDeepBookPool: u64 = 4;
 
 // === Public Proxy Functions - Trading ===
 /// Places a limit order in the pool.
@@ -31,7 +31,7 @@ public fun place_limit_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &TxContext,
 ): OrderInfo {
-    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepBookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
     assert!(pool.margin_trading_enabled(), EPoolNotEnabledForMarginTrading);
@@ -64,7 +64,7 @@ public fun place_market_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &TxContext,
 ): OrderInfo {
-    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepBookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
     assert!(pool.margin_trading_enabled(), EPoolNotEnabledForMarginTrading);
@@ -99,7 +99,7 @@ public fun place_reduce_only_limit_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &TxContext,
 ): OrderInfo {
-    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepBookPool);
     let (base_debt, quote_debt) = margin_manager.total_debt<BaseAsset, QuoteAsset>(
         base_margin_pool,
         quote_margin_pool,
@@ -150,7 +150,7 @@ public fun place_reduce_only_market_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &TxContext,
 ): OrderInfo {
-    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepBookPool);
     let (base_debt, quote_debt) = margin_manager.total_debt<BaseAsset, QuoteAsset>(
         base_margin_pool,
         quote_margin_pool,
@@ -199,7 +199,7 @@ public fun modify_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &TxContext,
 ) {
-    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepBookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
 
@@ -221,7 +221,7 @@ public fun cancel_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &TxContext,
 ) {
-    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepBookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
 
@@ -242,7 +242,7 @@ public fun cancel_orders<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &TxContext,
 ) {
-    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepBookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
 
@@ -262,7 +262,7 @@ public fun cancel_all_orders<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &TxContext,
 ) {
-    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepBookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
 
@@ -280,7 +280,7 @@ public fun withdraw_settled_amounts<BaseAsset, QuoteAsset>(
     pool: &mut Pool<BaseAsset, QuoteAsset>,
     ctx: &TxContext,
 ) {
-    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepBookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
 
@@ -297,7 +297,7 @@ public fun stake<BaseAsset, QuoteAsset>(
     amount: u64,
     ctx: &TxContext,
 ) {
-    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepBookPool);
     let base_asset_type = type_name::get<BaseAsset>();
     let quote_asset_type = type_name::get<QuoteAsset>();
     let deep_asset_type = type_name::get<DEEP>();
@@ -323,7 +323,7 @@ public fun unstake<BaseAsset, QuoteAsset>(
     pool: &mut Pool<BaseAsset, QuoteAsset>,
     ctx: &TxContext,
 ) {
-    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepBookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
 
@@ -343,7 +343,7 @@ public fun submit_proposal<BaseAsset, QuoteAsset>(
     stake_required: u64,
     ctx: &TxContext,
 ) {
-    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepBookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
 
@@ -364,7 +364,7 @@ public fun vote<BaseAsset, QuoteAsset>(
     proposal_id: ID,
     ctx: &TxContext,
 ) {
-    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepBookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
 
@@ -381,7 +381,7 @@ public fun claim_rebates<BaseAsset, QuoteAsset>(
     pool: &mut Pool<BaseAsset, QuoteAsset>,
     ctx: &mut TxContext,
 ) {
-    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepBookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
 

--- a/packages/margin_trading/sources/pool_proxy.move
+++ b/packages/margin_trading/sources/pool_proxy.move
@@ -31,7 +31,7 @@ public fun place_limit_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &TxContext,
 ): OrderInfo {
-    assert!(margin_manager.deepbook_pool() == pool.pool_id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepbookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
     assert!(pool.margin_trading_enabled(), EPoolNotEnabledForMarginTrading);
@@ -64,7 +64,7 @@ public fun place_market_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &TxContext,
 ): OrderInfo {
-    assert!(margin_manager.deepbook_pool() == pool.pool_id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepbookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
     assert!(pool.margin_trading_enabled(), EPoolNotEnabledForMarginTrading);
@@ -99,7 +99,7 @@ public fun place_reduce_only_limit_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &TxContext,
 ): OrderInfo {
-    assert!(margin_manager.deepbook_pool() == pool.pool_id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepbookPool);
     let (base_debt, quote_debt) = margin_manager.total_debt<BaseAsset, QuoteAsset>(
         base_margin_pool,
         quote_margin_pool,
@@ -150,7 +150,7 @@ public fun place_reduce_only_market_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &TxContext,
 ): OrderInfo {
-    assert!(margin_manager.deepbook_pool() == pool.pool_id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepbookPool);
     let (base_debt, quote_debt) = margin_manager.total_debt<BaseAsset, QuoteAsset>(
         base_margin_pool,
         quote_margin_pool,
@@ -199,7 +199,7 @@ public fun modify_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &TxContext,
 ) {
-    assert!(margin_manager.deepbook_pool() == pool.pool_id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepbookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
 
@@ -221,7 +221,7 @@ public fun cancel_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &TxContext,
 ) {
-    assert!(margin_manager.deepbook_pool() == pool.pool_id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepbookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
 
@@ -242,7 +242,7 @@ public fun cancel_orders<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &TxContext,
 ) {
-    assert!(margin_manager.deepbook_pool() == pool.pool_id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepbookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
 
@@ -262,7 +262,7 @@ public fun cancel_all_orders<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &TxContext,
 ) {
-    assert!(margin_manager.deepbook_pool() == pool.pool_id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepbookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
 
@@ -280,7 +280,7 @@ public fun withdraw_settled_amounts<BaseAsset, QuoteAsset>(
     pool: &mut Pool<BaseAsset, QuoteAsset>,
     ctx: &TxContext,
 ) {
-    assert!(margin_manager.deepbook_pool() == pool.pool_id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepbookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
 
@@ -297,7 +297,7 @@ public fun stake<BaseAsset, QuoteAsset>(
     amount: u64,
     ctx: &TxContext,
 ) {
-    assert!(margin_manager.deepbook_pool() == pool.pool_id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepbookPool);
     let base_asset_type = type_name::get<BaseAsset>();
     let quote_asset_type = type_name::get<QuoteAsset>();
     let deep_asset_type = type_name::get<DEEP>();
@@ -323,7 +323,7 @@ public fun unstake<BaseAsset, QuoteAsset>(
     pool: &mut Pool<BaseAsset, QuoteAsset>,
     ctx: &TxContext,
 ) {
-    assert!(margin_manager.deepbook_pool() == pool.pool_id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepbookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
 
@@ -343,7 +343,7 @@ public fun submit_proposal<BaseAsset, QuoteAsset>(
     stake_required: u64,
     ctx: &TxContext,
 ) {
-    assert!(margin_manager.deepbook_pool() == pool.pool_id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepbookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
 
@@ -364,7 +364,7 @@ public fun vote<BaseAsset, QuoteAsset>(
     proposal_id: ID,
     ctx: &TxContext,
 ) {
-    assert!(margin_manager.deepbook_pool() == pool.pool_id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepbookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
 
@@ -381,7 +381,7 @@ public fun claim_rebates<BaseAsset, QuoteAsset>(
     pool: &mut Pool<BaseAsset, QuoteAsset>,
     ctx: &mut TxContext,
 ) {
-    assert!(margin_manager.deepbook_pool() == pool.pool_id(), EIncorrectDeepbookPool);
+    assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepbookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
 

--- a/packages/margin_trading/sources/pool_proxy.move
+++ b/packages/margin_trading/sources/pool_proxy.move
@@ -13,6 +13,7 @@ use token::deep::DEEP;
 const ECannotStakeWithDeepMarginManager: u64 = 1;
 const EPoolNotEnabledForMarginTrading: u64 = 2;
 const ENotReduceOnlyOrder: u64 = 3;
+const EIncorrectDeepbookPool: u64 = 4;
 
 // === Public Proxy Functions - Trading ===
 /// Places a limit order in the pool.
@@ -30,6 +31,7 @@ public fun place_limit_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &TxContext,
 ): OrderInfo {
+    assert!(margin_manager.deepbook_pool() == pool.pool_id(), EIncorrectDeepbookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
     assert!(pool.margin_trading_enabled(), EPoolNotEnabledForMarginTrading);
@@ -62,6 +64,7 @@ public fun place_market_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &TxContext,
 ): OrderInfo {
+    assert!(margin_manager.deepbook_pool() == pool.pool_id(), EIncorrectDeepbookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
     assert!(pool.margin_trading_enabled(), EPoolNotEnabledForMarginTrading);
@@ -96,6 +99,7 @@ public fun place_reduce_only_limit_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &TxContext,
 ): OrderInfo {
+    assert!(margin_manager.deepbook_pool() == pool.pool_id(), EIncorrectDeepbookPool);
     let (base_debt, quote_debt) = margin_manager.total_debt<BaseAsset, QuoteAsset>(
         base_margin_pool,
         quote_margin_pool,
@@ -146,6 +150,7 @@ public fun place_reduce_only_market_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &TxContext,
 ): OrderInfo {
+    assert!(margin_manager.deepbook_pool() == pool.pool_id(), EIncorrectDeepbookPool);
     let (base_debt, quote_debt) = margin_manager.total_debt<BaseAsset, QuoteAsset>(
         base_margin_pool,
         quote_margin_pool,
@@ -194,6 +199,7 @@ public fun modify_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &TxContext,
 ) {
+    assert!(margin_manager.deepbook_pool() == pool.pool_id(), EIncorrectDeepbookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
 
@@ -215,6 +221,7 @@ public fun cancel_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &TxContext,
 ) {
+    assert!(margin_manager.deepbook_pool() == pool.pool_id(), EIncorrectDeepbookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
 
@@ -235,6 +242,7 @@ public fun cancel_orders<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &TxContext,
 ) {
+    assert!(margin_manager.deepbook_pool() == pool.pool_id(), EIncorrectDeepbookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
 
@@ -254,6 +262,7 @@ public fun cancel_all_orders<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &TxContext,
 ) {
+    assert!(margin_manager.deepbook_pool() == pool.pool_id(), EIncorrectDeepbookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
 
@@ -271,6 +280,7 @@ public fun withdraw_settled_amounts<BaseAsset, QuoteAsset>(
     pool: &mut Pool<BaseAsset, QuoteAsset>,
     ctx: &TxContext,
 ) {
+    assert!(margin_manager.deepbook_pool() == pool.pool_id(), EIncorrectDeepbookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
 
@@ -287,6 +297,7 @@ public fun stake<BaseAsset, QuoteAsset>(
     amount: u64,
     ctx: &TxContext,
 ) {
+    assert!(margin_manager.deepbook_pool() == pool.pool_id(), EIncorrectDeepbookPool);
     let base_asset_type = type_name::get<BaseAsset>();
     let quote_asset_type = type_name::get<QuoteAsset>();
     let deep_asset_type = type_name::get<DEEP>();
@@ -312,6 +323,7 @@ public fun unstake<BaseAsset, QuoteAsset>(
     pool: &mut Pool<BaseAsset, QuoteAsset>,
     ctx: &TxContext,
 ) {
+    assert!(margin_manager.deepbook_pool() == pool.pool_id(), EIncorrectDeepbookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
 
@@ -331,6 +343,7 @@ public fun submit_proposal<BaseAsset, QuoteAsset>(
     stake_required: u64,
     ctx: &TxContext,
 ) {
+    assert!(margin_manager.deepbook_pool() == pool.pool_id(), EIncorrectDeepbookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
 
@@ -351,6 +364,7 @@ public fun vote<BaseAsset, QuoteAsset>(
     proposal_id: ID,
     ctx: &TxContext,
 ) {
+    assert!(margin_manager.deepbook_pool() == pool.pool_id(), EIncorrectDeepbookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
 
@@ -367,6 +381,7 @@ public fun claim_rebates<BaseAsset, QuoteAsset>(
     pool: &mut Pool<BaseAsset, QuoteAsset>,
     ctx: &mut TxContext,
 ) {
+    assert!(margin_manager.deepbook_pool() == pool.pool_id(), EIncorrectDeepbookPool);
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
 


### PR DESCRIPTION
1. Each margin manager can only trade on a specific deepbook pool (if there are more than 1 SUI/USDC pools for example, the manager is tied to 1 only)
2. `Pool_id` accessor in core for readability