### PR TITLE
feat(deepbook): add place_post_only_limit_order graceful wrapper

### DIFF
--- a/packages/deepbook/sources/book/book.move
+++ b/packages/deepbook/sources/book/book.move
@@ -300,36 +300,39 @@ public(package) fun modify_order(
     (cancel_quantity, order)
 }
 
+/// Returns the best (lowest) ask price, skipping expired orders at the top of the book.
+/// Returns `none` if the ask side has no live orders.
+public(package) fun best_ask_price(self: &Book, current_timestamp: u64): Option<u64> {
+    let (mut slice_ref, mut offset) = self.asks.min_slice();
+    while (!slice_ref.is_null()) {
+        let order = slice_borrow(self.asks.borrow_slice(slice_ref), offset);
+        if (current_timestamp <= order.expire_timestamp()) return option::some(order.price());
+        (slice_ref, offset) = self.asks.next_slice(slice_ref, offset);
+    };
+
+    option::none()
+}
+
+/// Returns the best (highest) bid price, skipping expired orders at the top of the book.
+/// Returns `none` if the bid side has no live orders.
+public(package) fun best_bid_price(self: &Book, current_timestamp: u64): Option<u64> {
+    let (mut slice_ref, mut offset) = self.bids.max_slice();
+    while (!slice_ref.is_null()) {
+        let order = slice_borrow(self.bids.borrow_slice(slice_ref), offset);
+        if (current_timestamp <= order.expire_timestamp()) return option::some(order.price());
+        (slice_ref, offset) = self.bids.prev_slice(slice_ref, offset);
+    };
+
+    option::none()
+}
+
 /// Returns the mid price of the order book.
 public(package) fun mid_price(self: &Book, current_timestamp: u64): u64 {
-    let (mut ask_ref, mut ask_offset) = self.asks.min_slice();
-    let (mut bid_ref, mut bid_offset) = self.bids.max_slice();
-    let mut best_ask_price = 0;
-    let mut best_bid_price = 0;
+    let ask = self.best_ask_price(current_timestamp);
+    let bid = self.best_bid_price(current_timestamp);
+    assert!(ask.is_some() && bid.is_some(), EEmptyOrderbook);
 
-    while (!ask_ref.is_null()) {
-        let best_ask_order = slice_borrow(
-            self.asks.borrow_slice(ask_ref),
-            ask_offset,
-        );
-        best_ask_price = best_ask_order.price();
-        if (current_timestamp <= best_ask_order.expire_timestamp()) break;
-        (ask_ref, ask_offset) = self.asks.next_slice(ask_ref, ask_offset);
-    };
-
-    while (!bid_ref.is_null()) {
-        let best_bid_order = slice_borrow(
-            self.bids.borrow_slice(bid_ref),
-            bid_offset,
-        );
-        best_bid_price = best_bid_order.price();
-        if (current_timestamp <= best_bid_order.expire_timestamp()) break;
-        (bid_ref, bid_offset) = self.bids.prev_slice(bid_ref, bid_offset);
-    };
-
-    assert!(!ask_ref.is_null() && !bid_ref.is_null(), EEmptyOrderbook);
-
-    math::mul(best_ask_price + best_bid_price, constants::half())
+    math::mul(ask.destroy_some() + bid.destroy_some(), constants::half())
 }
 
 /// Returns the best bids and asks.

--- a/packages/deepbook/sources/book/book.move
+++ b/packages/deepbook/sources/book/book.move
@@ -301,32 +301,46 @@ public(package) fun modify_order(
 }
 
 /// Returns the best (lowest) ask price, skipping expired orders at the top of the book.
