### PR TITLE
Margin pool control

### DIFF
--- a/packages/margin_trading/sources/margin_manager.move
+++ b/packages/margin_trading/sources/margin_manager.move
@@ -40,6 +40,7 @@ const ECannotLiquidate: u64 = 5;
 const EInvalidMarginManagerOwner: u64 = 6;
 const ECannotHaveLoanInBothMarginPools: u64 = 7;
 const EIncorrectDeepBookPool: u64 = 8;
+const EDeepbookPoolNotAllowedForLoan: u64 = 9;
 
 // === Constants ===
 const WITHDRAW: u8 = 0;
@@ -183,6 +184,10 @@ public fun borrow_base<BaseAsset, QuoteAsset>(
         quote_margin_pool.user_loan_amount(margin_manager.id(), clock) == 0,
         ECannotHaveLoanInBothMarginPools,
     );
+    assert!(
+        base_margin_pool.deepbook_pool_allowed(margin_manager.deepbook_pool),
+        EDeepbookPoolNotAllowedForLoan,
+    );
     margin_manager.borrow<BaseAsset, QuoteAsset, BaseAsset>(
         base_margin_pool,
         loan_amount,
@@ -203,6 +208,10 @@ public fun borrow_quote<BaseAsset, QuoteAsset>(
     assert!(
         base_margin_pool.user_loan_amount(margin_manager.id(), clock) == 0,
         ECannotHaveLoanInBothMarginPools,
+    );
+    assert!(
+        quote_margin_pool.deepbook_pool_allowed(margin_manager.deepbook_pool),
+        EDeepbookPoolNotAllowedForLoan,
     );
     margin_manager.borrow<BaseAsset, QuoteAsset, QuoteAsset>(
         quote_margin_pool,

--- a/packages/margin_trading/sources/margin_pool/position_manager.move
+++ b/packages/margin_trading/sources/margin_pool/position_manager.move
@@ -174,6 +174,9 @@ fun update_supply_reward_shares(
             *reward_subtraction =
                 *reward_subtraction + math::mul(cumulative_reward_per_share, shares_before - shares_after);
         };
+        let offset = (*reward_addition).min(*reward_subtraction);
+        *reward_addition = *reward_addition - offset;
+        *reward_subtraction = *reward_subtraction - offset;
         i = i + 1;
     }
 }

--- a/packages/margin_trading/sources/margin_registry.move
+++ b/packages/margin_trading/sources/margin_registry.move
@@ -261,6 +261,26 @@ public fun add_reward_pool<Asset, RewardToken>(
     margin_pool.add_reward_pool<Asset, RewardToken>(reward_coin, end_time, clock);
 }
 
+/// Allow a margin manager tied to a deepbook pool to borrow from the margin pool.
+public fun enable_deepbook_pool_for_loan<Asset>(
+    margin_pool: &mut MarginPool<Asset>,
+    deepbook_pool_id: ID,
+    margin_pool_cap: &MarginPoolCap,
+) {
+    assert!(margin_pool_cap.margin_pool_id == margin_pool.id(), EInvalidMarginPoolCap);
+    margin_pool.enable_deepbook_pool_for_loan<Asset>(deepbook_pool_id);
+}
+
+/// Disable a margin manager tied to a deepbook pool from borrowing from the margin pool.
+public fun disable_deepbook_pool_for_loan<Asset>(
+    margin_pool: &mut MarginPool<Asset>,
+    deepbook_pool_id: ID,
+    margin_pool_cap: &MarginPoolCap,
+) {
+    assert!(margin_pool_cap.margin_pool_id == margin_pool.id(), EInvalidMarginPoolCap);
+    margin_pool.disable_deepbook_pool_for_loan<Asset>(deepbook_pool_id);
+}
+
 /// Create a PoolConfig with margin pool IDs and risk parameters
 /// Enable is false by default, must be enabled after registration
 public fun new_pool_config<BaseAsset, QuoteAsset>(


### PR DESCRIPTION
1. Margin pool PoolCap owner can decide which margin managers can borrow from the margin pool (exclude high risk deepbook pools for example)
2. Edge case update for rewards logic