### PR TITLE
predict: inventory-aware mid shift

### DIFF
--- a/packages/predict/simulations/toxic_flow_sim.py
+++ b/packages/predict/simulations/toxic_flow_sim.py
@@ -49,6 +49,7 @@ MIN_SPREAD = 0.0025
 BALANCE = 10_000_000.0
 DEFAULT_DEPTH_MULTIPLIER = 1.0
 BALANCE_VARIANTS = [100_000_000.0, 400_000_000.0]  # runs main() once per balance
+DAY2_START_TICK = int(N_MINUTES * 2 / 7)  # ≈ 2880
 
 
 # === CSV parsing ===
@@ -125,6 +126,10 @@ def baseline_up_ask(p: float) -> float:
     return min(p + spread_at(p), 1.0)
 
 
+def baseline_dn_ask(p: float) -> float:
+    return min((1 - p) + spread_at(p), 1.0)
+
+
 def shifted_up_ask(p: float, raw_ratio: float) -> float:
     ratio = max(-1.0, min(1.0, raw_ratio))
     mid_shift = ratio * (1 - p) if ratio > 0 else ratio * p
@@ -133,6 +138,20 @@ def shifted_up_ask(p: float, raw_ratio: float) -> float:
     # zero-edge floor: never sell UP below fair
     ask = max(ask, p)
     return min(ask, 1.0)
+
+
+def shifted_dn_ask(p: float, raw_ratio: float) -> float:
+    """DN ask under the inventory-aware mid shift.
+
+    Derived from `dn_ask = 1 − up_bid`, where `up_bid` is the shifted mid
+    minus the spread, clamped at the fair UP price (zero-edge floor).
+    """
+    ratio = max(-1.0, min(1.0, raw_ratio))
+    mid_shift = ratio * (1 - p) if ratio > 0 else ratio * p
+    shifted_mid = p + mid_shift
+    up_bid_raw = shifted_mid - spread_at(p)
+    up_bid = min(max(up_bid_raw, 0.0), p)
+    return 1.0 - up_bid
 
 
 # === Simulation ===
@@ -335,6 +354,106 @@ def render_charts(states, balance: float) -> None:
     print(f"  shifted  max payout: ${result['max_payout_shifted'][-1]:,.0f}")
 
 
+def simulate_dn_buyer(states, depth_multiplier: float, start_tick: int):
+    """Symmetric inverse of the UP scenario.
+
+    A trader buys DN at the same target strike every tick from `start_tick`
+    onward, $TRADE_SIZE per trade. Win-rate gating is disabled because DN at
+    a p_up≈0.20 strike costs ~$0.80 and would never clear `WIN_RATE = 0.40`;
+    the purpose of this chart is to show the shift working in the other
+    direction, not the trader's profit.
+    """
+    n_states = len(states)
+    state_idx = np.linspace(0, n_states - 1, N_MINUTES).astype(int)
+
+    baseline_ask_series = np.zeros(N_MINUTES)
+    shifted_ask_series = np.zeros(N_MINUTES)
+    p_series = np.zeros(N_MINUTES)
+
+    aggregate = 0.0
+    s_payout = 0.0
+
+    for i, si in enumerate(state_idx):
+        forward, svi = states[int(si)]
+        strike = find_strike_for_target_p(forward, svi, TARGET_P)
+        p = svi_up_price(strike, forward, svi) if strike is not None else None
+        if p is None or p <= 0 or p >= 1:
+            if i > 0:
+                baseline_ask_series[i] = baseline_ask_series[i - 1]
+                shifted_ask_series[i] = shifted_ask_series[i - 1]
+                p_series[i] = p_series[i - 1]
+            continue
+
+        tte_ms = SEVEN_DAYS_MS * (N_MINUTES - i) / N_MINUTES
+        tte_factor = math.sqrt(SEVEN_DAYS_MS / max(tte_ms, ONE_DAY_MS))
+        raw_ratio = (aggregate * tte_factor) / (BALANCE * depth_multiplier)
+
+        b_ask = baseline_dn_ask(p)
+        s_ask = shifted_dn_ask(p, raw_ratio)
+        baseline_ask_series[i] = b_ask
+        shifted_ask_series[i] = s_ask
+        p_series[i] = p
+
+        if i >= start_tick:
+            s_new_contracts = TRADE_SIZE / s_ask
+            if s_payout + s_new_contracts <= BALANCE:
+                s_payout += s_new_contracts
+                # DN insert contributes negatively to the signed aggregate:
+                # `aggregate += (q_up − q_dn) · √(p·(1−p))`.
+                aggregate -= TRADE_SIZE * math.sqrt(p * (1 - p))
+
+    return {
+        "ask_baseline": baseline_ask_series,
+        "ask_shifted": shifted_ask_series,
+        "p": p_series,
+    }
+
+
+def render_dn_buyer_chart(states, balance: float) -> None:
+    global BALANCE
+    BALANCE = balance
+
+    sweep_multipliers = [0.25, 0.5, 1.0, 2.0]
+    sweep_colors = ["#1f77b4", "#2ca02c", "#9467bd", "#ff7f0e"]
+    sweep_results = {
+        dm: simulate_dn_buyer(states, dm, DAY2_START_TICK) for dm in sweep_multipliers
+    }
+    baseline_ask = sweep_results[DEFAULT_DEPTH_MULTIPLIER]["ask_baseline"]
+
+    label = f"${int(balance / 1e6)}M vault"
+    suffix = _suffix(balance)
+
+    fig, ax = plt.subplots(figsize=(11, 6))
+    ax.plot(DAYS, baseline_ask, label="Baseline DN ask (no shift)",
+            color="#d62728", lw=2.0)
+    for dm, color in zip(sweep_multipliers, sweep_colors):
+        ax.plot(DAYS, sweep_results[dm]["ask_shifted"],
+                label=f"Shifted DN ask (depth_multiplier={dm})",
+                color=color, lw=1.6)
+    ax.axvline(DAY2_START_TICK / (24 * 60), color="black", lw=1.0,
+               ls="--", alpha=0.55, label="DN buying starts (day 2)")
+    ax.set_xlabel("Time elapsed (days)")
+    ax.set_ylabel("DN ask (same strike, p_up≈0.20)")
+    _style_day_axis(ax)
+    ax.set_title(
+        f"DN-buyer symmetry — {label}, "
+        f"${int(TRADE_SIZE):,}/trade, every tick from day 2 (no win-rate gate)"
+    )
+    ax.legend(loc="lower right", fontsize=9)
+    ax.grid(True, alpha=0.3)
+    fig.tight_layout()
+    out = OUT_DIR / f"dn_buyer_ask{suffix}.png"
+    fig.savefig(out, dpi=150)
+    plt.close(fig)
+    print(f"  wrote {out.relative_to(SCRIPT_DIR)}")
+
+    for dm in sweep_multipliers:
+        final_shifted = sweep_results[dm]["ask_shifted"][-1]
+        delta = final_shifted - baseline_ask[-1]
+        print(f"  dn final shifted ask (dm={dm}): {final_shifted:.4f}  "
+              f"(+{delta * 100:.2f}c over baseline)")
+
+
 def main() -> None:
     states = parse_states(CSV_PATH)
     print(f"Parsed {len(states)} (forward, svi) snapshots from {CSV_PATH.name}")
@@ -343,6 +462,9 @@ def main() -> None:
 
     for balance in BALANCE_VARIANTS:
         render_charts(states, balance)
+
+    print("\n=== DN-buyer symmetry check ===")
+    render_dn_buyer_chart(states, 100_000_000.0)
 
 
 if __name__ == "__main__":