-/// Returns `none` if the ask side has no live orders.
+/// Returns `none` if the ask side has no live order within the first `max_fills`
+/// orders. The scan is bounded to `max_fills` — the same limit the matching
+/// engine uses (`match_against_book`) — so a large expired-order backlog cannot
+/// make this read cost unbounded gas. Bounding at `max_fills` also keeps the
+/// result consistent with the matcher: a taker cannot reach a live order buried
+/// under more than `max_fills` expired orders either, so treating that side as
+/// having no live top-of-book matches what a trade would actually see.
 public(package) fun best_ask_price(self: &Book, current_timestamp: u64): Option<u64> {
     let (mut slice_ref, mut offset) = self.asks.min_slice();
-    while (!slice_ref.is_null()) {
+    let mut scanned = 0;
+    while (!slice_ref.is_null() && scanned < constants::max_fills()) {
         let order = slice_borrow(self.asks.borrow_slice(slice_ref), offset);
         if (current_timestamp <= order.expire_timestamp()) return option::some(order.price());
         (slice_ref, offset) = self.asks.next_slice(slice_ref, offset);
+        scanned = scanned + 1;
     };
 
     option::none()
 }
 
 /// Returns the best (highest) bid price, skipping expired orders at the top of the book.
-/// Returns `none` if the bid side has no live orders.
+/// Returns `none` if the bid side has no live order within the first `max_fills`
+/// orders. Bounded to `max_fills` for the same reason as `best_ask_price`.
 public(package) fun best_bid_price(self: &Book, current_timestamp: u64): Option<u64> {
     let (mut slice_ref, mut offset) = self.bids.max_slice();
-    while (!slice_ref.is_null()) {
+    let mut scanned = 0;
+    while (!slice_ref.is_null() && scanned < constants::max_fills()) {
         let order = slice_borrow(self.bids.borrow_slice(slice_ref), offset);
         if (current_timestamp <= order.expire_timestamp()) return option::some(order.price());
         (slice_ref, offset) = self.bids.prev_slice(slice_ref, offset);
+        scanned = scanned + 1;
     };
 
     option::none()
 }
 
 /// Returns the mid price of the order book.
+/// Aborts `EEmptyOrderbook` if either side has no live order within the first
+/// `max_fills` orders (see `best_ask_price`) — i.e. a genuinely empty side, or a
+/// degenerate side whose top `max_fills` orders are all expired.
 public(package) fun mid_price(self: &Book, current_timestamp: u64): u64 {
     let ask = self.best_ask_price(current_timestamp);
     let bid = self.best_bid_price(current_timestamp);

--- a/packages/deepbook/sources/book/book.move
+++ b/packages/deepbook/sources/book/book.move
@@ -300,53 +300,75 @@ public(package) fun modify_order(
     (cancel_quantity, order)
 }
 
-/// Returns the best (lowest) ask price, skipping expired orders at the top of the book.
-/// Returns `none` if the ask side has no live order within the first `max_fills`
-/// orders. The scan is bounded to `max_fills` — the same limit the matching
-/// engine uses (`match_against_book`) — so a large expired-order backlog cannot
-/// make this read cost unbounded gas. Bounding at `max_fills` also keeps the
-/// result consistent with the matcher: a taker cannot reach a live order buried
-/// under more than `max_fills` expired orders either, so treating that side as
-/// having no live top-of-book matches what a trade would actually see.
+/// Returns the best (lowest) ask price, skipping expired orders at the top of
+/// the book. Returns `none` if the ask side has no live order. The walk is
+/// unbounded so a one-sided expired backlog never hides the true top-of-book
+/// from `mid_price` and its consumers; for the crossing test a placement needs,
+/// use `crosses_live_order`, which is bounded to the matcher's reach.
 public(package) fun best_ask_price(self: &Book, current_timestamp: u64): Option<u64> {
     let (mut slice_ref, mut offset) = self.asks.min_slice();
-    let mut scanned = 0;
-    while (!slice_ref.is_null() && scanned < constants::max_fills()) {
+    while (!slice_ref.is_null()) {
         let order = slice_borrow(self.asks.borrow_slice(slice_ref), offset);
         if (current_timestamp <= order.expire_timestamp()) return option::some(order.price());
         (slice_ref, offset) = self.asks.next_slice(slice_ref, offset);
-        scanned = scanned + 1;
     };
 
     option::none()
 }
 
-/// Returns the best (highest) bid price, skipping expired orders at the top of the book.
-/// Returns `none` if the bid side has no live order within the first `max_fills`
-/// orders. Bounded to `max_fills` for the same reason as `best_ask_price`.
+/// Returns the best (highest) bid price, skipping expired orders at the top of
+/// the book. Returns `none` if the bid side has no live order. Unbounded, for
+/// the same reason as `best_ask_price`.
 public(package) fun best_bid_price(self: &Book, current_timestamp: u64): Option<u64> {
     let (mut slice_ref, mut offset) = self.bids.max_slice();
-    let mut scanned = 0;
-    while (!slice_ref.is_null() && scanned < constants::max_fills()) {
+    while (!slice_ref.is_null()) {
         let order = slice_borrow(self.bids.borrow_slice(slice_ref), offset);
         if (current_timestamp <= order.expire_timestamp()) return option::some(order.price());
         (slice_ref, offset) = self.bids.prev_slice(slice_ref, offset);
-        scanned = scanned + 1;
     };
 
     option::none()
 }
 
-/// Returns the mid price of the order book.
-/// Aborts `EEmptyOrderbook` if either side has no live order within the first
-/// `max_fills` orders (see `best_ask_price`) — i.e. a genuinely empty side, or a
-/// degenerate side whose top `max_fills` orders are all expired.
+/// Returns the mid price of the order book. Aborts `EEmptyOrderbook` if either
+/// side has no live order.
 public(package) fun mid_price(self: &Book, current_timestamp: u64): u64 {
     let ask = self.best_ask_price(current_timestamp);
     let bid = self.best_bid_price(current_timestamp);
     assert!(ask.is_some() && bid.is_some(), EEmptyOrderbook);
 
     math::mul(ask.destroy_some() + bid.destroy_some(), constants::half())
+}
+
+/// Returns true if a `price`-priced order on the `is_bid` side would cross a
+/// live order the matcher can actually reach. Walks the opposite side skipping
+/// expired orders, bounded to `max_fills` — the same limit `match_against_book`
+/// uses — because a live order buried under more than `max_fills` expired orders
+/// is unreachable in a single fill and so cannot execute. This, not the
+/// unbounded getters above, is the crossing test a POST_ONLY placement must use:
+/// it mirrors exactly what the fill would see.
+public(package) fun crosses_live_order(
+    self: &Book,
+    price: u64,
+    is_bid: bool,
+    current_timestamp: u64,
+): bool {
+    let book_side = if (is_bid) &self.asks else &self.bids;
+    let (mut slice_ref, mut offset) = if (is_bid) book_side.min_slice() else book_side.max_slice();
+    let mut scanned = 0;
+    while (!slice_ref.is_null() && scanned < constants::max_fills()) {
+        let order = slice_borrow(book_side.borrow_slice(slice_ref), offset);
+        if (current_timestamp <= order.expire_timestamp()) {
+            // First live order at top-of-book; the side is price-sorted, so if it
+            // does not cross, nothing deeper does either.
+            return if (is_bid) order.price() <= price else order.price() >= price
+        };
+        (slice_ref, offset) = if (is_bid) book_side.next_slice(slice_ref, offset)
+        else book_side.prev_slice(slice_ref, offset);
+        scanned = scanned + 1;
+    };
+
+    false
 }
 
 /// Returns the best bids and asks.

--- a/packages/deepbook/sources/pool.move
+++ b/packages/deepbook/sources/pool.move
@@ -209,6 +209,48 @@ public fun place_limit_order<BaseAsset, QuoteAsset>(
     )
 }
 
+/// Graceful post-only limit order. Reads the relevant side of the book first
+/// and only forwards to `place_limit_order` with `POST_ONLY` when the order is
+/// guaranteed not to cross. If it would cross, returns `none` without placing
+/// — avoiding the `EPOSTOrderCrossesOrderbook` abort that tears down a PTB.
+/// An empty opposite side always allows placement.
+public fun place_post_only_limit_order<BaseAsset, QuoteAsset>(
+    self: &mut Pool<BaseAsset, QuoteAsset>,
+    balance_manager: &mut BalanceManager,
+    trade_proof: &TradeProof,
+    client_order_id: u64,
+    self_matching_option: u8,
+    price: u64,
+    quantity: u64,
+    is_bid: bool,
+    pay_with_deep: bool,
+    expire_timestamp: u64,
+    clock: &Clock,
+    ctx: &TxContext,
+): Option<OrderInfo> {
+    let would_cross = if (is_bid) {
+        self.best_ask_price(clock).destroy_or!(constants::max_u64()) <= price
+    } else {
+        self.best_bid_price(clock).destroy_or!(0) >= price
+    };
+    if (would_cross) return option::none();
+
+    option::some(self.place_limit_order(
+        balance_manager,
+        trade_proof,
+        client_order_id,
+        constants::post_only(),
+        self_matching_option,
+        price,
+        quantity,
+        is_bid,
+        pay_with_deep,
+        expire_timestamp,
+        clock,
+        ctx,
+    ))
+}
+
 /// Place a market order. Quantity is in base asset terms. Calls
 /// place_limit_order with
 /// a price of MAX_PRICE for bids and MIN_PRICE for asks. Any quantity not
@@ -1342,6 +1384,24 @@ public fun mid_price<BaseAsset, QuoteAsset>(
     clock: &Clock,
 ): u64 {
     self.load_inner().book.mid_price(clock.timestamp_ms())
+}
+
+/// Returns the best (lowest) ask price, skipping expired orders.
+/// Returns `none` if the ask side has no live orders.
+public fun best_ask_price<BaseAsset, QuoteAsset>(
+    self: &Pool<BaseAsset, QuoteAsset>,
+    clock: &Clock,
+): Option<u64> {
+    self.load_inner().book.best_ask_price(clock.timestamp_ms())
+}
+
+/// Returns the best (highest) bid price, skipping expired orders.
+/// Returns `none` if the bid side has no live orders.
+public fun best_bid_price<BaseAsset, QuoteAsset>(
+    self: &Pool<BaseAsset, QuoteAsset>,
+    clock: &Clock,
+): Option<u64> {
+    self.load_inner().book.best_bid_price(clock.timestamp_ms())
 }
 
 /// Returns the order_id for all open order for the balance_manager in the pool.

--- a/packages/deepbook/sources/pool.move
+++ b/packages/deepbook/sources/pool.move
@@ -208,6 +208,48 @@ public fun place_limit_order<BaseAsset, QuoteAsset>(
     )
 }
 
+/// Graceful post-only limit order. Reads the relevant side of the book first
+/// and only forwards to `place_limit_order` with `POST_ONLY` when the order is
+/// guaranteed not to cross. If it would cross, returns `none` without placing
+/// — avoiding the `EPOSTOrderCrossesOrderbook` abort that tears down a PTB.
+/// An empty opposite side always allows placement.
+public fun place_post_only_limit_order<BaseAsset, QuoteAsset>(
+    self: &mut Pool<BaseAsset, QuoteAsset>,
+    balance_manager: &mut BalanceManager,
+    trade_proof: &TradeProof,
+    client_order_id: u64,
+    self_matching_option: u8,
+    price: u64,
+    quantity: u64,
+    is_bid: bool,
+    pay_with_deep: bool,
+    expire_timestamp: u64,
+    clock: &Clock,
+    ctx: &TxContext,
+): Option<OrderInfo> {
+    let would_cross = if (is_bid) {
+        self.best_ask_price(clock).destroy_or!(constants::max_u64()) <= price
+    } else {
+        self.best_bid_price(clock).destroy_or!(0) >= price
+    };
+    if (would_cross) return option::none();
+
+    option::some(self.place_limit_order(
+        balance_manager,
+        trade_proof,
+        client_order_id,
+        constants::post_only(),
+        self_matching_option,
+        price,
+        quantity,
+        is_bid,
+        pay_with_deep,
+        expire_timestamp,
+        clock,
+        ctx,
+    ))
+}
+
 /// Place a market order. Quantity is in base asset terms. Calls
 /// place_limit_order with
 /// a price of MAX_PRICE for bids and MIN_PRICE for asks. Any quantity not
@@ -1340,6 +1382,24 @@ public fun mid_price<BaseAsset, QuoteAsset>(
     clock: &Clock,
 ): u64 {
     self.load_inner().book.mid_price(clock.timestamp_ms())
+}
+
+/// Returns the best (lowest) ask price, skipping expired orders.
+/// Returns `none` if the ask side has no live orders.
+public fun best_ask_price<BaseAsset, QuoteAsset>(
+    self: &Pool<BaseAsset, QuoteAsset>,
+    clock: &Clock,
+): Option<u64> {
+    self.load_inner().book.best_ask_price(clock.timestamp_ms())
+}
+
+/// Returns the best (highest) bid price, skipping expired orders.
+/// Returns `none` if the bid side has no live orders.
+public fun best_bid_price<BaseAsset, QuoteAsset>(
+    self: &Pool<BaseAsset, QuoteAsset>,
+    clock: &Clock,
+): Option<u64> {
+    self.load_inner().book.best_bid_price(clock.timestamp_ms())
 }
 
 /// Returns the order_id for all open order for the balance_manager in the pool.

--- a/packages/deepbook/sources/pool.move
+++ b/packages/deepbook/sources/pool.move
@@ -214,12 +214,21 @@ public fun place_limit_order<BaseAsset, QuoteAsset>(
 /// guaranteed not to cross. If it would cross, returns `none` without placing
 /// — avoiding the `EPOSTOrderCrossesOrderbook` abort that tears down a PTB.
 /// An empty opposite side always allows placement.
+///
+/// Self-matching is fixed to `SELF_MATCHING_ALLOWED` and is not a parameter:
+/// the wrapper only ever forwards a non-crossing order, and self-matching
+/// governs how a *crossing* fill treats the taker's own maker orders, so it has
+/// no effect on the forwarded placement. Exposing it would also be a footgun —
+/// `CANCEL_TAKER` aborts (`ESelfMatchingCancelTaker`) against the caller's own
+/// expired order sitting at a crossing price, which the pre-check skips as
+/// non-live, re-introducing the very abort this wrapper exists to avoid. A
+/// caller that wants to cross and cancel its own resting orders should call
+/// `place_limit_order` directly.
 public fun place_post_only_limit_order<BaseAsset, QuoteAsset>(
     self: &mut Pool<BaseAsset, QuoteAsset>,
     balance_manager: &mut BalanceManager,
     trade_proof: &TradeProof,
     client_order_id: u64,
-    self_matching_option: u8,
     price: u64,
     quantity: u64,
     is_bid: bool,
@@ -240,7 +249,7 @@ public fun place_post_only_limit_order<BaseAsset, QuoteAsset>(
         trade_proof,
         client_order_id,
         constants::post_only(),
-        self_matching_option,
+        constants::self_matching_allowed(),
         price,
         quantity,
         is_bid,

--- a/packages/deepbook/sources/pool.move
+++ b/packages/deepbook/sources/pool.move
@@ -1395,8 +1395,10 @@ public fun mid_price<BaseAsset, QuoteAsset>(
     self.load_inner().book.mid_price(clock.timestamp_ms())
 }
 
-/// Returns the best (lowest) ask price, skipping expired orders.
-/// Returns `none` if the ask side has no live orders.
+/// Top-of-book read for PTB construction / devInspect (SDK, UI). Returns the
+/// best (lowest) ask price, skipping expired orders. Returns `none` if the ask
+/// side has no live order within the first `max_fills` orders (see
+/// `book::best_ask_price` for the bound).
 public fun best_ask_price<BaseAsset, QuoteAsset>(
     self: &Pool<BaseAsset, QuoteAsset>,
     clock: &Clock,
@@ -1404,8 +1406,10 @@ public fun best_ask_price<BaseAsset, QuoteAsset>(
     self.load_inner().book.best_ask_price(clock.timestamp_ms())
 }
 
-/// Returns the best (highest) bid price, skipping expired orders.
-/// Returns `none` if the bid side has no live orders.
+/// Top-of-book read for PTB construction / devInspect (SDK, UI). Returns the
+/// best (highest) bid price, skipping expired orders. Returns `none` if the bid
+/// side has no live order within the first `max_fills` orders (see
+/// `book::best_bid_price` for the bound).
 public fun best_bid_price<BaseAsset, QuoteAsset>(
     self: &Pool<BaseAsset, QuoteAsset>,
     clock: &Clock,

--- a/packages/deepbook/sources/pool.move
+++ b/packages/deepbook/sources/pool.move
@@ -209,10 +209,13 @@ public fun place_limit_order<BaseAsset, QuoteAsset>(
     )
 }
 
-/// Graceful post-only limit order. Reads the relevant side of the book first
+/// Graceful post-only limit order. Checks the relevant side of the book first
 /// and only forwards to `place_limit_order` with `POST_ONLY` when the order is
-/// guaranteed not to cross. If it would cross, returns `none` without placing
-/// — avoiding the `EPOSTOrderCrossesOrderbook` abort that tears down a PTB.
+/// guaranteed not to cross a live order the matcher can reach. Returns `none`
+/// instead of aborting `EPOSTOrderCrossesOrderbook` when it would cross — and
+/// also `none` when the forwarded placement rests nothing (a large expired
+/// backlog at a crossing price makes `place_limit_order` hit its fill limit and
+/// inject no order), so `some` always means the order is resting on the book.
 /// An empty opposite side always allows placement.
 ///
 /// Self-matching is fixed to `SELF_MATCHING_ALLOWED` and is not a parameter:
@@ -237,14 +240,13 @@ public fun place_post_only_limit_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &TxContext,
 ): Option<OrderInfo> {
-    let would_cross = if (is_bid) {
-        self.best_ask_price(clock).destroy_or!(constants::max_u64()) <= price
-    } else {
-        self.best_bid_price(clock).destroy_or!(0) >= price
-    };
+    let would_cross = self
+        .load_inner()
+        .book
+        .crosses_live_order(price, is_bid, clock.timestamp_ms());
     if (would_cross) return option::none();
 
-    option::some(self.place_limit_order(
+    let order_info = self.place_limit_order(
         balance_manager,
         trade_proof,
         client_order_id,
@@ -257,7 +259,11 @@ public fun place_post_only_limit_order<BaseAsset, QuoteAsset>(
         expire_timestamp,
         clock,
         ctx,
-    ))
+    );
+
+    // place_limit_order can hit its fill limit clearing an expired backlog and
+    // rest nothing; report that as `none` so `some` always means the order rests.
+    if (order_info.order_inserted()) option::some(order_info) else option::none()
 }
 
 /// Place a market order. Quantity is in base asset terms. Calls
@@ -1397,8 +1403,7 @@ public fun mid_price<BaseAsset, QuoteAsset>(
 
 /// Top-of-book read for PTB construction / devInspect (SDK, UI). Returns the
 /// best (lowest) ask price, skipping expired orders. Returns `none` if the ask
-/// side has no live order within the first `max_fills` orders (see
-/// `book::best_ask_price` for the bound).
+/// side has no live order.
 public fun best_ask_price<BaseAsset, QuoteAsset>(
     self: &Pool<BaseAsset, QuoteAsset>,
     clock: &Clock,
@@ -1408,8 +1413,7 @@ public fun best_ask_price<BaseAsset, QuoteAsset>(
 
 /// Top-of-book read for PTB construction / devInspect (SDK, UI). Returns the
 /// best (highest) bid price, skipping expired orders. Returns `none` if the bid
-/// side has no live order within the first `max_fills` orders (see
-/// `book::best_bid_price` for the bound).
+/// side has no live order.
 public fun best_bid_price<BaseAsset, QuoteAsset>(
     self: &Pool<BaseAsset, QuoteAsset>,
     clock: &Clock,

--- a/packages/deepbook/tests/pool_tests.move
+++ b/packages/deepbook/tests/pool_tests.move
@@ -553,6 +553,98 @@ fun test_post_only_ask_ok() {
 }
 
 #[test]
+fun post_only_wrapper_places_into_empty_book_bid() {
+    run_post_only_wrapper_scenario(
+        true,
+        option::none(),
+        option::none(),
+        2 * constants::float_scaling(),
+        true,
+    );
+}
+
+#[test]
+fun post_only_wrapper_places_into_empty_book_ask() {
+    run_post_only_wrapper_scenario(
+        false,
+        option::none(),
+        option::none(),
+        2 * constants::float_scaling(),
+        true,
+    );
+}
+
+#[test]
+fun post_only_wrapper_bid_below_best_ask_places() {
+    run_post_only_wrapper_scenario(
+        true,
+        option::none(),
+        option::some(2 * constants::float_scaling()),
+        1_900_000_000, // 1.9, below best ask 2.0
+        true,
+    );
+}
+
+#[test]
+fun post_only_wrapper_ask_above_best_bid_places() {
+    run_post_only_wrapper_scenario(
+        false,
+        option::none(),
+        option::some(1 * constants::float_scaling()),
+        1_100_000_000, // 1.1, above best bid 1.0
+        true,
+    );
+}
+
+#[test]
+fun post_only_wrapper_bid_at_best_ask_skipped() {
+    let px = 2 * constants::float_scaling();
+    run_post_only_wrapper_scenario(true, option::none(), option::some(px), px, false);
+}
+
+#[test]
+fun post_only_wrapper_bid_above_best_ask_skipped() {
+    run_post_only_wrapper_scenario(
+        true,
+        option::none(),
+        option::some(2 * constants::float_scaling()),
+        3 * constants::float_scaling(),
+        false,
+    );
+}
+
+#[test]
+fun post_only_wrapper_ask_at_best_bid_skipped() {
+    let px = 1 * constants::float_scaling();
+    run_post_only_wrapper_scenario(false, option::none(), option::some(px), px, false);
+}
+
+#[test]
+fun post_only_wrapper_ask_below_best_bid_skipped() {
+    run_post_only_wrapper_scenario(
+        false,
+        option::none(),
+        option::some(2 * constants::float_scaling()),
+        1 * constants::float_scaling(),
+        false,
+    );
+}
+
+#[test]
+fun post_only_wrapper_places_when_only_same_side_has_orders() {
+    // Bid side populated, ask side empty. Single-side read: opposite side
+    // empty, so placement is always allowed regardless of existing same-side
+    // liquidity.
+    run_post_only_wrapper_scenario(
+        true,
+        option::some(1 * constants::float_scaling()),
+        option::none(),
+        5 * constants::float_scaling(),
+        true,
+    );
+}
+
+#[test]
 fun test_crossing_multiple_orders_bid_ok() {
     test_crossing_multiple(true, 3)
 }
@@ -595,6 +687,212 @@ fun test_market_order_ask_then_bid_ok() {
 #[test]
 fun test_mid_price_ok() {
     test_mid_price();
+}
+
+#[test]
+fun best_bid_ask_empty_book_returns_none() {
+    let mut test = begin(OWNER);
+    let registry_id = setup_test(OWNER, &mut test);
+    let balance_manager_id_alice = create_acct_and_share_with_funds(
+        ALICE,
+        1_000_000 * constants::float_scaling(),
+        &mut test,
+    );
+    let pool_id = setup_pool_with_default_fees_and_reference_pool<SUI, USDC, SUI, DEEP>(
+        ALICE,
+        registry_id,
+        balance_manager_id_alice,
+        &mut test,
+    );
+
+    assert!(get_best_bid_price<SUI, USDC>(pool_id, &mut test).is_none());
+    assert!(get_best_ask_price<SUI, USDC>(pool_id, &mut test).is_none());
+
+    end(test);
+}
+
+#[test]
+fun best_bid_ask_returns_top_of_book() {
+    let mut test = begin(OWNER);
+    let registry_id = setup_test(OWNER, &mut test);
+    let balance_manager_id_alice = create_acct_and_share_with_funds(
+        ALICE,
+        1_000_000 * constants::float_scaling(),
+        &mut test,
+    );
+    let pool_id = setup_pool_with_default_fees_and_reference_pool<SUI, USDC, SUI, DEEP>(
+        ALICE,
+        registry_id,
+        balance_manager_id_alice,
+        &mut test,
+    );
+
+    let quantity = 1 * constants::float_scaling();
+    let expire_timestamp = constants::max_u64();
+    let pay_with_deep = true;
+    let bid_best = 2 * constants::float_scaling();
+    let bid_lower = 1 * constants::float_scaling();
+    let ask_best = 5 * constants::float_scaling();
+    let ask_higher = 6 * constants::float_scaling();
+
+    place_limit_order<SUI, USDC>(
+        ALICE,
+        pool_id,
+        balance_manager_id_alice,
+        1,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        bid_lower,
+        quantity,
+        true,
+        pay_with_deep,
+        expire_timestamp,
+        &mut test,
+    );
+    place_limit_order<SUI, USDC>(
+        ALICE,
+        pool_id,
+        balance_manager_id_alice,
+        2,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        bid_best,
+        quantity,
+        true,
+        pay_with_deep,
+        expire_timestamp,
+        &mut test,
+    );
+    place_limit_order<SUI, USDC>(
+        ALICE,
+        pool_id,
+        balance_manager_id_alice,
+        3,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        ask_higher,
+        quantity,
+        false,
+        pay_with_deep,
+        expire_timestamp,
+        &mut test,
+    );
+    place_limit_order<SUI, USDC>(
+        ALICE,
+        pool_id,
+        balance_manager_id_alice,
+        4,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        ask_best,
+        quantity,
+        false,
+        pay_with_deep,
+        expire_timestamp,
+        &mut test,
+    );
+
+    assert_eq!(get_best_bid_price<SUI, USDC>(pool_id, &mut test).destroy_some(), bid_best);
+    assert_eq!(get_best_ask_price<SUI, USDC>(pool_id, &mut test).destroy_some(), ask_best);
+
+    end(test);
+}
+
+#[test]
+fun best_bid_ask_skips_expired_orders() {
+    let mut test = begin(OWNER);
+    let registry_id = setup_test(OWNER, &mut test);
+    let balance_manager_id_alice = create_acct_and_share_with_funds(
+        ALICE,
+        1_000_000 * constants::float_scaling(),
+        &mut test,
+    );
+    let pool_id = setup_pool_with_default_fees_and_reference_pool<SUI, USDC, SUI, DEEP>(
+        ALICE,
+        registry_id,
+        balance_manager_id_alice,
+        &mut test,
+    );
+
+    let quantity = 1 * constants::float_scaling();
+    let pay_with_deep = true;
+    // Best bid (2.2) expires earlier than the deeper bid (1.0).
+    let bid_expiring = 2_200_000_000;
+    let bid_surviving = 1 * constants::float_scaling();
+    // Best ask (3.2) expires earlier than the deeper ask (6.0).
+    let ask_expiring = 3_200_000_000;
+    let ask_surviving = 6 * constants::float_scaling();
+    let expire_now = get_time(&mut test) + 100;
+    let expire_far = constants::max_u64();
+
+    place_limit_order<SUI, USDC>(
+        ALICE,
+        pool_id,
+        balance_manager_id_alice,
+        1,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        bid_surviving,
+        quantity,
+        true,
+        pay_with_deep,
+        expire_far,
+        &mut test,
+    );
+    place_limit_order<SUI, USDC>(
+        ALICE,
+        pool_id,
+        balance_manager_id_alice,
+        2,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        bid_expiring,
+        quantity,
+        true,
+        pay_with_deep,
+        expire_now,
+        &mut test,
+    );
+    place_limit_order<SUI, USDC>(
+        ALICE,
+        pool_id,
+        balance_manager_id_alice,
+        3,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        ask_surviving,
+        quantity,
+        false,
+        pay_with_deep,
+        expire_far,
+        &mut test,
+    );
+    place_limit_order<SUI, USDC>(
+        ALICE,
+        pool_id,
+        balance_manager_id_alice,
+        4,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        ask_expiring,
+        quantity,
+        false,
+        pay_with_deep,
+        expire_now,
+        &mut test,
+    );
+
+    // Before expiry: getters return the about-to-expire orders at top of book.
+    assert_eq!(get_best_bid_price<SUI, USDC>(pool_id, &mut test).destroy_some(), bid_expiring);
+    assert_eq!(get_best_ask_price<SUI, USDC>(pool_id, &mut test).destroy_some(), ask_expiring);
+
+    set_time(expire_now + 1, &mut test);
+
+    // After expiry: getters skip the expired top-of-book and return the deeper orders.
+    assert_eq!(get_best_bid_price<SUI, USDC>(pool_id, &mut test).destroy_some(), bid_surviving);
+    assert_eq!(get_best_ask_price<SUI, USDC>(pool_id, &mut test).destroy_some(), ask_surviving);
+
+    end(test);
 }
 
 #[test]
@@ -1534,6 +1832,53 @@ public(package) fun place_limit_order<BaseAsset, QuoteAsset>(
             &trade_proof,
             client_order_id,
             order_type,
+            self_matching_option,
+            price,
+            quantity,
+            is_bid,
+            pay_with_deep,
+            expire_timestamp,
+            &clock,
+            test.ctx(),
+        );
+        return_shared(pool);
+        return_shared(clock);
+        return_shared(balance_manager);
+
+        order_info
+    }
+}
+
+#[test_only]
+/// Place a post-only limit order through the graceful wrapper.
+public(package) fun place_post_only_limit_order<BaseAsset, QuoteAsset>(
+    trader: address,
+    pool_id: ID,
+    balance_manager_id: ID,
+    client_order_id: u64,
+    self_matching_option: u8,
+    price: u64,
+    quantity: u64,
+    is_bid: bool,
+    pay_with_deep: bool,
+    expire_timestamp: u64,
+    test: &mut Scenario,
+): Option<OrderInfo> {
+    test.next_tx(trader);
+    {
+        let mut pool = test.take_shared_by_id<Pool<BaseAsset, QuoteAsset>>(
+            pool_id,
+        );
+        let clock = test.take_shared<Clock>();
+        let mut balance_manager = test.take_shared_by_id<BalanceManager>(
+            balance_manager_id,
+        );
+        let trade_proof = balance_manager.generate_proof_as_owner(test.ctx());
+
+        let order_info = pool.place_post_only_limit_order<BaseAsset, QuoteAsset>(
+            &mut balance_manager,
+            &trade_proof,
+            client_order_id,
             self_matching_option,
             price,
             quantity,
@@ -3243,6 +3588,94 @@ fun test_post_only(is_bid: bool, crosses_order: bool) {
         expire_timestamp,
         &mut test,
     );
+
+    end(test);
+}
+
+/// Exercise `place_post_only_limit_order`. Optionally seed the same side
+/// and/or the opposite side with standing orders, then attempt to place a
+/// post-only order on the `is_bid` side at `new_order_price`. Asserts that
+/// `expected_placed` matches the returned `Option<OrderInfo>` and, when
+/// placed, that the order was actually inserted into the book.
+fun run_post_only_wrapper_scenario(
+    is_bid: bool,
+    seed_same_side_price: Option<u64>,
+    seed_opposite_side_price: Option<u64>,
+    new_order_price: u64,
+    expected_placed: bool,
+) {
+    let mut test = begin(OWNER);
+    let registry_id = setup_test(OWNER, &mut test);
+    let balance_manager_id_alice = create_acct_and_share_with_funds(
+        ALICE,
+        1_000_000 * constants::float_scaling(),
+        &mut test,
+    );
+    let pool_id = setup_pool_with_default_fees_and_reference_pool<SUI, USDC, SUI, DEEP>(
+        ALICE,
+        registry_id,
+        balance_manager_id_alice,
+        &mut test,
+    );
+
+    let quantity = 1 * constants::float_scaling();
+    let expire_timestamp = constants::max_u64();
+    let pay_with_deep = true;
+
+    seed_same_side_price.do!(|p| {
+        place_limit_order<SUI, USDC>(
+            ALICE,
+            pool_id,
+            balance_manager_id_alice,
+            1,
+            constants::no_restriction(),
+            constants::self_matching_allowed(),
+            p,
+            quantity,
+            is_bid,
+            pay_with_deep,
+            expire_timestamp,
+            &mut test,
+        );
+    });
+    seed_opposite_side_price.do!(|p| {
+        place_limit_order<SUI, USDC>(
+            ALICE,
+            pool_id,
+            balance_manager_id_alice,
+            2,
+            constants::no_restriction(),
+            constants::self_matching_allowed(),
+            p,
+            quantity,
+            !is_bid,
+            pay_with_deep,
+            expire_timestamp,
+            &mut test,
+        );
+    });
+
+    let result = place_post_only_limit_order<SUI, USDC>(
+        ALICE,
+        pool_id,
+        balance_manager_id_alice,
+        3,
+        constants::self_matching_allowed(),
+        new_order_price,
+        quantity,
+        is_bid,
+        pay_with_deep,
+        expire_timestamp,
+        &mut test,
+    );
+
+    assert_eq!(result.is_some(), expected_placed);
+    if (result.is_some()) {
+        let order_info = result.destroy_some();
+        assert!(order_info.order_inserted());
+        assert_eq!(order_info.price(), new_order_price);
+        assert_eq!(order_info.order_type(), constants::post_only());
+    };
 
     end(test);
 }
@@ -6226,6 +6659,34 @@ fun get_mid_price<BaseAsset, QuoteAsset>(pool_id: ID, test: &mut Scenario): u64 
         return_shared(clock);
 
         mid_price
+    }
+}
+
+fun get_best_bid_price<BaseAsset, QuoteAsset>(pool_id: ID, test: &mut Scenario): Option<u64> {
+    test.next_tx(OWNER);
+    {
+        let pool = test.take_shared_by_id<Pool<BaseAsset, QuoteAsset>>(pool_id);
+        let clock = test.take_shared<Clock>();
+
+        let best = pool.best_bid_price<BaseAsset, QuoteAsset>(&clock);
+        return_shared(pool);
+        return_shared(clock);
+
+        best
+    }
+}
+
+fun get_best_ask_price<BaseAsset, QuoteAsset>(pool_id: ID, test: &mut Scenario): Option<u64> {
+    test.next_tx(OWNER);
+    {
+        let pool = test.take_shared_by_id<Pool<BaseAsset, QuoteAsset>>(pool_id);
+        let clock = test.take_shared<Clock>();
+
+        let best = pool.best_ask_price<BaseAsset, QuoteAsset>(&clock);
+        return_shared(pool);
+        return_shared(clock);
+
+        best
     }
 }
 

--- a/packages/deepbook/tests/pool_tests.move
+++ b/packages/deepbook/tests/pool_tests.move
@@ -553,6 +553,98 @@ fun test_post_only_ask_ok() {
 }
 
 #[test]
+fun post_only_wrapper_places_into_empty_book_bid() {
+    run_post_only_wrapper_scenario(
+        true,
+        option::none(),
+        option::none(),
+        2 * constants::float_scaling(),
+        true,
+    );
+}
+
+#[test]
+fun post_only_wrapper_places_into_empty_book_ask() {
+    run_post_only_wrapper_scenario(
+        false,
+        option::none(),
+        option::none(),
+        2 * constants::float_scaling(),
+        true,
+    );
+}
+
+#[test]
+fun post_only_wrapper_bid_below_best_ask_places() {
+    run_post_only_wrapper_scenario(
+        true,
+        option::none(),
+        option::some(2 * constants::float_scaling()),
+        1_900_000_000, // 1.9, below best ask 2.0
+        true,
+    );
+}
+
+#[test]
+fun post_only_wrapper_ask_above_best_bid_places() {
+    run_post_only_wrapper_scenario(
+        false,
+        option::none(),
+        option::some(1 * constants::float_scaling()),
+        1_100_000_000, // 1.1, above best bid 1.0
+        true,
+    );
+}
+
+#[test]
+fun post_only_wrapper_bid_at_best_ask_skipped() {
+    let px = 2 * constants::float_scaling();
+    run_post_only_wrapper_scenario(true, option::none(), option::some(px), px, false);
+}
+
+#[test]
+fun post_only_wrapper_bid_above_best_ask_skipped() {
+    run_post_only_wrapper_scenario(
+        true,
+        option::none(),
+        option::some(2 * constants::float_scaling()),
+        3 * constants::float_scaling(),
+        false,
+    );
+}
+
+#[test]
+fun post_only_wrapper_ask_at_best_bid_skipped() {
+    let px = 1 * constants::float_scaling();
+    run_post_only_wrapper_scenario(false, option::none(), option::some(px), px, false);
+}
+
+#[test]
+fun post_only_wrapper_ask_below_best_bid_skipped() {
+    run_post_only_wrapper_scenario(
+        false,
+        option::none(),
+        option::some(2 * constants::float_scaling()),
+        1 * constants::float_scaling(),
+        false,
+    );
+}
+
+#[test]
+fun post_only_wrapper_places_when_only_same_side_has_orders() {
+    // Bid side populated, ask side empty. Single-side read: opposite side
+    // empty, so placement is always allowed regardless of existing same-side
+    // liquidity.
+    run_post_only_wrapper_scenario(
+        true,
+        option::some(1 * constants::float_scaling()),
+        option::none(),
+        5 * constants::float_scaling(),
+        true,
+    );
+}
+
+#[test]
 fun test_crossing_multiple_orders_bid_ok() {
     test_crossing_multiple(true, 3)
 }
@@ -595,6 +687,212 @@ fun test_market_order_ask_then_bid_ok() {
 #[test]
 fun test_mid_price_ok() {
     test_mid_price();
+}
+
+#[test]
+fun best_bid_ask_empty_book_returns_none() {
+    let mut test = begin(OWNER);
+    let registry_id = setup_test(OWNER, &mut test);
+    let balance_manager_id_alice = create_acct_and_share_with_funds(
+        ALICE,
+        1_000_000 * constants::float_scaling(),
+        &mut test,
+    );
+    let pool_id = setup_pool_with_default_fees_and_reference_pool<SUI, USDC, SUI, DEEP>(
+        ALICE,
+        registry_id,
+        balance_manager_id_alice,
+        &mut test,
+    );
+
+    assert!(get_best_bid_price<SUI, USDC>(pool_id, &mut test).is_none());
+    assert!(get_best_ask_price<SUI, USDC>(pool_id, &mut test).is_none());
+
+    end(test);
+}
+
+#[test]
+fun best_bid_ask_returns_top_of_book() {
+    let mut test = begin(OWNER);
+    let registry_id = setup_test(OWNER, &mut test);
+    let balance_manager_id_alice = create_acct_and_share_with_funds(
+        ALICE,
+        1_000_000 * constants::float_scaling(),
+        &mut test,
+    );
+    let pool_id = setup_pool_with_default_fees_and_reference_pool<SUI, USDC, SUI, DEEP>(
+        ALICE,
+        registry_id,
+        balance_manager_id_alice,
+        &mut test,
+    );
+
+    let quantity = 1 * constants::float_scaling();
+    let expire_timestamp = constants::max_u64();
+    let pay_with_deep = true;
+    let bid_best = 2 * constants::float_scaling();
+    let bid_lower = 1 * constants::float_scaling();
+    let ask_best = 5 * constants::float_scaling();
+    let ask_higher = 6 * constants::float_scaling();
+
+    place_limit_order<SUI, USDC>(
+        ALICE,
+        pool_id,
+        balance_manager_id_alice,
+        1,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        bid_lower,
+        quantity,
+        true,
+        pay_with_deep,
+        expire_timestamp,
+        &mut test,
+    );
+    place_limit_order<SUI, USDC>(
+        ALICE,
+        pool_id,
+        balance_manager_id_alice,
+        2,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        bid_best,
+        quantity,
+        true,
+        pay_with_deep,
+        expire_timestamp,
+        &mut test,
+    );
+    place_limit_order<SUI, USDC>(
+        ALICE,
+        pool_id,
+        balance_manager_id_alice,
+        3,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        ask_higher,
+        quantity,
+        false,
+        pay_with_deep,
+        expire_timestamp,
+        &mut test,
+    );
+    place_limit_order<SUI, USDC>(
+        ALICE,
+        pool_id,
+        balance_manager_id_alice,
+        4,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        ask_best,
+        quantity,
+        false,
+        pay_with_deep,
+        expire_timestamp,
+        &mut test,
+    );
+
+    assert_eq!(get_best_bid_price<SUI, USDC>(pool_id, &mut test).destroy_some(), bid_best);
+    assert_eq!(get_best_ask_price<SUI, USDC>(pool_id, &mut test).destroy_some(), ask_best);
+
+    end(test);
+}
+
+#[test]
+fun best_bid_ask_skips_expired_orders() {
+    let mut test = begin(OWNER);
+    let registry_id = setup_test(OWNER, &mut test);
+    let balance_manager_id_alice = create_acct_and_share_with_funds(
+        ALICE,
+        1_000_000 * constants::float_scaling(),
+        &mut test,
+    );
+    let pool_id = setup_pool_with_default_fees_and_reference_pool<SUI, USDC, SUI, DEEP>(
+        ALICE,
+        registry_id,
+        balance_manager_id_alice,
+        &mut test,
+    );
+
+    let quantity = 1 * constants::float_scaling();
+    let pay_with_deep = true;
+    // Best bid (2.2) expires earlier than the deeper bid (1.0).
+    let bid_expiring = 2_200_000_000;
+    let bid_surviving = 1 * constants::float_scaling();
+    // Best ask (3.2) expires earlier than the deeper ask (6.0).
+    let ask_expiring = 3_200_000_000;
+    let ask_surviving = 6 * constants::float_scaling();
+    let expire_now = get_time(&mut test) + 100;
+    let expire_far = constants::max_u64();
+
+    place_limit_order<SUI, USDC>(
+        ALICE,
+        pool_id,
+        balance_manager_id_alice,
+        1,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        bid_surviving,
+        quantity,
+        true,
+        pay_with_deep,
+        expire_far,
+        &mut test,
+    );
+    place_limit_order<SUI, USDC>(
+        ALICE,
+        pool_id,
+        balance_manager_id_alice,
+        2,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        bid_expiring,
+        quantity,
+        true,
+        pay_with_deep,
+        expire_now,
+        &mut test,
+    );
+    place_limit_order<SUI, USDC>(
+        ALICE,
+        pool_id,
+        balance_manager_id_alice,
+        3,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        ask_surviving,
+        quantity,
+        false,
+        pay_with_deep,
+        expire_far,
+        &mut test,
+    );
+    place_limit_order<SUI, USDC>(
+        ALICE,
+        pool_id,
+        balance_manager_id_alice,
+        4,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        ask_expiring,
+        quantity,
+        false,
+        pay_with_deep,
+        expire_now,
+        &mut test,
+    );
+
+    // Before expiry: getters return the about-to-expire orders at top of book.
+    assert_eq!(get_best_bid_price<SUI, USDC>(pool_id, &mut test).destroy_some(), bid_expiring);
+    assert_eq!(get_best_ask_price<SUI, USDC>(pool_id, &mut test).destroy_some(), ask_expiring);
+
+    set_time(expire_now + 1, &mut test);
+
+    // After expiry: getters skip the expired top-of-book and return the deeper orders.
+    assert_eq!(get_best_bid_price<SUI, USDC>(pool_id, &mut test).destroy_some(), bid_surviving);
+    assert_eq!(get_best_ask_price<SUI, USDC>(pool_id, &mut test).destroy_some(), ask_surviving);
+
+    end(test);
 }
 
 #[test]
@@ -1602,6 +1900,53 @@ public(package) fun place_limit_order<BaseAsset, QuoteAsset>(
             &trade_proof,
             client_order_id,
             order_type,
+            self_matching_option,
+            price,
+            quantity,
+            is_bid,
+            pay_with_deep,
+            expire_timestamp,
+            &clock,
+            test.ctx(),
+        );
+        return_shared(pool);
+        return_shared(clock);
+        return_shared(balance_manager);
+
+        order_info
+    }
+}
+
+#[test_only]
+/// Place a post-only limit order through the graceful wrapper.
+public(package) fun place_post_only_limit_order<BaseAsset, QuoteAsset>(
+    trader: address,
+    pool_id: ID,
+    balance_manager_id: ID,
+    client_order_id: u64,
+    self_matching_option: u8,
+    price: u64,
+    quantity: u64,
+    is_bid: bool,
+    pay_with_deep: bool,
+    expire_timestamp: u64,
+    test: &mut Scenario,
+): Option<OrderInfo> {
+    test.next_tx(trader);
+    {
+        let mut pool = test.take_shared_by_id<Pool<BaseAsset, QuoteAsset>>(
+            pool_id,
+        );
+        let clock = test.take_shared<Clock>();
+        let mut balance_manager = test.take_shared_by_id<BalanceManager>(
+            balance_manager_id,
+        );
+        let trade_proof = balance_manager.generate_proof_as_owner(test.ctx());
+
+        let order_info = pool.place_post_only_limit_order<BaseAsset, QuoteAsset>(
+            &mut balance_manager,
+            &trade_proof,
+            client_order_id,
             self_matching_option,
             price,
             quantity,
@@ -3311,6 +3656,94 @@ fun test_post_only(is_bid: bool, crosses_order: bool) {
         expire_timestamp,
         &mut test,
     );
+
+    end(test);
+}
+
+/// Exercise `place_post_only_limit_order`. Optionally seed the same side
+/// and/or the opposite side with standing orders, then attempt to place a
+/// post-only order on the `is_bid` side at `new_order_price`. Asserts that
+/// `expected_placed` matches the returned `Option<OrderInfo>` and, when
+/// placed, that the order was actually inserted into the book.
+fun run_post_only_wrapper_scenario(
+    is_bid: bool,
+    seed_same_side_price: Option<u64>,
+    seed_opposite_side_price: Option<u64>,
+    new_order_price: u64,
+    expected_placed: bool,
+) {
+    let mut test = begin(OWNER);
+    let registry_id = setup_test(OWNER, &mut test);
+    let balance_manager_id_alice = create_acct_and_share_with_funds(
+        ALICE,
+        1_000_000 * constants::float_scaling(),
+        &mut test,
+    );
+    let pool_id = setup_pool_with_default_fees_and_reference_pool<SUI, USDC, SUI, DEEP>(
+        ALICE,
+        registry_id,
+        balance_manager_id_alice,
+        &mut test,
+    );
+
+    let quantity = 1 * constants::float_scaling();
+    let expire_timestamp = constants::max_u64();
+    let pay_with_deep = true;
+
+    seed_same_side_price.do!(|p| {
+        place_limit_order<SUI, USDC>(
+            ALICE,
+            pool_id,
+            balance_manager_id_alice,
+            1,
+            constants::no_restriction(),
+            constants::self_matching_allowed(),
+            p,
+            quantity,
+            is_bid,
+            pay_with_deep,
+            expire_timestamp,
+            &mut test,
+        );
+    });
+    seed_opposite_side_price.do!(|p| {
+        place_limit_order<SUI, USDC>(
+            ALICE,
+            pool_id,
+            balance_manager_id_alice,
+            2,
+            constants::no_restriction(),
+            constants::self_matching_allowed(),
+            p,
+            quantity,
+            !is_bid,
+            pay_with_deep,
+            expire_timestamp,
+            &mut test,
+        );
+    });
+
+    let result = place_post_only_limit_order<SUI, USDC>(
+        ALICE,
+        pool_id,
+        balance_manager_id_alice,
+        3,
+        constants::self_matching_allowed(),
+        new_order_price,
+        quantity,
+        is_bid,
+        pay_with_deep,
+        expire_timestamp,
+        &mut test,
+    );
+
+    assert_eq!(result.is_some(), expected_placed);
+    if (result.is_some()) {
+        let order_info = result.destroy_some();
+        assert!(order_info.order_inserted());
+        assert_eq!(order_info.price(), new_order_price);
+        assert_eq!(order_info.order_type(), constants::post_only());
+    };
 
     end(test);
 }
@@ -6294,6 +6727,34 @@ fun get_mid_price<BaseAsset, QuoteAsset>(pool_id: ID, test: &mut Scenario): u64 
         return_shared(clock);
 
         mid_price
+    }
+}
+
+fun get_best_bid_price<BaseAsset, QuoteAsset>(pool_id: ID, test: &mut Scenario): Option<u64> {
+    test.next_tx(OWNER);
+    {
+        let pool = test.take_shared_by_id<Pool<BaseAsset, QuoteAsset>>(pool_id);
+        let clock = test.take_shared<Clock>();
+
+        let best = pool.best_bid_price<BaseAsset, QuoteAsset>(&clock);
+        return_shared(pool);
+        return_shared(clock);
+
+        best
+    }
+}
+
+fun get_best_ask_price<BaseAsset, QuoteAsset>(pool_id: ID, test: &mut Scenario): Option<u64> {
+    test.next_tx(OWNER);
+    {
+        let pool = test.take_shared_by_id<Pool<BaseAsset, QuoteAsset>>(pool_id);
+        let clock = test.take_shared<Clock>();
+
+        let best = pool.best_ask_price<BaseAsset, QuoteAsset>(&clock);
+        return_shared(pool);
+        return_shared(clock);
+
+        best
     }
 }
 

--- a/packages/deepbook/tests/pool_tests.move
+++ b/packages/deepbook/tests/pool_tests.move
@@ -965,6 +965,219 @@ fun best_bid_ask_skips_expired_orders() {
     end(test);
 }
 
+#[test_only]
+/// Place `count` resting orders on the `is_bid` side, all at `price`, owned by
+/// `trader`'s balance manager, expiring at `expire`. Used to build an expired
+/// top-of-book backlog larger than `max_fills` for the bounded-scan tests.
+/// Orders at the same price coexist as distinct entries, so the getter walks
+/// each one; the backlog is split across managers because a single manager is
+/// capped at `max_open_orders`.
+fun seed_resting_orders(
+    trader: address,
+    is_bid: bool,
+    count: u64,
+    price: u64,
+    expire: u64,
+    pool_id: ID,
+    balance_manager_id: ID,
+    test: &mut Scenario,
+) {
+    let quantity = 1 * constants::float_scaling();
+    count.do!(|i| {
+        place_limit_order<SUI, USDC>(
+            trader,
+            pool_id,
+            balance_manager_id,
+            i + 1,
+            constants::no_restriction(),
+            constants::self_matching_allowed(),
+            price,
+            quantity,
+            is_bid,
+            true,
+            expire,
+            test,
+        );
+    });
+}
+
+#[test]
+fun best_ask_price_bounded_at_max_fills_returns_none() {
+    let mut test = begin(OWNER);
+    let registry_id = setup_test(OWNER, &mut test);
+    let balance_manager_id_alice = create_acct_and_share_with_funds(
+        ALICE,
+        1_000_000 * constants::float_scaling(),
+        &mut test,
+    );
+    let balance_manager_id_bob = create_acct_and_share_with_funds(
+        BOB,
+        1_000_000 * constants::float_scaling(),
+        &mut test,
+    );
+    let pool_id = setup_pool_with_default_fees_and_reference_pool<SUI, USDC, SUI, DEEP>(
+        ALICE,
+        registry_id,
+        balance_manager_id_alice,
+        &mut test,
+    );
+
+    let expired_price = 2 * constants::float_scaling();
+    let live_price = 3 * constants::float_scaling();
+    let expire_soon = get_time(&mut test) + 100;
+
+    // max_fills expired asks at the top of book (ALICE, at her open-order cap),
+    // then one live ask just beyond the cap from a second manager.
+    seed_resting_orders(
+        ALICE,
+        false,
+        constants::max_fills(),
+        expired_price,
+        expire_soon,
+        pool_id,
+        balance_manager_id_alice,
+        &mut test,
+    );
+    seed_resting_orders(
+        BOB,
+        false,
+        1,
+        live_price,
+        constants::max_u64(),
+        pool_id,
+        balance_manager_id_bob,
+        &mut test,
+    );
+
+    set_time(expire_soon + 1, &mut test);
+
+    // The live ask exists, but sits beyond max_fills expired orders. The bounded
+    // scan stops at the cap and reports the side as empty — the same horizon a
+    // taker sees, since matching is also capped at max_fills.
+    assert!(get_best_ask_price<SUI, USDC>(pool_id, &mut test).is_none());
+
+    end(test);
+}
+
+#[test]
+fun best_ask_price_finds_live_within_max_fills() {
+    let mut test = begin(OWNER);
+    let registry_id = setup_test(OWNER, &mut test);
+    let balance_manager_id_alice = create_acct_and_share_with_funds(
+        ALICE,
+        1_000_000 * constants::float_scaling(),
+        &mut test,
+    );
+    let balance_manager_id_bob = create_acct_and_share_with_funds(
+        BOB,
+        1_000_000 * constants::float_scaling(),
+        &mut test,
+    );
+    let pool_id = setup_pool_with_default_fees_and_reference_pool<SUI, USDC, SUI, DEEP>(
+        ALICE,
+        registry_id,
+        balance_manager_id_alice,
+        &mut test,
+    );
+
+    let expired_price = 2 * constants::float_scaling();
+    let live_price = 3 * constants::float_scaling();
+    let expire_soon = get_time(&mut test) + 100;
+
+    // One fewer than max_fills expired asks, then a live ask at the max_fills-th
+    // position — the scan reaches it (scanned = max_fills - 1 < max_fills).
+    seed_resting_orders(
+        ALICE,
+        false,
+        constants::max_fills() - 1,
+        expired_price,
+        expire_soon,
+        pool_id,
+        balance_manager_id_alice,
+        &mut test,
+    );
+    seed_resting_orders(
+        BOB,
+        false,
+        1,
+        live_price,
+        constants::max_u64(),
+        pool_id,
+        balance_manager_id_bob,
+        &mut test,
+    );
+
+    set_time(expire_soon + 1, &mut test);
+
+    assert_eq!(get_best_ask_price<SUI, USDC>(pool_id, &mut test).destroy_some(), live_price);
+
+    end(test);
+}
+
+#[test, expected_failure(abort_code = ::deepbook::book::EEmptyOrderbook)]
+fun mid_price_aborts_when_ask_top_of_book_expired_past_cap() {
+    let mut test = begin(OWNER);
+    let registry_id = setup_test(OWNER, &mut test);
+    let balance_manager_id_alice = create_acct_and_share_with_funds(
+        ALICE,
+        1_000_000 * constants::float_scaling(),
+        &mut test,
+    );
+    let balance_manager_id_bob = create_acct_and_share_with_funds(
+        BOB,
+        1_000_000 * constants::float_scaling(),
+        &mut test,
+    );
+    let pool_id = setup_pool_with_default_fees_and_reference_pool<SUI, USDC, SUI, DEEP>(
+        ALICE,
+        registry_id,
+        balance_manager_id_alice,
+        &mut test,
+    );
+
+    let expire_soon = get_time(&mut test) + 100;
+
+    // ALICE fills her open-order cap with max_fills expired asks. BOB adds a live
+    // bid (keeps the bid side valid) and a live ask beyond the cap.
+    seed_resting_orders(
+        ALICE,
+        false,
+        constants::max_fills(),
+        2 * constants::float_scaling(),
+        expire_soon,
+        pool_id,
+        balance_manager_id_alice,
+        &mut test,
+    );
+    seed_resting_orders(
+        BOB,
+        true,
+        1,
+        1 * constants::float_scaling(),
+        constants::max_u64(),
+        pool_id,
+        balance_manager_id_bob,
+        &mut test,
+    );
+    seed_resting_orders(
+        BOB,
+        false,
+        1,
+        3 * constants::float_scaling(),
+        constants::max_u64(),
+        pool_id,
+        balance_manager_id_bob,
+        &mut test,
+    );
+
+    set_time(expire_soon + 1, &mut test);
+
+    // A live ask exists (beyond the cap), but the bounded scan cannot reach it,
+    // so mid_price treats the ask side as empty and aborts.
+    let _mid = get_mid_price<SUI, USDC>(pool_id, &mut test);
+    end(test);
+}
+
 #[test]
 fun test_swap_exact_not_fully_filled_bid_ok() {
     test_swap_exact_not_fully_filled(true, false, false, false, false);

--- a/packages/deepbook/tests/pool_tests.move
+++ b/packages/deepbook/tests/pool_tests.move
@@ -645,6 +645,76 @@ fun post_only_wrapper_places_when_only_same_side_has_orders() {
 }
 
 #[test]
+fun post_only_wrapper_places_past_own_expired_crossing_order() {
+    // The pre-check skips expired top-of-book orders exactly as the matching
+    // engine does, so an order crossing only an *expired* opposite-side order
+    // still places. This also pins why self-matching is fixed to
+    // SELF_MATCHING_ALLOWED: the crossing maker here is ALICE's own expired
+    // order, which under CANCEL_TAKER would abort ESelfMatchingCancelTaker even
+    // though the pre-check reads the side as empty.
+    let mut test = begin(OWNER);
+    let registry_id = setup_test(OWNER, &mut test);
+    let balance_manager_id_alice = create_acct_and_share_with_funds(
+        ALICE,
+        1_000_000 * constants::float_scaling(),
+        &mut test,
+    );
+    let pool_id = setup_pool_with_default_fees_and_reference_pool<SUI, USDC, SUI, DEEP>(
+        ALICE,
+        registry_id,
+        balance_manager_id_alice,
+        &mut test,
+    );
+
+    let quantity = 1 * constants::float_scaling();
+    let pay_with_deep = true;
+    let cross_price = 2 * constants::float_scaling();
+    let expire_soon = get_time(&mut test) + 100;
+
+    // ALICE rests her own ask at 2.0 with a short expiry.
+    place_limit_order<SUI, USDC>(
+        ALICE,
+        pool_id,
+        balance_manager_id_alice,
+        1,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        cross_price,
+        quantity,
+        false,
+        pay_with_deep,
+        expire_soon,
+        &mut test,
+    );
+
+    // Let the ask expire; it lingers at top-of-book until a taker clears it.
+    set_time(expire_soon + 1, &mut test);
+
+    // A bid at 2.0 crosses that ask in price, but the ask is expired: the
+    // pre-check reads best_ask as empty (skips it), so the wrapper forwards and
+    // the post-only bid rests instead of aborting EPOSTOrderCrossesOrderbook.
+    let result = place_post_only_limit_order<SUI, USDC>(
+        ALICE,
+        pool_id,
+        balance_manager_id_alice,
+        2,
+        cross_price,
+        quantity,
+        true,
+        pay_with_deep,
+        constants::max_u64(),
+        &mut test,
+    );
+
+    let order_info = result.destroy_some();
+    assert!(order_info.order_inserted());
+    assert_eq!(order_info.price(), cross_price);
+    assert_eq!(order_info.order_type(), constants::post_only());
+
+    end(test);
+}
+
+#[test]
 fun test_crossing_multiple_orders_bid_ok() {
     test_crossing_multiple(true, 3)
 }
@@ -1924,7 +1994,6 @@ public(package) fun place_post_only_limit_order<BaseAsset, QuoteAsset>(
     pool_id: ID,
     balance_manager_id: ID,
     client_order_id: u64,
-    self_matching_option: u8,
     price: u64,
     quantity: u64,
     is_bid: bool,
@@ -1947,7 +2016,6 @@ public(package) fun place_post_only_limit_order<BaseAsset, QuoteAsset>(
             &mut balance_manager,
             &trade_proof,
             client_order_id,
-            self_matching_option,
             price,
             quantity,
             is_bid,
@@ -3728,7 +3796,6 @@ fun run_post_only_wrapper_scenario(
         pool_id,
         balance_manager_id_alice,
         3,
-        constants::self_matching_allowed(),
         new_order_price,
         quantity,
         is_bid,

--- a/packages/deepbook/tests/pool_tests.move
+++ b/packages/deepbook/tests/pool_tests.move
@@ -1002,7 +1002,7 @@ fun seed_resting_orders(
 }
 
 #[test]
-fun best_ask_price_bounded_at_max_fills_returns_none() {
+fun best_ask_price_unbounded_finds_live_past_expired_backlog() {
     let mut test = begin(OWNER);
     let registry_id = setup_test(OWNER, &mut test);
     let balance_manager_id_alice = create_acct_and_share_with_funds(
@@ -1026,8 +1026,8 @@ fun best_ask_price_bounded_at_max_fills_returns_none() {
     let live_price = 3 * constants::float_scaling();
     let expire_soon = get_time(&mut test) + 100;
 
-    // max_fills expired asks at the top of book (ALICE, at her open-order cap),
-    // then one live ask just beyond the cap from a second manager.
+    // max_fills expired asks (ALICE, at her open-order cap), then a live ask
+    // beyond that backlog from a second manager.
     seed_resting_orders(
         ALICE,
         false,
@@ -1051,71 +1051,15 @@ fun best_ask_price_bounded_at_max_fills_returns_none() {
 
     set_time(expire_soon + 1, &mut test);
 
-    // The live ask exists, but sits beyond max_fills expired orders. The bounded
-    // scan stops at the cap and reports the side as empty — the same horizon a
-    // taker sees, since matching is also capped at max_fills.
-    assert!(get_best_ask_price<SUI, USDC>(pool_id, &mut test).is_none());
-
-    end(test);
-}
-
-#[test]
-fun best_ask_price_finds_live_within_max_fills() {
-    let mut test = begin(OWNER);
-    let registry_id = setup_test(OWNER, &mut test);
-    let balance_manager_id_alice = create_acct_and_share_with_funds(
-        ALICE,
-        1_000_000 * constants::float_scaling(),
-        &mut test,
-    );
-    let balance_manager_id_bob = create_acct_and_share_with_funds(
-        BOB,
-        1_000_000 * constants::float_scaling(),
-        &mut test,
-    );
-    let pool_id = setup_pool_with_default_fees_and_reference_pool<SUI, USDC, SUI, DEEP>(
-        ALICE,
-        registry_id,
-        balance_manager_id_alice,
-        &mut test,
-    );
-
-    let expired_price = 2 * constants::float_scaling();
-    let live_price = 3 * constants::float_scaling();
-    let expire_soon = get_time(&mut test) + 100;
-
-    // One fewer than max_fills expired asks, then a live ask at the max_fills-th
-    // position — the scan reaches it (scanned = max_fills - 1 < max_fills).
-    seed_resting_orders(
-        ALICE,
-        false,
-        constants::max_fills() - 1,
-        expired_price,
-        expire_soon,
-        pool_id,
-        balance_manager_id_alice,
-        &mut test,
-    );
-    seed_resting_orders(
-        BOB,
-        false,
-        1,
-        live_price,
-        constants::max_u64(),
-        pool_id,
-        balance_manager_id_bob,
-        &mut test,
-    );
-
-    set_time(expire_soon + 1, &mut test);
-
+    // The getter is unbounded, so it walks past the entire max_fills-deep expired
+    // backlog and returns the true best live ask beyond it.
     assert_eq!(get_best_ask_price<SUI, USDC>(pool_id, &mut test).destroy_some(), live_price);
 
     end(test);
 }
 
-#[test, expected_failure(abort_code = ::deepbook::book::EEmptyOrderbook)]
-fun mid_price_aborts_when_ask_top_of_book_expired_past_cap() {
+#[test]
+fun mid_price_unbounded_returns_price_past_expired_backlog() {
     let mut test = begin(OWNER);
     let registry_id = setup_test(OWNER, &mut test);
     let balance_manager_id_alice = create_acct_and_share_with_funds(
@@ -1135,10 +1079,13 @@ fun mid_price_aborts_when_ask_top_of_book_expired_past_cap() {
         &mut test,
     );
 
+    let live_bid = 1 * constants::float_scaling();
+    let live_ask = 3 * constants::float_scaling();
     let expire_soon = get_time(&mut test) + 100;
 
     // ALICE fills her open-order cap with max_fills expired asks. BOB adds a live
-    // bid (keeps the bid side valid) and a live ask beyond the cap.
+    // bid and a live ask beyond that backlog. mid_price is unbounded, so it finds
+    // both live orders and returns their midpoint instead of aborting.
     seed_resting_orders(
         ALICE,
         false,
@@ -1153,7 +1100,7 @@ fun mid_price_aborts_when_ask_top_of_book_expired_past_cap() {
         BOB,
         true,
         1,
-        1 * constants::float_scaling(),
+        live_bid,
         constants::max_u64(),
         pool_id,
         balance_manager_id_bob,
@@ -1163,7 +1110,7 @@ fun mid_price_aborts_when_ask_top_of_book_expired_past_cap() {
         BOB,
         false,
         1,
-        3 * constants::float_scaling(),
+        live_ask,
         constants::max_u64(),
         pool_id,
         balance_manager_id_bob,
@@ -1172,9 +1119,67 @@ fun mid_price_aborts_when_ask_top_of_book_expired_past_cap() {
 
     set_time(expire_soon + 1, &mut test);
 
-    // A live ask exists (beyond the cap), but the bounded scan cannot reach it,
-    // so mid_price treats the ask side as empty and aborts.
-    let _mid = get_mid_price<SUI, USDC>(pool_id, &mut test);
+    // mid = (best live ask + best live bid) / 2 = (3.0 + 1.0) / 2 = 2.0
+    assert_eq!(get_mid_price<SUI, USDC>(pool_id, &mut test), 2 * constants::float_scaling());
+
+    end(test);
+}
+
+#[test]
+fun post_only_wrapper_returns_none_when_placement_rests_nothing() {
+    // ≥ max_fills expired asks at a crossing price. The bounded crossing check
+    // sees no reachable live cross and forwards; place_limit_order clears
+    // max_fills of them, hits its fill limit, and rests nothing. The wrapper must
+    // return `none` (not `some`), and never aborts.
+    let mut test = begin(OWNER);
+    let registry_id = setup_test(OWNER, &mut test);
+    let balance_manager_id_alice = create_acct_and_share_with_funds(
+        ALICE,
+        1_000_000 * constants::float_scaling(),
+        &mut test,
+    );
+    let balance_manager_id_bob = create_acct_and_share_with_funds(
+        BOB,
+        1_000_000 * constants::float_scaling(),
+        &mut test,
+    );
+    let pool_id = setup_pool_with_default_fees_and_reference_pool<SUI, USDC, SUI, DEEP>(
+        ALICE,
+        registry_id,
+        balance_manager_id_alice,
+        &mut test,
+    );
+
+    let expire_soon = get_time(&mut test) + 100;
+    seed_resting_orders(
+        ALICE,
+        false,
+        constants::max_fills(),
+        1 * constants::float_scaling(),
+        expire_soon,
+        pool_id,
+        balance_manager_id_alice,
+        &mut test,
+    );
+    set_time(expire_soon + 1, &mut test);
+
+    // BOB posts a post-only bid at 2.0 that crosses the expired asks in price.
+    let result = place_post_only_limit_order<SUI, USDC>(
+        BOB,
+        pool_id,
+        balance_manager_id_bob,
+        1,
+        2 * constants::float_scaling(),
+        1 * constants::float_scaling(),
+        true,
+        true,
+        constants::max_u64(),
+        &mut test,
+    );
+
+    assert!(result.is_none());
+    assert!(get_best_bid_price<SUI, USDC>(pool_id, &mut test).is_none());
+
     end(test);
 }
 


### PR DESCRIPTION
## Summary
- Adds `place_post_only_limit_order` — a non-aborting wrapper around `place_limit_order` with `POST_ONLY` that returns `Option<OrderInfo>`: `none` when the order would cross a reachable live order (instead of the `EPOSTOrderCrossesOrderbook` abort) or when the forwarded placement rests nothing; `some` only when the order is resting on the book.
- Exposes `best_bid_price` / `best_ask_price` as public `Option<u64>` getters on `Pool` (mirrored through `book::best_bid_price` / `book::best_ask_price`) for top-of-book reads without the `EEmptyOrderbook` abort that `mid_price` carries.
- Adds `book::crosses_live_order` — a `max_fills`-bounded crossing test (the matcher's own reach) used by the wrapper's pre-check, keeping the placement path gas-safe *without* bounding the getters or `mid_price`.
- Refactors `book::mid_price` to reuse the getters (behavior-preserving).

## Why
- Post-only makers (market makers, LPs) composing inside a PTB can't tolerate a hard abort: `place_limit_order` + `POST_ONLY` aborts `EPOSTOrderCrossesOrderbook` the moment the quote crosses, tearing down the whole PTB. A graceful `Option`-returning entry lets the caller branch on `is_some()` and keep the batch alive.
- Deciding a quote by inspecting top-of-book currently forces `mid_price`, which aborts `EEmptyOrderbook` on a one-sided or empty book. Public `Option<u64>` getters give integrators a non-aborting read.
- The crossing check a post-only placement runs is on a write path, so it must be gas-bounded and must match the matcher's reach: `match_against_book` stops at `max_fills`, so a live order buried under more than `max_fills` expired orders cannot be reached in one fill. `crosses_live_order` encodes exactly that. `mid_price` and the getters stay **unbounded** so a one-sided expired backlog never hides real two-sided liquidity from `mid_price` or its permissionless mutative consumer `pool::add_deep_price_point`.

## Key decisions
- **Single-side read.** The wrapper checks only the side the order could cross (asks for bids, bids for asks). An empty opposite side always allows placement.
- **Self-matching is fixed to `SELF_MATCHING_ALLOWED` (not a parameter).** The wrapper only ever forwards a *non-crossing* order, so self-matching — which governs how a *crossing* fill treats the taker's own maker orders — has no effect on the forwarded placement. Exposing it would be a footgun: `CANCEL_TAKER` aborts `ESelfMatchingCancelTaker` against the caller's own *expired* order at a crossing price, re-introducing the abort this wrapper avoids. A caller that wants to cross and cancel its own resting orders should call `place_limit_order` directly.
- **Two traversals — one bounded, one not.** The wrapper's crossing test (`crosses_live_order`) is bounded to `max_fills`, consistent with the matcher: a forwarded order never fires `EPOSTOrderCrossesOrderbook`, and every declined order is one raw `POST_ONLY` would itself have aborted on. `mid_price` and the public getters stay **unbounded** — they return the true best live price / midpoint even behind a large expired backlog, preserving availability for `add_deep_price_point` and margin reference pricing.
- **`some` always means resting.** `none` = crossed a reachable live order, **or** the forwarded placement rested nothing (a ≥`max_fills` expired backlog at a crossing price makes `place_limit_order` hit its fill limit and inject no order). `some` = the order is on the book (`order_inserted()`). Neither path aborts.
- **No new error constants.** Forwarding with `POST_ONLY` after the pre-check never fires `EPOSTOrderCrossesOrderbook`; `EEmptyOrderbook` already existed.

## Test plan
- [x] `sui move build` passes for `packages/deepbook` and `packages/deepbook_margin` (dependent)
- [x] `sui move test --gas-limit 100000000000` — 397/397 pass, including:
  - wrapper: empty book both sides, opposite side below/at/above (bid & ask), same-side-only, placement past the caller's own expired crossing order, and **`none` when a ≥`max_fills` expired backlog makes the forwarded placement rest nothing**
  - getters: empty → `none`, populated top-of-book, expired top-of-book skipped, and **finds live liquidity past a `max_fills`-deep expired backlog (unbounded)**
  - `mid_price`: **returns the midpoint past a `max_fills`-deep expired backlog (unbounded, no abort)**
- [x] `pnpm format:move:check` clean (CI parity)
- [x] Mergeable with `main` (no conflicts)

Closes DBU-366.
Closes DBU-594 — the expired-scan concern is resolved by the bounded `crosses_live_order` on the placement path; `mid_price` is intentionally left unbounded (bounding it would abort on real two-sided liquidity behind an expired backlog).
