### PR TITLE
predict: add mint ask price bounds

### DIFF
--- a/packages/predict/sources/config/pricing_config.move
+++ b/packages/predict/sources/config/pricing_config.move
@@ -84,7 +84,7 @@ public(package) fun set_min_ask_price(config: &mut PricingConfig, value: u64) {
 
 public(package) fun set_max_ask_price(config: &mut PricingConfig, value: u64) {
     assert!(value > config.min_ask_price, EInvalidAskBound);
-    assert!(value <= constants::float_scaling!(), EInvalidAskBound);
+    assert!(value < constants::float_scaling!(), EInvalidAskBound);
     config.max_ask_price = value;
 }
 

--- a/packages/predict/sources/config/pricing_config.move
+++ b/packages/predict/sources/config/pricing_config.move
@@ -10,6 +10,7 @@ use deepbook_predict::{constants, math as predict_math};
 // === Errors ===
 const EInvalidSpread: u64 = 0;
 const EFairPriceAlreadySettled: u64 = 1;
+const EInvalidAskBound: u64 = 2;
 
 // === Structs ===
 
@@ -22,6 +23,10 @@ public struct PricingConfig has store {
     /// Utilization multiplier in FLOAT_SCALING (e.g., 2_000_000_000 = 2x).
     /// Controls how aggressively spread widens as vault approaches capacity.
     utilization_multiplier: u64,
+    /// Global minimum allowed post-spread ask price at mint time.
+    min_ask_price: u64,
+    /// Global maximum allowed post-spread ask price at mint time.
+    max_ask_price: u64,
 }
 
 // === Public Functions ===
@@ -38,6 +43,14 @@ public fun utilization_multiplier(config: &PricingConfig): u64 {
     config.utilization_multiplier
 }
 
+public fun min_ask_price(config: &PricingConfig): u64 {
+    config.min_ask_price
+}
+
+public fun max_ask_price(config: &PricingConfig): u64 {
+    config.max_ask_price
+}
+
 // === Public-Package Functions ===
 
 public(package) fun new(): PricingConfig {
@@ -45,6 +58,8 @@ public(package) fun new(): PricingConfig {
         base_spread: constants::default_base_spread!(),
         min_spread: constants::default_min_spread!(),
         utilization_multiplier: constants::default_utilization_multiplier!(),
+        min_ask_price: constants::default_min_ask_price!(),
+        max_ask_price: constants::default_max_ask_price!(),
     }
 }
 
@@ -62,8 +77,17 @@ public(package) fun set_utilization_multiplier(config: &mut PricingConfig, multi
     config.utilization_multiplier = multiplier;
 }
 
-// TODO: Add admin-configurable tail guards so minting can reject fair prices
-// in unreliable extremes (for example <= 0.02 or >= 0.98).
+public(package) fun set_min_ask_price(config: &mut PricingConfig, value: u64) {
+    assert!(value < config.max_ask_price, EInvalidAskBound);
+    config.min_ask_price = value;
+}
+
+public(package) fun set_max_ask_price(config: &mut PricingConfig, value: u64) {
+    assert!(value > config.min_ask_price, EInvalidAskBound);
+    assert!(value <= constants::float_scaling!(), EInvalidAskBound);
+    config.max_ask_price = value;
+}
+
 public(package) fun quote_spread_from_fair_price(
     config: &PricingConfig,
     fair_price: u64,

--- a/packages/predict/sources/helper/constants.move
+++ b/packages/predict/sources/helper/constants.move
@@ -32,6 +32,12 @@ public macro fun default_min_spread(): u64 { 5_000_000 }
 /// Controls how aggressively spread widens as vault approaches capacity
 public macro fun default_utilization_multiplier(): u64 { 2_000_000_000 }
 
+/// Minimum ask price the protocol will allow at mint (1% in FLOAT_SCALING)
+public macro fun default_min_ask_price(): u64 { 10_000_000 }
+
+/// Maximum ask price the protocol will allow at mint (99% in FLOAT_SCALING)
+public macro fun default_max_ask_price(): u64 { 990_000_000 }
+
 // === Time Constants ===
 
 public macro fun ms_per_year(): u64 { 31_536_000_000 }

--- a/packages/predict/sources/oracle.move
+++ b/packages/predict/sources/oracle.move
@@ -360,6 +360,10 @@ public(package) fun create_oracle_cap(ctx: &mut TxContext): OracleSVICap {
     OracleSVICap { id: object::new(ctx) }
 }
 
+public(package) fun assert_authorized_cap(oracle: &OracleSVI, cap: &OracleSVICap) {
+    assert!(oracle.authorized_caps.contains(&cap.id.to_inner()), EInvalidOracleCap);
+}
+
 /// Create a new SVI Oracle for an underlying + expiry. Returns the oracle ID.
 public(package) fun create_oracle(underlying_asset: String, expiry: u64, ctx: &mut TxContext): ID {
     let oracle_uid = object::new(ctx);
@@ -388,10 +392,6 @@ public(package) fun create_oracle(underlying_asset: String, expiry: u64, ctx: &m
 }
 
 // === Private Functions ===
-
-fun assert_authorized_cap(oracle: &OracleSVI, cap: &OracleSVICap) {
-    assert!(oracle.authorized_caps.contains(&cap.id.to_inner()), EInvalidOracleCap);
-}
 
 /// Binary pricing from SVI total variance:
 /// - k = ln(strike / forward)

--- a/packages/predict/sources/oracle_config.move
+++ b/packages/predict/sources/oracle_config.move
@@ -11,7 +11,7 @@ module deepbook_predict::oracle_config;
 use deepbook_predict::{
     constants,
     market_key::MarketKey,
-    oracle::{Self, OracleSVI},
+    oracle::{Self, OracleSVI, OracleSVICap},
     range_key::RangeKey
 };
 use sui::{clock::Clock, table::{Self, Table}};
@@ -28,6 +28,7 @@ const EOracleConfigNotFound: u64 = 7;
 const EInvalidCurveRange: u64 = 8;
 const ERangeKeyOracleMismatch: u64 = 9;
 const ERangeKeyExpiryMismatch: u64 = 10;
+const EInvalidAskBound: u64 = 11;
 
 public struct OracleGrid has copy, drop, store {
     min_strike: u64,
@@ -35,8 +36,19 @@ public struct OracleGrid has copy, drop, store {
     tick_size: u64,
 }
 
+/// Per-oracle override on the protocol-wide ask-price bounds enforced at mint.
+/// Present in `OracleConfig.oracle_ask_bounds` only when the oracle has set an
+/// override; otherwise the global default on `PricingConfig` applies.
+public struct AskBounds has copy, drop, store {
+    min_ask_price: u64,
+    max_ask_price: u64,
+}
+
 public struct OracleConfig has store {
     oracle_grids: Table<ID, OracleGrid>,
+    /// Per-oracle ask-bound overrides; presence in this table means an override
+    /// is active for that oracle id.
+    oracle_ask_bounds: Table<ID, AskBounds>,
 }
 
 /// Curve sample point with strike and one-sided UP price.
@@ -59,10 +71,17 @@ public fun strike(point: &CurvePoint): u64 { point.strike }
 /// Return the UP price stored in a curve point.
 public fun up_price(point: &CurvePoint): u64 { point.up_price }
 
+/// Return the minimum ask price stored in an `AskBounds`.
+public fun ask_bounds_min(bounds: &AskBounds): u64 { bounds.min_ask_price }
+
+/// Return the maximum ask price stored in an `AskBounds`.
+public fun ask_bounds_max(bounds: &AskBounds): u64 { bounds.max_ask_price }
+
 /// Create an empty oracle config registry for Predict.
 public(package) fun new(ctx: &mut TxContext): OracleConfig {
     OracleConfig {
         oracle_grids: table::new(ctx),
+        oracle_ask_bounds: table::new(ctx),
     }
 }
 
@@ -80,6 +99,58 @@ public(package) fun add_oracle_grid(
         tick_size,
     };
     oracle_config.oracle_grids.add(oracle_id, grid);
+}
+
+/// Set or update a per-oracle ask-bound override. The caller must hold an
+/// `OracleSVICap` authorized for `oracle`. Validates the math invariant
+/// `min < max <= float_scaling`; the "no looser than the global default"
+/// constraint is enforced by the caller (see `predict::set_oracle_ask_bounds`).
+public(package) fun set_oracle_ask_bounds(
+    oracle_config: &mut OracleConfig,
+    oracle: &OracleSVI,
+    cap: &OracleSVICap,
+    min: u64,
+    max: u64,
+) {
+    oracle.assert_authorized_cap(cap);
+    assert!(min < max, EInvalidAskBound);
+    assert!(max <= constants::float_scaling!(), EInvalidAskBound);
+
+    let oracle_id = oracle.id();
+    let bounds = AskBounds { min_ask_price: min, max_ask_price: max };
+    if (oracle_config.oracle_ask_bounds.contains(oracle_id)) {
+        let row = &mut oracle_config.oracle_ask_bounds[oracle_id];
+        *row = bounds;
+    } else {
+        oracle_config.oracle_ask_bounds.add(oracle_id, bounds);
+    }
+}
+
+/// Remove the per-oracle ask-bound override so the oracle inherits the global
+/// default again. No-op if no override is currently set.
+public(package) fun clear_oracle_ask_bounds(
+    oracle_config: &mut OracleConfig,
+    oracle: &OracleSVI,
+    cap: &OracleSVICap,
+) {
+    oracle.assert_authorized_cap(cap);
+    let oracle_id = oracle.id();
+    if (oracle_config.oracle_ask_bounds.contains(oracle_id)) {
+        oracle_config.oracle_ask_bounds.remove(oracle_id);
+    };
+}
+
+/// Return the per-oracle ask-bound override, or `None` if the oracle inherits
+/// the global default.
+public(package) fun ask_bounds_override(
+    oracle_config: &OracleConfig,
+    oracle_id: ID,
+): Option<AskBounds> {
+    if (oracle_config.oracle_ask_bounds.contains(oracle_id)) {
+        option::some(oracle_config.oracle_ask_bounds[oracle_id])
+    } else {
+        option::none()
+    }
 }
 
 /// Assert that a strike lies on the configured grid for this oracle.

--- a/packages/predict/sources/oracle_config.move
+++ b/packages/predict/sources/oracle_config.move
@@ -103,7 +103,7 @@ public(package) fun add_oracle_grid(
 
 /// Set or update a per-oracle ask-bound override. The caller must hold an
 /// `OracleSVICap` authorized for `oracle`. Validates the math invariant
-/// `min < max <= float_scaling`; the "no looser than the global default"
+/// `min < max < float_scaling`; the "no looser than the global default"
 /// constraint is enforced by the caller (see `predict::set_oracle_ask_bounds`).
 public(package) fun set_oracle_ask_bounds(
     oracle_config: &mut OracleConfig,
@@ -114,7 +114,7 @@ public(package) fun set_oracle_ask_bounds(
 ) {
     oracle.assert_authorized_cap(cap);
     assert!(min < max, EInvalidAskBound);
-    assert!(max <= constants::float_scaling!(), EInvalidAskBound);
+    assert!(max < constants::float_scaling!(), EInvalidAskBound);
 
     let oracle_id = oracle.id();
     let bounds = AskBounds { min_ask_price: min, max_ask_price: max };

--- a/packages/predict/sources/predict.move
+++ b/packages/predict/sources/predict.move
@@ -13,7 +13,7 @@ use deepbook_predict::{
     constants,
     market_key::MarketKey,
     math::mul_div_round_down,
-    oracle::OracleSVI,
+    oracle::{OracleSVI, OracleSVICap},
     oracle_config::{Self, OracleConfig},
     plp::PLP,
     predict_manager::{Self, PredictManager},
@@ -40,6 +40,8 @@ const EZeroQuantity: u64 = 3;
 const EZeroAmount: u64 = 4;
 const EZeroVaultValue: u64 = 5;
 const EZeroSharesMinted: u64 = 6;
+const EAskPriceOutOfBounds: u64 = 7;
+const EAskBoundLooserThanGlobal: u64 = 8;
 
 // === Events ===
 
@@ -116,6 +118,20 @@ public struct PricingConfigUpdated has copy, drop, store {
     base_spread: u64,
     min_spread: u64,
     utilization_multiplier: u64,
+    min_ask_price: u64,
+    max_ask_price: u64,
+}
+
+public struct OracleAskBoundsSet has copy, drop, store {
+    predict_id: ID,
+    oracle_id: ID,
+    min_ask_price: u64,
+    max_ask_price: u64,
+}
+
+public struct OracleAskBoundsCleared has copy, drop, store {
+    predict_id: ID,
+    oracle_id: ID,
 }
 
 public struct RiskConfigUpdated has copy, drop, store {
@@ -191,41 +207,14 @@ public fun get_trade_amounts(
     quantity: u64,
     clock: &Clock,
 ): (u64, u64) {
-    predict.oracle_config.assert_key_matches(oracle, &key);
-    oracle_config::assert_quoteable_oracle(oracle, clock);
+    let (ask, bid) = predict.trade_prices(oracle, key, clock);
+    (math::mul(ask, quantity), math::mul(bid, quantity))
+}
 
-    let up_price = oracle.compute_price(key.strike());
-    if (oracle.is_settled()) {
-        let fair_price = if (key.is_up()) {
-            up_price
-        } else {
-            constants::float_scaling!() - up_price
-        };
-        let amount = math::mul(fair_price, quantity);
-        return (amount, amount)
-    };
-
-    let spread = predict
-        .pricing_config
-        .quote_spread_from_fair_price(
-            up_price,
-            predict.vault.total_mtm(),
-            predict.vault.balance(),
-        );
-    let up_bid = if (up_price > spread) {
-        up_price - spread
-    } else {
-        0
-    };
-    let up_ask = (up_price + spread).min(constants::float_scaling!());
-    let dn_bid = constants::float_scaling!() - up_ask;
-    let dn_ask = constants::float_scaling!() - up_bid;
-
-    if (key.is_up()) {
-        (math::mul(up_ask, quantity), math::mul(up_bid, quantity))
-    } else {
-        (math::mul(dn_ask, quantity), math::mul(dn_bid, quantity))
-    }
+/// Resolved ask-price bounds for an oracle, after intersecting any per-oracle
+/// override with the global default. Exposed for UI/preview.
+public fun ask_bounds(predict: &Predict, oracle_id: ID): (u64, u64) {
+    predict.resolve_ask_bounds(oracle_id)
 }
 
 /// Buy a position using an enabled quote asset.
@@ -256,7 +245,9 @@ public fun mint<Quote>(
 
     // Quote against the post-trade state so the trader pays for the liability
     // their own mint just added to the vault.
-    let (cost, _) = predict.get_trade_amounts(oracle, key, quantity, clock);
+    let (ask, _) = predict.trade_prices(oracle, key, clock);
+    predict.assert_mintable_ask(oracle.id(), ask);
+    let cost = math::mul(ask, quantity);
 
     let payment = manager.withdraw<Quote>(cost, ctx).into_balance();
     predict.vault.accept_payment(payment);
@@ -274,7 +265,7 @@ public fun mint<Quote>(
         is_up,
         quantity,
         cost,
-        ask_price: math::div(cost, quantity),
+        ask_price: ask,
     });
 }
 
@@ -338,37 +329,7 @@ public fun get_range_trade_amounts(
     quantity: u64,
     clock: &Clock,
 ): (u64, u64) {
-    predict.oracle_config.assert_range_key_matches(oracle, &key);
-    oracle_config::assert_quoteable_oracle(oracle, clock);
-
-    // Fair range price = up(lower) − up(higher). UP price is monotone
-    // non-increasing in strike, so this is always non-negative for a well-formed
-    // key (`lower < higher`). Settled compute_price returns 1.0 if settlement >
-    // strike, 0 otherwise, so the range evaluates to 1.0 iff settlement is in
-    // the half-open band (lower, higher].
-    let lower_up_price = oracle.compute_price(key.lower_strike());
-    let higher_up_price = oracle.compute_price(key.higher_strike());
-    let fair_price = lower_up_price - higher_up_price;
-
-    if (oracle.is_settled()) {
-        let amount = math::mul(fair_price, quantity);
-        return (amount, amount)
-    };
-
-    let spread = predict
-        .pricing_config
-        .quote_spread_from_fair_price(
-            fair_price,
-            predict.vault.total_mtm(),
-            predict.vault.balance(),
-        );
-    let ask = (fair_price + spread).min(constants::float_scaling!());
-    let bid = if (fair_price > spread) {
-        fair_price - spread
-    } else {
-        0
-    };
-
+    let (ask, bid) = predict.range_trade_prices(oracle, key, clock);
     (math::mul(ask, quantity), math::mul(bid, quantity))
 }
 
@@ -399,7 +360,9 @@ public fun mint_range<Quote>(
 
     // Quote against the post-trade state so the trader pays for the liability
     // their own mint just added to the vault.
-    let (cost, _) = predict.get_range_trade_amounts(oracle, key, quantity, clock);
+    let (ask, _) = predict.range_trade_prices(oracle, key, clock);
+    predict.assert_mintable_ask(oracle.id(), ask);
+    let cost = math::mul(ask, quantity);
 
     let payment = manager.withdraw<Quote>(cost, ctx).into_balance();
     predict.vault.accept_payment(payment);
@@ -417,7 +380,7 @@ public fun mint_range<Quote>(
         higher_strike: higher,
         quantity,
         cost,
-        ask_price: math::div(cost, quantity),
+        ask_price: ask,
     });
 }
 
@@ -642,6 +605,52 @@ public(package) fun set_utilization_multiplier(predict: &mut Predict, multiplier
     predict.emit_pricing_config_updated();
 }
 
+/// Set the global minimum allowed post-spread ask price at mint time.
+public(package) fun set_min_ask_price(predict: &mut Predict, value: u64) {
+    predict.pricing_config.set_min_ask_price(value);
+    predict.emit_pricing_config_updated();
+}
+
+/// Set the global maximum allowed post-spread ask price at mint time.
+public(package) fun set_max_ask_price(predict: &mut Predict, value: u64) {
+    predict.pricing_config.set_max_ask_price(value);
+    predict.emit_pricing_config_updated();
+}
+
+/// Set a per-oracle ask-bound override. Authorized by the oracle's own cap.
+/// The override may only tighten the global bounds — never loosen them.
+public(package) fun set_oracle_ask_bounds(
+    predict: &mut Predict,
+    oracle: &OracleSVI,
+    cap: &OracleSVICap,
+    min: u64,
+    max: u64,
+) {
+    assert!(min >= predict.pricing_config.min_ask_price(), EAskBoundLooserThanGlobal);
+    assert!(max <= predict.pricing_config.max_ask_price(), EAskBoundLooserThanGlobal);
+    predict.oracle_config.set_oracle_ask_bounds(oracle, cap, min, max);
+    event::emit(OracleAskBoundsSet {
+        predict_id: object::id(predict),
+        oracle_id: oracle.id(),
+        min_ask_price: min,
+        max_ask_price: max,
+    });
+}
+
+/// Clear a per-oracle ask-bound override so the oracle inherits the global
+/// default again. Authorized by the oracle's own cap.
+public(package) fun clear_oracle_ask_bounds(
+    predict: &mut Predict,
+    oracle: &OracleSVI,
+    cap: &OracleSVICap,
+) {
+    predict.oracle_config.clear_oracle_ask_bounds(oracle, cap);
+    event::emit(OracleAskBoundsCleared {
+        predict_id: object::id(predict),
+        oracle_id: oracle.id(),
+    });
+}
+
 /// Set max total exposure percentage.
 public(package) fun set_max_total_exposure_pct(predict: &mut Predict, pct: u64) {
     predict.risk_config.set_max_total_exposure_pct(pct);
@@ -708,7 +717,109 @@ fun emit_pricing_config_updated(predict: &Predict) {
         base_spread: predict.pricing_config.base_spread(),
         min_spread: predict.pricing_config.min_spread(),
         utilization_multiplier: predict.pricing_config.utilization_multiplier(),
+        min_ask_price: predict.pricing_config.min_ask_price(),
+        max_ask_price: predict.pricing_config.max_ask_price(),
     });
+}
+
+/// Per-unit `(ask, bid)` for a single-strike position, post-spread (or settled
+/// fair price when the oracle is settled).
+fun trade_prices(predict: &Predict, oracle: &OracleSVI, key: MarketKey, clock: &Clock): (u64, u64) {
+    predict.oracle_config.assert_key_matches(oracle, &key);
+    oracle_config::assert_quoteable_oracle(oracle, clock);
+
+    let up_price = oracle.compute_price(key.strike());
+    if (oracle.is_settled()) {
+        let fair_price = if (key.is_up()) {
+            up_price
+        } else {
+            constants::float_scaling!() - up_price
+        };
+        return (fair_price, fair_price)
+    };
+
+    let spread = predict
+        .pricing_config
+        .quote_spread_from_fair_price(
+            up_price,
+            predict.vault.total_mtm(),
+            predict.vault.balance(),
+        );
+    let up_bid = if (up_price > spread) {
+        up_price - spread
+    } else {
+        0
+    };
+    let up_ask = (up_price + spread).min(constants::float_scaling!());
+    let dn_bid = constants::float_scaling!() - up_ask;
+    let dn_ask = constants::float_scaling!() - up_bid;
+
+    if (key.is_up()) {
+        (up_ask, up_bid)
+    } else {
+        (dn_ask, dn_bid)
+    }
+}
+
+/// Per-unit `(ask, bid)` for a vertical range position, post-spread.
+fun range_trade_prices(
+    predict: &Predict,
+    oracle: &OracleSVI,
+    key: RangeKey,
+    clock: &Clock,
+): (u64, u64) {
+    predict.oracle_config.assert_range_key_matches(oracle, &key);
+    oracle_config::assert_quoteable_oracle(oracle, clock);
+
+    // Fair range price = up(lower) − up(higher). UP price is monotone
+    // non-increasing in strike, so this is always non-negative for a well-formed
+    // key (`lower < higher`). Settled compute_price returns 1.0 if settlement >
+    // strike, 0 otherwise, so the range evaluates to 1.0 iff settlement is in
+    // the half-open band (lower, higher].
+    let lower_up_price = oracle.compute_price(key.lower_strike());
+    let higher_up_price = oracle.compute_price(key.higher_strike());
+    let fair_price = lower_up_price - higher_up_price;
+
+    if (oracle.is_settled()) {
+        return (fair_price, fair_price)
+    };
+
+    let spread = predict
+        .pricing_config
+        .quote_spread_from_fair_price(
+            fair_price,
+            predict.vault.total_mtm(),
+            predict.vault.balance(),
+        );
+    let ask = (fair_price + spread).min(constants::float_scaling!());
+    let bid = if (fair_price > spread) {
+        fair_price - spread
+    } else {
+        0
+    };
+
+    (ask, bid)
+}
+
+/// Resolve the effective ask-price bounds for an oracle: the per-oracle
+/// override (if any) intersected with the global default. The intersection
+/// guarantees the resolved bounds are never looser than the global, even if
+/// admin tightens the global after a per-oracle override has been set.
+fun resolve_ask_bounds(predict: &Predict, oracle_id: ID): (u64, u64) {
+    let global_min = predict.pricing_config.min_ask_price();
+    let global_max = predict.pricing_config.max_ask_price();
+    let override = predict.oracle_config.ask_bounds_override(oracle_id);
+    if (override.is_some()) {
+        let bounds = override.destroy_some();
+        (bounds.ask_bounds_min().max(global_min), bounds.ask_bounds_max().min(global_max))
+    } else {
+        (global_min, global_max)
+    }
+}
+
+fun assert_mintable_ask(predict: &Predict, oracle_id: ID, ask_price: u64) {
+    let (min_ask, max_ask) = predict.resolve_ask_bounds(oracle_id);
+    assert!(ask_price >= min_ask && ask_price <= max_ask, EAskPriceOutOfBounds);
 }
 
 fun refresh_oracle_risk(predict: &mut Predict, oracle: &OracleSVI) {

--- a/packages/predict/sources/registry.move
+++ b/packages/predict/sources/registry.move
@@ -170,6 +170,34 @@ public fun set_utilization_multiplier(
     predict.set_utilization_multiplier(multiplier);
 }
 
+/// Set the global minimum allowed post-spread ask price at mint time.
+public fun set_min_ask_price(predict: &mut Predict, _admin_cap: &AdminCap, value: u64) {
+    predict.set_min_ask_price(value);
+}
+
+/// Set the global maximum allowed post-spread ask price at mint time.
+public fun set_max_ask_price(predict: &mut Predict, _admin_cap: &AdminCap, value: u64) {
+    predict.set_max_ask_price(value);
+}
+
+/// Set a per-oracle ask-bound override. Authorized by the oracle's own cap;
+/// no `AdminCap` required. The override may only tighten the global bounds.
+public fun set_oracle_ask_bounds(
+    predict: &mut Predict,
+    oracle: &OracleSVI,
+    cap: &OracleSVICap,
+    min: u64,
+    max: u64,
+) {
+    predict.set_oracle_ask_bounds(oracle, cap, min, max);
+}
+
+/// Clear a per-oracle ask-bound override so the oracle inherits the global
+/// default again. Authorized by the oracle's own cap.
+public fun clear_oracle_ask_bounds(predict: &mut Predict, oracle: &OracleSVI, cap: &OracleSVICap) {
+    predict.clear_oracle_ask_bounds(oracle, cap);
+}
+
 /// Set max total exposure percentage.
 public fun set_max_total_exposure_pct(predict: &mut Predict, _admin_cap: &AdminCap, pct: u64) {
     predict.set_max_total_exposure_pct(pct);


### PR DESCRIPTION
## Summary
- add configurable global mint ask-price bounds to `PricingConfig` and surface them in pricing config update events
- add per-oracle ask-bound overrides authorized by `OracleSVICap`, with the invariant that oracle-specific bounds can only tighten the global bounds
- refactor single-market and range quoting into shared price helpers and enforce the resolved ask bounds during `mint` and `mint_range`
- expose registry entrypoints for admins and oracle operators to manage these bounds
- relate this PR to Linear issue `DBU-352`

## Key decisions
- bounds are enforced on post-spread ask prices at mint time, not on fair prices, so the protection matches what users actually pay
- per-oracle overrides are stored independently and intersected with the global bounds at read time, which preserves safety if the global bounds are tightened after an override was set
- oracle-specific overrides are authorized by the oracle cap rather than the admin cap so the oracle owner can tighten quoting for its own market without widening protocol risk controls

## Test plan
- [x] Run `sui move test --path packages/predict --gas-limit 100000000000`
- [x] Confirm the command completes successfully in the current checkout
- [ ] Add or update targeted predict tests if this branch is extended further; the current suite reports `Total tests: 0` for this package in this environment