--- a/packages/predict/simulations/toxic_flow_sim.py
+++ b/packages/predict/simulations/toxic_flow_sim.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Toxic-flow simulation comparing baseline symmetric spread vs inventory-aware mid shift.
+
+Scenario:
+- 7 days, one toxic trade per minute (10080 ticks).
+- Each tick: find the strike K where fair p_up(K) ≈ 0.20 and buy UP there.
+- Assume every trade wins (PnL per unit notional = 1 - ask).
+- Market state (forward, SVI params) is sampled from scenario_mar6_1000mints.csv.
+
+Usage:
+    packages/predict/simulations/.venv/bin/python \
+        packages/predict/simulations/toxic_flow_sim.py
+"""
+from __future__ import annotations
+
+import csv
+import math
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy.stats import norm
+
+# === Paths / constants ===
+SCRIPT_DIR = Path(__file__).parent
+CSV_PATH = SCRIPT_DIR / "data" / "scenario_mar6_1000mints.csv"
+OUT_DIR = SCRIPT_DIR / "runs"
+OUT_DIR.mkdir(exist_ok=True)
+
+FLOAT_SCALING = 1e9
+SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000
+ONE_DAY_MS = 24 * 60 * 60 * 1000
+
+# Simulation config
+N_MINUTES = 7 * 24 * 60  # 10080 ticks
+TARGET_P = 0.20  # trader always buys UP at strike where p_up ≈ 0.20
+TRADE_SIZE = 10_000.0  # $10k notional per trade
+
+# Spread config (defaults from predict/constants.move)
+BASE_SPREAD = 0.01
+MIN_SPREAD = 0.0025
+
+# Mid-shift config
+BALANCE = 10_000_000.0
+DEFAULT_DEPTH_MULTIPLIER = 1.0
+
+
+# === CSV parsing ===
+
+def parse_states(path: Path) -> list[tuple[float, tuple[float, float, float, float, float]]]:
+    """Parse CSV into an ordered list of (forward, svi_params) snapshots.
+
+    Each `update_prices`/`update_svi` pair yields one state. `mint` rows are ignored.
+    """
+    states: list[tuple[float, tuple[float, float, float, float, float]]] = []
+    cur_forward: float | None = None
+    cur_svi: tuple[float, float, float, float, float] | None = None
+    with open(path) as f:
+        for row in csv.DictReader(f):
+            action = row["action"]
+            if action == "update_prices":
+                cur_forward = float(row["forward"]) / FLOAT_SCALING
+            elif action == "update_svi":
+                a = float(row["a"]) / FLOAT_SCALING
+                b = float(row["b"]) / FLOAT_SCALING
+                rho = float(row["rho"]) / FLOAT_SCALING
+                if row["rho_negative"].strip().lower() == "true":
+                    rho = -rho
+                m = float(row["m"]) / FLOAT_SCALING
+                if row["m_negative"].strip().lower() == "true":
+                    m = -m
+                sigma = float(row["sigma"]) / FLOAT_SCALING
+                cur_svi = (a, b, rho, m, sigma)
+                if cur_forward is not None and cur_svi is not None:
+                    states.append((cur_forward, cur_svi))
+    return states
+
+
+# === SVI → binary UP price (port of oracle::compute_nd2) ===
+
+def svi_up_price(strike: float, forward: float, svi) -> float | None:
+    a, b, rho, m, sigma = svi
+    if strike <= 0 or forward <= 0:
+        return None
+    k = math.log(strike / forward)
+    km = k - m
+    inner = rho * km + math.sqrt(km * km + sigma * sigma)
+    if inner < 0:
+        return None
+    w = a + b * inner
+    if w <= 0:
+        return None
+    d2 = -(k + w / 2) / math.sqrt(w)
+    return float(norm.cdf(d2))
+
+
+def find_strike_for_target_p(forward: float, svi, target_p: float) -> float | None:
+    """Binary search for strike K where p_up(K) ≈ target_p. p_up decreases in K."""
+    lo, hi = forward * 0.2, forward * 5.0
+    for _ in range(80):
+        mid = 0.5 * (lo + hi)
+        p = svi_up_price(mid, forward, svi)
+        if p is None:
+            return None
+        if p > target_p:
+            lo = mid
+        else:
+            hi = mid
+    return 0.5 * (lo + hi)
+
+
+# === Pricing ===
+
+def spread_at(p: float) -> float:
+    return max(BASE_SPREAD * math.sqrt(p * (1 - p)), MIN_SPREAD)
+
+
+def baseline_up_ask(p: float) -> float:
+    return min(p + spread_at(p), 1.0)
+
+
+def shifted_up_ask(p: float, raw_ratio: float) -> float:
+    ratio = max(-1.0, min(1.0, raw_ratio))
+    mid_shift = ratio * (1 - p) if ratio > 0 else ratio * p
+    shifted_mid = p + mid_shift
+    ask = shifted_mid + spread_at(p)
+    # zero-edge floor: never sell UP below fair
+    ask = max(ask, p)
+    return min(ask, 1.0)
+
+
+# === Simulation ===
+
+def simulate(states, depth_multiplier: float):
+    n_states = len(states)
+    state_idx = np.linspace(0, n_states - 1, N_MINUTES).astype(int)
+
+    baseline_pnl = np.zeros(N_MINUTES)
+    shifted_pnl = np.zeros(N_MINUTES)
+    raw_ratio_series = np.zeros(N_MINUTES)
+    ask_baseline_series = np.zeros(N_MINUTES)
+    ask_shifted_series = np.zeros(N_MINUTES)
+
+    aggregate = 0.0
+    b_pnl = 0.0
+    s_pnl = 0.0
+
+    for i, si in enumerate(state_idx):
+        forward, svi = states[int(si)]
+        strike = find_strike_for_target_p(forward, svi, TARGET_P)
+        if strike is None:
+            baseline_pnl[i] = b_pnl
+            shifted_pnl[i] = s_pnl
+            continue
+        p = svi_up_price(strike, forward, svi)
+        if p is None or p <= 0 or p >= 1:
+            baseline_pnl[i] = b_pnl
+            shifted_pnl[i] = s_pnl
+            continue
+
+        tte_ms = SEVEN_DAYS_MS * (N_MINUTES - i) / N_MINUTES
+        tte_factor = math.sqrt(SEVEN_DAYS_MS / max(tte_ms, ONE_DAY_MS))
+        raw_ratio = (aggregate * tte_factor) / (BALANCE * depth_multiplier)
+
+        b_ask = baseline_up_ask(p)
+        s_ask = shifted_up_ask(p, raw_ratio)
+
+        # Toxic trader knows the trade wins. PnL per unit = 1 - ask. Skip if ask ≥ 1.
+        if b_ask < 1.0:
+            b_pnl += TRADE_SIZE * (1.0 - b_ask)
+        if s_ask < 1.0:
+            s_pnl += TRADE_SIZE * (1.0 - s_ask)
+            aggregate += TRADE_SIZE * math.sqrt(p * (1 - p))
+
+        baseline_pnl[i] = b_pnl
+        shifted_pnl[i] = s_pnl
+        raw_ratio_series[i] = raw_ratio
+        ask_baseline_series[i] = b_ask
+        ask_shifted_series[i] = s_ask
+
+    return {
+        "baseline_pnl": baseline_pnl,
+        "shifted_pnl": shifted_pnl,
+        "raw_ratio": raw_ratio_series,
+        "ask_baseline": ask_baseline_series,
+        "ask_shifted": ask_shifted_series,
+    }
+
+
+# === Main ===
+
+def main() -> None:
+    states = parse_states(CSV_PATH)
+    print(f"Parsed {len(states)} (forward, svi) snapshots from {CSV_PATH.name}")
+    print(f"Running {N_MINUTES} ticks, trade size ${TRADE_SIZE:,.0f}, balance ${BALANCE:,.0f}")
+
+    result = simulate(states, DEFAULT_DEPTH_MULTIPLIER)
+
+    baseline_final = result["baseline_pnl"][-1]
+    shifted_final = result["shifted_pnl"][-1]
+    print(f"Baseline final toxic PnL: ${baseline_final:,.0f}")
+    print(f"Shifted  final toxic PnL: ${shifted_final:,.0f}  "
+          f"(depth_multiplier={DEFAULT_DEPTH_MULTIPLIER})")
+    if baseline_final > 0:
+        print(f"Reduction: {1 - shifted_final / baseline_final:.1%}")
+
+    ticks = np.arange(N_MINUTES)
+
+    # Chart 1: baseline vs shifted cumulative PnL
+    fig, ax = plt.subplots(figsize=(11, 6))
+    ax.plot(
+        ticks,
+        result["baseline_pnl"] / 1_000,
+        label="Baseline (symmetric spread only)",
+        color="#d62728",
+        lw=2,
+    )
+    ax.plot(
+        ticks,
+        result["shifted_pnl"] / 1_000,
+        label=f"With mid shift (depth_multiplier={DEFAULT_DEPTH_MULTIPLIER})",
+        color="#2ca02c",
+        lw=2,
+    )
+    ax.set_xlabel("Minute since start of 7d window")
+    ax.set_ylabel("Cumulative toxic trader PnL ($ thousands)")
+    ax.set_title(
+        f"Toxic flow: buy strike at p_up≈{TARGET_P}, ${int(TRADE_SIZE):,}/trade, "
+        f"${int(BALANCE / 1e6)}M vault"
+    )
+    ax.legend(loc="upper left")
+    ax.grid(True, alpha=0.3)
+    fig.tight_layout()
+    out1 = OUT_DIR / "toxic_flow_pnl.png"
+    fig.savefig(out1, dpi=150)
+    plt.close(fig)
+    print(f"Wrote {out1.relative_to(SCRIPT_DIR)}")
+
+    # Chart 2: depth_multiplier sensitivity
+    fig, ax = plt.subplots(figsize=(11, 6))
+    ax.plot(ticks, result["baseline_pnl"] / 1_000, label="Baseline", color="#d62728", lw=2.2)
+    colors = ["#1f77b4", "#2ca02c", "#9467bd", "#ff7f0e"]
+    for dm, color in zip([0.25, 0.5, 1.0, 2.0], colors):
+        sweep = simulate(states, dm)
+        ax.plot(
+            ticks,
+            sweep["shifted_pnl"] / 1_000,
+            label=f"depth_multiplier={dm}",
+            color=color,
+            lw=1.6,
+        )
+    ax.set_xlabel("Minute since start of 7d window")
+    ax.set_ylabel("Cumulative toxic trader PnL ($ thousands)")
+    ax.set_title("Toxic flow PnL — depth_multiplier sensitivity")
+    ax.legend(loc="upper left")
+    ax.grid(True, alpha=0.3)
+    fig.tight_layout()
+    out2 = OUT_DIR / "toxic_flow_depth_sweep.png"
+    fig.savefig(out2, dpi=150)
+    plt.close(fig)
+    print(f"Wrote {out2.relative_to(SCRIPT_DIR)}")
+
+    # Chart 3: diagnostic — how the ask evolves under the shift vs baseline
+    fig, ax = plt.subplots(figsize=(11, 6))
+    ax.plot(ticks, result["ask_baseline"], label="Baseline ask", color="#d62728", lw=1.5)
+    ax.plot(ticks, result["ask_shifted"], label="Shifted ask", color="#2ca02c", lw=1.5)
+    ax.axhline(1.0, color="grey", lw=0.8, ls="--", alpha=0.6)
+    ax.set_xlabel("Minute since start of 7d window")
+    ax.set_ylabel("Ask price (UP at target strike)")
+    ax.set_title("UP ask over time — baseline vs. mid-shift defense")
+    ax.legend(loc="upper left")
+    ax.grid(True, alpha=0.3)
+    fig.tight_layout()
+    out3 = OUT_DIR / "toxic_flow_ask_trace.png"
+    fig.savefig(out3, dpi=150)
+    plt.close(fig)
+    print(f"Wrote {out3.relative_to(SCRIPT_DIR)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/predict/simulations/toxic_flow_sim.py
+++ b/packages/predict/simulations/toxic_flow_sim.py
@@ -83,9 +83,9 @@ def parse_states(path: Path) -> list[tuple[float, tuple[float, float, float, flo
     return states
 
 
-# === SVI → binary UP price (port of oracle::compute_nd2) ===
+# === SVI → binary UP price (port of oracle::compute_d2) ===
 
-def svi_up_price(strike: float, forward: float, svi) -> float | None:
+def svi_d2(strike: float, forward: float, svi) -> float | None:
     a, b, rho, m, sigma = svi
     if strike <= 0 or forward <= 0:
         return None
@@ -97,8 +97,23 @@ def svi_up_price(strike: float, forward: float, svi) -> float | None:
     w = a + b * inner
     if w <= 0:
         return None
-    d2 = -(k + w / 2) / math.sqrt(w)
+    return -(k + w / 2) / math.sqrt(w)
+
+
+def svi_up_price(strike: float, forward: float, svi) -> float | None:
+    d2 = svi_d2(strike, forward, svi)
+    if d2 is None:
+        return None
     return float(norm.cdf(d2))
+
+
+def risk_weight_at(strike: float, forward: float, svi) -> float:
+    """Per-strike risk weight n(d₂) — the true cross-sectional binary delta
+    proxy (mirrors `oracle::compute_risk_weight`)."""
+    d2 = svi_d2(strike, forward, svi)
+    if d2 is None:
+        return 0.0
+    return float(norm.pdf(d2))
 
 
 def find_strike_for_target_p(forward: float, svi, target_p: float) -> float | None:
@@ -211,7 +226,7 @@ def simulate(states, depth_multiplier: float):
         if s_ask < WIN_RATE and s_payout + s_new_contracts <= BALANCE:
             s_pnl += TRADE_SIZE * (WIN_RATE - s_ask)
             s_payout += s_new_contracts
-            aggregate += TRADE_SIZE * math.sqrt(p * (1 - p))
+            aggregate += TRADE_SIZE * risk_weight_at(strike, forward, svi)
 
         baseline_pnl[i] = b_pnl
         shifted_pnl[i] = s_pnl
@@ -399,8 +414,8 @@ def simulate_dn_buyer(states, depth_multiplier: float, start_tick: int):
             if s_payout + s_new_contracts <= BALANCE:
                 s_payout += s_new_contracts
                 # DN insert contributes negatively to the signed aggregate:
-                # `aggregate += (q_up − q_dn) · √(p·(1−p))`.
-                aggregate -= TRADE_SIZE * math.sqrt(p * (1 - p))
+                # `aggregate += (q_up − q_dn) · n(d₂)`.
+                aggregate -= TRADE_SIZE * risk_weight_at(strike, forward, svi)
 
     return {
         "ask_baseline": baseline_ask_series,

--- a/packages/predict/simulations/toxic_flow_sim.py
+++ b/packages/predict/simulations/toxic_flow_sim.py
@@ -4,7 +4,9 @@
 Scenario:
 - 7 days, one toxic trade per minute (10080 ticks).
 - Each tick: find the strike K where fair p_up(K) ≈ 0.20 and buy UP there.
-- Assume every trade wins (PnL per unit notional = 1 - ask).
+- Trader's realized win rate on the 20c strike is WIN_RATE (default 40%).
+- Trader only takes the trade when EV is positive: ask < WIN_RATE.
+- Expected PnL per unit = WIN_RATE − ask.
 - Market state (forward, SVI params) is sampled from scenario_mar6_1000mints.csv.
 
 Usage:
@@ -21,6 +23,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 from scipy.stats import norm
 
+plt.rcParams["text.parse_math"] = False  # allow literal "$" in labels/titles
+
 # === Paths / constants ===
 SCRIPT_DIR = Path(__file__).parent
 CSV_PATH = SCRIPT_DIR / "data" / "scenario_mar6_1000mints.csv"
@@ -34,7 +38,8 @@ ONE_DAY_MS = 24 * 60 * 60 * 1000
 # Simulation config
 N_MINUTES = 7 * 24 * 60  # 10080 ticks
 TARGET_P = 0.20  # trader always buys UP at strike where p_up ≈ 0.20
-TRADE_SIZE = 10_000.0  # $10k notional per trade
+TRADE_SIZE = 2_000.0  # $2k notional per trade
+WIN_RATE = 0.40  # realized win rate on 20c strikes (toxic but not omniscient)
 
 # Spread config (defaults from predict/constants.move)
 BASE_SPREAD = 0.01
@@ -43,6 +48,7 @@ MIN_SPREAD = 0.0025
 # Mid-shift config
 BALANCE = 10_000_000.0
 DEFAULT_DEPTH_MULTIPLIER = 1.0
+BALANCE_VARIANTS = [100_000_000.0, 400_000_000.0]  # runs main() once per balance
 
 
 # === CSV parsing ===
@@ -140,10 +146,14 @@ def simulate(states, depth_multiplier: float):
     raw_ratio_series = np.zeros(N_MINUTES)
     ask_baseline_series = np.zeros(N_MINUTES)
     ask_shifted_series = np.zeros(N_MINUTES)
+    max_payout_baseline = np.zeros(N_MINUTES)
+    max_payout_shifted = np.zeros(N_MINUTES)
 
     aggregate = 0.0
     b_pnl = 0.0
     s_pnl = 0.0
+    b_payout = 0.0  # max possible vault liability (= contracts sold × $1 payout)
+    s_payout = 0.0
 
     for i, si in enumerate(state_idx):
         forward, svi = states[int(si)]
@@ -151,11 +161,15 @@ def simulate(states, depth_multiplier: float):
         if strike is None:
             baseline_pnl[i] = b_pnl
             shifted_pnl[i] = s_pnl
+            max_payout_baseline[i] = b_payout
+            max_payout_shifted[i] = s_payout
             continue
         p = svi_up_price(strike, forward, svi)
         if p is None or p <= 0 or p >= 1:
             baseline_pnl[i] = b_pnl
             shifted_pnl[i] = s_pnl
+            max_payout_baseline[i] = b_payout
+            max_payout_shifted[i] = s_payout
             continue
 
         tte_ms = SEVEN_DAYS_MS * (N_MINUTES - i) / N_MINUTES
@@ -165,11 +179,19 @@ def simulate(states, depth_multiplier: float):
         b_ask = baseline_up_ask(p)
         s_ask = shifted_up_ask(p, raw_ratio)
 
-        # Toxic trader knows the trade wins. PnL per unit = 1 - ask. Skip if ask ≥ 1.
-        if b_ask < 1.0:
-            b_pnl += TRADE_SIZE * (1.0 - b_ask)
-        if s_ask < 1.0:
-            s_pnl += TRADE_SIZE * (1.0 - s_ask)
+        # Trader takes the trade only if expected value is positive: WIN_RATE > ask.
+        # Expected PnL per unit = WIN_RATE · (1 − ask) + (1 − WIN_RATE) · (−ask) = WIN_RATE − ask.
+        # Contracts bought for a $TRADE_SIZE spend = TRADE_SIZE / ask. Max payout = 1 per contract.
+        # Vault exposure gate: refuse the trade if cumulative max payout would
+        # exceed the vault balance (vault cannot pay out more than it holds).
+        b_new_contracts = TRADE_SIZE / b_ask
+        if b_ask < WIN_RATE and b_payout + b_new_contracts <= BALANCE:
+            b_pnl += TRADE_SIZE * (WIN_RATE - b_ask)
+            b_payout += b_new_contracts
+        s_new_contracts = TRADE_SIZE / s_ask
+        if s_ask < WIN_RATE and s_payout + s_new_contracts <= BALANCE:
+            s_pnl += TRADE_SIZE * (WIN_RATE - s_ask)
+            s_payout += s_new_contracts
             aggregate += TRADE_SIZE * math.sqrt(p * (1 - p))
 
         baseline_pnl[i] = b_pnl
@@ -177,6 +199,8 @@ def simulate(states, depth_multiplier: float):
         raw_ratio_series[i] = raw_ratio
         ask_baseline_series[i] = b_ask
         ask_shifted_series[i] = s_ask
+        max_payout_baseline[i] = b_payout
+        max_payout_shifted[i] = s_payout
 
     return {
         "baseline_pnl": baseline_pnl,
@@ -184,97 +208,141 @@ def simulate(states, depth_multiplier: float):
         "raw_ratio": raw_ratio_series,
         "ask_baseline": ask_baseline_series,
         "ask_shifted": ask_shifted_series,
+        "max_payout_baseline": max_payout_baseline,
+        "max_payout_shifted": max_payout_shifted,
     }
 
 
-# === Main ===
+# === Charting ===
+
+DAYS = np.arange(N_MINUTES) / (24 * 60)
+DAY_TICKS = list(range(8))
+DAY_LABELS = [f"Day {d}" for d in DAY_TICKS]
+
+
+def _style_day_axis(ax) -> None:
+    ax.set_xticks(DAY_TICKS)
+    ax.set_xticklabels(DAY_LABELS)
+    ax.set_xlim(0, 7)
+
+
+def _suffix(balance: float) -> str:
+    return f"_{int(balance / 1e6)}m"
+
+
+def render_charts(states, balance: float) -> None:
+    global BALANCE
+    BALANCE = balance
+
+    sweep_multipliers = [0.25, 0.5, 1.0, 2.0]
+    sweep_colors = ["#1f77b4", "#2ca02c", "#9467bd", "#ff7f0e"]
+    sweep_results = {dm: simulate(states, dm) for dm in sweep_multipliers}
+    result = sweep_results[DEFAULT_DEPTH_MULTIPLIER]
+
+    baseline_final = result["baseline_pnl"][-1]
+    print(f"\n=== Balance ${balance:,.0f} ===")
+    print(f"  baseline final toxic PnL: ${baseline_final:,.0f}")
+    for dm in sweep_multipliers:
+        shifted_final = sweep_results[dm]["shifted_pnl"][-1]
+        reduction = (1 - shifted_final / baseline_final) if baseline_final > 0 else 0.0
+        print(f"  shifted final (dm={dm}): ${shifted_final:,.0f}  "
+              f"(reduction {reduction:.1%})")
+
+    label = f"${int(balance / 1e6)}M vault"
+    suffix = _suffix(balance)
+
+    # Chart 1: baseline vs shifted cumulative PnL across depth_multipliers
+    fig, ax = plt.subplots(figsize=(11, 6))
+    ax.plot(DAYS, result["baseline_pnl"] / 1_000,
+            label="Baseline (symmetric spread only)", color="#d62728", lw=2.2)
+    for dm, color in zip(sweep_multipliers, sweep_colors):
+        ax.plot(DAYS, sweep_results[dm]["shifted_pnl"] / 1_000,
+                label=f"Mid shift (depth_multiplier={dm})",
+                color=color, lw=1.8)
+    ax.set_xlabel("Time elapsed (days)")
+    ax.set_ylabel("Cumulative toxic trader PnL ($ thousands)")
+    _style_day_axis(ax)
+    ax.set_title(
+        f"Toxic flow PnL — {label}, buy strike at p_up≈{TARGET_P}, "
+        f"win rate {int(WIN_RATE * 100)}%, ${int(TRADE_SIZE):,}/trade"
+    )
+    ax.legend(loc="upper left")
+    ax.grid(True, alpha=0.3)
+    fig.tight_layout()
+    out1 = OUT_DIR / f"toxic_flow_pnl{suffix}.png"
+    fig.savefig(out1, dpi=150)
+    plt.close(fig)
+    print(f"  wrote {out1.relative_to(SCRIPT_DIR)}")
+
+    # Chart 3: diagnostic — ask evolves vs. trader reservation, with max payout
+    fig, ax = plt.subplots(figsize=(11, 6))
+    ax.plot(DAYS, result["ask_baseline"], label="Baseline ask",
+            color="#d62728", lw=1.5)
+    ax.plot(DAYS, result["ask_shifted"], label="Shifted ask",
+            color="#2ca02c", lw=1.5)
+    ax.axhline(WIN_RATE, color="grey", lw=0.9, ls="--", alpha=0.7,
+               label=f"Trader reservation = {WIN_RATE}")
+    ax.set_xlabel("Time elapsed (days)")
+    ax.set_ylabel("Ask price (UP at target strike)")
+    _style_day_axis(ax)
+    ax.set_ylim(0.1, 1.02)
+    ax.set_title(f"UP ask over time — {label} — baseline vs. mid-shift defense")
+
+    ax2 = ax.twinx()
+    ax2.plot(DAYS, result["max_payout_baseline"] / 1e6,
+             label="Baseline max payout (right axis)",
+             color="#d62728", lw=1.2, ls=":")
+    ax2.plot(DAYS, result["max_payout_shifted"] / 1e6,
+             label="Shifted max payout (right axis)",
+             color="#2ca02c", lw=1.2, ls=":")
+    ax2.set_ylabel("Cumulative max vault payout ($M)")
+    ax2.set_ylim(bottom=0)
+
+    lines1, labels1 = ax.get_legend_handles_labels()
+    lines2, labels2 = ax2.get_legend_handles_labels()
+    ax.legend(lines1 + lines2, labels1 + labels2, loc="upper left", fontsize=9)
+    ax.grid(True, alpha=0.3)
+    fig.tight_layout()
+    out3 = OUT_DIR / f"toxic_flow_ask_trace{suffix}.png"
+    fig.savefig(out3, dpi=150)
+    plt.close(fig)
+    print(f"  wrote {out3.relative_to(SCRIPT_DIR)}")
+
+    # Chart 4: standalone max payout chart
+    fig, ax = plt.subplots(figsize=(11, 6))
+    ax.plot(DAYS, result["max_payout_baseline"] / 1e6,
+            label="Baseline max payout", color="#d62728", lw=2)
+    ax.plot(DAYS, result["max_payout_shifted"] / 1e6,
+            label="Shifted max payout", color="#2ca02c", lw=2)
+    ax.axhline(balance / 1e6, color="black", lw=1.0, ls="--", alpha=0.6,
+               label=f"Vault balance = ${int(balance / 1e6)}M")
+    ax.set_xlabel("Time elapsed (days)")
+    ax.set_ylabel("Cumulative max vault payout ($M)")
+    _style_day_axis(ax)
+    ax.set_title(
+        f"Max possible vault liability — {label}, "
+        f"buy strike at p_up≈{TARGET_P}, win rate {int(WIN_RATE * 100)}%"
+    )
+    ax.legend(loc="upper left")
+    ax.grid(True, alpha=0.3)
+    fig.tight_layout()
+    out4 = OUT_DIR / f"toxic_flow_max_payout{suffix}.png"
+    fig.savefig(out4, dpi=150)
+    plt.close(fig)
+    print(f"  wrote {out4.relative_to(SCRIPT_DIR)}")
+
+    print(f"  baseline max payout: ${result['max_payout_baseline'][-1]:,.0f}")
+    print(f"  shifted  max payout: ${result['max_payout_shifted'][-1]:,.0f}")
+
 
 def main() -> None:
     states = parse_states(CSV_PATH)
     print(f"Parsed {len(states)} (forward, svi) snapshots from {CSV_PATH.name}")
-    print(f"Running {N_MINUTES} ticks, trade size ${TRADE_SIZE:,.0f}, balance ${BALANCE:,.0f}")
+    print(f"Running {N_MINUTES} ticks, trade size ${TRADE_SIZE:,.0f}, "
+          f"win rate {int(WIN_RATE * 100)}%")
 
-    result = simulate(states, DEFAULT_DEPTH_MULTIPLIER)
-
-    baseline_final = result["baseline_pnl"][-1]
-    shifted_final = result["shifted_pnl"][-1]
-    print(f"Baseline final toxic PnL: ${baseline_final:,.0f}")
-    print(f"Shifted  final toxic PnL: ${shifted_final:,.0f}  "
-          f"(depth_multiplier={DEFAULT_DEPTH_MULTIPLIER})")
-    if baseline_final > 0:
-        print(f"Reduction: {1 - shifted_final / baseline_final:.1%}")
-
-    ticks = np.arange(N_MINUTES)
-
-    # Chart 1: baseline vs shifted cumulative PnL
-    fig, ax = plt.subplots(figsize=(11, 6))
-    ax.plot(
-        ticks,
-        result["baseline_pnl"] / 1_000,
-        label="Baseline (symmetric spread only)",
-        color="#d62728",
-        lw=2,
-    )
-    ax.plot(
-        ticks,
-        result["shifted_pnl"] / 1_000,
-        label=f"With mid shift (depth_multiplier={DEFAULT_DEPTH_MULTIPLIER})",
-        color="#2ca02c",
-        lw=2,
-    )
-    ax.set_xlabel("Minute since start of 7d window")
-    ax.set_ylabel("Cumulative toxic trader PnL ($ thousands)")
-    ax.set_title(
-        f"Toxic flow: buy strike at p_up≈{TARGET_P}, ${int(TRADE_SIZE):,}/trade, "
-        f"${int(BALANCE / 1e6)}M vault"
-    )
-    ax.legend(loc="upper left")
-    ax.grid(True, alpha=0.3)
-    fig.tight_layout()
-    out1 = OUT_DIR / "toxic_flow_pnl.png"
-    fig.savefig(out1, dpi=150)
-    plt.close(fig)
-    print(f"Wrote {out1.relative_to(SCRIPT_DIR)}")
-
-    # Chart 2: depth_multiplier sensitivity
-    fig, ax = plt.subplots(figsize=(11, 6))
-    ax.plot(ticks, result["baseline_pnl"] / 1_000, label="Baseline", color="#d62728", lw=2.2)
-    colors = ["#1f77b4", "#2ca02c", "#9467bd", "#ff7f0e"]
-    for dm, color in zip([0.25, 0.5, 1.0, 2.0], colors):
-        sweep = simulate(states, dm)
-        ax.plot(
-            ticks,
-            sweep["shifted_pnl"] / 1_000,
-            label=f"depth_multiplier={dm}",
-            color=color,
-            lw=1.6,
-        )
-    ax.set_xlabel("Minute since start of 7d window")
-    ax.set_ylabel("Cumulative toxic trader PnL ($ thousands)")
-    ax.set_title("Toxic flow PnL — depth_multiplier sensitivity")
-    ax.legend(loc="upper left")
-    ax.grid(True, alpha=0.3)
-    fig.tight_layout()
-    out2 = OUT_DIR / "toxic_flow_depth_sweep.png"
-    fig.savefig(out2, dpi=150)
-    plt.close(fig)
-    print(f"Wrote {out2.relative_to(SCRIPT_DIR)}")
-
-    # Chart 3: diagnostic — how the ask evolves under the shift vs baseline
-    fig, ax = plt.subplots(figsize=(11, 6))
-    ax.plot(ticks, result["ask_baseline"], label="Baseline ask", color="#d62728", lw=1.5)
-    ax.plot(ticks, result["ask_shifted"], label="Shifted ask", color="#2ca02c", lw=1.5)
-    ax.axhline(1.0, color="grey", lw=0.8, ls="--", alpha=0.6)
-    ax.set_xlabel("Minute since start of 7d window")
-    ax.set_ylabel("Ask price (UP at target strike)")
-    ax.set_title("UP ask over time — baseline vs. mid-shift defense")
-    ax.legend(loc="upper left")
-    ax.grid(True, alpha=0.3)
-    fig.tight_layout()
-    out3 = OUT_DIR / "toxic_flow_ask_trace.png"
-    fig.savefig(out3, dpi=150)
-    plt.close(fig)
-    print(f"Wrote {out3.relative_to(SCRIPT_DIR)}")
+    for balance in BALANCE_VARIANTS:
+        render_charts(states, balance)
 
 
 if __name__ == "__main__":

--- a/packages/predict/sources/config/pricing_config.move
+++ b/packages/predict/sources/config/pricing_config.move
@@ -5,7 +5,7 @@
 module deepbook_predict::pricing_config;
 
 use deepbook::math;
-use deepbook_predict::{constants, math as predict_math};
+use deepbook_predict::{constants, i64::{Self, I64}, math as predict_math};
 
 // === Errors ===
 const EInvalidSpread: u64 = 0;
@@ -27,6 +27,11 @@ public struct PricingConfig has store {
     min_ask_price: u64,
     /// Global maximum allowed post-spread ask price at mint time.
     max_ask_price: u64,
+    /// Depth multiplier for the inventory-aware mid shift, in FLOAT_SCALING.
+    /// `raw_ratio = aggregate · tte_factor / (balance · depth_multiplier)`, so
+    /// lower values make the shift respond more aggressively to a given
+    /// directional inventory.
+    depth_multiplier: u64,
 }
 
 // === Public Functions ===
@@ -51,6 +56,10 @@ public fun max_ask_price(config: &PricingConfig): u64 {
     config.max_ask_price
 }
 
+public fun depth_multiplier(config: &PricingConfig): u64 {
+    config.depth_multiplier
+}
+
 // === Public-Package Functions ===
 
 public(package) fun new(): PricingConfig {
@@ -60,6 +69,7 @@ public(package) fun new(): PricingConfig {
         utilization_multiplier: constants::default_utilization_multiplier!(),
         min_ask_price: constants::default_min_ask_price!(),
         max_ask_price: constants::default_max_ask_price!(),
+        depth_multiplier: constants::default_depth_multiplier!(),
     }
 }
 
@@ -88,6 +98,10 @@ public(package) fun set_max_ask_price(config: &mut PricingConfig, value: u64) {
     config.max_ask_price = value;
 }
 
+public(package) fun set_depth_multiplier(config: &mut PricingConfig, multiplier: u64) {
+    config.depth_multiplier = multiplier;
+}
+
 public(package) fun quote_spread_from_fair_price(
     config: &PricingConfig,
     fair_price: u64,
@@ -106,6 +120,36 @@ public(package) fun quote_spread_from_fair_price(
     spread
 }
 
+/// Compute the post-shift UP ask / bid for `up_price`. Applies a symmetric
+/// spread around the inventory-shifted mid and clamps both quotes at the fair
+/// price (zero-edge floor — LP never sells UP below fair or buys UP above fair).
+public(package) fun compute_up_quote(
+    config: &PricingConfig,
+    up_price: u64,
+    aggregate: &I64,
+    liability: u64,
+    balance: u64,
+    tte_ms: u64,
+): (u64, u64) {
+    let spread = config.quote_spread_from_fair_price(up_price, liability, balance);
+    let shifted_mid = shifted_up_mid(
+        up_price,
+        aggregate,
+        balance,
+        tte_ms,
+        config.depth_multiplier,
+    );
+
+    let up_ask = (shifted_mid + spread).max(up_price).min(constants::float_scaling!());
+    let up_bid = if (shifted_mid > spread) {
+        (shifted_mid - spread).min(up_price)
+    } else {
+        0
+    };
+
+    (up_ask, up_bid)
+}
+
 fun utilization_spread(config: &PricingConfig, liability: u64, balance: u64): u64 {
     if (balance == 0 || liability == 0) return 0;
 
@@ -121,4 +165,47 @@ fun utilization_spread(config: &PricingConfig, liability: u64, balance: u64): u6
         config.base_spread,
         math::mul(config.utilization_multiplier, util_sq),
     )
+}
+
+/// Shifted UP mid in FLOAT_SCALING. The shift is
+/// `clamp(aggregate · tte_factor / (balance · depth_multiplier), −1, +1)`
+/// scaled by the per-strike distance to the nearest bound: `(1 − p)` for a
+/// positive ratio (LP net short UP, push the mid up) or `p` for a negative
+/// ratio. Result is always in `[0, float_scaling]` because the scaling caps
+/// each direction at the bound.
+fun shifted_up_mid(
+    up_price: u64,
+    aggregate: &I64,
+    balance: u64,
+    tte_ms: u64,
+    depth_multiplier: u64,
+): u64 {
+    if (i64::is_zero(aggregate) || balance == 0 || depth_multiplier == 0) return up_price;
+
+    let fs = constants::float_scaling!();
+    let clamped_tte = tte_ms.max(constants::min_tte_ms!());
+    let tte_ratio = predict_math::mul_div_round_down(
+        constants::reference_tte_ms!(),
+        fs,
+        clamped_tte,
+    );
+    let tte_factor = predict_math::sqrt(tte_ratio, fs);
+
+    let denominator = math::mul(balance, depth_multiplier);
+    if (denominator == 0) return up_price;
+
+    let num = i64::mul_scaled(aggregate, &i64::from_u64(tte_factor));
+    let ratio = i64::div_scaled(&num, &i64::from_u64(denominator));
+    let ratio_mag = i64::magnitude(&ratio).min(fs);
+    if (ratio_mag == 0) return up_price;
+
+    let ratio_negative = i64::is_negative(&ratio);
+    let room = if (ratio_negative) up_price else fs - up_price;
+    let shift = math::mul(ratio_mag, room);
+
+    if (ratio_negative) {
+        up_price - shift
+    } else {
+        up_price + shift
+    }
 }

--- a/packages/predict/sources/config/pricing_config.move
+++ b/packages/predict/sources/config/pricing_config.move
@@ -11,6 +11,7 @@ use deepbook_predict::{constants, i64::{Self, I64}, math as predict_math};
 const EInvalidSpread: u64 = 0;
 const EFairPriceAlreadySettled: u64 = 1;
 const EInvalidAskBound: u64 = 2;
+const EInvalidTteBound: u64 = 3;
 
 // === Structs ===
 
@@ -32,6 +33,13 @@ public struct PricingConfig has store {
     /// lower values make the shift respond more aggressively to a given
     /// directional inventory.
     depth_multiplier: u64,
+    /// Reference time-to-expiry for the inventory-aware mid shift.
+    /// `tte_factor = √(reference_tte_ms / max(tte_ms, min_tte_ms))`, so
+    /// `tte_factor == 1` when `tte_ms == reference_tte_ms`.
+    reference_tte_ms: u64,
+    /// Minimum TTE floor used to cap near-expiry amplification of `tte_factor`.
+    /// Once `tte_ms < min_tte_ms`, further time decay stops increasing the shift.
+    min_tte_ms: u64,
 }
 
 // === Public Functions ===
@@ -60,6 +68,14 @@ public fun depth_multiplier(config: &PricingConfig): u64 {
     config.depth_multiplier
 }
 
+public fun reference_tte_ms(config: &PricingConfig): u64 {
+    config.reference_tte_ms
+}
+
+public fun min_tte_ms(config: &PricingConfig): u64 {
+    config.min_tte_ms
+}
+
 // === Public-Package Functions ===
 
 public(package) fun new(): PricingConfig {
@@ -70,6 +86,8 @@ public(package) fun new(): PricingConfig {
         min_ask_price: constants::default_min_ask_price!(),
         max_ask_price: constants::default_max_ask_price!(),
         depth_multiplier: constants::default_depth_multiplier!(),
+        reference_tte_ms: constants::default_reference_tte_ms!(),
+        min_tte_ms: constants::default_min_tte_ms!(),
     }
 }
 
@@ -100,6 +118,16 @@ public(package) fun set_max_ask_price(config: &mut PricingConfig, value: u64) {
 
 public(package) fun set_depth_multiplier(config: &mut PricingConfig, multiplier: u64) {
     config.depth_multiplier = multiplier;
+}
+
+public(package) fun set_reference_tte_ms(config: &mut PricingConfig, value: u64) {
+    assert!(value >= config.min_tte_ms, EInvalidTteBound);
+    config.reference_tte_ms = value;
+}
+
+public(package) fun set_min_tte_ms(config: &mut PricingConfig, value: u64) {
+    assert!(value > 0 && value <= config.reference_tte_ms, EInvalidTteBound);
+    config.min_tte_ms = value;
 }
 
 public(package) fun quote_spread_from_fair_price(
@@ -138,6 +166,8 @@ public(package) fun compute_up_quote(
         balance,
         tte_ms,
         config.depth_multiplier,
+        config.reference_tte_ms,
+        config.min_tte_ms,
     );
 
     let up_ask = (shifted_mid + spread).max(up_price).min(constants::float_scaling!());
@@ -179,13 +209,15 @@ fun shifted_up_mid(
     balance: u64,
     tte_ms: u64,
     depth_multiplier: u64,
+    reference_tte_ms: u64,
+    min_tte_ms: u64,
 ): u64 {
     if (i64::is_zero(aggregate) || balance == 0 || depth_multiplier == 0) return up_price;
 
     let fs = constants::float_scaling!();
-    let clamped_tte = tte_ms.max(constants::min_tte_ms!());
+    let clamped_tte = tte_ms.max(min_tte_ms);
     let tte_ratio = predict_math::mul_div_round_down(
-        constants::reference_tte_ms!(),
+        reference_tte_ms,
         fs,
         clamped_tte,
     );

--- a/packages/predict/sources/helper/constants.move
+++ b/packages/predict/sources/helper/constants.move
@@ -38,9 +38,25 @@ public macro fun default_min_ask_price(): u64 { 10_000_000 }
 /// Maximum ask price the protocol will allow at mint (99% in FLOAT_SCALING)
 public macro fun default_max_ask_price(): u64 { 990_000_000 }
 
+/// Depth multiplier for the inventory-aware mid shift (1x in FLOAT_SCALING).
+/// `raw_ratio = aggregate · tte_factor / (balance · depth_multiplier)`, so
+/// lower values produce larger shifts from the same inventory.
+public macro fun default_depth_multiplier(): u64 { 1_000_000_000 }
+
 // === Time Constants ===
 
 public macro fun ms_per_year(): u64 { 31_536_000_000 }
+
+/// One day in milliseconds.
+public macro fun ms_per_day(): u64 { 86_400_000 }
+
+/// Reference time-to-expiry for the inventory-aware mid shift (7 days).
+/// `tte_factor = √(reference_tte_ms / max(tte_ms, min_tte_ms))`.
+public macro fun reference_tte_ms(): u64 { 604_800_000 }
+
+/// Minimum time-to-expiry floor (1 day) used by the inventory-aware mid shift
+/// to cap the near-expiry amplification of `tte_factor`.
+public macro fun min_tte_ms(): u64 { 86_400_000 }
 
 /// Oracle staleness threshold (30 seconds)
 public macro fun staleness_threshold_ms(): u64 { 30_000 }

--- a/packages/predict/sources/helper/constants.move
+++ b/packages/predict/sources/helper/constants.move
@@ -50,13 +50,13 @@ public macro fun ms_per_year(): u64 { 31_536_000_000 }
 /// One day in milliseconds.
 public macro fun ms_per_day(): u64 { 86_400_000 }
 
-/// Reference time-to-expiry for the inventory-aware mid shift (7 days).
+/// Default reference time-to-expiry for the inventory-aware mid shift (7 days).
 /// `tte_factor = √(reference_tte_ms / max(tte_ms, min_tte_ms))`.
-public macro fun reference_tte_ms(): u64 { 604_800_000 }
+public macro fun default_reference_tte_ms(): u64 { 604_800_000 }
 
-/// Minimum time-to-expiry floor (1 day) used by the inventory-aware mid shift
-/// to cap the near-expiry amplification of `tte_factor`.
-public macro fun min_tte_ms(): u64 { 86_400_000 }
+/// Default minimum time-to-expiry floor (1 day) used by the inventory-aware
+/// mid shift to cap the near-expiry amplification of `tte_factor`.
+public macro fun default_min_tte_ms(): u64 { 86_400_000 }
 
 /// Oracle staleness threshold (30 seconds)
 public macro fun staleness_threshold_ms(): u64 { 30_000 }

--- a/packages/predict/sources/helper/math.move
+++ b/packages/predict/sources/helper/math.move
@@ -124,6 +124,17 @@ public fun sqrt(x: u64, precision: u64): u64 {
     (sqrt_u128(scaled) / multiplier) as u64
 }
 
+/// Bernoulli standard deviation `√(p · (1 − p))` in FLOAT_SCALING, with `p` also
+/// in FLOAT_SCALING. Returns 0 outside the open interval (0, 1). Maxes out at
+/// `p = 0.5` (≈ 500_000_000).
+public fun bernoulli_weight(p: u64): u64 {
+    let scaling = constants::float_scaling!();
+    if (p == 0 || p >= scaling) return 0;
+    // p · (1 − p) in FLOAT_SCALING via u128 intermediate.
+    let variance = (((p as u128) * ((scaling - p) as u128) / (scaling as u128)) as u64);
+    sqrt(variance, scaling)
+}
+
 // ============================================================
 // u128 internal functions
 // ============================================================

--- a/packages/predict/sources/helper/math.move
+++ b/packages/predict/sources/helper/math.move
@@ -8,6 +8,7 @@
 /// - exp(x): exponential function for signed fixed-point inputs
 /// - sqrt(x, precision): fixed-point square root
 /// - normal_cdf(x): standard normal CDF for signed fixed-point inputs
+/// - normal_pdf(x): standard normal PDF for signed fixed-point inputs
 ///
 /// Public functions use `u64` for nonnegative values and `i64::I64` for signed
 /// fixed-point values. Internal math uses u128 to minimize truncation.
@@ -22,6 +23,8 @@ const EInvalidPrecision: u64 = 2;
 // u128 constants for internal math
 const F: u128 = 1_000_000_000;
 const LN2_U128: u128 = 693_147_180;
+// 1 / sqrt(2 * pi) scaled by F = 1e9.
+const INV_SQRT_2PI: u128 = 398_942_280;
 
 // Max input for exp(x, false) before u64 overflow.
 // Derived: with LN2_U128=693_147_180, at x=23_638_153_700 the bit-shift
@@ -124,15 +127,16 @@ public fun sqrt(x: u64, precision: u64): u64 {
     (sqrt_u128(scaled) / multiplier) as u64
 }
 
-/// Bernoulli standard deviation `√(p · (1 − p))` in FLOAT_SCALING, with `p` also
-/// in FLOAT_SCALING. Returns 0 outside the open interval (0, 1). Maxes out at
-/// `p = 0.5` (≈ 500_000_000).
-public fun bernoulli_weight(p: u64): u64 {
-    let scaling = constants::float_scaling!();
-    if (p == 0 || p >= scaling) return 0;
-    // p · (1 − p) in FLOAT_SCALING via u128 intermediate.
-    let variance = (((p as u128) * ((scaling - p) as u128) / (scaling as u128)) as u64);
-    sqrt(variance, scaling)
+/// Standard normal PDF `n(x) = exp(−x²/2) / √(2π)` in FLOAT_SCALING. Peaks at
+/// `x = 0` with value ≈ `0.3989` (≈ 398_942_280).
+public fun normal_pdf(x: &i64::I64): u64 {
+    let x_mag = i64::magnitude(x) as u128;
+    if (x_mag > 8 * F) return 0;
+    let x_sq = x_mag * x_mag / F;
+    let half_x_sq = i64::from_u64((x_sq / 2) as u64);
+    let neg_half_x_sq = i64::neg(&half_x_sq);
+    let exp_val = exp(&neg_half_x_sq) as u128;
+    (exp_val * INV_SQRT_2PI / F) as u64
 }
 
 // ============================================================

--- a/packages/predict/sources/helper/strike_matrix.move
+++ b/packages/predict/sources/helper/strike_matrix.move
@@ -157,19 +157,19 @@ public(package) fun new(
 
 /// Insert a position at `strike` for `qty` units on the `is_up` side.
 ///
-/// `bernoulli_weight` is `√(p · (1 − p))` for the current fair price at the
-/// touched strike, in FLOAT_SCALING. The caller is responsible for computing
-/// and passing it; the matrix folds it into `directional_aggregate` so readers
-/// see the post-trade inventory risk.
+/// `weight` is the per-strike risk weight `n(d₂)` at the touched strike, in
+/// FLOAT_SCALING. The caller is responsible for computing and passing it; the
+/// matrix folds it into `directional_aggregate` so readers see the post-trade
+/// inventory risk.
 public(package) fun insert(
     matrix: &mut StrikeMatrix,
     strike: u64,
     qty: u64,
     is_up: bool,
-    bernoulli_weight: u64,
+    weight: u64,
 ) {
     apply_position(matrix, strike, qty, is_up, true);
-    apply_aggregate_delta(matrix, qty, bernoulli_weight, is_up, true);
+    apply_aggregate_delta(matrix, qty, weight, is_up, true);
 }
 
 public(package) fun remove(
@@ -177,18 +177,18 @@ public(package) fun remove(
     strike: u64,
     qty: u64,
     is_up: bool,
-    bernoulli_weight: u64,
+    weight: u64,
 ) {
     apply_position(matrix, strike, qty, is_up, false);
-    apply_aggregate_delta(matrix, qty, bernoulli_weight, is_up, false);
+    apply_aggregate_delta(matrix, qty, weight, is_up, false);
 }
 
 /// Insert a vertical range `(lower, higher)`. Equivalent to a long UP@lower,
 /// a long DN@higher, and a `qty` increment to `range_qty`.
 ///
-/// `lower_weight` and `higher_weight` are the Bernoulli weights at the fair
-/// UP prices of the lower and higher strikes, used to fold the range's two
-/// legs into `directional_aggregate`.
+/// `lower_weight` and `higher_weight` are the per-strike risk weights `n(d₂)`
+/// at the lower and higher strikes, used to fold the range's two legs into
+/// `directional_aggregate`.
 public(package) fun insert_range(
     matrix: &mut StrikeMatrix,
     lower: u64,
@@ -380,12 +380,12 @@ fun apply_range(matrix: &mut StrikeMatrix, lower: u64, higher: u64, qty: u64, ad
 fun apply_aggregate_delta(
     matrix: &mut StrikeMatrix,
     qty: u64,
-    bernoulli_weight: u64,
+    weight: u64,
     is_up: bool,
     add: bool,
 ) {
-    if (qty == 0 || bernoulli_weight == 0) return;
-    let magnitude = math::mul(qty, bernoulli_weight);
+    if (qty == 0 || weight == 0) return;
+    let magnitude = math::mul(qty, weight);
     if (magnitude == 0) return;
     let is_negative = if (add) !is_up else is_up;
     let delta = i64::from_parts(magnitude, is_negative);

--- a/packages/predict/sources/helper/strike_matrix.move
+++ b/packages/predict/sources/helper/strike_matrix.move
@@ -60,7 +60,7 @@
 module deepbook_predict::strike_matrix;
 
 use deepbook::{constants::max_u64, math};
-use deepbook_predict::{constants, oracle_config::CurvePoint};
+use deepbook_predict::{constants, i64::{Self, I64}, oracle_config::CurvePoint};
 use sui::table::{Self, Table};
 
 const PAGE_SLOTS: u64 = 512;
@@ -90,6 +90,10 @@ public struct StrikeMatrix has store {
     /// from `evaluate(curve)`, `evaluate_settled(s)`, and `max_payout()` to
     /// recover the actual vault liability for ranges.
     range_qty: u64,
+    /// Bernoulli-weighted signed inventory `Σ (q_up − q_dn) · √(p · (1 − p))`,
+    /// updated on every insert/remove at the fair price of that leg. The
+    /// inventory-aware mid shift reads this field to gauge directional risk.
+    directional_aggregate: I64,
 }
 
 /// Exact per-strike inventory stored in dense page slots.
@@ -147,26 +151,69 @@ public(package) fun new(
         minted_max_strike: 0,
         mtm: 0,
         range_qty: 0,
+        directional_aggregate: i64::zero(),
     }
 }
 
-public(package) fun insert(matrix: &mut StrikeMatrix, strike: u64, qty: u64, is_up: bool) {
+/// Insert a position at `strike` for `qty` units on the `is_up` side.
+///
+/// `bernoulli_weight` is `√(p · (1 − p))` for the current fair price at the
+/// touched strike, in FLOAT_SCALING. The caller is responsible for computing
+/// and passing it; the matrix folds it into `directional_aggregate` so readers
+/// see the post-trade inventory risk.
+public(package) fun insert(
+    matrix: &mut StrikeMatrix,
+    strike: u64,
+    qty: u64,
+    is_up: bool,
+    bernoulli_weight: u64,
+) {
     apply_position(matrix, strike, qty, is_up, true);
+    apply_aggregate_delta(matrix, qty, bernoulli_weight, is_up, true);
 }
 
-public(package) fun remove(matrix: &mut StrikeMatrix, strike: u64, qty: u64, is_up: bool) {
+public(package) fun remove(
+    matrix: &mut StrikeMatrix,
+    strike: u64,
+    qty: u64,
+    is_up: bool,
+    bernoulli_weight: u64,
+) {
     apply_position(matrix, strike, qty, is_up, false);
+    apply_aggregate_delta(matrix, qty, bernoulli_weight, is_up, false);
 }
 
 /// Insert a vertical range `(lower, higher)`. Equivalent to a long UP@lower,
 /// a long DN@higher, and a `qty` increment to `range_qty`.
-public(package) fun insert_range(matrix: &mut StrikeMatrix, lower: u64, higher: u64, qty: u64) {
+///
+/// `lower_weight` and `higher_weight` are the Bernoulli weights at the fair
+/// UP prices of the lower and higher strikes, used to fold the range's two
+/// legs into `directional_aggregate`.
+public(package) fun insert_range(
+    matrix: &mut StrikeMatrix,
+    lower: u64,
+    higher: u64,
+    qty: u64,
+    lower_weight: u64,
+    higher_weight: u64,
+) {
     matrix.apply_range(lower, higher, qty, true);
+    apply_aggregate_delta(matrix, qty, lower_weight, true, true);
+    apply_aggregate_delta(matrix, qty, higher_weight, false, true);
 }
 
 /// Remove a vertical range `(lower, higher)`. Symmetric to `insert_range`.
-public(package) fun remove_range(matrix: &mut StrikeMatrix, lower: u64, higher: u64, qty: u64) {
+public(package) fun remove_range(
+    matrix: &mut StrikeMatrix,
+    lower: u64,
+    higher: u64,
+    qty: u64,
+    lower_weight: u64,
+    higher_weight: u64,
+) {
     matrix.apply_range(lower, higher, qty, false);
+    apply_aggregate_delta(matrix, qty, lower_weight, true, false);
+    apply_aggregate_delta(matrix, qty, higher_weight, false, false);
 }
 
 /// Evaluate the current book against a sampled live curve.
@@ -290,6 +337,12 @@ public(package) fun range_qty(matrix: &StrikeMatrix): u64 {
     matrix.range_qty
 }
 
+/// Bernoulli-weighted signed inventory accumulated over all insert/remove
+/// operations at their trade-time fair prices.
+public(package) fun directional_aggregate(matrix: &StrikeMatrix): I64 {
+    matrix.directional_aggregate
+}
+
 /// Cached mark-to-market value stored by the vault after oracle refresh.
 public(package) fun mtm(matrix: &StrikeMatrix): u64 {
     matrix.mtm
@@ -319,6 +372,24 @@ fun apply_range(matrix: &mut StrikeMatrix, lower: u64, higher: u64, qty: u64, ad
     matrix.apply_position(lower, qty, true, add);
     matrix.apply_position(higher, qty, false, add);
     apply_exact_delta(&mut matrix.range_qty, qty, add);
+}
+
+/// Fold one leg's risk-weighted quantity into the signed directional aggregate.
+/// UP legs contribute positively, DN legs negatively; removes flip the sign so
+/// that an insert+remove pair cancels exactly.
+fun apply_aggregate_delta(
+    matrix: &mut StrikeMatrix,
+    qty: u64,
+    bernoulli_weight: u64,
+    is_up: bool,
+    add: bool,
+) {
+    if (qty == 0 || bernoulli_weight == 0) return;
+    let magnitude = math::mul(qty, bernoulli_weight);
+    if (magnitude == 0) return;
+    let is_negative = if (add) !is_up else is_up;
+    let delta = i64::from_parts(magnitude, is_negative);
+    matrix.directional_aggregate = i64::add(&matrix.directional_aggregate, &delta);
 }
 
 /// Apply one position delta, refresh the touched page summary, then rebuild the

--- a/packages/predict/sources/oracle.move
+++ b/packages/predict/sources/oracle.move
@@ -337,8 +337,18 @@ public(package) fun compute_price(oracle: &OracleSVI, strike: u64): u64 {
             0
         }
     } else {
-        compute_nd2(oracle, strike)
+        predict_math::normal_cdf(&compute_d2(oracle, strike))
     }
+}
+
+/// Per-strike risk weight `n(d₂)` for the inventory-aware mid shift. This is
+/// the cross-sectional (strike-dependent) part of the textbook binary delta
+/// `Δ = e^(−rτ) · n(d₂) / (S · σ · √τ)` — the constant factors are absorbed
+/// into `depth_multiplier` and `tte_factor`. Returns 0 for settled oracles
+/// since the directional risk has already been realized.
+public(package) fun compute_risk_weight(oracle: &OracleSVI, strike: u64): u64 {
+    if (oracle.settlement_price.is_some()) return 0;
+    predict_math::normal_pdf(&compute_d2(oracle, strike))
 }
 
 /// Return the exact fair prices for both sides of a binary market.
@@ -393,11 +403,11 @@ public(package) fun create_oracle(underlying_asset: String, expiry: u64, ctx: &m
 
 // === Private Functions ===
 
-/// Binary pricing from SVI total variance:
+/// Compute `d₂` for a strike under the current SVI surface. Signed.
 /// - k = ln(strike / forward)
 /// - w(k) = a + b * (rho * (k - m) + sqrt((k - m)^2 + sigma^2))
 /// - d2 = -((k + w(k) / 2) / sqrt(w(k)))
-fun compute_nd2(oracle: &OracleSVI, strike: u64): u64 {
+fun compute_d2(oracle: &OracleSVI, strike: u64): i64::I64 {
     let forward = oracle.forward_price();
     assert!(forward > 0, EZeroForward);
 
@@ -417,13 +427,11 @@ fun compute_nd2(oracle: &OracleSVI, strike: u64): u64 {
     let total_var = svi.a + math::mul(svi.b, i64::magnitude(&inner));
     assert!(total_var > 0, EZeroVariance);
 
-    // d2 = -((k + total_var/2) / sqrt(total_var)), then N(±d2).
+    // d2 = -((k + total_var/2) / sqrt(total_var)).
     let sqrt_var = predict_math::sqrt(total_var, constants::float_scaling!());
     let sqrt_var_i64 = i64::from_u64(sqrt_var);
     let half_var_i64 = i64::from_u64(total_var / 2);
     let d2_numerator = i64::add(&k, &half_var_i64);
     let d2 = i64::div_scaled(&d2_numerator, &sqrt_var_i64);
-    let d2 = i64::neg(&d2);
-
-    predict_math::normal_cdf(&d2)
+    i64::neg(&d2)
 }

--- a/packages/predict/sources/predict.move
+++ b/packages/predict/sources/predict.move
@@ -123,6 +123,8 @@ public struct PricingConfigUpdated has copy, drop, store {
     min_ask_price: u64,
     max_ask_price: u64,
     depth_multiplier: u64,
+    reference_tte_ms: u64,
+    min_tte_ms: u64,
 }
 
 public struct OracleAskBoundsSet has copy, drop, store {
@@ -619,6 +621,18 @@ public(package) fun set_depth_multiplier(predict: &mut Predict, multiplier: u64)
     predict.emit_pricing_config_updated();
 }
 
+/// Set the reference TTE for the inventory-aware mid shift.
+public(package) fun set_reference_tte_ms(predict: &mut Predict, value: u64) {
+    predict.pricing_config.set_reference_tte_ms(value);
+    predict.emit_pricing_config_updated();
+}
+
+/// Set the minimum TTE floor for the inventory-aware mid shift.
+public(package) fun set_min_tte_ms(predict: &mut Predict, value: u64) {
+    predict.pricing_config.set_min_tte_ms(value);
+    predict.emit_pricing_config_updated();
+}
+
 /// Set a per-oracle ask-bound override. Authorized by the oracle's own cap.
 /// The override may only tighten the global bounds — never loosen them.
 public(package) fun set_oracle_ask_bounds(
@@ -652,7 +666,6 @@ public(package) fun clear_oracle_ask_bounds(
         oracle_id: oracle.id(),
     });
 }
-
 
 /// Set max total exposure percentage.
 public(package) fun set_max_total_exposure_pct(predict: &mut Predict, pct: u64) {
@@ -771,6 +784,8 @@ fun emit_pricing_config_updated(predict: &Predict) {
         min_ask_price: predict.pricing_config.min_ask_price(),
         max_ask_price: predict.pricing_config.max_ask_price(),
         depth_multiplier: predict.pricing_config.depth_multiplier(),
+        reference_tte_ms: predict.pricing_config.reference_tte_ms(),
+        min_tte_ms: predict.pricing_config.min_tte_ms(),
     });
 }
 

--- a/packages/predict/sources/predict.move
+++ b/packages/predict/sources/predict.move
@@ -12,7 +12,7 @@ use deepbook::math;
 use deepbook_predict::{
     constants,
     market_key::MarketKey,
-    math::mul_div_round_down,
+    math::{bernoulli_weight, mul_div_round_down},
     oracle::{OracleSVI, OracleSVICap},
     oracle_config::{Self, OracleConfig},
     plp::PLP,
@@ -122,6 +122,7 @@ public struct PricingConfigUpdated has copy, drop, store {
     utilization_multiplier: u64,
     min_ask_price: u64,
     max_ask_price: u64,
+    depth_multiplier: u64,
 }
 
 public struct OracleAskBoundsSet has copy, drop, store {
@@ -242,7 +243,8 @@ public fun mint<Quote>(
     let strike = key.strike();
     let is_up = key.is_up();
 
-    predict.vault.insert_position(oracle.id(), is_up, strike, quantity);
+    let weight = bernoulli_weight(oracle.compute_price(strike));
+    predict.vault.insert_position(oracle.id(), is_up, strike, quantity, weight);
     predict.refresh_oracle_risk(oracle);
 
     // Quote against the post-trade state so the trader pays for the liability
@@ -340,7 +342,9 @@ public fun mint_range<Quote>(
     let lower = key.lower_strike();
     let higher = key.higher_strike();
 
-    predict.vault.insert_range(oracle.id(), lower, higher, quantity);
+    let lower_weight = bernoulli_weight(oracle.compute_price(lower));
+    let higher_weight = bernoulli_weight(oracle.compute_price(higher));
+    predict.vault.insert_range(oracle.id(), lower, higher, quantity, lower_weight, higher_weight);
     predict.refresh_oracle_risk(oracle);
 
     // Quote against the post-trade state so the trader pays for the liability
@@ -390,7 +394,9 @@ public fun redeem_range<Quote>(
     let lower = key.lower_strike();
     let higher = key.higher_strike();
 
-    predict.vault.remove_range(oracle.id(), lower, higher, quantity);
+    let lower_weight = bernoulli_weight(oracle.compute_price(lower));
+    let higher_weight = bernoulli_weight(oracle.compute_price(higher));
+    predict.vault.remove_range(oracle.id(), lower, higher, quantity, lower_weight, higher_weight);
     predict.refresh_oracle_risk(oracle);
 
     // Quote against the post-trade state so the seller is paid from the
@@ -558,6 +564,11 @@ public fun utilization_multiplier(predict: &Predict): u64 {
     predict.pricing_config.utilization_multiplier()
 }
 
+/// Get the depth multiplier (inventory-aware mid-shift aggressiveness knob).
+public fun depth_multiplier(predict: &Predict): u64 {
+    predict.pricing_config.depth_multiplier()
+}
+
 /// Get the max total exposure percentage.
 public fun max_total_exposure_pct(predict: &Predict): u64 {
     predict.risk_config.max_total_exposure_pct()
@@ -602,6 +613,12 @@ public(package) fun set_max_ask_price(predict: &mut Predict, value: u64) {
     predict.emit_pricing_config_updated();
 }
 
+/// Set depth multiplier for the inventory-aware mid shift.
+public(package) fun set_depth_multiplier(predict: &mut Predict, multiplier: u64) {
+    predict.pricing_config.set_depth_multiplier(multiplier);
+    predict.emit_pricing_config_updated();
+}
+
 /// Set a per-oracle ask-bound override. Authorized by the oracle's own cap.
 /// The override may only tighten the global bounds — never loosen them.
 public(package) fun set_oracle_ask_bounds(
@@ -635,6 +652,7 @@ public(package) fun clear_oracle_ask_bounds(
         oracle_id: oracle.id(),
     });
 }
+
 
 /// Set max total exposure percentage.
 public(package) fun set_max_total_exposure_pct(predict: &mut Predict, pct: u64) {
@@ -703,7 +721,11 @@ fun redeem_internal<Quote>(
 
     manager.decrease_position(key, quantity);
 
-    predict.vault.remove_position(oracle.id(), key.is_up(), key.strike(), quantity);
+    let strike = key.strike();
+    let is_up = key.is_up();
+
+    let weight = bernoulli_weight(oracle.compute_price(strike));
+    predict.vault.remove_position(oracle.id(), is_up, strike, quantity, weight);
     predict.refresh_oracle_risk(oracle);
 
     // Quote against the post-trade state so the seller is paid from the
@@ -721,8 +743,8 @@ fun redeem_internal<Quote>(
         quote_asset: type_name::with_defining_ids<Quote>(),
         oracle_id: key.oracle_id(),
         expiry: key.expiry(),
-        strike: key.strike(),
-        is_up: key.is_up(),
+        strike,
+        is_up,
         quantity,
         payout,
         bid_price: math::div(payout, quantity),
@@ -748,6 +770,7 @@ fun emit_pricing_config_updated(predict: &Predict) {
         utilization_multiplier: predict.pricing_config.utilization_multiplier(),
         min_ask_price: predict.pricing_config.min_ask_price(),
         max_ask_price: predict.pricing_config.max_ask_price(),
+        depth_multiplier: predict.pricing_config.depth_multiplier(),
     });
 }
 
@@ -767,19 +790,16 @@ fun trade_prices(predict: &Predict, oracle: &OracleSVI, key: MarketKey, clock: &
         return (fair_price, fair_price)
     };
 
-    let spread = predict
+    let aggregate = predict.vault.oracle_directional_aggregate(oracle.id());
+    let (up_ask, up_bid) = predict
         .pricing_config
-        .quote_spread_from_fair_price(
+        .compute_up_quote(
             up_price,
+            &aggregate,
             predict.vault.total_mtm(),
             predict.vault.balance(),
+            time_to_expiry(key.expiry(), clock),
         );
-    let up_bid = if (up_price > spread) {
-        up_price - spread
-    } else {
-        0
-    };
-    let up_ask = (up_price + spread).min(constants::float_scaling!());
     let dn_bid = constants::float_scaling!() - up_ask;
     let dn_ask = constants::float_scaling!() - up_bid;
 
@@ -813,21 +833,16 @@ fun range_trade_prices(
         return (fair_price, fair_price)
     };
 
-    let spread = predict
+    let aggregate = predict.vault.oracle_directional_aggregate(oracle.id());
+    predict
         .pricing_config
-        .quote_spread_from_fair_price(
+        .compute_up_quote(
             fair_price,
+            &aggregate,
             predict.vault.total_mtm(),
             predict.vault.balance(),
-        );
-    let ask = (fair_price + spread).min(constants::float_scaling!());
-    let bid = if (fair_price > spread) {
-        fair_price - spread
-    } else {
-        0
-    };
-
-    (ask, bid)
+            time_to_expiry(key.expiry(), clock),
+        )
 }
 
 /// Resolve the effective ask-price bounds for an oracle: the per-oracle
@@ -849,6 +864,11 @@ fun resolve_ask_bounds(predict: &Predict, oracle_id: ID): (u64, u64) {
 fun assert_mintable_ask(predict: &Predict, oracle_id: ID, ask_price: u64) {
     let (min_ask, max_ask) = predict.resolve_ask_bounds(oracle_id);
     assert!(ask_price >= min_ask && ask_price <= max_ask, EAskPriceOutOfBounds);
+}
+
+fun time_to_expiry(expiry_ms: u64, clock: &Clock): u64 {
+    let now = clock.timestamp_ms();
+    if (expiry_ms > now) expiry_ms - now else 0
 }
 
 fun refresh_oracle_risk(predict: &mut Predict, oracle: &OracleSVI) {

--- a/packages/predict/sources/predict.move
+++ b/packages/predict/sources/predict.move
@@ -12,7 +12,7 @@ use deepbook::math;
 use deepbook_predict::{
     constants,
     market_key::MarketKey,
-    math::{bernoulli_weight, mul_div_round_down},
+    math::mul_div_round_down,
     oracle::{OracleSVI, OracleSVICap},
     oracle_config::{Self, OracleConfig},
     plp::PLP,
@@ -245,7 +245,7 @@ public fun mint<Quote>(
     let strike = key.strike();
     let is_up = key.is_up();
 
-    let weight = bernoulli_weight(oracle.compute_price(strike));
+    let weight = oracle.compute_risk_weight(strike);
     predict.vault.insert_position(oracle.id(), is_up, strike, quantity, weight);
     predict.refresh_oracle_risk(oracle);
 
@@ -344,8 +344,8 @@ public fun mint_range<Quote>(
     let lower = key.lower_strike();
     let higher = key.higher_strike();
 
-    let lower_weight = bernoulli_weight(oracle.compute_price(lower));
-    let higher_weight = bernoulli_weight(oracle.compute_price(higher));
+    let lower_weight = oracle.compute_risk_weight(lower);
+    let higher_weight = oracle.compute_risk_weight(higher);
     predict.vault.insert_range(oracle.id(), lower, higher, quantity, lower_weight, higher_weight);
     predict.refresh_oracle_risk(oracle);
 
@@ -396,8 +396,8 @@ public fun redeem_range<Quote>(
     let lower = key.lower_strike();
     let higher = key.higher_strike();
 
-    let lower_weight = bernoulli_weight(oracle.compute_price(lower));
-    let higher_weight = bernoulli_weight(oracle.compute_price(higher));
+    let lower_weight = oracle.compute_risk_weight(lower);
+    let higher_weight = oracle.compute_risk_weight(higher);
     predict.vault.remove_range(oracle.id(), lower, higher, quantity, lower_weight, higher_weight);
     predict.refresh_oracle_risk(oracle);
 
@@ -737,7 +737,7 @@ fun redeem_internal<Quote>(
     let strike = key.strike();
     let is_up = key.is_up();
 
-    let weight = bernoulli_weight(oracle.compute_price(strike));
+    let weight = oracle.compute_risk_weight(strike);
     predict.vault.remove_position(oracle.id(), is_up, strike, quantity, weight);
     predict.refresh_oracle_risk(oracle);
 

--- a/packages/predict/sources/registry.move
+++ b/packages/predict/sources/registry.move
@@ -185,6 +185,16 @@ public fun set_depth_multiplier(predict: &mut Predict, _admin_cap: &AdminCap, mu
     predict.set_depth_multiplier(multiplier);
 }
 
+/// Set reference TTE for the inventory-aware mid shift.
+public fun set_reference_tte_ms(predict: &mut Predict, _admin_cap: &AdminCap, value: u64) {
+    predict.set_reference_tte_ms(value);
+}
+
+/// Set minimum TTE floor for the inventory-aware mid shift.
+public fun set_min_tte_ms(predict: &mut Predict, _admin_cap: &AdminCap, value: u64) {
+    predict.set_min_tte_ms(value);
+}
+
 /// Set a per-oracle ask-bound override. Authorized by the oracle's own cap;
 /// no `AdminCap` required. The override may only tighten the global bounds.
 public fun set_oracle_ask_bounds(

--- a/packages/predict/sources/registry.move
+++ b/packages/predict/sources/registry.move
@@ -180,6 +180,11 @@ public fun set_max_ask_price(predict: &mut Predict, _admin_cap: &AdminCap, value
     predict.set_max_ask_price(value);
 }
 
+/// Set depth multiplier for the inventory-aware mid shift.
+public fun set_depth_multiplier(predict: &mut Predict, _admin_cap: &AdminCap, multiplier: u64) {
+    predict.set_depth_multiplier(multiplier);
+}
+
 /// Set a per-oracle ask-bound override. Authorized by the oracle's own cap;
 /// no `AdminCap` required. The override may only tighten the global bounds.
 public fun set_oracle_ask_bounds(

--- a/packages/predict/sources/vault/vault.move
+++ b/packages/predict/sources/vault/vault.move
@@ -14,7 +14,7 @@
 module deepbook_predict::vault;
 
 use deepbook::math;
-use deepbook_predict::{oracle_config::CurvePoint, strike_matrix::{Self, StrikeMatrix}};
+use deepbook_predict::{i64::I64, oracle_config::CurvePoint, strike_matrix::{Self, StrikeMatrix}};
 use sui::{bag::{Self, Bag}, balance::Balance, table::{Self, Table}};
 
 use fun net_max_payout as StrikeMatrix.net_max_payout;
@@ -105,16 +105,21 @@ public(package) fun init_oracle_matrix(
 }
 
 /// Insert a position into the per-oracle exposure structure and update cached max payout.
+///
+/// `bernoulli_weight` is `√(p · (1 − p))` for the current fair price at `strike`,
+/// used to fold this leg into the directional aggregate consumed by the
+/// inventory-aware mid shift.
 public(package) fun insert_position(
     vault: &mut Vault,
     oracle_id: ID,
     is_up: bool,
     strike: u64,
     quantity: u64,
+    bernoulli_weight: u64,
 ) {
     assert!(vault.oracle_matrices.contains(oracle_id), EOracleExposureNotFound);
     let old_max_payout = vault.oracle_matrices[oracle_id].max_payout();
-    vault.oracle_matrices[oracle_id].insert(strike, quantity, is_up);
+    vault.oracle_matrices[oracle_id].insert(strike, quantity, is_up, bernoulli_weight);
     let new_max_payout = vault.oracle_matrices[oracle_id].max_payout();
     vault.total_max_payout = vault.total_max_payout + new_max_payout - old_max_payout;
 }
@@ -123,16 +128,23 @@ public(package) fun insert_position(
 /// cached max payout. The range is recorded as `long UP@lower + long DN@higher`
 /// plus a `quantity` range_qty delta; the vault's `total_max_payout` reflects the
 /// range_qty-adjusted (net) contribution.
+///
+/// `lower_weight` and `higher_weight` are `√(p · (1 − p))` at the fair UP prices
+/// of the lower and higher strikes, folded into the per-leg directional aggregate.
 public(package) fun insert_range(
     vault: &mut Vault,
     oracle_id: ID,
     lower: u64,
     higher: u64,
     quantity: u64,
+    lower_weight: u64,
+    higher_weight: u64,
 ) {
     assert!(vault.oracle_matrices.contains(oracle_id), EOracleExposureNotFound);
     let old_net_max_payout = vault.oracle_matrices[oracle_id].net_max_payout();
-    vault.oracle_matrices[oracle_id].insert_range(lower, higher, quantity);
+    vault
+        .oracle_matrices[oracle_id]
+        .insert_range(lower, higher, quantity, lower_weight, higher_weight);
     let new_net_max_payout = vault.oracle_matrices[oracle_id].net_max_payout();
     vault.total_max_payout = vault.total_max_payout + new_net_max_payout - old_net_max_payout;
 }
@@ -144,17 +156,20 @@ public(package) fun accept_payment<T>(vault: &mut Vault, payment: Balance<T>) {
     vault.balance = vault.balance + amount;
 }
 
-/// Remove a position from the strike matrix.
+/// Remove a position from the strike matrix. `bernoulli_weight` is the Bernoulli
+/// weight at the current fair price of `strike`, used to unwind this leg's
+/// contribution to the directional aggregate.
 public(package) fun remove_position(
     vault: &mut Vault,
     oracle_id: ID,
     is_up: bool,
     strike: u64,
     quantity: u64,
+    bernoulli_weight: u64,
 ) {
     assert!(vault.oracle_matrices.contains(oracle_id), EOracleExposureNotFound);
     let old_max_payout = vault.oracle_matrices[oracle_id].max_payout();
-    vault.oracle_matrices[oracle_id].remove(strike, quantity, is_up);
+    vault.oracle_matrices[oracle_id].remove(strike, quantity, is_up, bernoulli_weight);
     let new_max_payout = vault.oracle_matrices[oracle_id].max_payout();
     vault.total_max_payout = vault.total_max_payout + new_max_payout - old_max_payout;
 }
@@ -167,10 +182,14 @@ public(package) fun remove_range(
     lower: u64,
     higher: u64,
     quantity: u64,
+    lower_weight: u64,
+    higher_weight: u64,
 ) {
     assert!(vault.oracle_matrices.contains(oracle_id), EOracleExposureNotFound);
     let old_net_max_payout = vault.oracle_matrices[oracle_id].net_max_payout();
-    vault.oracle_matrices[oracle_id].remove_range(lower, higher, quantity);
+    vault
+        .oracle_matrices[oracle_id]
+        .remove_range(lower, higher, quantity, lower_weight, higher_weight);
     let new_net_max_payout = vault.oracle_matrices[oracle_id].net_max_payout();
     vault.total_max_payout = vault.total_max_payout + new_net_max_payout - old_net_max_payout;
 }
@@ -193,6 +212,13 @@ public(package) fun oracle_strike_range(vault: &Vault, oracle_id: ID): (u64, u64
     assert!(vault.oracle_matrices.contains(oracle_id), EOracleExposureNotFound);
     let matrix = &vault.oracle_matrices[oracle_id];
     matrix.minted_strike_range()
+}
+
+/// Bernoulli-weighted signed inventory for this oracle. Positive means the
+/// vault is net short UP across touched strikes; negative means net long.
+public(package) fun oracle_directional_aggregate(vault: &Vault, oracle_id: ID): I64 {
+    assert!(vault.oracle_matrices.contains(oracle_id), EOracleExposureNotFound);
+    vault.oracle_matrices[oracle_id].directional_aggregate()
 }
 
 public(package) fun set_mtm_with_curve(

--- a/packages/predict/sources/vault/vault.move
+++ b/packages/predict/sources/vault/vault.move
@@ -106,20 +106,20 @@ public(package) fun init_oracle_matrix(
 
 /// Insert a position into the per-oracle exposure structure and update cached max payout.
 ///
-/// `bernoulli_weight` is `√(p · (1 − p))` for the current fair price at `strike`,
-/// used to fold this leg into the directional aggregate consumed by the
-/// inventory-aware mid shift.
+/// `weight` is the per-strike risk weight `n(d₂)` at `strike`, used to fold
+/// this leg into the directional aggregate consumed by the inventory-aware mid
+/// shift.
 public(package) fun insert_position(
     vault: &mut Vault,
     oracle_id: ID,
     is_up: bool,
     strike: u64,
     quantity: u64,
-    bernoulli_weight: u64,
+    weight: u64,
 ) {
     assert!(vault.oracle_matrices.contains(oracle_id), EOracleExposureNotFound);
     let old_max_payout = vault.oracle_matrices[oracle_id].max_payout();
-    vault.oracle_matrices[oracle_id].insert(strike, quantity, is_up, bernoulli_weight);
+    vault.oracle_matrices[oracle_id].insert(strike, quantity, is_up, weight);
     let new_max_payout = vault.oracle_matrices[oracle_id].max_payout();
     vault.total_max_payout = vault.total_max_payout + new_max_payout - old_max_payout;
 }
@@ -129,8 +129,8 @@ public(package) fun insert_position(
 /// plus a `quantity` range_qty delta; the vault's `total_max_payout` reflects the
 /// range_qty-adjusted (net) contribution.
 ///
-/// `lower_weight` and `higher_weight` are `√(p · (1 − p))` at the fair UP prices
-/// of the lower and higher strikes, folded into the per-leg directional aggregate.
+/// `lower_weight` and `higher_weight` are `n(d₂)` at the lower and higher
+/// strikes, folded into the per-leg directional aggregate.
 public(package) fun insert_range(
     vault: &mut Vault,
     oracle_id: ID,
@@ -156,20 +156,20 @@ public(package) fun accept_payment<T>(vault: &mut Vault, payment: Balance<T>) {
     vault.balance = vault.balance + amount;
 }
 
-/// Remove a position from the strike matrix. `bernoulli_weight` is the Bernoulli
-/// weight at the current fair price of `strike`, used to unwind this leg's
-/// contribution to the directional aggregate.
+/// Remove a position from the strike matrix. `weight` is the per-strike risk
+/// weight `n(d₂)` at `strike`, used to unwind this leg's contribution to the
+/// directional aggregate.
 public(package) fun remove_position(
     vault: &mut Vault,
     oracle_id: ID,
     is_up: bool,
     strike: u64,
     quantity: u64,
-    bernoulli_weight: u64,
+    weight: u64,
 ) {
     assert!(vault.oracle_matrices.contains(oracle_id), EOracleExposureNotFound);
     let old_max_payout = vault.oracle_matrices[oracle_id].max_payout();
-    vault.oracle_matrices[oracle_id].remove(strike, quantity, is_up, bernoulli_weight);
+    vault.oracle_matrices[oracle_id].remove(strike, quantity, is_up, weight);
     let new_max_payout = vault.oracle_matrices[oracle_id].max_payout();
     vault.total_max_payout = vault.total_max_payout + new_max_payout - old_max_payout;
 }


### PR DESCRIPTION
## Summary

Adds an **inventory-aware mid shift** to Predict pricing so the LP self-corrects when directional flow accumulates against a stale oracle surface. Previously, `trade_prices` / `range_trade_prices` applied a purely symmetric spread around fair — one-sided flow could bleed the vault with no mechanical response until the oracle got refreshed.

## Method

Per-strike mid shift with a zero-edge floor, folded into the existing `set_mtm_with_curve` walk:

1. **Risk signal — `n(d₂)`-weighted signed inventory.** On every mint/redeem, the vault accumulates:
   ```
   aggregate += (Δq_up − Δq_dn) · n(d₂[K])
   ```
   `n(d₂)` is the textbook binary delta proxy — it's the strike-dependent part of `Δ = e^(−rτ) · n(d₂) / (S · σ · √τ)`, so using it directly makes each leg's contribution proportional to its true directional risk. Peaks at ATM (~0.399) and tapers out toward the bounds more sharply than `√(p·(1−p))` at the wings — matching the actual gradient of a binary contract. Ranges absorb naturally: the two legs contribute opposing signs at their respective strikes. Stored as a new `I64` field on the vault's per-oracle row, updated incrementally in O(1) via the strike matrix.

2. **Per-oracle raw ratio.** At quote time:
   ```
   tte_factor = √(reference_tte_ms / max(tte_ms, min_tte_ms))
   raw_ratio  = aggregate · tte_factor / (balance · depth_multiplier)
   ```
   `tte_factor` escalates the shift near expiry (binary delta scales ~1/√τ at ATM), floored at `min_tte_ms` to prevent blowup. `depth_multiplier` is the single admin knob: the value of `aggregate · tte_factor` at which `raw_ratio = 1` equals `balance · depth_multiplier`. Lower = more aggressive rebalancing. Constant per-oracle factors (`1/σ`, `1/(S·√τ)`) are absorbed into `depth_multiplier` — they don't affect cross-strike relative weighting.

3. **Asymmetric per-strike shift.** One `raw_ratio` for the whole oracle, scaled per strike by the distance to its own bound:
   ```
   ratio = clamp(raw_ratio, −1, +1)
   mid_shift[K] = ratio > 0 ? ratio · (1 − p[K])   // LP short UP → push mid up
                            : ratio · p[K]         // LP long  UP → push mid down
   ```
   Same `ratio` across strikes, but a 10c option can only shift up by 90c while a 50c option can shift by 50c — no fixed-cents cap needed, each strike's natural bound handles it. At `|ratio| = 1`, every strike's mid converges on the same boundary (1.0 or 0.0): "LP is willing to trade for zero edge versus the binary's full value to retire this risk."

4. **Zero-edge floor.** Spread is applied symmetrically around the shifted mid, then each quote is clamped at fair:
   ```
   up_ask = max(shifted_mid + spread, up_price)    // never sell UP below fair
   up_bid = min(shifted_mid − spread, up_price)    // never buy UP above fair
   ```
   When `|mid_shift| ≤ spread` the clamp is inactive and round-trip LP revenue stays `2 × spread`. When `|mid_shift| > spread`, the derisking side pins at fair (zero edge, not negative edge) and the adverse side carries the whole shift as a widened spread — LP charges more for new adverse flow but never pays a premium to retire risk.

5. **Layering with PR #968 ask bounds.** The DBU-352 `min_ask_price` / `max_ask_price` bounds remain an outer clamp applied *after* the mid-shift computation in `assert_mintable_ask`. If a shifted ask exceeds `max_ask_price`, the mint aborts with `EAskPriceOutOfBounds` — consistent with "we don't want more of this at any price."

## Key decisions

- **Why `n(d₂)` and not `√(p·(1−p))`.** Both peak at ATM and vanish at the bounds, but `√(p·(1−p))` over-weights wings vs the true `n(d₂)` curve by up to ~3× at deep OTM. The fix is free because the oracle already computes `d₂` internally for `normal_cdf` — `compute_d2` is factored out so `compute_price` (CDF) and `compute_risk_weight` (PDF) share one SVI walk. **Spread formula is unchanged** — `√(p·(1−p))` is still correct there as a variance-based bid/ask width, not a directional gradient.
- **Admin-configurable TTE.** `reference_tte_ms` (default 7 days), `min_tte_ms` (default 1 day), and `depth_multiplier` (default 1×) are all tunable via `set_*` on `PricingConfig`. Defaults are structural starting points; tuning belongs off-chain.
- **Global config only.** No per-oracle depth_multiplier overrides in v1. Per-oracle ask bounds already exist (PR #968) and can act as a finer guardrail; per-oracle depth can be added later mirroring that pattern.
- **Symmetric on mint and redeem.** Both sides see the shifted mid (with the fair-price clamp). LP never loses edge on a single trade and always captures at least `spread` per round-trip.
- **Incremental aggregate.** Updated in the strike matrix on each `insert_position` / `remove_position` / `insert_range` / `remove_range` call rather than recomputed from walking the matrix, so hot paths stay O(1).

## Simulation

Validated with `packages/predict/simulations/toxic_flow_sim.py` against the real SVI timeline in `scenario_mar6_1000mints.csv` (7 days, 10,080 minute ticks, toxic trader buys the 20c UP strike every minute with 40% realized win rate, $2k notional/trade, exposure-capped at vault balance). Regenerated with the `n(d₂)` weight:

**$100M vault**

| depth_multiplier | Toxic PnL ($) | Reduction vs baseline |
|---|---|---|
| baseline (symmetric spread) | 3,951,360 | — |
| 2.0 | 3,512,502 | 11.1% |
| 1.0 | 3,073,645 | 22.2% |
| 0.5 | 2,271,195 | 42.5% |
| 0.25 | 1,519,472 | 61.5% |

**$400M vault**

| depth_multiplier | Toxic PnL ($) | Reduction vs baseline |
|---|---|---|
| baseline | 3,951,360 | — |
| 2.0 | 3,841,646 | 2.8% |
| 1.0 | 3,731,931 | 5.6% |
| 0.5 | 3,512,502 | 11.1% |
| 0.25 | 3,073,645 | 22.2% |

DN-buyer symmetry check (same strike, DN buys starting day 2) confirms the shift is symmetric — at dm=0.25 the shifted DN ask ends +8.53c over baseline, at dm=0.5 +4.27c.

> [!NOTE]
> With `n(d₂)` the ATM weight is ≈0.399 vs `√(p·(1−p))`'s 0.5, and wing weights drop harder — so for an equivalent defensive strength vs the earlier `√(p·(1−p))` curves, `depth_multiplier` should be set a bit lower than before. Re-check against the regenerated simulation curves before mainnet deploy.

## Test plan

- [x] `sui move build` on `packages/predict`
- [x] Python simulation regenerated with `n(d₂)` weight — reductions remain monotone-defensive across dm sweep
- [ ] Add Move unit tests per design doc: one-sided UP at ATM, zero-edge floor active/inactive, balanced → no shift, per-strike scaling, full derisk (`raw_ratio` clamps to 1), range absorption, round-trip LP revenue (clamped & non-clamped), bounds interaction with PR #968, TTE scaling, `normal_pdf` unit sanity (p=0.5 → ≈0.3989, p=0.1 → ≈0.176)
- [ ] Audit `packages/predict/simulations/src/runtime.ts` for any stale `typeArguments` (no Move entrypoint signatures changed, but the vault `insert_position` / `insert_range` signatures gained weight params — verify sim harness still matches)
- [ ] Simulation setup smoke test: `cd packages/predict/simulations && bash run.sh --setup --skip-analysis`
- [ ] Simulation end-to-end smoke test: `SIM_MAX_ROWS=1 bash run.sh --skip-analysis`
- [ ] Block Scholes sanity-check on `depth_multiplier` / TTE defaults before mainnet deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)