### PR TITLE
DRAFT PENDING PULL/680: Add config_json to indexer, schema, and server for DeepbookPoolRegist…

### DIFF
--- a/crates/indexer/src/models.rs
+++ b/crates/indexer/src/models.rs
@@ -530,6 +530,13 @@ pub mod deepbook_margin {
         }
 
         #[derive(Debug, Clone, Serialize, Deserialize)]
+        pub struct DeepbookPoolRegisteredV2 {
+            pub pool_id: ObjectID,
+            pub config: PoolConfig,
+            pub timestamp: u64,
+        }
+
+        #[derive(Debug, Clone, Serialize, Deserialize)]
         pub struct DeepbookPoolUpdated {
             pub pool_id: ObjectID,
             pub enabled: bool,
@@ -568,6 +575,11 @@ pub mod deepbook_margin {
         impl MoveStruct for DeepbookPoolRegistered {
             const MODULE: &'static str = "margin_registry";
             const NAME: &'static str = "DeepbookPoolRegistered";
+        }
+
+        impl MoveStruct for DeepbookPoolRegisteredV2 {
+            const MODULE: &'static str = "margin_registry";
+            const NAME: &'static str = "DeepbookPoolRegisteredV2";
         }
 
         impl MoveStruct for DeepbookPoolUpdated {

--- a/crates/schema/migrations/2025-11-18-000000-0000_add_config_to_pool_registered/down.sql
+++ b/crates/schema/migrations/2025-11-18-000000-0000_add_config_to_pool_registered/down.sql
@@ -1,0 +1,4 @@
+-- Remove config_json column from deepbook_pool_registered table
+DROP INDEX IF EXISTS idx_deepbook_pool_registered_config;
+ALTER TABLE deepbook_pool_registered DROP COLUMN config_json;
+

--- a/crates/schema/migrations/2025-11-18-000000-0000_add_config_to_pool_registered/up.sql
+++ b/crates/schema/migrations/2025-11-18-000000-0000_add_config_to_pool_registered/up.sql
@@ -1,0 +1,12 @@
+-- Add config_json column to deepbook_pool_registered table
+ALTER TABLE deepbook_pool_registered 
+ADD COLUMN config_json JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+-- Create GIN index for efficient JSONB queries
+CREATE INDEX idx_deepbook_pool_registered_config 
+ON deepbook_pool_registered USING gin(config_json);
+
+-- Remove the default value now that the column exists
+ALTER TABLE deepbook_pool_registered 
+ALTER COLUMN config_json DROP DEFAULT;
+

--- a/crates/schema/src/models.rs
+++ b/crates/schema/src/models.rs
@@ -494,6 +494,7 @@ pub struct DeepbookPoolRegistered {
     pub checkpoint_timestamp_ms: i64,
     pub package: String,
     pub pool_id: String,
+    pub config_json: serde_json::Value,
     pub onchain_timestamp: i64,
 }
 

--- a/crates/schema/src/schema.rs
+++ b/crates/schema/src/schema.rs
@@ -451,6 +451,7 @@ diesel::table! {
         checkpoint_timestamp_ms -> Int8,
         package -> Text,
         pool_id -> Text,
+        config_json -> Jsonb,
         onchain_timestamp -> Int8,
     }
 }

--- a/crates/server/src/reader.rs
+++ b/crates/server/src/reader.rs
@@ -1710,7 +1710,7 @@ impl Reader {
         end_time: i64,
         limit: i64,
         pool_id_filter: Option<String>,
-    ) -> Result<Vec<(String, String, String, i64, i64, String, String, i64)>, DeepBookError> {
+    ) -> Result<Vec<(String, String, String, i64, i64, String, String, serde_json::Value, i64)>, DeepBookError> {
         let mut connection = self.db.connect().await?;
         let mut query = schema::deepbook_pool_registered::table
             .filter(
@@ -1726,6 +1726,7 @@ impl Reader {
                 schema::deepbook_pool_registered::checkpoint_timestamp_ms,
                 schema::deepbook_pool_registered::package,
                 schema::deepbook_pool_registered::pool_id,
+                schema::deepbook_pool_registered::config_json,
                 schema::deepbook_pool_registered::onchain_timestamp,
             ))
             .limit(limit)


### PR DESCRIPTION
- Add DeepbookPoolRegisteredV2 model in indexer with config field
- Update handler to process V2 events and serialize config to JSON
- Add config_json column to deepbook_pool_registered table schema
- Create database migration to add config_json JSONB column with GIN index
- Update server reader to include config_json in query response
- Handler now only processes V2 events (deprecated event ignored)


Will extend package version and add unit test to this draft MR once https://github.com/MystenLabs/deepbookv3/pull/680 as been merged