### PR TITLE
Update COINGR_USDC pool min/lot size

### DIFF
--- a/scripts/transactions/updatePoolMinLotSize.ts
+++ b/scripts/transactions/updatePoolMinLotSize.ts
@@ -10,6 +10,29 @@ import { SuiGrpcClient } from "@mysten/sui/grpc";
   // Update constant for env
   const env = "mainnet";
 
+  const coins = {
+    COINGR: {
+      address:
+        "0xd2e5cb84b33e2acadff5d1c8a30181e8871de44b5bfbea5b8c615ec6218b2fca",
+      type: "0xd2e5cb84b33e2acadff5d1c8a30181e8871de44b5bfbea5b8c615ec6218b2fca::coin_gr::COIN_GR",
+      scalar: 1000000000,
+    },
+    USDC: {
+      address:
+        "0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7",
+      type: "0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC",
+      scalar: 1000000,
+    },
+  };
+
+  const pools = {
+    COINGR_USDC: {
+      address: "0xb04a92daba7e164a0eb31d13f642d3de50233b07c09637698de6ee376beb5c4a",
+      baseCoin: "COINGR",
+      quoteCoin: "USDC",
+    },
+  };
+
   const client = new SuiGrpcClient({
     baseUrl: "https://sui-mainnet.mystenlabs.com",
     network: "mainnet",
@@ -17,13 +40,14 @@ import { SuiGrpcClient } from "@mysten/sui/grpc";
     deepbook({
       address: "0x0",
       adminCap: adminCapID[env],
+      coins,
+      pools,
     }),
   );
 
   const tx = new Transaction();
 
-  client.deepbook.deepBookAdmin.adjustMinLotSize("DEEP_USDC", 1, 10)(tx);
-  client.deepbook.deepBookAdmin.adjustMinLotSize("DEEP_SUI", 1, 10)(tx);
+  client.deepbook.deepBookAdmin.adjustMinLotSize("COINGR_USDC", 0.01, 0.1)(tx);
 
   let res = await prepareMultisigTx(tx, env, adminCapOwner[env]);
 


### PR DESCRIPTION
## Summary
- Point `updatePoolMinLotSize.ts` at the COINGR/USDC mainnet pool (`0xb04a9...5c4a`) with COIN_GR (9 decimals) as base and USDC (6 decimals) as quote
- Set lot size to 0.01 and min size to 0.1 (real-number values)

## Key decisions
- Used the SDK `coins` + `pools` overrides to describe the permissionless pool inline rather than registering it in the shared constants, since this is a one-off admin adjustment

## Test plan
- [ ] Run `pnpm tsx transactions/updatePoolMinLotSize.ts` with a gas object and inspect the serialized tx in `scripts/tx/tx-data.txt`
- [ ] Execute the multisig and confirm the pool's new lot/min size on-chain