### PR TITLE
Testing Framework

### DIFF
--- a/packages/margin_trading/sources/helper/margin_constants.move
+++ b/packages/margin_trading/sources/helper/margin_constants.move
@@ -10,10 +10,6 @@ const DEFAULT_POOL_LIQUIDATION_REWARD: u64 = 40_000_000; // 4%
 const MIN_LEVERAGE: u64 = 1_000_000_000; // 1x
 const MAX_LEVERAGE: u64 = 20_000_000_000; // 20x
 const YEAR_MS: u64 = 365 * 24 * 60 * 60 * 1000;
-// === Reward Constraints ===
-const MIN_REWARD_AMOUNT: u64 = 1000;
-const MIN_REWARD_DURATION_SECONDS: u64 = 3600;
-const MAX_REWARD_TYPES: u64 = 10;
 
 public fun margin_version(): u64 {
     MARGIN_VERSION
@@ -37,18 +33,6 @@ public fun min_leverage(): u64 {
 
 public fun max_leverage(): u64 {
     MAX_LEVERAGE
-}
-
-public fun min_reward_amount(): u64 {
-    MIN_REWARD_AMOUNT
-}
-
-public fun min_reward_duration_seconds(): u64 {
-    MIN_REWARD_DURATION_SECONDS
-}
-
-public fun max_reward_types(): u64 {
-    MAX_REWARD_TYPES
 }
 
 public fun year_ms(): u64 {

--- a/packages/margin_trading/sources/helper/test_constants.move
+++ b/packages/margin_trading/sources/helper/test_constants.move
@@ -5,9 +5,13 @@
 module margin_trading::test_constants;
 
 // Test constants
-const SUPPLY_CAP: u64 = 1_000_000_000_000; // 1M tokens with 9 decimals
-const MAX_UTILIZATION_RATE: u64 = 800_000_000; // 80% with 9 decimals
-const PROTOCOL_SPREAD: u64 = 100_000_000; // 10% with 9 decimals
+const SUPPLY_CAP: u64 = 1_000_000_000_000;
+const MAX_UTILIZATION_RATE: u64 = 800_000_000; // 80%
+const PROTOCOL_SPREAD: u64 = 100_000_000; // 10%
+const BASE_RATE: u64 = 50_000_000; // 5%
+const BASE_SLOPE: u64 = 100_000_000; // 10%
+const OPTIMAL_UTILIZATION: u64 = 800_000_000; // 80%
+const EXCESS_SLOPE: u64 = 2_000_000_000; // 200%
 
 public fun supply_cap(): u64 {
     SUPPLY_CAP
@@ -19,4 +23,20 @@ public fun max_utilization_rate(): u64 {
 
 public fun protocol_spread(): u64 {
     PROTOCOL_SPREAD
+}
+
+public fun base_rate(): u64 {
+    BASE_RATE
+}
+
+public fun base_slope(): u64 {
+    BASE_SLOPE
+}
+
+public fun optimal_utilization(): u64 {
+    OPTIMAL_UTILIZATION
+}
+
+public fun excess_slope(): u64 {
+    EXCESS_SLOPE
 }

--- a/packages/margin_trading/sources/helper/test_constants.move
+++ b/packages/margin_trading/sources/helper/test_constants.move
@@ -1,0 +1,22 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module margin_trading::test_constants;
+
+// Test constants
+const SUPPLY_CAP: u64 = 1_000_000_000_000; // 1M tokens with 9 decimals
+const MAX_UTILIZATION_RATE: u64 = 800_000_000; // 80% with 9 decimals
+const PROTOCOL_SPREAD: u64 = 100_000_000; // 10% with 9 decimals
+
+public fun supply_cap(): u64 {
+    SUPPLY_CAP
+}
+
+public fun max_utilization_rate(): u64 {
+    MAX_UTILIZATION_RATE
+}
+
+public fun protocol_spread(): u64 {
+    PROTOCOL_SPREAD
+}

--- a/packages/margin_trading/sources/helper/test_constants.move
+++ b/packages/margin_trading/sources/helper/test_constants.move
@@ -13,6 +13,13 @@ const BASE_SLOPE: u64 = 100_000_000; // 10%
 const OPTIMAL_UTILIZATION: u64 = 800_000_000; // 80%
 const EXCESS_SLOPE: u64 = 2_000_000_000; // 200%
 
+const USER1: address = @0xA;
+const USER2: address = @0xB;
+const ADMIN: address = @0x1;
+
+public struct USDC has drop {}
+public struct USDT has drop {}
+
 public fun supply_cap(): u64 {
     SUPPLY_CAP
 }
@@ -39,4 +46,16 @@ public fun optimal_utilization(): u64 {
 
 public fun excess_slope(): u64 {
     EXCESS_SLOPE
+}
+
+public fun user1(): address {
+    USER1
+}
+
+public fun user2(): address {
+    USER2
+}
+
+public fun admin(): address {
+    ADMIN
 }

--- a/packages/margin_trading/sources/margin_registry.move
+++ b/packages/margin_trading/sources/margin_registry.move
@@ -534,7 +534,7 @@ fun calculate_risk_ratios(leverage_factor: u64): RiskRatios {
 }
 
 #[test_only]
-public fun new_for_testing(ctx: &mut TxContext): (MarginRegistry, MarginAdminCap) {
+public fun new_for_testing(ctx: &mut TxContext): MarginAdminCap {
     let id = object::new(ctx);
     let margin_registry_inner = MarginRegistryInner {
         registry_id: id.to_inner(),
@@ -550,5 +550,7 @@ public fun new_for_testing(ctx: &mut TxContext): (MarginRegistry, MarginAdminCap
     };
     let margin_admin_cap = MarginAdminCap { id: object::new(ctx) };
 
-    (registry, margin_admin_cap)
+    transfer::share_object(registry);
+
+    margin_admin_cap
 }

--- a/packages/margin_trading/tests/margin_pool_tests.move
+++ b/packages/margin_trading/tests/margin_pool_tests.move
@@ -8,59 +8,39 @@ use margin_trading::{
     margin_pool::{Self, MarginPool},
     margin_registry::{Self, MarginRegistry, MarginAdminCap, MaintainerCap, MarginPoolCap},
     protocol_config,
-    test_constants
+    test_constants::{Self, USDC, USDT},
+    test_helpers::{Self, mint_coin}
 };
 use sui::{
-    clock::{Self, Clock},
-    coin::{Self, Coin},
-    test_scenario::{Self as test, Scenario},
+    clock::Clock,
+    coin::Coin,
+    test_scenario::{Self as test, Scenario, return_shared},
     test_utils::destroy
 };
 
-public struct USDC has drop {}
-public struct USDT has drop {}
+fun setup_test(): (Scenario, Clock, MarginAdminCap, MaintainerCap, ID) {
+    let (mut scenario, admin_cap) = test_helpers::setup_test();
 
-const USER1: address = @0x1;
-const USER2: address = @0x2;
-const ADMIN: address = @0x0;
-
-fun setup_test(): (Scenario, Clock, MarginRegistry, MarginAdminCap, MaintainerCap, ID) {
-    let mut scenario = test::begin(ADMIN);
-    let clock = clock::create_for_testing(scenario.ctx());
-
-    let (mut registry, admin_cap) = margin_registry::new_for_testing(scenario.ctx());
+    scenario.next_tx(test_constants::admin());
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let clock = scenario.take_shared<Clock>();
     let maintainer_cap = margin_registry::mint_maintainer_cap(
         &mut registry,
         &admin_cap,
         &clock,
         scenario.ctx(),
     );
+    test::return_shared(registry);
 
-    let margin_pool_config = protocol_config::new_margin_pool_config(
-        test_constants::supply_cap(),
-        test_constants::max_utilization_rate(),
-        test_constants::protocol_spread(),
-    );
-    let interest_config = protocol_config::new_interest_config(
-        50_000_000, // base_rate: 5% with 9 decimals
-        100_000_000, // base_slope: 10% with 9 decimals
-        800_000_000, // optimal_utilization: 80% with 9 decimals
-        2_000_000_000, // excess_slope: 200% with 9 decimals
-    );
-    let protocol_config = protocol_config::new_protocol_config(margin_pool_config, interest_config);
-    let pool_id = margin_pool::create_margin_pool<USDC>(
-        &mut registry,
-        protocol_config,
+    let protocol_config = test_helpers::default_protocol_config();
+    let pool_id = test_helpers::create_margin_pool<USDC>(
+        &mut scenario,
         &maintainer_cap,
+        protocol_config,
         &clock,
-        scenario.ctx(),
     );
 
-    (scenario, clock, registry, admin_cap, maintainer_cap, pool_id)
-}
-
-fun mint_coin<T>(amount: u64, ctx: &mut TxContext): Coin<T> {
-    coin::mint_for_testing<T>(amount, ctx)
+    (scenario, clock, admin_cap, maintainer_cap, pool_id)
 }
 
 fun cleanup_test(
@@ -70,15 +50,13 @@ fun cleanup_test(
     clock: Clock,
     scenario: Scenario,
 ) {
-    destroy(registry);
+    return_shared(registry);
     destroy(admin_cap);
     destroy(maintainer_cap);
     destroy(clock);
     scenario.end();
 }
 
-/// Test-only wrapper for borrow function to test ENotEnoughAssetInPool
-#[test_only]
 public fun test_borrow<Asset>(
     pool: &mut MarginPool<Asset>,
     amount: u64,
@@ -90,13 +68,14 @@ public fun test_borrow<Asset>(
 
 #[test]
 fun test_supply_and_withdraw_basic() {
-    let (mut scenario, mut clock, registry, admin_cap, maintainer_cap, pool_id) = setup_test();
+    let (mut scenario, mut clock, admin_cap, maintainer_cap, pool_id) = setup_test();
     clock.set_for_testing(1000);
 
-    scenario.next_tx(ADMIN);
+    scenario.next_tx(test_constants::admin());
     let mut pool = scenario.take_shared_by_id<MarginPool<USDC>>(pool_id);
+    let registry = scenario.take_shared<MarginRegistry>();
 
-    scenario.next_tx(USER1);
+    scenario.next_tx(test_constants::user1());
     let supply_coin = mint_coin<USDC>(100_000_000_000, scenario.ctx()); // 100 tokens with 9 decimals
     pool.supply<USDC>(&registry, supply_coin, &clock, scenario.ctx());
 
@@ -115,13 +94,13 @@ fun test_supply_and_withdraw_basic() {
 
 #[test, expected_failure(abort_code = margin_trading::margin_pool::ESupplyCapExceeded)]
 fun test_supply_cap_enforcement() {
-    let (mut scenario, mut clock, registry, admin_cap, maintainer_cap, pool_id) = setup_test();
+    let (mut scenario, mut clock, admin_cap, maintainer_cap, pool_id) = setup_test();
     clock.set_for_testing(1000);
 
-    scenario.next_tx(ADMIN);
+    scenario.next_tx(test_constants::admin());
     let mut pool = scenario.take_shared_by_id<MarginPool<USDC>>(pool_id);
-
-    scenario.next_tx(USER1);
+    let registry = scenario.take_shared<MarginRegistry>();
+    scenario.next_tx(test_constants::user1());
     let supply_coin = mint_coin<USDC>(test_constants::supply_cap() + 1, scenario.ctx());
 
     // This should fail due to supply cap
@@ -133,23 +112,24 @@ fun test_supply_cap_enforcement() {
 
 #[test]
 fun test_multiple_users_supply_withdraw() {
-    let (mut scenario, mut clock, registry, admin_cap, maintainer_cap, pool_id) = setup_test();
+    let (mut scenario, mut clock, admin_cap, maintainer_cap, pool_id) = setup_test();
     clock.set_for_testing(1000);
 
-    scenario.next_tx(ADMIN);
+    scenario.next_tx(test_constants::admin());
     let mut pool = scenario.take_shared_by_id<MarginPool<USDC>>(pool_id);
+    let registry = scenario.take_shared<MarginRegistry>();
 
     // User1 supplies
-    scenario.next_tx(USER1);
+    scenario.next_tx(test_constants::user1());
     let supply_coin1 = mint_coin<USDC>(50_000_000_000, scenario.ctx()); // 50 tokens
     pool.supply<USDC>(&registry, supply_coin1, &clock, scenario.ctx());
 
     // User2 supplies
-    scenario.next_tx(USER2);
+    scenario.next_tx(test_constants::user2());
     let supply_coin2 = mint_coin<USDC>(30_000_000_000, scenario.ctx()); // 30 tokens
     pool.supply<USDC>(&registry, supply_coin2, &clock, scenario.ctx());
 
-    scenario.next_tx(USER1);
+    scenario.next_tx(test_constants::user1());
     let withdrawn1 = pool.withdraw<USDC>(
         &registry,
         option::some(25_000_000_000),
@@ -158,7 +138,7 @@ fun test_multiple_users_supply_withdraw() {
     );
     assert!(withdrawn1.value() == 25_000_000_000);
 
-    scenario.next_tx(USER2);
+    scenario.next_tx(test_constants::user2());
     let withdrawn2 = pool.withdraw<USDC>(
         &registry,
         option::some(15_000_000_000),
@@ -175,13 +155,14 @@ fun test_multiple_users_supply_withdraw() {
 
 #[test]
 fun test_withdraw_all() {
-    let (mut scenario, mut clock, registry, admin_cap, maintainer_cap, pool_id) = setup_test();
+    let (mut scenario, mut clock, admin_cap, maintainer_cap, pool_id) = setup_test();
     clock.set_for_testing(1000);
 
-    scenario.next_tx(ADMIN);
+    scenario.next_tx(test_constants::admin());
     let mut pool = scenario.take_shared_by_id<MarginPool<USDC>>(pool_id);
+    let registry = scenario.take_shared<MarginRegistry>();
 
-    scenario.next_tx(USER1);
+    scenario.next_tx(test_constants::user1());
     let supply_amount = 100_000_000_000; // 100 tokens
     let supply_coin = mint_coin<USDC>(supply_amount, scenario.ctx());
     pool.supply<USDC>(&registry, supply_coin, &clock, scenario.ctx());
@@ -196,13 +177,13 @@ fun test_withdraw_all() {
 
 #[test, expected_failure(abort_code = margin_trading::margin_pool::ECannotWithdrawMoreThanSupply)]
 fun test_withdraw_more_than_supplied() {
-    let (mut scenario, mut clock, registry, admin_cap, maintainer_cap, pool_id) = setup_test();
+    let (mut scenario, mut clock, admin_cap, maintainer_cap, pool_id) = setup_test();
     clock.set_for_testing(1000);
 
-    scenario.next_tx(ADMIN);
+    scenario.next_tx(test_constants::admin());
     let mut pool = scenario.take_shared_by_id<MarginPool<USDC>>(pool_id);
-
-    scenario.next_tx(USER1);
+    let registry = scenario.take_shared<MarginRegistry>();
+    scenario.next_tx(test_constants::user1());
     let supply_coin = mint_coin<USDC>(50_000_000_000, scenario.ctx()); // 50 tokens
     pool.supply<USDC>(&registry, supply_coin, &clock, scenario.ctx());
 
@@ -220,10 +201,11 @@ fun test_withdraw_more_than_supplied() {
 
 #[test]
 fun test_create_margin_pool_with_config() {
-    let (mut scenario, clock, registry, admin_cap, maintainer_cap, pool_id) = setup_test();
+    let (mut scenario, clock, admin_cap, maintainer_cap, pool_id) = setup_test();
 
-    scenario.next_tx(ADMIN);
+    scenario.next_tx(test_constants::admin());
     let pool = scenario.take_shared_by_id<MarginPool<USDC>>(pool_id);
+    let registry = scenario.take_shared<MarginRegistry>();
 
     test::return_shared(pool);
     cleanup_test(registry, admin_cap, maintainer_cap, clock, scenario);
@@ -231,13 +213,13 @@ fun test_create_margin_pool_with_config() {
 
 #[test]
 fun test_interest_accrual_over_time() {
-    let (mut scenario, mut clock, registry, admin_cap, maintainer_cap, pool_id) = setup_test();
+    let (mut scenario, mut clock, admin_cap, maintainer_cap, pool_id) = setup_test();
     clock.set_for_testing(1000);
 
-    scenario.next_tx(ADMIN);
+    scenario.next_tx(test_constants::admin());
     let mut pool = scenario.take_shared_by_id<MarginPool<USDC>>(pool_id);
-
-    scenario.next_tx(USER1);
+    let registry = scenario.take_shared<MarginRegistry>();
+    scenario.next_tx(test_constants::user1());
     let supply_amount = 100_000_000_000; // 100 tokens
     let supply_coin = mint_coin<USDC>(supply_amount, scenario.ctx());
     pool.supply<USDC>(&registry, supply_coin, &clock, scenario.ctx());
@@ -255,23 +237,23 @@ fun test_interest_accrual_over_time() {
 
 #[test, expected_failure(abort_code = margin_trading::margin_pool::ENotEnoughAssetInPool)]
 fun test_not_enough_asset_in_pool() {
-    let (mut scenario, mut clock, registry, admin_cap, maintainer_cap, pool_id) = setup_test();
+    let (mut scenario, mut clock, admin_cap, maintainer_cap, pool_id) = setup_test();
 
     clock.set_for_testing(1000);
 
-    scenario.next_tx(ADMIN);
+    scenario.next_tx(test_constants::admin());
     let mut pool = scenario.take_shared_by_id<MarginPool<USDC>>(pool_id);
-
-    scenario.next_tx(USER1);
+    let registry = scenario.take_shared<MarginRegistry>();
+    scenario.next_tx(test_constants::user1());
     let supply_coin = mint_coin<USDC>(100_000_000_000, scenario.ctx()); // 100 tokens
     pool.supply<USDC>(&registry, supply_coin, &clock, scenario.ctx());
 
-    scenario.next_tx(USER2);
+    scenario.next_tx(test_constants::user2());
     let borrowed_coin = test_borrow(&mut pool, 80_000_000_000, &clock, scenario.ctx()); // 80 tokens
     destroy(borrowed_coin);
 
     // Should fail due to outstanding loan
-    scenario.next_tx(USER1);
+    scenario.next_tx(test_constants::user1());
     let withdrawn = pool.withdraw<USDC>(&registry, option::none(), &clock, scenario.ctx());
 
     destroy(withdrawn);
@@ -286,19 +268,19 @@ fun test_not_enough_asset_in_pool() {
     ),
 ]
 fun test_max_pool_borrow_percentage_exceeded() {
-    let (mut scenario, mut clock, registry, admin_cap, maintainer_cap, pool_id) = setup_test();
+    let (mut scenario, mut clock, admin_cap, maintainer_cap, pool_id) = setup_test();
 
     clock.set_for_testing(1000);
 
-    scenario.next_tx(ADMIN);
+    scenario.next_tx(test_constants::admin());
     let mut pool = scenario.take_shared_by_id<MarginPool<USDC>>(pool_id);
-
-    scenario.next_tx(USER1);
+    let registry = scenario.take_shared<MarginRegistry>();
+    scenario.next_tx(test_constants::user1());
     let supply_coin = mint_coin<USDC>(100_000_000_000, scenario.ctx()); // 100 tokens
     pool.supply<USDC>(&registry, supply_coin, &clock, scenario.ctx());
 
     // Above max utilization rate
-    scenario.next_tx(USER2);
+    scenario.next_tx(test_constants::user2());
     let borrowed_coin = test_borrow(&mut pool, 85_000_000_000, &clock, scenario.ctx()); // 85 tokens > 80%
 
     destroy(borrowed_coin);
@@ -308,18 +290,19 @@ fun test_max_pool_borrow_percentage_exceeded() {
 
 #[test, expected_failure(abort_code = margin_trading::margin_pool::EInvalidLoanQuantity)]
 fun test_invalid_loan_quantity() {
-    let (mut scenario, mut clock, registry, admin_cap, maintainer_cap, pool_id) = setup_test();
+    let (mut scenario, mut clock, admin_cap, maintainer_cap, pool_id) = setup_test();
 
     clock.set_for_testing(1000);
 
-    scenario.next_tx(ADMIN);
+    scenario.next_tx(test_constants::admin());
     let mut pool = scenario.take_shared_by_id<MarginPool<USDC>>(pool_id);
+    let registry = scenario.take_shared<MarginRegistry>();
 
-    scenario.next_tx(USER1);
+    scenario.next_tx(test_constants::user1());
     let supply_coin = mint_coin<USDC>(100_000_000_000, scenario.ctx()); // 100 tokens
     pool.supply<USDC>(&registry, supply_coin, &clock, scenario.ctx());
 
-    scenario.next_tx(USER2);
+    scenario.next_tx(test_constants::user2());
     let borrowed_coin = test_borrow(&mut pool, 0, &clock, scenario.ctx());
 
     destroy(borrowed_coin);
@@ -329,12 +312,14 @@ fun test_invalid_loan_quantity() {
 
 #[test, expected_failure(abort_code = margin_trading::margin_pool::EDeepbookPoolAlreadyAllowed)]
 fun test_deepbook_pool_already_allowed() {
-    let (mut scenario, mut clock, registry, admin_cap, maintainer_cap, pool_id) = setup_test();
+    let (mut scenario, mut clock, admin_cap, maintainer_cap, pool_id) = setup_test();
 
     clock.set_for_testing(1000);
 
-    scenario.next_tx(ADMIN);
+    scenario.next_tx(test_constants::admin());
     let mut pool = scenario.take_shared_by_id<MarginPool<USDC>>(pool_id);
+    let registry = scenario.take_shared<MarginRegistry>();
+
     let margin_pool_cap = scenario.take_from_sender<MarginPoolCap>();
 
     let deepbook_pool_id = object::id_from_address(@0x123);
@@ -349,12 +334,13 @@ fun test_deepbook_pool_already_allowed() {
 
 #[test, expected_failure(abort_code = margin_trading::margin_pool::EInvalidMarginPoolCap)]
 fun test_invalid_margin_pool_cap() {
-    let (mut scenario, mut clock, mut registry, admin_cap, maintainer_cap, pool_id) = setup_test();
+    let (mut scenario, mut clock, admin_cap, maintainer_cap, pool_id) = setup_test();
 
     clock.set_for_testing(1000);
 
     // Create a second margin pool to get a different MarginPoolCap
-    scenario.next_tx(ADMIN);
+    scenario.next_tx(test_constants::admin());
+    let mut registry = scenario.take_shared<MarginRegistry>();
     let margin_pool_config2 = protocol_config::new_margin_pool_config(
         500_000_000_000, // Different supply cap
         test_constants::max_utilization_rate(),
@@ -378,8 +364,9 @@ fun test_invalid_margin_pool_cap() {
         scenario.ctx(),
     );
 
-    scenario.next_tx(ADMIN);
+    scenario.next_tx(test_constants::admin());
     let mut pool = scenario.take_shared_by_id<MarginPool<USDC>>(pool_id);
+
     let wrong_margin_pool_cap = scenario.take_from_sender<MarginPoolCap>(); // This cap belongs to pool2, not pool
 
     let deepbook_pool_id = object::id_from_address(@0x123);

--- a/packages/margin_trading/tests/margin_pool_tests.move
+++ b/packages/margin_trading/tests/margin_pool_tests.move
@@ -7,7 +7,8 @@ module margin_trading::margin_pool_tests;
 use margin_trading::{
     margin_pool::{Self, MarginPool},
     margin_registry::{Self, MarginRegistry, MarginAdminCap, MaintainerCap, MarginPoolCap},
-    protocol_config
+    protocol_config,
+    test_constants
 };
 use sui::{
     clock::{Self, Clock},
@@ -23,11 +24,6 @@ const USER1: address = @0x1;
 const USER2: address = @0x2;
 const ADMIN: address = @0x0;
 
-// Test constants
-const SUPPLY_CAP: u64 = 1_000_000_000_000; // 1M tokens with 9 decimals
-const MAX_UTILIZATION_RATE: u64 = 800_000_000; // 80% with 9 decimals
-const PROTOCOL_SPREAD: u64 = 100_000_000; // 10% with 9 decimals
-
 fun setup_test(): (Scenario, Clock, MarginRegistry, MarginAdminCap, MaintainerCap, ID) {
     let mut scenario = test::begin(ADMIN);
     let clock = clock::create_for_testing(scenario.ctx());
@@ -41,9 +37,9 @@ fun setup_test(): (Scenario, Clock, MarginRegistry, MarginAdminCap, MaintainerCa
     );
 
     let margin_pool_config = protocol_config::new_margin_pool_config(
-        SUPPLY_CAP,
-        MAX_UTILIZATION_RATE,
-        PROTOCOL_SPREAD,
+        test_constants::supply_cap(),
+        test_constants::max_utilization_rate(),
+        test_constants::protocol_spread(),
     );
     let interest_config = protocol_config::new_interest_config(
         50_000_000, // base_rate: 5% with 9 decimals
@@ -126,7 +122,7 @@ fun test_supply_cap_enforcement() {
     let mut pool = scenario.take_shared_by_id<MarginPool<USDC>>(pool_id);
 
     scenario.next_tx(USER1);
-    let supply_coin = mint_coin<USDC>(SUPPLY_CAP + 1, scenario.ctx());
+    let supply_coin = mint_coin<USDC>(test_constants::supply_cap() + 1, scenario.ctx());
 
     // This should fail due to supply cap
     pool.supply<USDC>(&registry, supply_coin, &clock, scenario.ctx());
@@ -361,8 +357,8 @@ fun test_invalid_margin_pool_cap() {
     scenario.next_tx(ADMIN);
     let margin_pool_config2 = protocol_config::new_margin_pool_config(
         500_000_000_000, // Different supply cap
-        MAX_UTILIZATION_RATE,
-        PROTOCOL_SPREAD,
+        test_constants::max_utilization_rate(),
+        test_constants::protocol_spread(),
     );
     let interest_config2 = protocol_config::new_interest_config(
         50_000_000,

--- a/packages/margin_trading/tests/test_helpers.move
+++ b/packages/margin_trading/tests/test_helpers.move
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[test_only]
-module margin_trading::test_utils;
+module margin_trading::test_helpers;
 
 use margin_trading::{
     margin_pool,
@@ -16,10 +16,8 @@ use sui::{
     test_scenario::{Scenario, begin, return_shared}
 };
 
-const ADMIN: address = @0x1;
-
 public fun setup_test(): (Scenario, MarginAdminCap) {
-    let mut test = begin(ADMIN);
+    let mut test = begin(test_constants::admin());
     let clock = clock::create_for_testing(test.ctx());
 
     let admin_cap = margin_registry::new_for_testing(test.ctx());
@@ -35,7 +33,7 @@ public fun create_margin_pool<Asset>(
     protocol_config: ProtocolConfig,
     clock: &Clock,
 ): ID {
-    test.next_tx(ADMIN);
+    test.next_tx(test_constants::admin());
 
     let mut registry = test.take_shared<MarginRegistry>();
 

--- a/packages/margin_trading/tests/test_utils.move
+++ b/packages/margin_trading/tests/test_utils.move
@@ -1,0 +1,58 @@
+// // Copyright (c) Mysten Labs, Inc.
+// // SPDX-License-Identifier: Apache-2.0
+
+// #[test_only]
+// module margin_trading::test_utils;
+
+// use margin_trading::margin_pool::{Self, MarginPool};
+// use margin_trading::margin_registry::{
+//     Self,
+//     MarginRegistry,
+//     MarginAdminCap,
+//     MaintainerCap,
+//     MarginPoolCap
+// };
+// use margin_trading::protocol_config;
+// use sui::clock::{Self, Clock};
+// use sui::coin::{Self, Coin};
+// use sui::test_scenario::{Self as test, Scenario};
+// use sui::test_utils::destroy;
+
+// const ADMIN: address = @0x1;
+// const ALICE: address = @0xAAAA;
+// const BOB: address = @0xBBBB;
+
+// public fun setup_test(): (Scenario, Clock, MarginRegistry, MarginAdminCap, MaintainerCap, ID) {
+//     let mut scenario = test::begin(ADMIN);
+//     let clock = clock::create_for_testing(scenario.ctx());
+
+//     let (mut registry, admin_cap) = margin_registry::new_for_testing(scenario.ctx());
+//     let maintainer_cap = margin_registry::mint_maintainer_cap(
+//         &mut registry,
+//         &admin_cap,
+//         &clock,
+//         scenario.ctx(),
+//     );
+
+//     let margin_pool_config = protocol_config::new_margin_pool_config(
+//         SUPPLY_CAP,
+//         MAX_UTILIZATION_RATE,
+//         PROTOCOL_SPREAD,
+//     );
+//     let interest_config = protocol_config::new_interest_config(
+//         50_000_000, // base_rate: 5% with 9 decimals
+//         100_000_000, // base_slope: 10% with 9 decimals
+//         800_000_000, // optimal_utilization: 80% with 9 decimals
+//         2_000_000_000, // excess_slope: 200% with 9 decimals
+//     );
+//     let protocol_config = protocol_config::new_protocol_config(margin_pool_config, interest_config);
+//     let pool_id = margin_pool::create_margin_pool<USDC>(
+//         &mut registry,
+//         protocol_config,
+//         &maintainer_cap,
+//         &clock,
+//         scenario.ctx(),
+//     );
+
+//     (scenario, clock, registry, admin_cap, maintainer_cap, pool_id)
+// }


### PR DESCRIPTION
1. Testing constants should be inside test_constants.move if possible
2. Useful functions often reused should be in test_helpers.move
3. If an object is shared, try to keep it as shared and borrow if possible