### PR TITLE
clean up indexer server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2129,6 +2129,8 @@ dependencies = [
 name = "deepbook-schema"
 version = "0.1.0"
 dependencies = [
+ "bigdecimal",
+ "chrono",
  "diesel",
  "diesel_migrations",
  "serde",

--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -14,3 +14,5 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 strum = "0.27.1"
 strum_macros = "0.27.1"
+bigdecimal = "0.4"
+chrono = "0.4"

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -13,8 +13,8 @@ use deepbook_schema::models::{
     AssetSupplied, AssetWithdrawn, BalancesSummary, DeepbookPoolConfigUpdated,
     DeepbookPoolRegistered, DeepbookPoolUpdated, DeepbookPoolUpdatedRegistry,
     InterestParamsUpdated, Liquidation, LoanBorrowed, LoanRepaid, MaintainerCapUpdated,
-    MaintainerFeesWithdrawn, MarginManagerCreated, MarginPoolConfigUpdated, MarginPoolCreated,
-    PauseCapUpdated, Pools, ProtocolFeesIncreasedEvent, ProtocolFeesWithdrawn,
+    MaintainerFeesWithdrawn, MarginManagerCreated, MarginManagerState, MarginPoolConfigUpdated,
+    MarginPoolCreated, PauseCapUpdated, Pools, ProtocolFeesIncreasedEvent, ProtocolFeesWithdrawn,
     ReferralFeesClaimedEvent, SupplierCapMinted, SupplyReferralMinted,
 };
 use deepbook_schema::*;
@@ -1689,10 +1689,7 @@ async fn margin_manager_created(
         .start_time()
         .unwrap_or_else(|| end_time - 24 * 60 * 60 * 1000);
     let limit = params.limit();
-    let margin_manager_id_filter = params
-        .get("margin_manager_id")
-        .cloned()
-        .unwrap_or_default();
+    let margin_manager_id_filter = params.get("margin_manager_id").cloned().unwrap_or_default();
 
     let results = state
         .reader
@@ -1711,10 +1708,7 @@ async fn loan_borrowed(
         .start_time()
         .unwrap_or_else(|| end_time - 24 * 60 * 60 * 1000);
     let limit = params.limit();
-    let margin_manager_id_filter = params
-        .get("margin_manager_id")
-        .cloned()
-        .unwrap_or_default();
+    let margin_manager_id_filter = params.get("margin_manager_id").cloned().unwrap_or_default();
     let margin_pool_id_filter = params.get("margin_pool_id").cloned().unwrap_or_default();
 
     let results = state
@@ -1740,10 +1734,7 @@ async fn loan_repaid(
         .start_time()
         .unwrap_or_else(|| end_time - 24 * 60 * 60 * 1000);
     let limit = params.limit();
-    let margin_manager_id_filter = params
-        .get("margin_manager_id")
-        .cloned()
-        .unwrap_or_default();
+    let margin_manager_id_filter = params.get("margin_manager_id").cloned().unwrap_or_default();
     let margin_pool_id_filter = params.get("margin_pool_id").cloned().unwrap_or_default();
 
     let results = state
@@ -2209,7 +2200,7 @@ async fn margin_managers_info(
 async fn margin_manager_states(
     Query(params): Query<HashMap<String, String>>,
     State(state): State<Arc<AppState>>,
-) -> Result<Json<Vec<serde_json::Value>>, DeepBookError> {
+) -> Result<Json<Vec<MarginManagerState>>, DeepBookError> {
     let max_risk_ratio = params
         .get("max_risk_ratio")
         .and_then(|v| v.parse::<f64>().ok());


### PR DESCRIPTION
Lot of boilerplate from boxed queries which run into issues with Diesel, refactoring so we don't need to manually construct the return objects everywhere

```
=== ENDPOINT COMPARISON: Local (localhost:9008) vs Production (deepbook-indexer.testnet.mystenlabs.com) ===

=== /assets ===

--- LOCAL ---
{
    "SUI": {
        "can_deposit": "true",
        "can_withdraw": "true",
        "asset_type": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
        "name": "Sui"
    },
    "DEEP": {
        "contractAddress": "0x36dbef866a1d62bf7328989a10fb2f07d769f4ee587c0de4a0a256e57e0a58a8",
        "asset_type": "0x6864a6f921804860930db6ddbe2e16acdf8504495ea7481637a1c8b9a8fe54b::deep::DEEP",
        "can_deposit": "true",
        "can_withdraw": "true",
        "name": "Deepbook Token"
    },
    "DBUSDC": {
        "name": "Deepbook USDC",
        "can_withdraw": "true",
        "asset_type": "0xdd1e6bce65c388a193e3f1b63cba7ba7be353ece5f91e00ec006e389ea851224::usdc::USDC",
        "can_deposit": "true",
        "contractAddress": "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7"
    },
    "DBUSDT": {
        "can_withdraw": "true",
        "asset_type": "0xd070e88e5c777b14e7f79ba51e1ea5da5b06e10f1e23f5ebf8fbbd7344491c46::usdt::USDT",
        "contractAddress": "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7",
        "name": "Deepbook USDT",
        "can_deposit": "true"
    },
    "WAL": {
        "name": "Walrus",
        "asset_type": "0xd10f518797ba1b960c3a1a52af0c09c0c3b96ae070d6e88a88e7e87e866e6c75::wal::WAL",
        "can_withdraw": "true",
        "contractAddress": "0x9ef7676a9f81937a52ae4b2af8d511a28a0b080477c0c2db40b0ab8882240d76",
        "can_deposit": "true"
    }
}

--- PRODUCTION ---
{
    "DBUSDT": {
        "asset_type": "0xd070e88e5c777b14e7f79ba51e1ea5da5b06e10f1e23f5ebf8fbbd7344491c46::usdt::USDT",
        "can_deposit": "true",
        "contractAddress": "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7",
        "name": "Deepbook USDT",
        "can_withdraw": "true"
    },
    "DBUSDC": {
        "name": "Deepbook USDC",
        "asset_type": "0xdd1e6bce65c388a193e3f1b63cba7ba7be353ece5f91e00ec006e389ea851224::usdc::USDC",
        "can_withdraw": "true",
        "can_deposit": "true",
        "contractAddress": "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7"
    },
    "SUI": {
        "name": "Sui",
        "asset_type": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
        "can_withdraw": "true",
        "can_deposit": "true"
    },
    "WAL": {
        "asset_type": "0xd10f518797ba1b960c3a1a52af0c09c0c3b96ae070d6e88a88e7e87e866e6c75::wal::WAL",
        "contractAddress": "0x9ef7676a9f81937a52ae4b2af8d511a28a0b080477c0c2db40b0ab8882240d76",
        "can_withdraw": "true",
        "name": "Walrus",
        "can_deposit": "true"
    },
    "DEEP": {
        "contractAddress": "0x36dbef866a1d62bf7328989a10fb2f07d769f4ee587c0de4a0a256e57e0a58a8",
        "can_withdraw": "true",
        "asset_type": "0x6864a6f921804860930db6ddbe2e16acdf8504495ea7481637a1c8b9a8fe54b::deep::DEEP",
        "can_deposit": "true",
        "name": "Deepbook Token"
    }
}


=== /get_pools ===

--- LOCAL ---
[
    {
        "pool_id": "0x48c95963e9eac37a316b7ae04a0deb761bcdcc2b67912374d6036e7f0e9bae9f",
        "pool_name": "DEEP_SUI",
        "base_asset_id": "0x36dbef866a1d62bf7328989a10fb2f07d769f4ee587c0de4a0a256e57e0a58a8::deep::DEEP",
        "base_asset_decimals": 6,
        "base_asset_symbol": "DEEP",
        "base_asset_name": "Deepbook Token",
        "quote_asset_id": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
        "quote_asset_decimals": 9,
        "quote_asset_symbol": "SUI",
        "quote_asset_name": "Sui",
        "min_size": 10000000,
        "lot_size": 1000000,
        "tick_size": 10000000
    },
    {
        "pool_id": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
        "pool_name": "SUI_DBUSDC",
        "base_asset_id": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
        "base_asset_decimals": 9,
        "base_asset_symbol": "SUI",
        "base_asset_name": "Sui",
        "quote_asset_id": "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
        "quote_asset_decimals": 6,
        "quote_asset_symbol": "DBUSDC",
        "quote_asset_name": "Deepbook USDC",
        "min_size": 1000000000,
        "lot_size": 100000000,
        "tick_size": 10
    },
    {
        "pool_id": "0xe86b991f8632217505fd859445f9803967ac84a9d4a1219065bf191fcb74b622",
        "pool_name": "DEEP_DBUSDC",
        "base_asset_id": "0x36dbef866a1d62bf7328989a10fb2f07d769f4ee587c0de4a0a256e57e0a58a8::deep::DEEP",
        "base_asset_decimals": 6,
        "base_asset_symbol": "DEEP",
        "base_asset_name": "Deepbook Token",
        "quote_asset_id": "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
        "quote_asset_decimals": 6,
        "quote_asset_symbol": "DBUSDC",
        "quote_asset_name": "Deepbook USDC",
        "min_size": 10000000,
        "lot_size": 1000000,
        "tick_size": 1000000
    },
    {
        "pool_id": "0x83970bb02e3636efdff8c141ab06af5e3c9a22e2f74d7f02a9c3430d0d10c1ca",
        "pool_name": "DBUSDT_DBUSDC",
        "base_asset_id": "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDT::DBUSDT",
        "base_asset_decimals": 6,
        "base_asset_symbol": "DBUSDT",
        "base_asset_name": "Deepbook USDT",
        "quote_asset_id": "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
        "quote_asset_decimals": 6,
        "quote_asset_symbol": "DBUSDC",
        "quote_asset_name": "Deepbook USDC",
        "min_size": 1000000,
        "lot_size": 100000,
        "tick_size": 1000000
    },
    {
        "pool_id": "0x8c1c1b186c4fddab1ebd53e0895a36c1d1b3b9a77cd34e607bef49a38af0150a",
        "pool_name": "WAL_SUI",
        "base_asset_id": "0x9ef7676a9f81937a52ae4b2af8d511a28a0b080477c0c2db40b0ab8882240d76::wal::WAL",
        "base_asset_decimals": 9,
        "base_asset_symbol": "WAL",
        "base_asset_name": "Walrus",
        "quote_asset_id": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
        "quote_asset_decimals": 9,
        "quote_asset_symbol": "SUI",
        "quote_asset_name": "Sui",
        "min_size": 1000000000,
        "lot_size": 100000000,
        "tick_size": 1000
    },
    {
        "pool_id": "0xeb524b6aea0ec4b494878582e0b78924208339d360b62aec4a8ecd4031520dbb",
        "pool_name": "WAL_DBUSDC",
        "base_asset_id": "0x9ef7676a9f81937a52ae4b2af8d511a28a0b080477c0c2db40b0ab8882240d76::wal::WAL",

--- PRODUCTION ---
[
    {
        "pool_id": "0x48c95963e9eac37a316b7ae04a0deb761bcdcc2b67912374d6036e7f0e9bae9f",
        "pool_name": "DEEP_SUI",
        "base_asset_id": "0x36dbef866a1d62bf7328989a10fb2f07d769f4ee587c0de4a0a256e57e0a58a8::deep::DEEP",
        "base_asset_decimals": 6,
        "base_asset_symbol": "DEEP",
        "base_asset_name": "Deepbook Token",
        "quote_asset_id": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
        "quote_asset_decimals": 9,
        "quote_asset_symbol": "SUI",
        "quote_asset_name": "Sui",
        "min_size": 10000000,
        "lot_size": 1000000,
        "tick_size": 10000000
    },
    {
        "pool_id": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
        "pool_name": "SUI_DBUSDC",
        "base_asset_id": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
        "base_asset_decimals": 9,
        "base_asset_symbol": "SUI",
        "base_asset_name": "Sui",
        "quote_asset_id": "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
        "quote_asset_decimals": 6,
        "quote_asset_symbol": "DBUSDC",
        "quote_asset_name": "Deepbook USDC",
        "min_size": 1000000000,
        "lot_size": 100000000,
        "tick_size": 10
    },
    {
        "pool_id": "0xe86b991f8632217505fd859445f9803967ac84a9d4a1219065bf191fcb74b622",
        "pool_name": "DEEP_DBUSDC",
        "base_asset_id": "0x36dbef866a1d62bf7328989a10fb2f07d769f4ee587c0de4a0a256e57e0a58a8::deep::DEEP",
        "base_asset_decimals": 6,
        "base_asset_symbol": "DEEP",
        "base_asset_name": "Deepbook Token",
        "quote_asset_id": "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
        "quote_asset_decimals": 6,
        "quote_asset_symbol": "DBUSDC",
        "quote_asset_name": "Deepbook USDC",
        "min_size": 10000000,
        "lot_size": 1000000,
        "tick_size": 1000000
    },
    {
        "pool_id": "0x83970bb02e3636efdff8c141ab06af5e3c9a22e2f74d7f02a9c3430d0d10c1ca",
        "pool_name": "DBUSDT_DBUSDC",
        "base_asset_id": "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDT::DBUSDT",
        "base_asset_decimals": 6,
        "base_asset_symbol": "DBUSDT",
        "base_asset_name": "Deepbook USDT",
        "quote_asset_id": "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
        "quote_asset_decimals": 6,
        "quote_asset_symbol": "DBUSDC",
        "quote_asset_name": "Deepbook USDC",
        "min_size": 1000000,
        "lot_size": 100000,
        "tick_size": 1000000
    },
    {
        "pool_id": "0x8c1c1b186c4fddab1ebd53e0895a36c1d1b3b9a77cd34e607bef49a38af0150a",
        "pool_name": "WAL_SUI",
        "base_asset_id": "0x9ef7676a9f81937a52ae4b2af8d511a28a0b080477c0c2db40b0ab8882240d76::wal::WAL",
        "base_asset_decimals": 9,
        "base_asset_symbol": "WAL",
        "base_asset_name": "Walrus",
        "quote_asset_id": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
        "quote_asset_decimals": 9,
        "quote_asset_symbol": "SUI",
        "quote_asset_name": "Sui",
        "min_size": 1000000000,
        "lot_size": 100000000,
        "tick_size": 1000
    },
    {
        "pool_id": "0xeb524b6aea0ec4b494878582e0b78924208339d360b62aec4a8ecd4031520dbb",
        "pool_name": "WAL_DBUSDC",
        "base_asset_id": "0x9ef7676a9f81937a52ae4b2af8d511a28a0b080477c0c2db40b0ab8882240d76::wal::WAL",
```