### PR TITLE
Track unsettled oracle exposure for predict MTM

### DIFF
--- a/packages/predict/simulations/src/runtime.ts
+++ b/packages/predict/simulations/src/runtime.ts
@@ -136,6 +136,7 @@ export function createOracleTx(params: {
       tx.pure.u64(params.expiry),
       tx.pure.u64(params.minStrike),
       tx.pure.u64(params.tickSize),
+      tx.object(CLOCK_ID),
     ],
   });
   return tx;

--- a/packages/predict/sources/config/risk_config.move
+++ b/packages/predict/sources/config/risk_config.move
@@ -8,12 +8,15 @@ use deepbook_predict::constants;
 
 // === Errors ===
 const EExceedsMaxPct: u64 = 0;
+const EInvalidMtmFreshnessMs: u64 = 1;
 
 // === Structs ===
 
 public struct RiskConfig has store {
     /// Max total liability as % of balance (e.g., 800_000_000 = 80%)
     max_total_exposure_pct: u64,
+    /// Max MTM age allowed for LP supply/withdraw gating.
+    mtm_freshness_ms: u64,
 }
 
 // === Public Functions ===
@@ -22,15 +25,25 @@ public fun max_total_exposure_pct(config: &RiskConfig): u64 {
     config.max_total_exposure_pct
 }
 
+public fun mtm_freshness_ms(config: &RiskConfig): u64 {
+    config.mtm_freshness_ms
+}
+
 // === Public-Package Functions ===
 
 public(package) fun new(): RiskConfig {
     RiskConfig {
         max_total_exposure_pct: constants::default_max_total_exposure_pct!(),
+        mtm_freshness_ms: constants::default_mtm_freshness_ms!(),
     }
 }
 
 public(package) fun set_max_total_exposure_pct(config: &mut RiskConfig, pct: u64) {
     assert!(pct > 0 && pct <= constants::float_scaling!(), EExceedsMaxPct);
     config.max_total_exposure_pct = pct;
+}
+
+public(package) fun set_mtm_freshness_ms(config: &mut RiskConfig, value: u64) {
+    assert!(value > 0, EInvalidMtmFreshnessMs);
+    config.mtm_freshness_ms = value;
 }

--- a/packages/predict/sources/helper/constants.move
+++ b/packages/predict/sources/helper/constants.move
@@ -68,5 +68,6 @@ public macro fun required_quote_decimals(): u8 { 6 }
 
 // === MTM Tracking ===
 
-/// MTM freshness threshold: maximum age of MTM values before they're considered stale (10 seconds).
-public macro fun mtm_freshness_ms(): u64 { 10_000 }
+/// Default MTM freshness threshold: maximum age of MTM values before they're
+/// considered stale for LP supply/withdraw gating (10 seconds).
+public macro fun default_mtm_freshness_ms(): u64 { 10_000 }

--- a/packages/predict/sources/helper/constants.move
+++ b/packages/predict/sources/helper/constants.move
@@ -64,3 +64,7 @@ public macro fun oracle_tick_size_unit(): u64 { 10_000 }
 /// Required decimals for all accepted quote assets in phase 1.
 public macro fun required_quote_decimals(): u8 { 6 }
 
+// === MTM Tracking ===
+
+/// MTM freshness threshold: maximum age of MTM values before they're considered stale (10 seconds).
+public macro fun mtm_freshness_ms(): u64 { 10_000 }

--- a/packages/predict/sources/helper/strike_matrix.move
+++ b/packages/predict/sources/helper/strike_matrix.move
@@ -49,8 +49,11 @@
 //     * the best prefix entirely inside `left`, or
 //     * all of `left` plus the best prefix of `right`
 //
-// After that path is rebuilt, the root summary is enough to answer:
-//     max_payout = root.total_q_dn + root.best_prefix_up - root.best_prefix_dn
+// After that path is rebuilt, the root summary is enough to answer the raw
+// binary-combination peak:
+//     root.total_q_dn + root.best_prefix_up - root.best_prefix_dn
+// `max_payout()` then applies the stored range cash offset to recover the
+// actual vault liability peak.
 //
 // So the design is intentionally asymmetric:
 // - page-local aggregates optimize MTM
@@ -88,8 +91,8 @@ public struct StrikeMatrix has store {
     /// Aggregate `$1`-per-unit cash obligation accumulated by range mints.
     /// Each range mint of a `(lower, higher)` band records `q_up[lower] += qty`,
     /// `q_dn[higher] += qty`, and `range_qty += qty`. Callers subtract `range_qty`
-    /// from `evaluate(curve)`, `evaluate_settled(s)`, and `max_payout()` to
-    /// recover the actual vault liability for ranges.
+    /// from `evaluate(curve)` and `evaluate_settled(s)`; `max_payout()` applies
+    /// the same adjustment internally.
     range_qty: u64,
 }
 
@@ -285,7 +288,7 @@ public(package) fun evaluate_settled(matrix: &StrikeMatrix, settlement: u64): u6
 
 public(package) fun max_payout(matrix: &StrikeMatrix): u64 {
     let root = matrix.page_tree[0];
-    root.total_q_dn + root.best_prefix_up - root.best_prefix_dn
+    root.total_q_dn + root.best_prefix_up - root.best_prefix_dn - matrix.range_qty
 }
 
 /// Aggregate `$1`-per-unit range quantity contributed by range mints.
