### PR TITLE
feat(predict): add token bucket rate limiter for LP withdrawals

### DIFF
--- a/packages/predict/simulations/src/runtime.ts
+++ b/packages/predict/simulations/src/runtime.ts
@@ -100,6 +100,7 @@ export function createPredictTx(currencyId: string): Transaction {
       tx.object(ADMIN_CAP_ID),
       tx.object(currencyId),
       tx.object(PLP_TREASURY_CAP_ID),
+      tx.object(CLOCK_ID),
     ],
   });
   return tx;
@@ -225,7 +226,7 @@ export function supplyTx(predictId: string, amount: bigint): Transaction {
   const [plpCoin] = tx.moveCall({
     target: target("predict", "supply"),
     typeArguments: [DUSDC_TYPE],
-    arguments: [tx.object(predictId), dusdc],
+    arguments: [tx.object(predictId), dusdc, tx.object(CLOCK_ID)],
   });
   tx.transferObjects([plpCoin], tx.pure.address(address));
   return tx;

--- a/packages/predict/sources/helper/constants.move
+++ b/packages/predict/sources/helper/constants.move
@@ -63,3 +63,4 @@ public macro fun oracle_tick_size_unit(): u64 { 10_000 }
 
 /// Required decimals for all accepted quote assets in phase 1.
 public macro fun required_quote_decimals(): u8 { 6 }
+

--- a/packages/predict/sources/helper/rate_limiter.move
+++ b/packages/predict/sources/helper/rate_limiter.move
@@ -11,7 +11,6 @@
 /// https://github.com/code-423n4/2024-11-chainlink/blob/main/contracts/src/ccip/libraries/RateLimiter.sol
 module deepbook_predict::rate_limiter;
 
-use std::u128::min;
 use sui::clock::Clock;
 
 // === Errors ===
@@ -35,21 +34,49 @@ public struct RateLimiter has store {
     enabled: bool,
 }
 
+// === Public Functions ===
+
+public fun is_enabled(self: &RateLimiter): bool {
+    self.enabled
+}
+
+public fun capacity(self: &RateLimiter): u64 {
+    self.capacity
+}
+
+public fun refill_rate_per_ms(self: &RateLimiter): u64 {
+    self.refill_rate_per_ms
+}
+
+public fun available(self: &RateLimiter): u64 {
+    self.available
+}
+
+/// Returns the currently available withdrawal amount (read-only).
+public fun available_withdrawal(self: &RateLimiter, clock: &Clock): u64 {
+    if (!self.enabled) return std::u64::max_value!();
+
+    let elapsed = elapsed_ms(self.last_updated_ms, clock);
+    // u128 needed: elapsed (u64) * refill_rate_per_ms (u64) can overflow u64
+    // when large time gaps accumulate (e.g. 1M seconds × 16667 rate = 1.6e13,
+    // plus available up to 5e12, sum can approach u64::MAX).
+    let refill_amount = (elapsed as u128) * (self.refill_rate_per_ms as u128);
+    let new_available = (self.available as u128) + refill_amount;
+
+    new_available.min(self.capacity as u128) as u64
+}
+
 // === Public-Package Functions ===
 
-/// Create a new rate limiter. Starts with a full bucket.
-public(package) fun new(
-    capacity: u64,
-    refill_rate_per_ms: u64,
-    enabled: bool,
-    clock: &Clock,
-): RateLimiter {
+/// Create a new rate limiter. Starts disabled with zero capacity.
+/// Admin must call enable() and update_config() to activate.
+public(package) fun new(clock: &Clock): RateLimiter {
     RateLimiter {
-        available: capacity,
+        available: 0,
         last_updated_ms: clock.timestamp_ms(),
-        capacity,
-        refill_rate_per_ms,
-        enabled,
+        capacity: 0,
+        refill_rate_per_ms: 0,
+        enabled: false,
     }
 }
 
@@ -73,54 +100,38 @@ public(package) fun record_deposit(self: &mut RateLimiter, amount: u64, clock: &
 
     self.refill(clock);
 
+    // u128 needed: available (up to capacity, u64) + amount (u64) can overflow u64
+    // when a large deposit arrives on top of a nearly-full bucket.
     let new_available = (self.available as u128) + (amount as u128);
-    self.available = min(new_available, self.capacity as u128) as u64;
+    self.available = new_available.min(self.capacity as u128) as u64;
 }
 
-/// Returns the currently available withdrawal amount (read-only).
-public(package) fun available_withdrawal(self: &RateLimiter, clock: &Clock): u64 {
-    if (!self.enabled) return std::u64::max_value!();
-
-    let elapsed = elapsed_ms(self.last_updated_ms, clock);
-    let refill_amount = (elapsed as u128) * (self.refill_rate_per_ms as u128);
-    let new_available = (self.available as u128) + refill_amount;
-
-    min(new_available, self.capacity as u128) as u64
+/// Enable the rate limiter without changing capacity or rate.
+public(package) fun enable(self: &mut RateLimiter, clock: &Clock) {
+    self.refill(clock);
+    self.enabled = true;
 }
 
-/// Update configuration. Refills with the old rate first, then applies new config.
+/// Disable the rate limiter without changing capacity or rate.
+public(package) fun disable(self: &mut RateLimiter) {
+    self.enabled = false;
+}
+
+/// Update capacity and refill rate. Does not change the enabled flag.
 public(package) fun update_config(
     self: &mut RateLimiter,
     capacity: u64,
     refill_rate_per_ms: u64,
-    enabled: bool,
     clock: &Clock,
 ) {
-    if (enabled) {
-        assert!(refill_rate_per_ms > 0 && refill_rate_per_ms < capacity, EInvalidConfig);
-    };
+    assert!(refill_rate_per_ms > 0 && refill_rate_per_ms < capacity, EInvalidConfig);
 
     self.refill(clock);
     self.capacity = capacity;
     self.refill_rate_per_ms = refill_rate_per_ms;
-    self.enabled = enabled;
     if (self.available > capacity) {
         self.available = capacity;
     };
-}
-
-// === Public View Functions ===
-
-public fun is_enabled(self: &RateLimiter): bool {
-    self.enabled
-}
-
-public fun capacity(self: &RateLimiter): u64 {
-    self.capacity
-}
-
-public fun refill_rate_per_ms(self: &RateLimiter): u64 {
-    self.refill_rate_per_ms
 }
 
 // === Internal Functions ===
@@ -130,9 +141,10 @@ fun refill(self: &mut RateLimiter, clock: &Clock) {
     let elapsed = elapsed_ms(self.last_updated_ms, clock);
 
     if (elapsed > 0) {
+        // u128 needed: see available_withdrawal() comment for overflow reasoning.
         let refill_amount = (elapsed as u128) * (self.refill_rate_per_ms as u128);
         let new_available = (self.available as u128) + refill_amount;
-        self.available = min(new_available, self.capacity as u128) as u64;
+        self.available = new_available.min(self.capacity as u128) as u64;
         self.last_updated_ms = clock.timestamp_ms();
     }
 }
@@ -150,423 +162,22 @@ fun elapsed_ms(last_updated_ms: u64, clock: &Clock): u64 {
 // === Test-only Functions ===
 
 #[test_only]
-public fun available(self: &RateLimiter): u64 {
-    self.available
-}
-
-#[test_only]
-public fun last_updated_ms(self: &RateLimiter): u64 {
-    self.last_updated_ms
-}
-
-#[test_only]
 public fun destroy_for_testing(self: RateLimiter) {
     let RateLimiter { available: _, last_updated_ms: _, capacity: _, refill_rate_per_ms: _, enabled: _ } = self;
 }
 
-// === Tests ===
-//
-// Vault holds $10M. Withdrawal capacity = $5M (half of vault).
-// This tests edge cases where deposits exceed capacity, multiple
-// withdrawals drain the bucket, and refill/deposit interactions.
-
 #[test_only]
-const VAULT_SIZE: u64 = 10_000_000_000_000; // $10M
-#[test_only]
-const TEST_CAPACITY: u64 = 5_000_000_000_000; // $5M (half of vault)
-#[test_only]
-const TEST_RATE: u64 = 16_667; // ~$1M/min
-
-#[test_only]
-fun setup(): (RateLimiter, sui::clock::Clock) {
-    let ctx = &mut tx_context::dummy();
-    let clock = sui::clock::create_for_testing(ctx);
-    let limiter = new(TEST_CAPACITY, TEST_RATE, true, &clock);
-    (limiter, clock)
-}
-
-// --- Basic operations ---
-
-#[test]
-fun new_limiter_starts_full() {
-    let (limiter, clock) = setup();
-    assert!(limiter.available() == TEST_CAPACITY);
-    assert!(limiter.capacity() == TEST_CAPACITY);
-    assert!(limiter.refill_rate_per_ms() == TEST_RATE);
-    assert!(limiter.is_enabled());
-    limiter.destroy_for_testing();
-    clock.destroy_for_testing();
-}
-
-#[test]
-fun consume_reduces_available() {
-    let (mut limiter, clock) = setup();
-    let amount = 1_000_000_000_000; // $1M
-    limiter.consume(amount, &clock);
-    assert!(limiter.available() == TEST_CAPACITY - amount);
-    limiter.destroy_for_testing();
-    clock.destroy_for_testing();
-}
-
-#[test]
-fun consume_zero_is_noop() {
-    let (mut limiter, clock) = setup();
-    limiter.consume(0, &clock);
-    assert!(limiter.available() == TEST_CAPACITY);
-    limiter.destroy_for_testing();
-    clock.destroy_for_testing();
-}
-
-#[test]
-fun consume_entire_bucket() {
-    let (mut limiter, clock) = setup();
-    limiter.consume(TEST_CAPACITY, &clock);
-    assert!(limiter.available() == 0);
-    limiter.destroy_for_testing();
-    clock.destroy_for_testing();
-}
-
-#[test]
-fun disabled_limiter_allows_anything() {
-    let ctx = &mut tx_context::dummy();
-    let clock = sui::clock::create_for_testing(ctx);
-    let mut limiter = new(TEST_CAPACITY, TEST_RATE, false, &clock);
-    assert!(!limiter.is_enabled());
-    // Even VAULT_SIZE (2x capacity) should pass when disabled.
-    limiter.consume(VAULT_SIZE, &clock);
-    limiter.destroy_for_testing();
-    clock.destroy_for_testing();
-}
-
-// --- Abort cases ---
-
-#[test, expected_failure(abort_code = EInsufficientWithdrawalBudget)]
-fun consume_exceeds_available_aborts() {
-    let (mut limiter, clock) = setup();
-    limiter.consume(TEST_CAPACITY, &clock);
-    limiter.consume(1, &clock);
-    abort
-}
-
-#[test, expected_failure(abort_code = EExceedsCapacity)]
-fun consume_exceeds_capacity_aborts() {
-    let (mut limiter, clock) = setup();
-    // A single withdrawal of $5M + 1 exceeds max burst.
-    limiter.consume(TEST_CAPACITY + 1, &clock);
-    abort 999
-}
-
-#[test, expected_failure(abort_code = EExceedsCapacity)]
-fun single_withdrawal_of_full_vault_aborts() {
-    let (mut limiter, clock) = setup();
-    // Vault is $10M but capacity is $5M — can't withdraw it all at once.
-    limiter.consume(VAULT_SIZE, &clock);
-    abort 999
-}
-
-// --- Draining half the vault (capacity boundary) ---
-
-#[test]
-fun can_withdraw_exactly_half_vault() {
-    let (mut limiter, clock) = setup();
-    // Capacity = $5M = half of $10M vault. Should succeed.
-    limiter.consume(VAULT_SIZE / 2, &clock);
-    assert!(limiter.available() == 0);
-    limiter.destroy_for_testing();
-    clock.destroy_for_testing();
-}
-
-#[test]
-fun two_withdrawals_drain_bucket() {
-    let (mut limiter, clock) = setup();
-    let half_capacity = TEST_CAPACITY / 2; // $2.5M
-    limiter.consume(half_capacity, &clock);
-    assert!(limiter.available() == TEST_CAPACITY - half_capacity);
-    limiter.consume(half_capacity, &clock);
-    assert!(limiter.available() == TEST_CAPACITY - 2 * half_capacity);
-    limiter.destroy_for_testing();
-    clock.destroy_for_testing();
-}
-
-#[test, expected_failure(abort_code = EInsufficientWithdrawalBudget)]
-fun third_large_withdrawal_blocked_without_refill() {
-    let (mut limiter, clock) = setup();
-    let amount = 2_000_000_000_000; // $2M
-    limiter.consume(amount, &clock); // $3M left
-    limiter.consume(amount, &clock); // $1M left
-    limiter.consume(amount, &clock); // needs $2M, only $1M → abort
-    abort
-}
-
-// --- Refill behavior ---
-
-#[test]
-fun refill_after_drain() {
-    let (mut limiter, mut clock) = setup();
-    limiter.consume(TEST_CAPACITY, &clock);
-    assert!(limiter.available() == 0);
-    // Wait 60s → refill ~$1M
-    clock.increment_for_testing(60_000);
-    let expected_refill = 60_000 * TEST_RATE; // 1,000,020,000
-    limiter.consume(1, &clock); // trigger refill
-    assert!(limiter.available() == expected_refill - 1);
-    limiter.destroy_for_testing();
-    clock.destroy_for_testing();
-}
-
-#[test]
-fun refill_caps_at_capacity_not_vault_size() {
-    let (mut limiter, mut clock) = setup();
-    limiter.consume(1_000_000, &clock);
-    // Wait a very long time — refill should cap at $5M, not $10M.
-    clock.increment_for_testing(1_000_000_000);
-    limiter.consume(1, &clock);
-    assert!(limiter.available() == TEST_CAPACITY - 1);
-    limiter.destroy_for_testing();
-    clock.destroy_for_testing();
-}
-
-#[test]
-fun partial_refill_allows_partial_withdrawal() {
-    let (mut limiter, mut clock) = setup();
-    limiter.consume(TEST_CAPACITY, &clock);
-    // Wait 30s → refill ~$500k
-    clock.increment_for_testing(30_000);
-    let refilled = 30_000 * TEST_RATE;
-    limiter.consume(refilled, &clock);
-    assert!(limiter.available() == 0);
-    limiter.destroy_for_testing();
-    clock.destroy_for_testing();
-}
-
-#[test, expected_failure(abort_code = EInsufficientWithdrawalBudget)]
-fun partial_refill_rejects_larger_withdrawal() {
-    let (mut limiter, mut clock) = setup();
-    limiter.consume(TEST_CAPACITY, &clock);
-    clock.increment_for_testing(30_000);
-    let refilled = 30_000 * TEST_RATE;
-    limiter.consume(refilled + 1, &clock);
-    abort
-}
-
-#[test]
-fun full_refill_time_to_capacity() {
-    let (mut limiter, mut clock) = setup();
-    limiter.consume(TEST_CAPACITY, &clock);
-    // Time to fully refill = capacity / rate = 5_000_000_000_000 / 16_667 ≈ 299,988,001 ms (~5 min)
-    let refill_time = TEST_CAPACITY / TEST_RATE;
-    clock.increment_for_testing(refill_time);
-    let refilled = refill_time * TEST_RATE;
-    // May be slightly less than capacity due to integer division.
-    limiter.consume(1, &clock);
-    assert!(limiter.available() == refilled - 1);
-    limiter.destroy_for_testing();
-    clock.destroy_for_testing();
-}
-
-// --- Deposit interactions ---
-
-#[test]
-fun deposit_replenishes_after_withdrawal() {
-    let (mut limiter, clock) = setup();
-    limiter.consume(3_000_000_000_000, &clock); // withdraw $3M → $2M left
-    assert!(limiter.available() == 2_000_000_000_000);
-    // Deposit $3M → should restore to capacity ($5M), not $5M + deposited
-    limiter.record_deposit(3_000_000_000_000, &clock);
-    assert!(limiter.available() == TEST_CAPACITY);
-    limiter.destroy_for_testing();
-    clock.destroy_for_testing();
-}
-
-#[test]
-fun deposit_larger_than_capacity_caps() {
-    let (mut limiter, clock) = setup();
-    // Deposit $10M (full vault size) — should cap at $5M capacity.
-    limiter.record_deposit(VAULT_SIZE, &clock);
-    assert!(limiter.available() == TEST_CAPACITY);
-    limiter.destroy_for_testing();
-    clock.destroy_for_testing();
-}
-
-#[test]
-fun deposit_after_full_drain_partial_restore() {
-    let (mut limiter, clock) = setup();
-    limiter.consume(TEST_CAPACITY, &clock);
-    assert!(limiter.available() == 0);
-    // Small deposit — doesn't reach capacity.
-    let deposit = 1_000_000_000_000; // $1M
-    limiter.record_deposit(deposit, &clock);
-    assert!(limiter.available() == deposit);
-    limiter.destroy_for_testing();
-    clock.destroy_for_testing();
-}
-
-#[test]
-fun deposit_plus_refill_interaction() {
-    let (mut limiter, mut clock) = setup();
-    limiter.consume(TEST_CAPACITY, &clock); // drain to 0
-    clock.increment_for_testing(30_000); // 30s → ~$500k refill
-    // Deposit $2M — refill happens first, then deposit adds on top.
-    let deposit = 2_000_000_000_000;
-    limiter.record_deposit(deposit, &clock);
-    let refilled = 30_000 * TEST_RATE;
-    let expected = refilled + deposit; // should not exceed capacity
-    assert!(limiter.available() == expected);
-    limiter.destroy_for_testing();
-    clock.destroy_for_testing();
-}
-
-#[test]
-fun deposit_plus_refill_caps_at_capacity() {
-    let (mut limiter, mut clock) = setup();
-    limiter.consume(1_000_000_000_000, &clock); // withdraw $1M → $4M left
-    clock.increment_for_testing(120_000); // 2 min → refills ~$2M → caps at $5M
-    // Deposit $3M on top — still caps at $5M.
-    limiter.record_deposit(3_000_000_000_000, &clock);
-    assert!(limiter.available() == TEST_CAPACITY);
-    limiter.destroy_for_testing();
-    clock.destroy_for_testing();
-}
-
-// --- Withdraw-deposit-withdraw cycle ---
-
-#[test]
-fun withdraw_deposit_withdraw_cycle() {
-    let (mut limiter, clock) = setup();
-    // Withdraw $4M → $1M left
-    limiter.consume(4_000_000_000_000, &clock);
-    assert!(limiter.available() == 1_000_000_000_000);
-    // Deposit $2M → $3M available
-    limiter.record_deposit(2_000_000_000_000, &clock);
-    assert!(limiter.available() == 3_000_000_000_000);
-    // Withdraw $3M → $0 left
-    limiter.consume(3_000_000_000_000, &clock);
-    assert!(limiter.available() == 0);
-    limiter.destroy_for_testing();
-    clock.destroy_for_testing();
-}
-
-#[test, expected_failure(abort_code = EInsufficientWithdrawalBudget)]
-fun withdraw_deposit_withdraw_exceeds() {
-    let (mut limiter, clock) = setup();
-    limiter.consume(4_000_000_000_000, &clock); // $1M left
-    limiter.record_deposit(2_000_000_000_000, &clock); // $3M available
-    limiter.consume(3_000_000_000_000, &clock); // $0 left
-    limiter.consume(1, &clock); // nothing left → abort
-    abort
-}
-
-// --- Available withdrawal (read-only) ---
-
-#[test]
-fun available_withdrawal_reflects_refill() {
-    let (mut limiter, mut clock) = setup();
-    limiter.consume(TEST_CAPACITY, &clock);
-    clock.increment_for_testing(60_000);
-    let expected = 60_000 * TEST_RATE;
-    // Read-only — should not modify state.
-    assert!(limiter.available_withdrawal(&clock) == expected);
-    assert!(limiter.available() == 0); // internal state unchanged
-    limiter.destroy_for_testing();
-    clock.destroy_for_testing();
-}
-
-#[test]
-fun available_withdrawal_when_disabled_returns_max() {
-    let ctx = &mut tx_context::dummy();
-    let clock = sui::clock::create_for_testing(ctx);
-    let limiter = new(TEST_CAPACITY, TEST_RATE, false, &clock);
-    assert!(limiter.available_withdrawal(&clock) == std::u64::max_value!());
-    limiter.destroy_for_testing();
-    clock.destroy_for_testing();
-}
-
-// --- Config updates ---
-
-#[test]
-fun update_config_preserves_refilled_tokens() {
-    let (mut limiter, mut clock) = setup();
-    limiter.consume(TEST_CAPACITY, &clock);
-    clock.increment_for_testing(60_000);
-    let old_refill = 60_000 * TEST_RATE;
-    let new_capacity = 10_000_000_000_000; // $10M
-    let new_rate = 33_334;
-    limiter.update_config(new_capacity, new_rate, true, &clock);
-    assert!(limiter.available() == old_refill);
-    assert!(limiter.capacity() == new_capacity);
-    assert!(limiter.refill_rate_per_ms() == new_rate);
-    limiter.destroy_for_testing();
-    clock.destroy_for_testing();
-}
-
-#[test]
-fun update_config_shrink_capacity_caps_available() {
-    let (mut limiter, clock) = setup();
-    // Bucket is full at $5M. Shrink capacity to $2M.
-    let smaller = 2_000_000_000_000;
-    limiter.update_config(smaller, TEST_RATE, true, &clock);
-    assert!(limiter.available() == smaller);
-    limiter.destroy_for_testing();
-    clock.destroy_for_testing();
-}
-
-#[test, expected_failure(abort_code = EInvalidConfig)]
-fun update_config_rate_exceeds_capacity_aborts() {
-    let (mut limiter, clock) = setup();
-    limiter.update_config(100, 100, true, &clock);
-    abort
-}
-
-#[test, expected_failure(abort_code = EInvalidConfig)]
-fun update_config_zero_rate_when_enabled_aborts() {
-    let (mut limiter, clock) = setup();
-    limiter.update_config(TEST_CAPACITY, 0, true, &clock);
-    abort
-}
-
-#[test]
-fun update_config_disable_allows_zero() {
-    let (mut limiter, clock) = setup();
-    limiter.update_config(0, 0, false, &clock);
-    assert!(!limiter.is_enabled());
-    limiter.destroy_for_testing();
-    clock.destroy_for_testing();
-}
-
-// --- Rapid cycle ---
-
-#[test]
-fun rapid_withdraw_refill_cycle() {
-    let (mut limiter, mut clock) = setup();
-    let amount = 1_000_000_000_000; // $1M per withdrawal
-    // 5 withdrawals with 10s gaps between them.
-    limiter.consume(amount, &clock);
-    clock.increment_for_testing(10_000);
-    limiter.consume(amount, &clock);
-    clock.increment_for_testing(10_000);
-    limiter.consume(amount, &clock);
-    clock.increment_for_testing(10_000);
-    limiter.consume(amount, &clock);
-    clock.increment_for_testing(10_000);
-    limiter.consume(amount, &clock);
-    // 5 × $1M consumed, 4 × 10s × RATE refilled.
-    let total_consumed = 5 * amount;
-    let total_refilled = 4 * 10_000 * TEST_RATE;
-    assert!(limiter.available() == TEST_CAPACITY - total_consumed + total_refilled);
-    limiter.destroy_for_testing();
-    clock.destroy_for_testing();
-}
-
-#[test, expected_failure(abort_code = EInsufficientWithdrawalBudget)]
-fun rapid_withdrawals_eventually_blocked() {
-    let (mut limiter, mut clock) = setup();
-    let amount = 2_000_000_000_000; // $2M per withdrawal
-    // $2M withdrawals with only 10s refill (~$166k) between.
-    limiter.consume(amount, &clock); // $3M left
-    clock.increment_for_testing(10_000);
-    limiter.consume(amount, &clock); // ~$1.17M left
-    clock.increment_for_testing(10_000);
-    // ~$1.33M available, need $2M → abort
-    limiter.consume(amount, &clock);
-    abort
+public fun new_for_testing(
+    capacity: u64,
+    refill_rate_per_ms: u64,
+    enabled: bool,
+    clock: &Clock,
+): RateLimiter {
+    RateLimiter {
+        available: capacity,
+        last_updated_ms: clock.timestamp_ms(),
+        capacity,
+        refill_rate_per_ms,
+        enabled,
+    }
 }

--- a/packages/predict/sources/helper/rate_limiter.move
+++ b/packages/predict/sources/helper/rate_limiter.move
@@ -34,26 +34,26 @@ public struct RateLimiter has store {
     enabled: bool,
 }
 
-// === Public Functions ===
+// === Public-Package View Functions ===
 
-public fun is_enabled(self: &RateLimiter): bool {
+public(package) fun is_enabled(self: &RateLimiter): bool {
     self.enabled
 }
 
-public fun capacity(self: &RateLimiter): u64 {
+public(package) fun capacity(self: &RateLimiter): u64 {
     self.capacity
 }
 
-public fun refill_rate_per_ms(self: &RateLimiter): u64 {
+public(package) fun refill_rate_per_ms(self: &RateLimiter): u64 {
     self.refill_rate_per_ms
 }
 
-public fun available(self: &RateLimiter): u64 {
+public(package) fun available(self: &RateLimiter): u64 {
     self.available
 }
 
 /// Returns the currently available withdrawal amount (read-only).
-public fun available_withdrawal(self: &RateLimiter, clock: &Clock): u64 {
+public(package) fun available_withdrawal(self: &RateLimiter, clock: &Clock): u64 {
     if (!self.enabled) return std::u64::max_value!();
 
     let elapsed = elapsed_ms(self.last_updated_ms, clock);

--- a/packages/predict/sources/helper/rate_limiter.move
+++ b/packages/predict/sources/helper/rate_limiter.move
@@ -1,0 +1,572 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Token bucket rate limiter for controlling LP withdrawal rates.
+///
+/// Prevents rapid vault drain by limiting how much can be withdrawn over time.
+/// The bucket refills continuously at a configurable rate, and each withdrawal
+/// consumes tokens from the bucket.
+///
+/// Reference: Chainlink CCIP RateLimiter
+/// https://github.com/code-423n4/2024-11-chainlink/blob/main/contracts/src/ccip/libraries/RateLimiter.sol
+module deepbook_predict::rate_limiter;
+
+use std::u128::min;
+use sui::clock::Clock;
+
+// === Errors ===
+
+const EExceedsCapacity: u64 = 0;
+const EInsufficientWithdrawalBudget: u64 = 1;
+const EInvalidConfig: u64 = 2;
+
+// === Structs ===
+
+public struct RateLimiter has store {
+    /// Current available tokens in the bucket.
+    available: u64,
+    /// Timestamp of the last refill (milliseconds).
+    last_updated_ms: u64,
+    /// Maximum burst capacity — single withdrawal cannot exceed this.
+    capacity: u64,
+    /// Tokens restored per millisecond.
+    refill_rate_per_ms: u64,
+    /// Whether the rate limiter is active.
+    enabled: bool,
+}
+
+// === Public-Package Functions ===
+
+/// Create a new rate limiter. Starts with a full bucket.
+public(package) fun new(
+    capacity: u64,
+    refill_rate_per_ms: u64,
+    enabled: bool,
+    clock: &Clock,
+): RateLimiter {
+    RateLimiter {
+        available: capacity,
+        last_updated_ms: clock.timestamp_ms(),
+        capacity,
+        refill_rate_per_ms,
+        enabled,
+    }
+}
+
+/// Attempt to consume `amount` from the bucket. Aborts if rate limited.
+public(package) fun consume(self: &mut RateLimiter, amount: u64, clock: &Clock) {
+    if (!self.enabled || amount == 0) return;
+
+    self.refill(clock);
+
+    assert!(amount <= self.capacity, EExceedsCapacity);
+    assert!(amount <= self.available, EInsufficientWithdrawalBudget);
+
+    self.available = self.available - amount;
+}
+
+/// Record a deposit — increases available tokens (capped at capacity).
+/// This allows deposits to partially replenish the withdrawal budget,
+/// preventing the limiter from blocking withdrawals after heavy inflows.
+public(package) fun record_deposit(self: &mut RateLimiter, amount: u64, clock: &Clock) {
+    if (!self.enabled) return;
+
+    self.refill(clock);
+
+    let new_available = (self.available as u128) + (amount as u128);
+    self.available = min(new_available, self.capacity as u128) as u64;
+}
+
+/// Returns the currently available withdrawal amount (read-only).
+public(package) fun available_withdrawal(self: &RateLimiter, clock: &Clock): u64 {
+    if (!self.enabled) return std::u64::max_value!();
+
+    let elapsed = elapsed_ms(self.last_updated_ms, clock);
+    let refill_amount = (elapsed as u128) * (self.refill_rate_per_ms as u128);
+    let new_available = (self.available as u128) + refill_amount;
+
+    min(new_available, self.capacity as u128) as u64
+}
+
+/// Update configuration. Refills with the old rate first, then applies new config.
+public(package) fun update_config(
+    self: &mut RateLimiter,
+    capacity: u64,
+    refill_rate_per_ms: u64,
+    enabled: bool,
+    clock: &Clock,
+) {
+    if (enabled) {
+        assert!(refill_rate_per_ms > 0 && refill_rate_per_ms < capacity, EInvalidConfig);
+    };
+
+    self.refill(clock);
+    self.capacity = capacity;
+    self.refill_rate_per_ms = refill_rate_per_ms;
+    self.enabled = enabled;
+    if (self.available > capacity) {
+        self.available = capacity;
+    };
+}
+
+// === Public View Functions ===
+
+public fun is_enabled(self: &RateLimiter): bool {
+    self.enabled
+}
+
+public fun capacity(self: &RateLimiter): u64 {
+    self.capacity
+}
+
+public fun refill_rate_per_ms(self: &RateLimiter): u64 {
+    self.refill_rate_per_ms
+}
+
+// === Internal Functions ===
+
+/// Refill the bucket based on time elapsed since last update.
+fun refill(self: &mut RateLimiter, clock: &Clock) {
+    let elapsed = elapsed_ms(self.last_updated_ms, clock);
+
+    if (elapsed > 0) {
+        let refill_amount = (elapsed as u128) * (self.refill_rate_per_ms as u128);
+        let new_available = (self.available as u128) + refill_amount;
+        self.available = min(new_available, self.capacity as u128) as u64;
+        self.last_updated_ms = clock.timestamp_ms();
+    }
+}
+
+/// Safe elapsed time calculation (handles clock edge cases).
+fun elapsed_ms(last_updated_ms: u64, clock: &Clock): u64 {
+    let current_time = clock.timestamp_ms();
+    if (current_time > last_updated_ms) {
+        current_time - last_updated_ms
+    } else {
+        0
+    }
+}
+
+// === Test-only Functions ===
+
+#[test_only]
+public fun available(self: &RateLimiter): u64 {
+    self.available
+}
+
+#[test_only]
+public fun last_updated_ms(self: &RateLimiter): u64 {
+    self.last_updated_ms
+}
+
+#[test_only]
+public fun destroy_for_testing(self: RateLimiter) {
+    let RateLimiter { available: _, last_updated_ms: _, capacity: _, refill_rate_per_ms: _, enabled: _ } = self;
+}
+
+// === Tests ===
+//
+// Vault holds $10M. Withdrawal capacity = $5M (half of vault).
+// This tests edge cases where deposits exceed capacity, multiple
+// withdrawals drain the bucket, and refill/deposit interactions.
+
+#[test_only]
+const VAULT_SIZE: u64 = 10_000_000_000_000; // $10M
+#[test_only]
+const TEST_CAPACITY: u64 = 5_000_000_000_000; // $5M (half of vault)
+#[test_only]
+const TEST_RATE: u64 = 16_667; // ~$1M/min
+
+#[test_only]
+fun setup(): (RateLimiter, sui::clock::Clock) {
+    let ctx = &mut tx_context::dummy();
+    let clock = sui::clock::create_for_testing(ctx);
+    let limiter = new(TEST_CAPACITY, TEST_RATE, true, &clock);
+    (limiter, clock)
+}
+
+// --- Basic operations ---
+
+#[test]
+fun new_limiter_starts_full() {
+    let (limiter, clock) = setup();
+    assert!(limiter.available() == TEST_CAPACITY);
+    assert!(limiter.capacity() == TEST_CAPACITY);
+    assert!(limiter.refill_rate_per_ms() == TEST_RATE);
+    assert!(limiter.is_enabled());
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun consume_reduces_available() {
+    let (mut limiter, clock) = setup();
+    let amount = 1_000_000_000_000; // $1M
+    limiter.consume(amount, &clock);
+    assert!(limiter.available() == TEST_CAPACITY - amount);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun consume_zero_is_noop() {
+    let (mut limiter, clock) = setup();
+    limiter.consume(0, &clock);
+    assert!(limiter.available() == TEST_CAPACITY);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun consume_entire_bucket() {
+    let (mut limiter, clock) = setup();
+    limiter.consume(TEST_CAPACITY, &clock);
+    assert!(limiter.available() == 0);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun disabled_limiter_allows_anything() {
+    let ctx = &mut tx_context::dummy();
+    let clock = sui::clock::create_for_testing(ctx);
+    let mut limiter = new(TEST_CAPACITY, TEST_RATE, false, &clock);
+    assert!(!limiter.is_enabled());
+    // Even VAULT_SIZE (2x capacity) should pass when disabled.
+    limiter.consume(VAULT_SIZE, &clock);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+// --- Abort cases ---
+
+#[test, expected_failure(abort_code = EInsufficientWithdrawalBudget)]
+fun consume_exceeds_available_aborts() {
+    let (mut limiter, clock) = setup();
+    limiter.consume(TEST_CAPACITY, &clock);
+    limiter.consume(1, &clock);
+    abort
+}
+
+#[test, expected_failure(abort_code = EExceedsCapacity)]
+fun consume_exceeds_capacity_aborts() {
+    let (mut limiter, clock) = setup();
+    // A single withdrawal of $5M + 1 exceeds max burst.
+    limiter.consume(TEST_CAPACITY + 1, &clock);
+    abort 999
+}
+
+#[test, expected_failure(abort_code = EExceedsCapacity)]
+fun single_withdrawal_of_full_vault_aborts() {
+    let (mut limiter, clock) = setup();
+    // Vault is $10M but capacity is $5M — can't withdraw it all at once.
+    limiter.consume(VAULT_SIZE, &clock);
+    abort 999
+}
+
+// --- Draining half the vault (capacity boundary) ---
+
+#[test]
+fun can_withdraw_exactly_half_vault() {
+    let (mut limiter, clock) = setup();
+    // Capacity = $5M = half of $10M vault. Should succeed.
+    limiter.consume(VAULT_SIZE / 2, &clock);
+    assert!(limiter.available() == 0);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun two_withdrawals_drain_bucket() {
+    let (mut limiter, clock) = setup();
+    let half_capacity = TEST_CAPACITY / 2; // $2.5M
+    limiter.consume(half_capacity, &clock);
+    assert!(limiter.available() == TEST_CAPACITY - half_capacity);
+    limiter.consume(half_capacity, &clock);
+    assert!(limiter.available() == TEST_CAPACITY - 2 * half_capacity);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test, expected_failure(abort_code = EInsufficientWithdrawalBudget)]
+fun third_large_withdrawal_blocked_without_refill() {
+    let (mut limiter, clock) = setup();
+    let amount = 2_000_000_000_000; // $2M
+    limiter.consume(amount, &clock); // $3M left
+    limiter.consume(amount, &clock); // $1M left
+    limiter.consume(amount, &clock); // needs $2M, only $1M → abort
+    abort
+}
+
+// --- Refill behavior ---
+
+#[test]
+fun refill_after_drain() {
+    let (mut limiter, mut clock) = setup();
+    limiter.consume(TEST_CAPACITY, &clock);
+    assert!(limiter.available() == 0);
+    // Wait 60s → refill ~$1M
+    clock.increment_for_testing(60_000);
+    let expected_refill = 60_000 * TEST_RATE; // 1,000,020,000
+    limiter.consume(1, &clock); // trigger refill
+    assert!(limiter.available() == expected_refill - 1);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun refill_caps_at_capacity_not_vault_size() {
+    let (mut limiter, mut clock) = setup();
+    limiter.consume(1_000_000, &clock);
+    // Wait a very long time — refill should cap at $5M, not $10M.
+    clock.increment_for_testing(1_000_000_000);
+    limiter.consume(1, &clock);
+    assert!(limiter.available() == TEST_CAPACITY - 1);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun partial_refill_allows_partial_withdrawal() {
+    let (mut limiter, mut clock) = setup();
+    limiter.consume(TEST_CAPACITY, &clock);
+    // Wait 30s → refill ~$500k
+    clock.increment_for_testing(30_000);
+    let refilled = 30_000 * TEST_RATE;
+    limiter.consume(refilled, &clock);
+    assert!(limiter.available() == 0);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test, expected_failure(abort_code = EInsufficientWithdrawalBudget)]
+fun partial_refill_rejects_larger_withdrawal() {
+    let (mut limiter, mut clock) = setup();
+    limiter.consume(TEST_CAPACITY, &clock);
+    clock.increment_for_testing(30_000);
+    let refilled = 30_000 * TEST_RATE;
+    limiter.consume(refilled + 1, &clock);
+    abort
+}
+
+#[test]
+fun full_refill_time_to_capacity() {
+    let (mut limiter, mut clock) = setup();
+    limiter.consume(TEST_CAPACITY, &clock);
+    // Time to fully refill = capacity / rate = 5_000_000_000_000 / 16_667 ≈ 299,988,001 ms (~5 min)
+    let refill_time = TEST_CAPACITY / TEST_RATE;
+    clock.increment_for_testing(refill_time);
+    let refilled = refill_time * TEST_RATE;
+    // May be slightly less than capacity due to integer division.
+    limiter.consume(1, &clock);
+    assert!(limiter.available() == refilled - 1);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+// --- Deposit interactions ---
+
+#[test]
+fun deposit_replenishes_after_withdrawal() {
+    let (mut limiter, clock) = setup();
+    limiter.consume(3_000_000_000_000, &clock); // withdraw $3M → $2M left
+    assert!(limiter.available() == 2_000_000_000_000);
+    // Deposit $3M → should restore to capacity ($5M), not $5M + deposited
+    limiter.record_deposit(3_000_000_000_000, &clock);
+    assert!(limiter.available() == TEST_CAPACITY);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun deposit_larger_than_capacity_caps() {
+    let (mut limiter, clock) = setup();
+    // Deposit $10M (full vault size) — should cap at $5M capacity.
+    limiter.record_deposit(VAULT_SIZE, &clock);
+    assert!(limiter.available() == TEST_CAPACITY);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun deposit_after_full_drain_partial_restore() {
+    let (mut limiter, clock) = setup();
+    limiter.consume(TEST_CAPACITY, &clock);
+    assert!(limiter.available() == 0);
+    // Small deposit — doesn't reach capacity.
+    let deposit = 1_000_000_000_000; // $1M
+    limiter.record_deposit(deposit, &clock);
+    assert!(limiter.available() == deposit);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun deposit_plus_refill_interaction() {
+    let (mut limiter, mut clock) = setup();
+    limiter.consume(TEST_CAPACITY, &clock); // drain to 0
+    clock.increment_for_testing(30_000); // 30s → ~$500k refill
+    // Deposit $2M — refill happens first, then deposit adds on top.
+    let deposit = 2_000_000_000_000;
+    limiter.record_deposit(deposit, &clock);
+    let refilled = 30_000 * TEST_RATE;
+    let expected = refilled + deposit; // should not exceed capacity
+    assert!(limiter.available() == expected);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun deposit_plus_refill_caps_at_capacity() {
+    let (mut limiter, mut clock) = setup();
+    limiter.consume(1_000_000_000_000, &clock); // withdraw $1M → $4M left
+    clock.increment_for_testing(120_000); // 2 min → refills ~$2M → caps at $5M
+    // Deposit $3M on top — still caps at $5M.
+    limiter.record_deposit(3_000_000_000_000, &clock);
+    assert!(limiter.available() == TEST_CAPACITY);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+// --- Withdraw-deposit-withdraw cycle ---
+
+#[test]
+fun withdraw_deposit_withdraw_cycle() {
+    let (mut limiter, clock) = setup();
+    // Withdraw $4M → $1M left
+    limiter.consume(4_000_000_000_000, &clock);
+    assert!(limiter.available() == 1_000_000_000_000);
+    // Deposit $2M → $3M available
+    limiter.record_deposit(2_000_000_000_000, &clock);
+    assert!(limiter.available() == 3_000_000_000_000);
+    // Withdraw $3M → $0 left
+    limiter.consume(3_000_000_000_000, &clock);
+    assert!(limiter.available() == 0);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test, expected_failure(abort_code = EInsufficientWithdrawalBudget)]
+fun withdraw_deposit_withdraw_exceeds() {
+    let (mut limiter, clock) = setup();
+    limiter.consume(4_000_000_000_000, &clock); // $1M left
+    limiter.record_deposit(2_000_000_000_000, &clock); // $3M available
+    limiter.consume(3_000_000_000_000, &clock); // $0 left
+    limiter.consume(1, &clock); // nothing left → abort
+    abort
+}
+
+// --- Available withdrawal (read-only) ---
+
+#[test]
+fun available_withdrawal_reflects_refill() {
+    let (mut limiter, mut clock) = setup();
+    limiter.consume(TEST_CAPACITY, &clock);
+    clock.increment_for_testing(60_000);
+    let expected = 60_000 * TEST_RATE;
+    // Read-only — should not modify state.
+    assert!(limiter.available_withdrawal(&clock) == expected);
+    assert!(limiter.available() == 0); // internal state unchanged
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun available_withdrawal_when_disabled_returns_max() {
+    let ctx = &mut tx_context::dummy();
+    let clock = sui::clock::create_for_testing(ctx);
+    let limiter = new(TEST_CAPACITY, TEST_RATE, false, &clock);
+    assert!(limiter.available_withdrawal(&clock) == std::u64::max_value!());
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+// --- Config updates ---
+
+#[test]
+fun update_config_preserves_refilled_tokens() {
+    let (mut limiter, mut clock) = setup();
+    limiter.consume(TEST_CAPACITY, &clock);
+    clock.increment_for_testing(60_000);
+    let old_refill = 60_000 * TEST_RATE;
+    let new_capacity = 10_000_000_000_000; // $10M
+    let new_rate = 33_334;
+    limiter.update_config(new_capacity, new_rate, true, &clock);
+    assert!(limiter.available() == old_refill);
+    assert!(limiter.capacity() == new_capacity);
+    assert!(limiter.refill_rate_per_ms() == new_rate);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun update_config_shrink_capacity_caps_available() {
+    let (mut limiter, clock) = setup();
+    // Bucket is full at $5M. Shrink capacity to $2M.
+    let smaller = 2_000_000_000_000;
+    limiter.update_config(smaller, TEST_RATE, true, &clock);
+    assert!(limiter.available() == smaller);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test, expected_failure(abort_code = EInvalidConfig)]
+fun update_config_rate_exceeds_capacity_aborts() {
+    let (mut limiter, clock) = setup();
+    limiter.update_config(100, 100, true, &clock);
+    abort
+}
+
+#[test, expected_failure(abort_code = EInvalidConfig)]
+fun update_config_zero_rate_when_enabled_aborts() {
+    let (mut limiter, clock) = setup();
+    limiter.update_config(TEST_CAPACITY, 0, true, &clock);
+    abort
+}
+
+#[test]
+fun update_config_disable_allows_zero() {
+    let (mut limiter, clock) = setup();
+    limiter.update_config(0, 0, false, &clock);
+    assert!(!limiter.is_enabled());
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+// --- Rapid cycle ---
+
+#[test]
+fun rapid_withdraw_refill_cycle() {
+    let (mut limiter, mut clock) = setup();
+    let amount = 1_000_000_000_000; // $1M per withdrawal
+    // 5 withdrawals with 10s gaps between them.
+    limiter.consume(amount, &clock);
+    clock.increment_for_testing(10_000);
+    limiter.consume(amount, &clock);
+    clock.increment_for_testing(10_000);
+    limiter.consume(amount, &clock);
+    clock.increment_for_testing(10_000);
+    limiter.consume(amount, &clock);
+    clock.increment_for_testing(10_000);
+    limiter.consume(amount, &clock);
+    // 5 × $1M consumed, 4 × 10s × RATE refilled.
+    let total_consumed = 5 * amount;
+    let total_refilled = 4 * 10_000 * TEST_RATE;
+    assert!(limiter.available() == TEST_CAPACITY - total_consumed + total_refilled);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test, expected_failure(abort_code = EInsufficientWithdrawalBudget)]
+fun rapid_withdrawals_eventually_blocked() {
+    let (mut limiter, mut clock) = setup();
+    let amount = 2_000_000_000_000; // $2M per withdrawal
+    // $2M withdrawals with only 10s refill (~$166k) between.
+    limiter.consume(amount, &clock); // $3M left
+    clock.increment_for_testing(10_000);
+    limiter.consume(amount, &clock); // ~$1.17M left
+    clock.increment_for_testing(10_000);
+    // ~$1.33M available, need $2M → abort
+    limiter.consume(amount, &clock);
+    abort
+}

--- a/packages/predict/sources/helper/rate_limiter.move
+++ b/packages/predict/sources/helper/rate_limiter.move
@@ -106,8 +106,9 @@ public(package) fun record_deposit(self: &mut RateLimiter, amount: u64, clock: &
     self.available = new_available.min(self.capacity as u128) as u64;
 }
 
-/// Enable the rate limiter without changing capacity or rate.
+/// Enable the rate limiter. Requires capacity and rate to be configured first.
 public(package) fun enable(self: &mut RateLimiter, clock: &Clock) {
+    assert!(self.refill_rate_per_ms > 0 && self.refill_rate_per_ms < self.capacity, EInvalidConfig);
     self.refill(clock);
     self.enabled = true;
 }

--- a/packages/predict/sources/predict.move
+++ b/packages/predict/sources/predict.move
@@ -19,6 +19,7 @@ use deepbook_predict::{
     predict_manager::{Self, PredictManager},
     pricing_config::{Self, PricingConfig},
     range_key::RangeKey,
+    rate_limiter::{Self, RateLimiter},
     risk_config::{Self, RiskConfig},
     treasury_config::{Self, TreasuryConfig},
     vault::{Self, Vault}
@@ -184,6 +185,8 @@ public struct Predict has key {
     treasury_config: TreasuryConfig,
     /// Oracle strike grid registry, operational checks, and curve builder
     oracle_config: OracleConfig,
+    /// Rate limiter for LP withdrawals
+    withdrawal_limiter: RateLimiter,
     /// Whether trading (mint) is globally paused
     trading_paused: bool,
 }
@@ -421,13 +424,19 @@ public fun redeem_range<Quote>(
 /// First depositor gets shares 1:1. Subsequent depositors get shares
 /// proportional to their deposit relative to current vault value.
 /// Supply an enabled quote asset into the shared LP pool.
-public fun supply<Quote>(predict: &mut Predict, coin: Coin<Quote>, ctx: &mut TxContext): Coin<PLP> {
+public fun supply<Quote>(
+    predict: &mut Predict,
+    coin: Coin<Quote>,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): Coin<PLP> {
     let amount = coin.value();
     assert!(amount > 0, EZeroAmount);
     predict.treasury_config.assert_quote_asset<Quote>();
 
     let vault_value = predict.vault.vault_value();
     predict.vault.accept_payment(coin.into_balance());
+    predict.withdrawal_limiter.record_deposit(amount, clock);
 
     let total = predict.treasury_cap.total_supply();
     let shares = if (total == 0) {
@@ -455,6 +464,7 @@ public fun supply<Quote>(predict: &mut Predict, coin: Coin<Quote>, ctx: &mut TxC
 public fun withdraw<Quote>(
     predict: &mut Predict,
     lp_coin: Coin<PLP>,
+    clock: &Clock,
     ctx: &mut TxContext,
 ): Coin<Quote> {
     let vault_value = predict.vault.vault_value();
@@ -469,6 +479,7 @@ public fun withdraw<Quote>(
         0
     };
     assert!(amount <= available, EWithdrawExceedsAvailable);
+    predict.withdrawal_limiter.consume(amount, clock);
     predict.treasury_cap.burn(lp_coin);
     event::emit(Withdrawn {
         predict_id: object::id(predict),
@@ -486,6 +497,7 @@ public fun withdraw<Quote>(
 public(package) fun create<Quote>(
     currency: &Currency<Quote>,
     treasury_cap: TreasuryCap<PLP>,
+    clock: &Clock,
     ctx: &mut TxContext,
 ): ID {
     let mut predict = Predict {
@@ -496,6 +508,10 @@ public(package) fun create<Quote>(
         risk_config: risk_config::new(),
         treasury_config: treasury_config::new(),
         oracle_config: oracle_config::new(ctx),
+        // Withdrawal rate limiter starts disabled. Admin must configure
+        // capacity and refill rate based on the actual quote asset value
+        // before enabling via registry::update_withdrawal_limiter().
+        withdrawal_limiter: rate_limiter::new(clock),
         trading_paused: false,
     };
     predict.enable_quote_asset<Quote>(currency);
@@ -645,6 +661,31 @@ public(package) fun set_max_total_exposure_pct(predict: &mut Predict, pct: u64) 
     });
 }
 
+/// Update withdrawal rate limiter capacity and refill rate.
+public(package) fun update_withdrawal_limiter(
+    predict: &mut Predict,
+    capacity: u64,
+    refill_rate_per_ms: u64,
+    clock: &Clock,
+) {
+    predict.withdrawal_limiter.update_config(capacity, refill_rate_per_ms, clock);
+}
+
+/// Enable the withdrawal rate limiter.
+public(package) fun enable_withdrawal_limiter(predict: &mut Predict, clock: &Clock) {
+    predict.withdrawal_limiter.enable(clock);
+}
+
+/// Disable the withdrawal rate limiter.
+public(package) fun disable_withdrawal_limiter(predict: &mut Predict) {
+    predict.withdrawal_limiter.disable();
+}
+
+/// Returns the currently available withdrawal amount.
+public fun available_withdrawal(predict: &Predict, clock: &Clock): u64 {
+    predict.withdrawal_limiter.available_withdrawal(clock)
+}
+
 #[test_only]
 /// Create a Predict object for testing without sharing it.
 public(package) fun create_test_predict<Quote>(
@@ -652,6 +693,7 @@ public(package) fun create_test_predict<Quote>(
     ctx: &mut TxContext,
 ): Predict {
     let treasury_cap = coin::create_treasury_cap_for_testing<PLP>(ctx);
+    let clock = sui::clock::create_for_testing(ctx);
     let mut predict = Predict {
         id: object::new(ctx),
         vault: vault::new(ctx),
@@ -660,9 +702,11 @@ public(package) fun create_test_predict<Quote>(
         risk_config: risk_config::new(),
         treasury_config: treasury_config::new(),
         oracle_config: oracle_config::new(ctx),
+        withdrawal_limiter: rate_limiter::new(&clock),
         trading_paused: false,
     };
     predict.enable_quote_asset<Quote>(currency);
+    clock.destroy_for_testing();
     predict
 }
 

--- a/packages/predict/sources/predict.move
+++ b/packages/predict/sources/predict.move
@@ -510,7 +510,9 @@ public(package) fun create<Quote>(
         oracle_config: oracle_config::new(ctx),
         // Withdrawal rate limiter starts disabled. Admin must configure
         // capacity and refill rate based on the actual quote asset value
-        // before enabling via registry::update_withdrawal_limiter().
+        // Withdrawal rate limiter starts disabled. Admin must call
+        // update_withdrawal_limiter() then enable_withdrawal_limiter()
+        // to activate, configuring capacity and rate for the quote asset.
         withdrawal_limiter: rate_limiter::new(clock),
         trading_paused: false,
     };

--- a/packages/predict/sources/registry.move
+++ b/packages/predict/sources/registry.move
@@ -15,7 +15,7 @@ use deepbook_predict::{
     predict::{Self, Predict}
 };
 use std::string::String;
-use sui::{coin::TreasuryCap, coin_registry::Currency, event, table::{Self, Table}};
+use sui::{clock::Clock, coin::TreasuryCap, coin_registry::Currency, event, table::{Self, Table}};
 
 // === Errors ===
 const EPredictAlreadyCreated: u64 = 0;
@@ -77,11 +77,12 @@ public fun create_predict<Quote>(
     _admin_cap: &AdminCap,
     currency: &Currency<Quote>,
     treasury_cap: TreasuryCap<PLP>,
+    clock: &Clock,
     ctx: &mut TxContext,
 ): ID {
     assert!(registry.predict_id.is_none(), EPredictAlreadyCreated);
 
-    let predict_id = predict::create<Quote>(currency, treasury_cap, ctx);
+    let predict_id = predict::create<Quote>(currency, treasury_cap, clock, ctx);
     registry.predict_id = option::some(predict_id);
 
     event::emit(PredictCreated { predict_id });
@@ -201,6 +202,27 @@ public fun clear_oracle_ask_bounds(predict: &mut Predict, oracle: &OracleSVI, ca
 /// Set max total exposure percentage.
 public fun set_max_total_exposure_pct(predict: &mut Predict, _admin_cap: &AdminCap, pct: u64) {
     predict.set_max_total_exposure_pct(pct);
+}
+
+/// Update withdrawal rate limiter capacity and refill rate.
+public fun update_withdrawal_limiter(
+    predict: &mut Predict,
+    _admin_cap: &AdminCap,
+    capacity: u64,
+    refill_rate_per_ms: u64,
+    clock: &Clock,
+) {
+    predict.update_withdrawal_limiter(capacity, refill_rate_per_ms, clock);
+}
+
+/// Enable the withdrawal rate limiter.
+public fun enable_withdrawal_limiter(predict: &mut Predict, _admin_cap: &AdminCap, clock: &Clock) {
+    predict.enable_withdrawal_limiter(clock);
+}
+
+/// Disable the withdrawal rate limiter.
+public fun disable_withdrawal_limiter(predict: &mut Predict, _admin_cap: &AdminCap) {
+    predict.disable_withdrawal_limiter();
 }
 
 // === Private Functions ===

--- a/packages/predict/tests/helper/rate_limiter_tests.move
+++ b/packages/predict/tests/helper/rate_limiter_tests.move
@@ -1,0 +1,419 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module deepbook_predict::rate_limiter_tests;
+
+use deepbook_predict::rate_limiter;
+use sui::clock;
+
+// Vault holds $10M. Withdrawal capacity = $5M (half of vault).
+const VAULT_SIZE: u64 = 10_000_000_000_000;
+const TEST_CAPACITY: u64 = 5_000_000_000_000;
+const TEST_RATE: u64 = 16_667; // ~$1M/min
+
+fun setup(): (rate_limiter::RateLimiter, clock::Clock) {
+    let ctx = &mut tx_context::dummy();
+    let clock = clock::create_for_testing(ctx);
+    let limiter = rate_limiter::new_for_testing(TEST_CAPACITY, TEST_RATE, true, &clock);
+    (limiter, clock)
+}
+
+// --- Basic operations ---
+
+#[test]
+fun new_default_is_disabled() {
+    let ctx = &mut tx_context::dummy();
+    let clock = clock::create_for_testing(ctx);
+    let limiter = rate_limiter::new(&clock);
+    assert!(!limiter.is_enabled());
+    assert!(limiter.capacity() == 0);
+    assert!(limiter.available() == 0);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun new_for_testing_starts_full() {
+    let (limiter, clock) = setup();
+    assert!(limiter.available() == TEST_CAPACITY);
+    assert!(limiter.capacity() == TEST_CAPACITY);
+    assert!(limiter.refill_rate_per_ms() == TEST_RATE);
+    assert!(limiter.is_enabled());
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun consume_reduces_available() {
+    let (mut limiter, clock) = setup();
+    let amount = 1_000_000_000_000;
+    limiter.consume(amount, &clock);
+    assert!(limiter.available() == TEST_CAPACITY - amount);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun consume_zero_is_noop() {
+    let (mut limiter, clock) = setup();
+    limiter.consume(0, &clock);
+    assert!(limiter.available() == TEST_CAPACITY);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun consume_entire_bucket() {
+    let (mut limiter, clock) = setup();
+    limiter.consume(TEST_CAPACITY, &clock);
+    assert!(limiter.available() == 0);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun disabled_limiter_allows_anything() {
+    let ctx = &mut tx_context::dummy();
+    let clock = clock::create_for_testing(ctx);
+    let mut limiter = rate_limiter::new_for_testing(TEST_CAPACITY, TEST_RATE, false, &clock);
+    assert!(!limiter.is_enabled());
+    limiter.consume(VAULT_SIZE, &clock);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+// --- Abort cases ---
+
+#[test, expected_failure(abort_code = rate_limiter::EInsufficientWithdrawalBudget)]
+fun consume_exceeds_available_aborts() {
+    let (mut limiter, clock) = setup();
+    limiter.consume(TEST_CAPACITY, &clock);
+    limiter.consume(1, &clock);
+    abort
+}
+
+#[test, expected_failure(abort_code = rate_limiter::EExceedsCapacity)]
+fun consume_exceeds_capacity_aborts() {
+    let (mut limiter, clock) = setup();
+    limiter.consume(TEST_CAPACITY + 1, &clock);
+    abort 999
+}
+
+#[test, expected_failure(abort_code = rate_limiter::EExceedsCapacity)]
+fun single_withdrawal_of_full_vault_aborts() {
+    let (mut limiter, clock) = setup();
+    limiter.consume(VAULT_SIZE, &clock);
+    abort 999
+}
+
+// --- Draining half the vault (capacity boundary) ---
+
+#[test]
+fun can_withdraw_exactly_half_vault() {
+    let (mut limiter, clock) = setup();
+    limiter.consume(VAULT_SIZE / 2, &clock);
+    assert!(limiter.available() == 0);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun two_withdrawals_drain_bucket() {
+    let (mut limiter, clock) = setup();
+    let half_capacity = TEST_CAPACITY / 2;
+    limiter.consume(half_capacity, &clock);
+    assert!(limiter.available() == TEST_CAPACITY - half_capacity);
+    limiter.consume(half_capacity, &clock);
+    assert!(limiter.available() == TEST_CAPACITY - 2 * half_capacity);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test, expected_failure(abort_code = rate_limiter::EInsufficientWithdrawalBudget)]
+fun third_large_withdrawal_blocked_without_refill() {
+    let (mut limiter, clock) = setup();
+    let amount = 2_000_000_000_000;
+    limiter.consume(amount, &clock);
+    limiter.consume(amount, &clock);
+    limiter.consume(amount, &clock);
+    abort
+}
+
+// --- Refill behavior ---
+
+#[test]
+fun refill_after_drain() {
+    let (mut limiter, mut clock) = setup();
+    limiter.consume(TEST_CAPACITY, &clock);
+    assert!(limiter.available() == 0);
+    clock.increment_for_testing(60_000);
+    let expected_refill = 60_000 * TEST_RATE;
+    limiter.consume(1, &clock);
+    assert!(limiter.available() == expected_refill - 1);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun refill_caps_at_capacity_not_vault_size() {
+    let (mut limiter, mut clock) = setup();
+    limiter.consume(1_000_000, &clock);
+    clock.increment_for_testing(1_000_000_000);
+    limiter.consume(1, &clock);
+    assert!(limiter.available() == TEST_CAPACITY - 1);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun partial_refill_allows_partial_withdrawal() {
+    let (mut limiter, mut clock) = setup();
+    limiter.consume(TEST_CAPACITY, &clock);
+    clock.increment_for_testing(30_000);
+    let refilled = 30_000 * TEST_RATE;
+    limiter.consume(refilled, &clock);
+    assert!(limiter.available() == 0);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test, expected_failure(abort_code = rate_limiter::EInsufficientWithdrawalBudget)]
+fun partial_refill_rejects_larger_withdrawal() {
+    let (mut limiter, mut clock) = setup();
+    limiter.consume(TEST_CAPACITY, &clock);
+    clock.increment_for_testing(30_000);
+    let refilled = 30_000 * TEST_RATE;
+    limiter.consume(refilled + 1, &clock);
+    abort
+}
+
+#[test]
+fun full_refill_time_to_capacity() {
+    let (mut limiter, mut clock) = setup();
+    limiter.consume(TEST_CAPACITY, &clock);
+    let refill_time = TEST_CAPACITY / TEST_RATE;
+    clock.increment_for_testing(refill_time);
+    let refilled = refill_time * TEST_RATE;
+    limiter.consume(1, &clock);
+    assert!(limiter.available() == refilled - 1);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+// --- Deposit interactions ---
+
+#[test]
+fun deposit_replenishes_after_withdrawal() {
+    let (mut limiter, clock) = setup();
+    limiter.consume(3_000_000_000_000, &clock);
+    assert!(limiter.available() == 2_000_000_000_000);
+    limiter.record_deposit(3_000_000_000_000, &clock);
+    assert!(limiter.available() == TEST_CAPACITY);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun deposit_larger_than_capacity_caps() {
+    let (mut limiter, clock) = setup();
+    limiter.record_deposit(VAULT_SIZE, &clock);
+    assert!(limiter.available() == TEST_CAPACITY);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun deposit_after_full_drain_partial_restore() {
+    let (mut limiter, clock) = setup();
+    limiter.consume(TEST_CAPACITY, &clock);
+    assert!(limiter.available() == 0);
+    let deposit = 1_000_000_000_000;
+    limiter.record_deposit(deposit, &clock);
+    assert!(limiter.available() == deposit);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun deposit_plus_refill_interaction() {
+    let (mut limiter, mut clock) = setup();
+    limiter.consume(TEST_CAPACITY, &clock);
+    clock.increment_for_testing(30_000);
+    let deposit = 2_000_000_000_000;
+    limiter.record_deposit(deposit, &clock);
+    let refilled = 30_000 * TEST_RATE;
+    let expected = refilled + deposit;
+    assert!(limiter.available() == expected);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun deposit_plus_refill_caps_at_capacity() {
+    let (mut limiter, mut clock) = setup();
+    limiter.consume(1_000_000_000_000, &clock);
+    clock.increment_for_testing(120_000);
+    limiter.record_deposit(3_000_000_000_000, &clock);
+    assert!(limiter.available() == TEST_CAPACITY);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+// --- Withdraw-deposit-withdraw cycle ---
+
+#[test]
+fun withdraw_deposit_withdraw_cycle() {
+    let (mut limiter, clock) = setup();
+    limiter.consume(4_000_000_000_000, &clock);
+    assert!(limiter.available() == 1_000_000_000_000);
+    limiter.record_deposit(2_000_000_000_000, &clock);
+    assert!(limiter.available() == 3_000_000_000_000);
+    limiter.consume(3_000_000_000_000, &clock);
+    assert!(limiter.available() == 0);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test, expected_failure(abort_code = rate_limiter::EInsufficientWithdrawalBudget)]
+fun withdraw_deposit_withdraw_exceeds() {
+    let (mut limiter, clock) = setup();
+    limiter.consume(4_000_000_000_000, &clock);
+    limiter.record_deposit(2_000_000_000_000, &clock);
+    limiter.consume(3_000_000_000_000, &clock);
+    limiter.consume(1, &clock);
+    abort
+}
+
+// --- Available withdrawal (read-only) ---
+
+#[test]
+fun available_withdrawal_reflects_refill() {
+    let (mut limiter, mut clock) = setup();
+    limiter.consume(TEST_CAPACITY, &clock);
+    clock.increment_for_testing(60_000);
+    let expected = 60_000 * TEST_RATE;
+    assert!(limiter.available_withdrawal(&clock) == expected);
+    assert!(limiter.available() == 0);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun available_withdrawal_when_disabled_returns_max() {
+    let ctx = &mut tx_context::dummy();
+    let clock = clock::create_for_testing(ctx);
+    let limiter = rate_limiter::new_for_testing(TEST_CAPACITY, TEST_RATE, false, &clock);
+    assert!(limiter.available_withdrawal(&clock) == std::u64::max_value!());
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+// --- Enable / disable ---
+
+#[test]
+fun enable_then_consume() {
+    let ctx = &mut tx_context::dummy();
+    let mut clock = clock::create_for_testing(ctx);
+    let mut limiter = rate_limiter::new(&clock);
+    assert!(!limiter.is_enabled());
+    // Configure first, then enable.
+    limiter.update_config(TEST_CAPACITY, TEST_RATE, &clock);
+    limiter.enable(&clock);
+    assert!(limiter.is_enabled());
+    assert!(limiter.capacity() == TEST_CAPACITY);
+    // Available is 0 because new() starts at 0 and update_config caps at capacity but doesn't increase.
+    // Need to record a deposit or wait for refill.
+    clock.increment_for_testing(60_000);
+    let refilled = 60_000 * TEST_RATE;
+    limiter.consume(refilled, &clock);
+    assert!(limiter.available() == 0);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun disable_allows_any_consume() {
+    let (mut limiter, clock) = setup();
+    limiter.disable();
+    assert!(!limiter.is_enabled());
+    limiter.consume(VAULT_SIZE * 100, &clock);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+// --- Config updates ---
+
+#[test]
+fun update_config_preserves_refilled_tokens() {
+    let (mut limiter, mut clock) = setup();
+    limiter.consume(TEST_CAPACITY, &clock);
+    clock.increment_for_testing(60_000);
+    let old_refill = 60_000 * TEST_RATE;
+    let new_capacity = 10_000_000_000_000;
+    let new_rate = 33_334;
+    limiter.update_config(new_capacity, new_rate, &clock);
+    assert!(limiter.available() == old_refill);
+    assert!(limiter.capacity() == new_capacity);
+    assert!(limiter.refill_rate_per_ms() == new_rate);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun update_config_shrink_capacity_caps_available() {
+    let (mut limiter, clock) = setup();
+    let smaller = 2_000_000_000_000;
+    limiter.update_config(smaller, TEST_RATE, &clock);
+    assert!(limiter.available() == smaller);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test, expected_failure(abort_code = rate_limiter::EInvalidConfig)]
+fun update_config_rate_exceeds_capacity_aborts() {
+    let (mut limiter, clock) = setup();
+    limiter.update_config(100, 100, &clock);
+    abort
+}
+
+#[test, expected_failure(abort_code = rate_limiter::EInvalidConfig)]
+fun update_config_zero_rate_aborts() {
+    let (mut limiter, clock) = setup();
+    limiter.update_config(TEST_CAPACITY, 0, &clock);
+    abort
+}
+
+// --- Rapid cycle ---
+
+#[test]
+fun rapid_withdraw_refill_cycle() {
+    let (mut limiter, mut clock) = setup();
+    let amount = 1_000_000_000_000;
+    limiter.consume(amount, &clock);
+    clock.increment_for_testing(10_000);
+    limiter.consume(amount, &clock);
+    clock.increment_for_testing(10_000);
+    limiter.consume(amount, &clock);
+    clock.increment_for_testing(10_000);
+    limiter.consume(amount, &clock);
+    clock.increment_for_testing(10_000);
+    limiter.consume(amount, &clock);
+    let total_consumed = 5 * amount;
+    let total_refilled = 4 * 10_000 * TEST_RATE;
+    assert!(limiter.available() == TEST_CAPACITY - total_consumed + total_refilled);
+    limiter.destroy_for_testing();
+    clock.destroy_for_testing();
+}
+
+#[test, expected_failure(abort_code = rate_limiter::EInsufficientWithdrawalBudget)]
+fun rapid_withdrawals_eventually_blocked() {
+    let (mut limiter, mut clock) = setup();
+    let amount = 2_000_000_000_000;
+    limiter.consume(amount, &clock);
+    clock.increment_for_testing(10_000);
+    limiter.consume(amount, &clock);
+    clock.increment_for_testing(10_000);
+    limiter.consume(amount, &clock);
+    abort
+}


### PR DESCRIPTION
## Summary
- Add withdrawal rate limiter using a token bucket algorithm to prevent rapid vault drain
- Follows the Chainlink CCIP RateLimiter pattern ([reference](https://github.com/code-423n4/2024-11-chainlink/blob/main/contracts/src/ccip/libraries/RateLimiter.sol)) and DeepBook Margin's existing `rate_limiter.move`
- Starts **disabled by default** — admin must configure capacity and refill rate based on the actual quote asset value before enabling

## How it works
```
Bucket: capacity = $5M, rate = ~$1M/min (example config)

Withdraw $3M  → bucket = $2M remaining
Withdraw $2M  → bucket = $0 (drained)
Withdraw $1   → REJECTED (bucket empty)
Wait 60s      → bucket refills to ~$1M
Withdraw $1M  → bucket = $0 again

Deposits also replenish the bucket (capped at capacity).
```

## Changes
- **`rate_limiter.move`** (new): token bucket with `consume`, `record_deposit`, `refill`, `update_config`, plus 32 inline tests
- **`predict.move`**: added `withdrawal_limiter` to Predict struct, wired into `supply()` (record_deposit) and `withdraw()` (consume). Both now take `clock` parameter.
- **`registry.move`**: added `update_withdrawal_limiter()` admin entry point, `create_predict()` now takes `clock`
- **`constants.move`**: added `required_quote_decimals` trailing newline

## Key decisions
- **Disabled by default**: capacity/rate depend on the quote asset's dollar value. A $5M capacity makes sense for USDC but not for a low-value token. Admin configures after deployment.
- **Deposits replenish**: `record_deposit()` on supply increases available budget, preventing the limiter from blocking withdrawals after heavy inflows.
- **Error codes start at 0**: follows codebase convention per Sui Move docs. Guard aborts in tests use `abort 999` for error code 0 to avoid collision.

## Test plan
- [x] `sui move build` — clean
- [x] `sui move test --gas-limit 100000000000` — 32 tests pass
- [x] Integration test with full supply → withdraw → rate limit flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)