### PR TITLE
scripts: bump newDeepbookVersion to v7.0.0

### DIFF
--- a/scripts/transactions/newDeepbookVersion.ts
+++ b/scripts/transactions/newDeepbookVersion.ts
@@ -18,8 +18,8 @@ import { prepareMultisigTx } from "../utils/utils.js";
   const data = {
     repository: "https://github.com/MystenLabs/deepbookv3",
     packageInfo: deepbookPackageInfo,
-    sha: "v6.0.0",
-    version: "6",
+    sha: "v7.0.0",
+    version: "7",
     path: "packages/deepbook",
   };
 


### PR DESCRIPTION
## Summary
- Update `newDeepbookVersion.ts` to register MVR git versioning for deepbook core v7
- Bump `sha` from `v6.0.0` to `v7.0.0` and `version` from `6` to `7`

## Key decisions
- MVR `set_git_versioning` call points at the `v7.0.0` tag — make sure that tag exists on the repo before running this transaction

## Test plan
- [x] Confirm `v7.0.0` git tag exists on `MystenLabs/deepbookv3`
- [x] Dry-run/run `pnpm tsx transactions/newDeepbookVersion.ts` and verify the multisig tx output