@@ -323,7 +326,7 @@ public(package) fun minted_strike_range(matrix: &StrikeMatrix): (u64, u64) {
 /// plus a `qty` range_qty delta. The matrix writes are byte-identical to two
 /// separate longs; `range_qty` is the algebraic constant from the dominance
 /// identity (`short X@k ≡ long ~X@k − $1`) that callers subtract from
-/// `evaluate`/`evaluate_settled`/`max_payout` to recover the range payoff.
+/// `evaluate`/`evaluate_settled`; `max_payout()` applies it internally.
 fun apply_range(matrix: &mut StrikeMatrix, lower: u64, higher: u64, qty: u64, add: bool) {
     matrix.apply_position(lower, qty, true, add);
     matrix.apply_position(higher, qty, false, add);

--- a/packages/predict/sources/helper/strike_matrix.move
+++ b/packages/predict/sources/helper/strike_matrix.move
@@ -61,8 +61,7 @@ module deepbook_predict::strike_matrix;
 
 use deepbook::{constants::max_u64, math};
 use deepbook_predict::{constants, oracle_config::CurvePoint};
-use sui::table::{Self, Table};
-use sui::clock::Clock;
+use sui::{clock::Clock, table::{Self, Table}};
 
 const PAGE_SLOTS: u64 = 512;
 

--- a/packages/predict/sources/helper/strike_matrix.move
+++ b/packages/predict/sources/helper/strike_matrix.move
@@ -62,6 +62,7 @@ module deepbook_predict::strike_matrix;
 use deepbook::{constants::max_u64, math};
 use deepbook_predict::{constants, oracle_config::CurvePoint};
 use sui::table::{Self, Table};
+use sui::clock::Clock;
 
 const PAGE_SLOTS: u64 = 512;
 
@@ -84,6 +85,7 @@ public struct StrikeMatrix has store {
     minted_min_strike: u64,
     minted_max_strike: u64,
     mtm: u64,
+    last_mtm_update: u64,
     /// Aggregate `$1`-per-unit cash obligation accumulated by range mints.
     /// Each range mint of a `(lower, higher)` band records `q_up[lower] += qty`,
     /// `q_dn[higher] += qty`, and `range_qty += qty`. Callers subtract `range_qty`
@@ -117,6 +119,7 @@ public(package) fun new(
     tick_size: u64,
     min_strike: u64,
     max_strike: u64,
+    clock: &Clock,
 ): StrikeMatrix {
     assert!(tick_size > 0, EInvalidTickSize);
     assert!(min_strike <= max_strike, EInvalidStrikeRange);
@@ -146,6 +149,7 @@ public(package) fun new(
         minted_min_strike: max_u64(),
         minted_max_strike: 0,
         mtm: 0,
+        last_mtm_update: clock.timestamp_ms(),
         range_qty: 0,
     }
 }
@@ -295,9 +299,15 @@ public(package) fun mtm(matrix: &StrikeMatrix): u64 {
     matrix.mtm
 }
 
+/// Timestamp of the last MTM update, used by the vault to decide when to refresh.
+public(package) fun last_mtm_update(matrix: &StrikeMatrix): u64 {
+    matrix.last_mtm_update
+}
+
 /// Overwrite the cached mark-to-market value after recomputing it from a curve.
-public(package) fun set_mtm(matrix: &mut StrikeMatrix, value: u64) {
+public(package) fun set_mtm(matrix: &mut StrikeMatrix, value: u64, clock: &Clock) {
     matrix.mtm = value;
+    matrix.last_mtm_update = clock.timestamp_ms();
 }
 
 /// Return the historical minted strike bounds, or `(0, 0)` for an untouched

--- a/packages/predict/sources/oracle_config.move
+++ b/packages/predict/sources/oracle_config.move
@@ -29,6 +29,7 @@ const EInvalidCurveRange: u64 = 8;
 const ERangeKeyOracleMismatch: u64 = 9;
 const ERangeKeyExpiryMismatch: u64 = 10;
 const EInvalidAskBound: u64 = 11;
+const ESettledOracleMtmStale: u64 = 12;
 
 public struct OracleGrid has copy, drop, store {
     min_strike: u64,
@@ -45,6 +46,7 @@ public struct AskBounds has copy, drop, store {
 }
 
 public struct OracleConfig has store {
+    active_oracles: vector<ID>,
     oracle_grids: Table<ID, OracleGrid>,
     /// Per-oracle ask-bound overrides; presence in this table means an override
     /// is active for that oracle id.
@@ -80,13 +82,18 @@ public fun ask_bounds_max(bounds: &AskBounds): u64 { bounds.max_ask_price }
 /// Create an empty oracle config registry for Predict.
 public(package) fun new(ctx: &mut TxContext): OracleConfig {
     OracleConfig {
+        active_oracles: vector::empty(),
         oracle_grids: table::new(ctx),
         oracle_ask_bounds: table::new(ctx),
     }
 }
 
+public(package) fun active_oracles(oracle_config: &OracleConfig): vector<ID> {
+    oracle_config.active_oracles
+}
+
 /// Register the configured strike grid for a newly created oracle.
-public(package) fun add_oracle_grid(
+public(package) fun add_active_oracle(
     oracle_config: &mut OracleConfig,
     oracle_id: ID,
     min_strike: u64,
@@ -99,6 +106,28 @@ public(package) fun add_oracle_grid(
         tick_size,
     };
     oracle_config.oracle_grids.add(oracle_id, grid);
+    oracle_config.active_oracles.push_back(oracle_id);
+}
+
+public(package) fun remove_settled_oracle(
+    oracle_config: &mut OracleConfig,
+    oracle: &OracleSVI,
+    last_mtm_update: u64,
+    clock: &Clock,
+) {
+    let oracle_status = oracle.status(clock);
+    assert!(oracle_status == oracle::status_settled(), EOracleSettled);
+    assert!(last_mtm_update > oracle.expiry(), ESettledOracleMtmStale);
+    let oracle_id = oracle.id();
+    let mut idx = 0;
+    let len = oracle_config.active_oracles.length();
+    while (idx < len) {
+        if (oracle_config.active_oracles[idx] == oracle_id) {
+            oracle_config.active_oracles.swap_remove(idx);
+            break
+        };
+        idx = idx + 1;
+    };
 }
 
 /// Set or update a per-oracle ask-bound override. The caller must hold an

--- a/packages/predict/sources/oracle_config.move
+++ b/packages/predict/sources/oracle_config.move
@@ -29,7 +29,6 @@ const EInvalidCurveRange: u64 = 8;
 const ERangeKeyOracleMismatch: u64 = 9;
 const ERangeKeyExpiryMismatch: u64 = 10;
 const EInvalidAskBound: u64 = 11;
-const ESettledOracleMtmStale: u64 = 12;
 
 public struct OracleGrid has copy, drop, store {
     min_strike: u64,
@@ -46,7 +45,6 @@ public struct AskBounds has copy, drop, store {
 }
 
 public struct OracleConfig has store {
-    active_oracles: vector<ID>,
     oracle_grids: Table<ID, OracleGrid>,
     /// Per-oracle ask-bound overrides; presence in this table means an override
     /// is active for that oracle id.
@@ -82,18 +80,13 @@ public fun ask_bounds_max(bounds: &AskBounds): u64 { bounds.max_ask_price }
 /// Create an empty oracle config registry for Predict.
 public(package) fun new(ctx: &mut TxContext): OracleConfig {
     OracleConfig {
-        active_oracles: vector::empty(),
         oracle_grids: table::new(ctx),
         oracle_ask_bounds: table::new(ctx),
     }
 }
 
-public(package) fun active_oracles(oracle_config: &OracleConfig): vector<ID> {
-    oracle_config.active_oracles
-}
-
 /// Register the configured strike grid for a newly created oracle.
-public(package) fun add_active_oracle(
+public(package) fun add_oracle_grid(
     oracle_config: &mut OracleConfig,
     oracle_id: ID,
     min_strike: u64,
@@ -106,28 +99,6 @@ public(package) fun add_active_oracle(
         tick_size,
     };
     oracle_config.oracle_grids.add(oracle_id, grid);
-    oracle_config.active_oracles.push_back(oracle_id);
-}
-
-public(package) fun remove_settled_oracle(
-    oracle_config: &mut OracleConfig,
-    oracle: &OracleSVI,
-    last_mtm_update: u64,
-    clock: &Clock,
-) {
-    let oracle_status = oracle.status(clock);
-    assert!(oracle_status == oracle::status_settled(), EOracleSettled);
-    assert!(last_mtm_update > oracle.expiry(), ESettledOracleMtmStale);
-    let oracle_id = oracle.id();
-    let mut idx = 0;
-    let len = oracle_config.active_oracles.length();
-    while (idx < len) {
-        if (oracle_config.active_oracles[idx] == oracle_id) {
-            oracle_config.active_oracles.swap_remove(idx);
-            break
-        };
-        idx = idx + 1;
-    };
 }
 
 /// Set or update a per-oracle ask-bound override. The caller must hold an

--- a/packages/predict/sources/predict.move
+++ b/packages/predict/sources/predict.move
@@ -216,6 +216,27 @@ public fun get_trade_amounts(
     (math::mul(ask, quantity), math::mul(bid, quantity))
 }
 
+public fun get_active_oracle_ids(predict: &Predict): vector<ID> {
+    predict.oracle_config.active_oracles()
+}
+
+public fun remove_active_oracle(
+    predict: &mut Predict,
+    oracle: &OracleSVI,
+    clock: &Clock,
+) {
+    let last_mtm_update = predict.vault.get_last_mtm_update(oracle.id());
+    predict.oracle_config.remove_settled_oracle(oracle, last_mtm_update, clock);
+}
+
+public fun update_oracle_mtm(
+    predict: &mut Predict,
+    oracle: &OracleSVI,
+    clock: &Clock,
+) {
+    predict.refresh_oracle_risk(oracle, clock);
+}
+
 /// Resolved ask-price bounds for an oracle, after intersecting any per-oracle
 /// override with the global default. Exposed for UI/preview.
 public fun ask_bounds(predict: &Predict, oracle_id: ID): (u64, u64) {
@@ -246,7 +267,7 @@ public fun mint<Quote>(
     let is_up = key.is_up();
 
     predict.vault.insert_position(oracle.id(), is_up, strike, quantity);
-    predict.refresh_oracle_risk(oracle);
+    predict.refresh_oracle_risk(oracle, clock);
 
     // Quote against the post-trade state so the trader pays for the liability
     // their own mint just added to the vault.
@@ -344,7 +365,7 @@ public fun mint_range<Quote>(
     let higher = key.higher_strike();
 
     predict.vault.insert_range(oracle.id(), lower, higher, quantity);
-    predict.refresh_oracle_risk(oracle);
+    predict.refresh_oracle_risk(oracle, clock);
 
     // Quote against the post-trade state so the trader pays for the liability
     // their own mint just added to the vault.
@@ -394,7 +415,7 @@ public fun redeem_range<Quote>(
     let higher = key.higher_strike();
 
     predict.vault.remove_range(oracle.id(), lower, higher, quantity);
-    predict.refresh_oracle_risk(oracle);
+    predict.refresh_oracle_risk(oracle, clock);
 
     // Quote against the post-trade state so the seller is paid from the
     // liability after their range has been removed from the vault.
@@ -430,6 +451,7 @@ public fun supply<Quote>(
     clock: &Clock,
     ctx: &mut TxContext,
 ): Coin<PLP> {
+    predict.assert_total_mtm_fresh(clock);
     let amount = coin.value();
     assert!(amount > 0, EZeroAmount);
     predict.treasury_config.assert_quote_asset<Quote>();
@@ -467,6 +489,7 @@ public fun withdraw<Quote>(
     clock: &Clock,
     ctx: &mut TxContext,
 ): Coin<Quote> {
+    predict.assert_total_mtm_fresh(clock);
     let vault_value = predict.vault.vault_value();
     let shares_burned = lp_coin.value();
     assert!(shares_burned > 0, EZeroAmount);
@@ -539,16 +562,17 @@ public(package) fun disable_quote_asset<Quote>(predict: &mut Predict) {
     });
 }
 
-public(package) fun add_oracle_grid(
+public(package) fun add_active_oracle(
     predict: &mut Predict,
     oracle_id: ID,
     min_strike: u64,
     tick_size: u64,
+    clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    predict.oracle_config.add_oracle_grid(oracle_id, min_strike, tick_size);
+    predict.oracle_config.add_active_oracle(oracle_id, min_strike, tick_size);
     let max_strike = min_strike + tick_size * constants::oracle_strike_grid_ticks!();
-    predict.vault.init_oracle_matrix(oracle_id, min_strike, max_strike, tick_size, ctx);
+    predict.vault.init_oracle_matrix(oracle_id, min_strike, max_strike, tick_size, clock, ctx);
 }
 
 /// Whether trading is currently paused.
@@ -734,6 +758,18 @@ public(package) fun vault_balance(predict: &Predict): u64 {
 
 // === Private Functions ===
 
+fun assert_total_mtm_fresh(predict: &Predict, clock: &Clock) {
+    let active_oracles = predict.oracle_config.active_oracles();
+    let mut i = 0;
+    let len = active_oracles.length();
+    while (i < len) {
+        let oracle_id = active_oracles[i];
+        let last_update = predict.vault.get_last_mtm_update(oracle_id);
+        assert!(clock.timestamp_ms() - last_update <= constants::mtm_freshness_ms!(), EOracleNotSettled);
+        i = i + 1;
+    }
+}
+
 fun redeem_internal<Quote>(
     predict: &mut Predict,
     manager: &mut PredictManager,
@@ -750,7 +786,7 @@ fun redeem_internal<Quote>(
     manager.decrease_position(key, quantity);
 
     predict.vault.remove_position(oracle.id(), key.is_up(), key.strike(), quantity);
-    predict.refresh_oracle_risk(oracle);
+    predict.refresh_oracle_risk(oracle, clock);
 
     // Quote against the post-trade state so the seller is paid from the
     // liability after their position has been removed from the vault.
@@ -897,21 +933,21 @@ fun assert_mintable_ask(predict: &Predict, oracle_id: ID, ask_price: u64) {
     assert!(ask_price >= min_ask && ask_price <= max_ask, EAskPriceOutOfBounds);
 }
 
-fun refresh_oracle_risk(predict: &mut Predict, oracle: &OracleSVI) {
+fun refresh_oracle_risk(predict: &mut Predict, oracle: &OracleSVI, clock: &Clock) {
     let oracle_id = oracle.id();
     let (min_strike, max_strike) = predict.vault.oracle_strike_range(oracle_id);
     if (min_strike == 0 && max_strike == 0) {
         // `(0, 0)` means this oracle has never had any minted exposure.
-        predict.vault.set_mtm(oracle_id, 0);
+        predict.vault.set_mtm(oracle_id, 0, clock);
         return
     };
     // Historical minted bounds do not shrink after a full unwind, so an empty
     // but previously touched book still rebuilds over the old range and
     // evaluates to 0 from zero `q_up` / `q_dn`.
     if (oracle.is_settled()) {
-        predict.vault.set_mtm_with_settlement(oracle_id, oracle.settlement_price().destroy_some());
+        predict.vault.set_mtm_with_settlement(oracle_id, oracle.settlement_price().destroy_some(), clock);
         return
     };
     let curve = predict.oracle_config.build_curve(oracle, min_strike, max_strike);
-    predict.vault.set_mtm_with_curve(oracle_id, &curve);
+    predict.vault.set_mtm_with_curve(oracle_id, &curve, clock);
 }

--- a/packages/predict/sources/predict.move
+++ b/packages/predict/sources/predict.move
@@ -44,6 +44,7 @@ const EZeroSharesMinted: u64 = 6;
 const EAskPriceOutOfBounds: u64 = 7;
 const EAskBoundLooserThanGlobal: u64 = 8;
 const EOracleNotSettled: u64 = 9;
+const EStaleOracleMtm: u64 = 10;
 
 // === Events ===
 
@@ -216,25 +217,8 @@ public fun get_trade_amounts(
     (math::mul(ask, quantity), math::mul(bid, quantity))
 }
 
-public fun get_active_oracle_ids(predict: &Predict): vector<ID> {
-    predict.oracle_config.active_oracles()
-}
-
-public fun remove_active_oracle(
-    predict: &mut Predict,
-    oracle: &OracleSVI,
-    clock: &Clock,
-) {
-    let last_mtm_update = predict.vault.get_last_mtm_update(oracle.id());
-    predict.oracle_config.remove_settled_oracle(oracle, last_mtm_update, clock);
-}
-
-public fun update_oracle_mtm(
-    predict: &mut Predict,
-    oracle: &OracleSVI,
-    clock: &Clock,
-) {
-    predict.refresh_oracle_risk(oracle, clock);
+public fun unsettled_exposed_oracles(predict: &Predict): &vector<ID> {
+    predict.vault.unsettled_exposed_oracles()
 }
 
 /// Resolved ask-price bounds for an oracle, after intersecting any per-oracle
@@ -562,7 +546,7 @@ public(package) fun disable_quote_asset<Quote>(predict: &mut Predict) {
     });
 }
 
-public(package) fun add_active_oracle(
+public(package) fun add_oracle_grid(
     predict: &mut Predict,
     oracle_id: ID,
     min_strike: u64,
@@ -570,9 +554,22 @@ public(package) fun add_active_oracle(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    predict.oracle_config.add_active_oracle(oracle_id, min_strike, tick_size);
+    predict.oracle_config.add_oracle_grid(oracle_id, min_strike, tick_size);
     let max_strike = min_strike + tick_size * constants::oracle_strike_grid_ticks!();
     predict.vault.init_oracle_matrix(oracle_id, min_strike, max_strike, tick_size, clock, ctx);
+}
+
+public fun refresh_oracle_mtm(predict: &mut Predict, oracle: &OracleSVI, clock: &Clock) {
+    if (!oracle.is_settled()) {
+        oracle_config::assert_live_oracle(oracle, clock);
+    };
+    predict.refresh_oracle_risk(oracle, clock);
+}
+
+public fun sync_settled_oracle(predict: &mut Predict, oracle: &OracleSVI, clock: &Clock) {
+    assert!(oracle.is_settled(), EOracleNotSettled);
+    predict.refresh_oracle_risk(oracle, clock);
+    predict.vault.remove_unsettled_exposed_oracle(oracle.id());
 }
 
 /// Whether trading is currently paused.
@@ -759,13 +756,16 @@ public(package) fun vault_balance(predict: &Predict): u64 {
 // === Private Functions ===
 
 fun assert_total_mtm_fresh(predict: &Predict, clock: &Clock) {
-    let active_oracles = predict.oracle_config.active_oracles();
+    let unsettled_exposed_oracles = predict.vault.unsettled_exposed_oracles();
     let mut i = 0;
-    let len = active_oracles.length();
+    let len = unsettled_exposed_oracles.length();
+    let now = clock.timestamp_ms();
     while (i < len) {
-        let oracle_id = active_oracles[i];
+        let oracle_id = unsettled_exposed_oracles[i];
         let last_update = predict.vault.get_last_mtm_update(oracle_id);
-        assert!(clock.timestamp_ms() - last_update <= constants::mtm_freshness_ms!(), EOracleNotSettled);
+        if (now > last_update) {
+            assert!(now - last_update <= constants::mtm_freshness_ms!(), EStaleOracleMtm);
+        };
         i = i + 1;
     }
 }
@@ -945,7 +945,9 @@ fun refresh_oracle_risk(predict: &mut Predict, oracle: &OracleSVI, clock: &Clock
     // but previously touched book still rebuilds over the old range and
     // evaluates to 0 from zero `q_up` / `q_dn`.
     if (oracle.is_settled()) {
-        predict.vault.set_mtm_with_settlement(oracle_id, oracle.settlement_price().destroy_some(), clock);
+        predict
+            .vault
+            .set_mtm_with_settlement(oracle_id, oracle.settlement_price().destroy_some(), clock);
         return
     };
     let curve = predict.oracle_config.build_curve(oracle, min_strike, max_strike);

--- a/packages/predict/sources/predict.move
+++ b/packages/predict/sources/predict.move
@@ -402,7 +402,7 @@ public fun redeem_range<Quote>(
 
     predict.vault.remove_range(oracle.id(), lower, higher, quantity);
     predict.refresh_oracle_risk(oracle, clock);
-    predict.vault.remove_unsettled_exposed_oracle_if_inactive(oracle.id());
+    predict.vault.remove_unsettled_exposed_oracle(oracle.id(), oracle.is_settled());
 
     // Quote against the post-trade state so the seller is paid from the
     // liability after their range has been removed from the vault.
@@ -572,7 +572,7 @@ public fun refresh_oracle_mtm(predict: &mut Predict, oracle: &OracleSVI, clock: 
 public fun sync_settled_oracle(predict: &mut Predict, oracle: &OracleSVI, clock: &Clock) {
     assert!(oracle.is_settled(), EOracleNotSettled);
     predict.refresh_oracle_risk(oracle, clock);
-    predict.vault.remove_unsettled_exposed_oracle(oracle.id());
+    predict.vault.remove_unsettled_exposed_oracle(oracle.id(), true);
 }
 
 /// Whether trading is currently paused.
@@ -790,7 +790,7 @@ fun redeem_internal<Quote>(
 
     predict.vault.remove_position(oracle.id(), key.is_up(), key.strike(), quantity);
     predict.refresh_oracle_risk(oracle, clock);
-    predict.vault.remove_unsettled_exposed_oracle_if_inactive(oracle.id());
+    predict.vault.remove_unsettled_exposed_oracle(oracle.id(), oracle.is_settled());
 
     // Quote against the post-trade state so the seller is paid from the
     // liability after their position has been removed from the vault.

--- a/packages/predict/sources/predict.move
+++ b/packages/predict/sources/predict.move
@@ -142,6 +142,7 @@ public struct OracleAskBoundsCleared has copy, drop, store {
 public struct RiskConfigUpdated has copy, drop, store {
     predict_id: ID,
     max_total_exposure_pct: u64,
+    mtm_freshness_ms: u64,
 }
 
 public struct QuoteAssetEnabled has copy, drop, store {
@@ -655,6 +656,11 @@ public fun max_total_exposure_pct(predict: &Predict): u64 {
     predict.risk_config.max_total_exposure_pct()
 }
 
+/// Get the MTM freshness threshold used for LP supply/withdraw gating.
+public fun mtm_freshness_ms(predict: &Predict): u64 {
+    predict.risk_config.mtm_freshness_ms()
+}
+
 /// Set trading pause state.
 public(package) fun set_trading_paused(predict: &mut Predict, paused: bool) {
     predict.trading_paused = paused;
@@ -731,10 +737,13 @@ public(package) fun clear_oracle_ask_bounds(
 /// Set max total exposure percentage.
 public(package) fun set_max_total_exposure_pct(predict: &mut Predict, pct: u64) {
     predict.risk_config.set_max_total_exposure_pct(pct);
-    event::emit(RiskConfigUpdated {
-        predict_id: object::id(predict),
-        max_total_exposure_pct: predict.risk_config.max_total_exposure_pct(),
-    });
+    predict.emit_risk_config_updated();
+}
+
+/// Update the MTM freshness threshold used for LP supply/withdraw gating.
+public(package) fun set_mtm_freshness_ms(predict: &mut Predict, value: u64) {
+    predict.risk_config.set_mtm_freshness_ms(value);
+    predict.emit_risk_config_updated();
 }
 
 /// Update the admin-tuned spot staleness threshold used to seed new oracles
@@ -899,7 +908,7 @@ fun assert_total_mtm_fresh(predict: &Predict, clock: &Clock) {
         let oracle_id = unsettled_exposed_oracles[i];
         let last_update = predict.vault.get_last_mtm_update(oracle_id);
         if (now > last_update) {
-            assert!(now - last_update <= constants::mtm_freshness_ms!(), EStaleOracleMtm);
+            assert!(now - last_update <= predict.risk_config.mtm_freshness_ms(), EStaleOracleMtm);
         };
         i = i + 1;
     }
@@ -1028,6 +1037,14 @@ fun emit_pricing_config_updated(predict: &Predict) {
         utilization_multiplier: predict.pricing_config.utilization_multiplier(),
         min_ask_price: predict.pricing_config.min_ask_price(),
         max_ask_price: predict.pricing_config.max_ask_price(),
+    });
+}
+
+fun emit_risk_config_updated(predict: &Predict) {
+    event::emit(RiskConfigUpdated {
+        predict_id: object::id(predict),
+        max_total_exposure_pct: predict.risk_config.max_total_exposure_pct(),
+        mtm_freshness_ms: predict.risk_config.mtm_freshness_ms(),
     });
 }
 

--- a/packages/predict/sources/predict.move
+++ b/packages/predict/sources/predict.move
@@ -567,12 +567,9 @@ public fun refresh_oracle_mtm(predict: &mut Predict, oracle: &OracleSVI, clock: 
         oracle_config::assert_live_oracle(oracle, clock);
     };
     predict.refresh_oracle_risk(oracle, clock);
-}
-
-public fun sync_settled_oracle(predict: &mut Predict, oracle: &OracleSVI, clock: &Clock) {
-    assert!(oracle.is_settled(), EOracleNotSettled);
-    predict.refresh_oracle_risk(oracle, clock);
-    predict.vault.remove_unsettled_exposed_oracle(oracle.id(), true);
+    if (oracle.is_settled()) {
+        predict.vault.remove_unsettled_exposed_oracle(oracle.id(), true);
+    };
 }
 
 /// Whether trading is currently paused.

--- a/packages/predict/sources/predict.move
+++ b/packages/predict/sources/predict.move
@@ -562,6 +562,9 @@ public(package) fun add_oracle_grid(
     predict.vault.init_oracle_matrix(oracle_id, min_strike, max_strike, tick_size, clock, ctx);
 }
 
+/// Keeper/ops hook for syncing one oracle's cached MTM into the vault. This is
+/// used to keep LP supply/withdraw accounting fresh across unsettled exposed
+/// oracles; trade paths still refresh only the touched oracle inline.
 public fun refresh_oracle_mtm(predict: &mut Predict, oracle: &OracleSVI, clock: &Clock) {
     if (!oracle.is_settled()) {
         oracle_config::assert_live_oracle(oracle, clock);
@@ -756,6 +759,9 @@ public(package) fun vault_balance(predict: &Predict): u64 {
 // === Private Functions ===
 
 fun assert_total_mtm_fresh(predict: &Predict, clock: &Clock) {
+    // MTM freshness is enforced only for LP supply/withdraw. Trade quoting
+    // still relies on cached aggregate `vault.total_mtm()` and refreshes the
+    // touched oracle inline.
     let unsettled_exposed_oracles = predict.vault.unsettled_exposed_oracles();
     let mut i = 0;
     let len = unsettled_exposed_oracles.length();
@@ -850,6 +856,9 @@ fun trade_prices(predict: &Predict, oracle: &OracleSVI, key: MarketKey, clock: &
         return (fair_price, fair_price)
     };
 
+    // Spread uses the cached aggregate MTM. This path does not require every
+    // exposed oracle to be freshly synced; only the traded oracle is refreshed
+    // inline before calling into pricing.
     let spread = predict
         .pricing_config
         .quote_spread_from_fair_price(
@@ -896,6 +905,9 @@ fun range_trade_prices(
         return (fair_price, fair_price)
     };
 
+    // Spread uses the cached aggregate MTM. This path does not require every
+    // exposed oracle to be freshly synced; only the traded oracle is refreshed
+    // inline before calling into pricing.
     let spread = predict
         .pricing_config
         .quote_spread_from_fair_price(

--- a/packages/predict/sources/predict.move
+++ b/packages/predict/sources/predict.move
@@ -252,6 +252,7 @@ public fun mint<Quote>(
 
     predict.vault.insert_position(oracle.id(), is_up, strike, quantity);
     predict.refresh_oracle_risk(oracle, clock);
+    predict.vault.add_unsettled_exposed_oracle(oracle.id());
 
     // Quote against the post-trade state so the trader pays for the liability
     // their own mint just added to the vault.
@@ -350,6 +351,7 @@ public fun mint_range<Quote>(
 
     predict.vault.insert_range(oracle.id(), lower, higher, quantity);
     predict.refresh_oracle_risk(oracle, clock);
+    predict.vault.add_unsettled_exposed_oracle(oracle.id());
 
     // Quote against the post-trade state so the trader pays for the liability
     // their own mint just added to the vault.
@@ -400,6 +402,7 @@ public fun redeem_range<Quote>(
 
     predict.vault.remove_range(oracle.id(), lower, higher, quantity);
     predict.refresh_oracle_risk(oracle, clock);
+    predict.vault.remove_unsettled_exposed_oracle_if_inactive(oracle.id());
 
     // Quote against the post-trade state so the seller is paid from the
     // liability after their range has been removed from the vault.
@@ -787,6 +790,7 @@ fun redeem_internal<Quote>(
 
     predict.vault.remove_position(oracle.id(), key.is_up(), key.strike(), quantity);
     predict.refresh_oracle_risk(oracle, clock);
+    predict.vault.remove_unsettled_exposed_oracle_if_inactive(oracle.id());
 
     // Quote against the post-trade state so the seller is paid from the
     // liability after their position has been removed from the vault.

--- a/packages/predict/sources/registry.move
+++ b/packages/predict/sources/registry.move
@@ -110,6 +110,7 @@ public fun create_oracle(
     expiry: u64,
     min_strike: u64,
     tick_size: u64,
+    clock: &Clock,
     ctx: &mut TxContext,
 ): ID {
     assert_valid_strike_grid(min_strike, tick_size);
@@ -120,7 +121,7 @@ public fun create_oracle(
         registry.oracle_ids.add(cap_id, vector[]);
     };
     registry.oracle_ids[cap_id].push_back(oracle_id);
-    predict.add_oracle_grid(oracle_id, min_strike, tick_size, ctx);
+    predict.add_active_oracle(oracle_id, min_strike, tick_size, clock, ctx);
     event::emit(OracleCreated {
         oracle_id,
         oracle_cap_id: cap_id,

--- a/packages/predict/sources/registry.move
+++ b/packages/predict/sources/registry.move
@@ -121,7 +121,7 @@ public fun create_oracle(
         registry.oracle_ids.add(cap_id, vector[]);
     };
     registry.oracle_ids[cap_id].push_back(oracle_id);
-    predict.add_active_oracle(oracle_id, min_strike, tick_size, clock, ctx);
+    predict.add_oracle_grid(oracle_id, min_strike, tick_size, clock, ctx);
     event::emit(OracleCreated {
         oracle_id,
         oracle_cap_id: cap_id,

--- a/packages/predict/sources/registry.move
+++ b/packages/predict/sources/registry.move
@@ -227,6 +227,11 @@ public fun set_max_total_exposure_pct(predict: &mut Predict, _admin_cap: &AdminC
     predict.set_max_total_exposure_pct(pct);
 }
 
+/// Set the MTM freshness threshold (ms) used for LP supply/withdraw gating.
+public fun set_mtm_freshness_ms(predict: &mut Predict, _admin_cap: &AdminCap, value: u64) {
+    predict.set_mtm_freshness_ms(value);
+}
+
 /// Update withdrawal rate limiter capacity and refill rate.
 public fun update_withdrawal_limiter(
     predict: &mut Predict,

--- a/packages/predict/sources/vault/vault.move
+++ b/packages/predict/sources/vault/vault.move
@@ -16,6 +16,7 @@ module deepbook_predict::vault;
 use deepbook::math;
 use deepbook_predict::{oracle_config::CurvePoint, strike_matrix::{Self, StrikeMatrix}};
 use sui::{bag::{Self, Bag}, balance::Balance, table::{Self, Table}};
+use sui::clock::Clock;
 
 use fun net_max_payout as StrikeMatrix.net_max_payout;
 
@@ -92,6 +93,7 @@ public(package) fun init_oracle_matrix(
     min_strike: u64,
     max_strike: u64,
     tick_size: u64,
+    clock: &Clock,
     ctx: &mut TxContext,
 ) {
     if (!vault.oracle_matrices.contains(oracle_id)) {
@@ -99,7 +101,7 @@ public(package) fun init_oracle_matrix(
             .oracle_matrices
             .add(
                 oracle_id,
-                strike_matrix::new(ctx, tick_size, min_strike, max_strike),
+                strike_matrix::new(ctx, tick_size, min_strike, max_strike, clock),
             );
     };
 }
@@ -199,6 +201,7 @@ public(package) fun set_mtm_with_curve(
     vault: &mut Vault,
     oracle_id: ID,
     curve: &vector<CurvePoint>,
+    clock: &Clock,
 ) {
     assert!(vault.oracle_matrices.contains(oracle_id), EOracleExposureNotFound);
 
@@ -207,11 +210,11 @@ public(package) fun set_mtm_with_curve(
     let new_mtm = matrix.evaluate(curve) - matrix.range_qty();
 
     let matrix = &mut vault.oracle_matrices[oracle_id];
-    matrix.set_mtm(new_mtm);
+    matrix.set_mtm(new_mtm, clock);
     vault.total_mtm = vault.total_mtm + new_mtm - old_mtm;
 }
 
-public(package) fun set_mtm_with_settlement(vault: &mut Vault, oracle_id: ID, settlement: u64) {
+public(package) fun set_mtm_with_settlement(vault: &mut Vault, oracle_id: ID, settlement: u64, clock: &Clock) {
     assert!(vault.oracle_matrices.contains(oracle_id), EOracleExposureNotFound);
 
     let matrix = &vault.oracle_matrices[oracle_id];
@@ -219,16 +222,21 @@ public(package) fun set_mtm_with_settlement(vault: &mut Vault, oracle_id: ID, se
     let new_mtm = matrix.evaluate_settled(settlement) - matrix.range_qty();
 
     let matrix = &mut vault.oracle_matrices[oracle_id];
-    matrix.set_mtm(new_mtm);
+    matrix.set_mtm(new_mtm, clock);
     vault.total_mtm = vault.total_mtm + new_mtm - old_mtm;
 }
 
-public(package) fun set_mtm(vault: &mut Vault, oracle_id: ID, mtm: u64) {
+public(package) fun set_mtm(vault: &mut Vault, oracle_id: ID, mtm: u64, clock: &Clock) {
     assert!(vault.oracle_matrices.contains(oracle_id), EOracleExposureNotFound);
 
     let old_mtm = vault.oracle_matrices[oracle_id].mtm();
-    vault.oracle_matrices[oracle_id].set_mtm(mtm);
+    vault.oracle_matrices[oracle_id].set_mtm(mtm, clock);
     vault.total_mtm = vault.total_mtm + mtm - old_mtm;
+}
+
+public(package) fun get_last_mtm_update(vault: &Vault, oracle_id: ID): u64 {
+    assert!(vault.oracle_matrices.contains(oracle_id), EOracleExposureNotFound);
+    vault.oracle_matrices[oracle_id].last_mtm_update()
 }
 
 /// Per-matrix max payout net of the range quantity contributed by range mints.

--- a/packages/predict/sources/vault/vault.move
+++ b/packages/predict/sources/vault/vault.move
@@ -248,7 +248,18 @@ public(package) fun get_last_mtm_update(vault: &Vault, oracle_id: ID): u64 {
     vault.oracle_matrices[oracle_id].last_mtm_update()
 }
 
-public(package) fun remove_unsettled_exposed_oracle(vault: &mut Vault, oracle_id: ID) {
+public(package) fun remove_unsettled_exposed_oracle(
+    vault: &mut Vault,
+    oracle_id: ID,
+    is_settled: bool,
+) {
+    assert!(vault.oracle_matrices.contains(oracle_id), EOracleExposureNotFound);
+
+    if (!is_settled) {
+        let matrix = &vault.oracle_matrices[oracle_id];
+        if (matrix.mtm() != 0 || matrix.max_payout() != 0) return;
+    };
+
     let mut i = 0;
     while (i < vault.unsettled_exposed_oracles.length()) {
         if (vault.unsettled_exposed_oracles[i] == oracle_id) {
@@ -256,14 +267,6 @@ public(package) fun remove_unsettled_exposed_oracle(vault: &mut Vault, oracle_id
             return
         };
         i = i + 1;
-    };
-}
-
-public(package) fun remove_unsettled_exposed_oracle_if_inactive(vault: &mut Vault, oracle_id: ID) {
-    assert!(vault.oracle_matrices.contains(oracle_id), EOracleExposureNotFound);
-    let matrix = &vault.oracle_matrices[oracle_id];
-    if (matrix.mtm() == 0 && matrix.max_payout() == 0) {
-        vault.remove_unsettled_exposed_oracle(oracle_id);
     };
 }
 

--- a/packages/predict/sources/vault/vault.move
+++ b/packages/predict/sources/vault/vault.move
@@ -15,8 +15,7 @@ module deepbook_predict::vault;
 
 use deepbook::math;
 use deepbook_predict::{oracle_config::CurvePoint, strike_matrix::{Self, StrikeMatrix}};
-use sui::{bag::{Self, Bag}, balance::Balance, table::{Self, Table}};
-use sui::clock::Clock;
+use sui::{bag::{Self, Bag}, balance::Balance, clock::Clock, table::{Self, Table}};
 
 use fun net_max_payout as StrikeMatrix.net_max_payout;
 
@@ -43,6 +42,8 @@ public struct Vault has store {
     total_mtm: u64,
     /// Sum of all oracle matrix max payout values.
     total_max_payout: u64,
+    /// Oracle IDs whose unsettled exposure must have fresh MTM before LP actions.
+    unsettled_exposed_oracles: vector<ID>,
 }
 
 // === Public Functions ===
@@ -74,6 +75,10 @@ public fun total_max_payout(vault: &Vault): u64 {
     vault.total_max_payout
 }
 
+public(package) fun unsettled_exposed_oracles(vault: &Vault): &vector<ID> {
+    &vault.unsettled_exposed_oracles
+}
+
 // === Public-Package Functions ===
 
 public(package) fun new(ctx: &mut TxContext): Vault {
@@ -83,6 +88,7 @@ public(package) fun new(ctx: &mut TxContext): Vault {
         oracle_matrices: table::new(ctx),
         total_mtm: 0,
         total_max_payout: 0,
+        unsettled_exposed_oracles: vector[],
     }
 }
 
@@ -116,9 +122,12 @@ public(package) fun insert_position(
 ) {
     assert!(vault.oracle_matrices.contains(oracle_id), EOracleExposureNotFound);
     let old_max_payout = vault.oracle_matrices[oracle_id].max_payout();
+    let old_net_max_payout = vault.oracle_matrices[oracle_id].net_max_payout();
     vault.oracle_matrices[oracle_id].insert(strike, quantity, is_up);
     let new_max_payout = vault.oracle_matrices[oracle_id].max_payout();
+    let new_net_max_payout = vault.oracle_matrices[oracle_id].net_max_payout();
     vault.total_max_payout = vault.total_max_payout + new_max_payout - old_max_payout;
+    vault.sync_unsettled_exposed_oracle(oracle_id, old_net_max_payout, new_net_max_payout);
 }
 
 /// Insert a vertical range into the per-oracle exposure structure and update
@@ -137,6 +146,7 @@ public(package) fun insert_range(
     vault.oracle_matrices[oracle_id].insert_range(lower, higher, quantity);
     let new_net_max_payout = vault.oracle_matrices[oracle_id].net_max_payout();
     vault.total_max_payout = vault.total_max_payout + new_net_max_payout - old_net_max_payout;
+    vault.sync_unsettled_exposed_oracle(oracle_id, old_net_max_payout, new_net_max_payout);
 }
 
 /// Accept payment into vault balance.
@@ -156,9 +166,12 @@ public(package) fun remove_position(
 ) {
     assert!(vault.oracle_matrices.contains(oracle_id), EOracleExposureNotFound);
     let old_max_payout = vault.oracle_matrices[oracle_id].max_payout();
+    let old_net_max_payout = vault.oracle_matrices[oracle_id].net_max_payout();
     vault.oracle_matrices[oracle_id].remove(strike, quantity, is_up);
     let new_max_payout = vault.oracle_matrices[oracle_id].max_payout();
+    let new_net_max_payout = vault.oracle_matrices[oracle_id].net_max_payout();
     vault.total_max_payout = vault.total_max_payout + new_max_payout - old_max_payout;
+    vault.sync_unsettled_exposed_oracle(oracle_id, old_net_max_payout, new_net_max_payout);
 }
 
 /// Remove a vertical range from the per-oracle exposure structure and update
@@ -175,6 +188,7 @@ public(package) fun remove_range(
     vault.oracle_matrices[oracle_id].remove_range(lower, higher, quantity);
     let new_net_max_payout = vault.oracle_matrices[oracle_id].net_max_payout();
     vault.total_max_payout = vault.total_max_payout + new_net_max_payout - old_net_max_payout;
+    vault.sync_unsettled_exposed_oracle(oracle_id, old_net_max_payout, new_net_max_payout);
 }
 
 /// Dispense payout from vault balance.
@@ -214,7 +228,12 @@ public(package) fun set_mtm_with_curve(
     vault.total_mtm = vault.total_mtm + new_mtm - old_mtm;
 }
 
-public(package) fun set_mtm_with_settlement(vault: &mut Vault, oracle_id: ID, settlement: u64, clock: &Clock) {
+public(package) fun set_mtm_with_settlement(
+    vault: &mut Vault,
+    oracle_id: ID,
+    settlement: u64,
+    clock: &Clock,
+) {
     assert!(vault.oracle_matrices.contains(oracle_id), EOracleExposureNotFound);
 
     let matrix = &vault.oracle_matrices[oracle_id];
@@ -239,9 +258,42 @@ public(package) fun get_last_mtm_update(vault: &Vault, oracle_id: ID): u64 {
     vault.oracle_matrices[oracle_id].last_mtm_update()
 }
 
+public(package) fun remove_unsettled_exposed_oracle(vault: &mut Vault, oracle_id: ID) {
+    let mut i = 0;
+    while (i < vault.unsettled_exposed_oracles.length()) {
+        if (vault.unsettled_exposed_oracles[i] == oracle_id) {
+            vault.unsettled_exposed_oracles.swap_remove(i);
+            return
+        };
+        i = i + 1;
+    };
+}
+
 /// Per-matrix max payout net of the range quantity contributed by range mints.
 fun net_max_payout(matrix: &StrikeMatrix): u64 {
     matrix.max_payout() - matrix.range_qty()
+}
+
+fun sync_unsettled_exposed_oracle(
+    vault: &mut Vault,
+    oracle_id: ID,
+    old_net_max_payout: u64,
+    new_net_max_payout: u64,
+) {
+    if (old_net_max_payout == 0 && new_net_max_payout > 0) {
+        vault.add_unsettled_exposed_oracle(oracle_id);
+    } else if (old_net_max_payout > 0 && new_net_max_payout == 0) {
+        vault.remove_unsettled_exposed_oracle(oracle_id);
+    };
+}
+
+fun add_unsettled_exposed_oracle(vault: &mut Vault, oracle_id: ID) {
+    let mut i = 0;
+    while (i < vault.unsettled_exposed_oracles.length()) {
+        if (vault.unsettled_exposed_oracles[i] == oracle_id) return;
+        i = i + 1;
+    };
+    vault.unsettled_exposed_oracles.push_back(oracle_id);
 }
 
 fun deposit_balance<T>(vault: &mut Vault, payment: Balance<T>) {

--- a/packages/predict/sources/vault/vault.move
+++ b/packages/predict/sources/vault/vault.move
@@ -250,6 +250,15 @@ public(package) fun get_last_mtm_update(vault: &Vault, oracle_id: ID): u64 {
     vault.oracle_matrices[oracle_id].last_mtm_update()
 }
 
+public(package) fun add_unsettled_exposed_oracle(vault: &mut Vault, oracle_id: ID) {
+    let mut i = 0;
+    while (i < vault.unsettled_exposed_oracles.length()) {
+        if (vault.unsettled_exposed_oracles[i] == oracle_id) return;
+        i = i + 1;
+    };
+    vault.unsettled_exposed_oracles.push_back(oracle_id);
+}
+
 public(package) fun remove_unsettled_exposed_oracle(
     vault: &mut Vault,
     oracle_id: ID,
@@ -270,15 +279,6 @@ public(package) fun remove_unsettled_exposed_oracle(
         };
         i = i + 1;
     };
-}
-
-public(package) fun add_unsettled_exposed_oracle(vault: &mut Vault, oracle_id: ID) {
-    let mut i = 0;
-    while (i < vault.unsettled_exposed_oracles.length()) {
-        if (vault.unsettled_exposed_oracles[i] == oracle_id) return;
-        i = i + 1;
-    };
-    vault.unsettled_exposed_oracles.push_back(oracle_id);
 }
 
 fun deposit_balance<T>(vault: &mut Vault, payment: Balance<T>) {

--- a/packages/predict/sources/vault/vault.move
+++ b/packages/predict/sources/vault/vault.move
@@ -17,8 +17,6 @@ use deepbook::math;
 use deepbook_predict::{oracle_config::CurvePoint, strike_matrix::{Self, StrikeMatrix}};
 use sui::{bag::{Self, Bag}, balance::Balance, clock::Clock, table::{Self, Table}};
 
-use fun net_max_payout as StrikeMatrix.net_max_payout;
-
 // === Errors ===
 const EInsufficientBalance: u64 = 0;
 const EExceedsMaxTotalExposure: u64 = 1;
@@ -122,18 +120,15 @@ public(package) fun insert_position(
 ) {
     assert!(vault.oracle_matrices.contains(oracle_id), EOracleExposureNotFound);
     let old_max_payout = vault.oracle_matrices[oracle_id].max_payout();
-    let old_net_max_payout = vault.oracle_matrices[oracle_id].net_max_payout();
     vault.oracle_matrices[oracle_id].insert(strike, quantity, is_up);
     let new_max_payout = vault.oracle_matrices[oracle_id].max_payout();
-    let new_net_max_payout = vault.oracle_matrices[oracle_id].net_max_payout();
     vault.total_max_payout = vault.total_max_payout + new_max_payout - old_max_payout;
-    vault.sync_unsettled_exposed_oracle(oracle_id, old_net_max_payout, new_net_max_payout);
 }
 
 /// Insert a vertical range into the per-oracle exposure structure and update
 /// cached max payout. The range is recorded as `long UP@lower + long DN@higher`
-/// plus a `quantity` range_qty delta; the vault's `total_max_payout` reflects the
-/// range_qty-adjusted (net) contribution.
+/// plus a `quantity` range_qty delta; `StrikeMatrix.max_payout()` already
+/// includes that adjustment.
 public(package) fun insert_range(
     vault: &mut Vault,
     oracle_id: ID,
@@ -142,11 +137,10 @@ public(package) fun insert_range(
     quantity: u64,
 ) {
     assert!(vault.oracle_matrices.contains(oracle_id), EOracleExposureNotFound);
-    let old_net_max_payout = vault.oracle_matrices[oracle_id].net_max_payout();
+    let old_max_payout = vault.oracle_matrices[oracle_id].max_payout();
     vault.oracle_matrices[oracle_id].insert_range(lower, higher, quantity);
-    let new_net_max_payout = vault.oracle_matrices[oracle_id].net_max_payout();
-    vault.total_max_payout = vault.total_max_payout + new_net_max_payout - old_net_max_payout;
-    vault.sync_unsettled_exposed_oracle(oracle_id, old_net_max_payout, new_net_max_payout);
+    let new_max_payout = vault.oracle_matrices[oracle_id].max_payout();
+    vault.total_max_payout = vault.total_max_payout + new_max_payout - old_max_payout;
 }
 
 /// Accept payment into vault balance.
@@ -166,12 +160,9 @@ public(package) fun remove_position(
 ) {
     assert!(vault.oracle_matrices.contains(oracle_id), EOracleExposureNotFound);
     let old_max_payout = vault.oracle_matrices[oracle_id].max_payout();
-    let old_net_max_payout = vault.oracle_matrices[oracle_id].net_max_payout();
     vault.oracle_matrices[oracle_id].remove(strike, quantity, is_up);
     let new_max_payout = vault.oracle_matrices[oracle_id].max_payout();
-    let new_net_max_payout = vault.oracle_matrices[oracle_id].net_max_payout();
     vault.total_max_payout = vault.total_max_payout + new_max_payout - old_max_payout;
-    vault.sync_unsettled_exposed_oracle(oracle_id, old_net_max_payout, new_net_max_payout);
 }
 
 /// Remove a vertical range from the per-oracle exposure structure and update
@@ -184,11 +175,10 @@ public(package) fun remove_range(
     quantity: u64,
 ) {
     assert!(vault.oracle_matrices.contains(oracle_id), EOracleExposureNotFound);
-    let old_net_max_payout = vault.oracle_matrices[oracle_id].net_max_payout();
+    let old_max_payout = vault.oracle_matrices[oracle_id].max_payout();
     vault.oracle_matrices[oracle_id].remove_range(lower, higher, quantity);
-    let new_net_max_payout = vault.oracle_matrices[oracle_id].net_max_payout();
-    vault.total_max_payout = vault.total_max_payout + new_net_max_payout - old_net_max_payout;
-    vault.sync_unsettled_exposed_oracle(oracle_id, old_net_max_payout, new_net_max_payout);
+    let new_max_payout = vault.oracle_matrices[oracle_id].max_payout();
+    vault.total_max_payout = vault.total_max_payout + new_max_payout - old_max_payout;
 }
 
 /// Dispense payout from vault balance.
@@ -269,25 +259,15 @@ public(package) fun remove_unsettled_exposed_oracle(vault: &mut Vault, oracle_id
     };
 }
 
-/// Per-matrix max payout net of the range quantity contributed by range mints.
-fun net_max_payout(matrix: &StrikeMatrix): u64 {
-    matrix.max_payout() - matrix.range_qty()
-}
-
-fun sync_unsettled_exposed_oracle(
-    vault: &mut Vault,
-    oracle_id: ID,
-    old_net_max_payout: u64,
-    new_net_max_payout: u64,
-) {
-    if (old_net_max_payout == 0 && new_net_max_payout > 0) {
-        vault.add_unsettled_exposed_oracle(oracle_id);
-    } else if (old_net_max_payout > 0 && new_net_max_payout == 0) {
+public(package) fun remove_unsettled_exposed_oracle_if_inactive(vault: &mut Vault, oracle_id: ID) {
+    assert!(vault.oracle_matrices.contains(oracle_id), EOracleExposureNotFound);
+    let matrix = &vault.oracle_matrices[oracle_id];
+    if (matrix.mtm() == 0 && matrix.max_payout() == 0) {
         vault.remove_unsettled_exposed_oracle(oracle_id);
     };
 }
 
-fun add_unsettled_exposed_oracle(vault: &mut Vault, oracle_id: ID) {
+public(package) fun add_unsettled_exposed_oracle(vault: &mut Vault, oracle_id: ID) {
     let mut i = 0;
     while (i < vault.unsettled_exposed_oracles.length()) {
         if (vault.unsettled_exposed_oracles[i] == oracle_id) return;

--- a/packages/predict/sources/vault/vault.move
+++ b/packages/predict/sources/vault/vault.move
@@ -40,7 +40,9 @@ public struct Vault has store {
     total_mtm: u64,
     /// Sum of all oracle matrix max payout values.
     total_max_payout: u64,
-    /// Oracle IDs whose unsettled exposure must have fresh MTM before LP actions.
+    /// Oracle IDs whose unsettled exposure must have fresh MTM before LP
+    /// supply/withdraw. Trade quoting still uses the cached aggregate MTM and
+    /// refreshes only the touched oracle inline.
     unsettled_exposed_oracles: vector<ID>,
 }
 


### PR DESCRIPTION
## Summary
- move predict MTM freshness tracking from config-owned created-oracle state to a vault-owned set of unsettled oracles with non-zero exposure
- gate LP supply and withdraw on fresh MTM only for unsettled exposed oracles, so dormant or never-traded markets do not block LP actions
- expose runtime MTM maintenance on `predict` via `refresh_oracle_mtm` and `sync_settled_oracle`, and keep `registry` focused on oracle creation and config wiring

## Key decisions
- the freshness set is driven by net exposure transitions in the vault, not by oracle creation or activation, because LP accounting only depends on oracles that currently contribute unsettled liability
- settlement sync is atomic: recompute settled MTM first, then remove the oracle from the LP freshness set, so settled books cannot bypass stale-liability checks
- runtime maintenance entrypoints live on `Predict` instead of `Registry` because they mutate only predict-owned state and are part of the protocol runtime surface rather than the admin/config surface

## Test plan
- [x] `sui move test --path packages/predict --gas-limit 100000000000`