### PR TITLE
Reject zero-rate price points in add_deep_price_point

### DIFF
--- a/packages/deepbook/sources/pool.move
+++ b/packages/deepbook/sources/pool.move
@@ -66,6 +66,7 @@ const EInvalidEWMAAlpha: u64 = 17;
 const EInvalidZScoreThreshold: u64 = 18;
 const EInvalidAdditionalTakerFee: u64 = 19;
 const EWrongPoolReferral: u64 = 20;
+const EInvalidDeepPrice: u64 = 21;
 
 // === Structs ===
 public struct Pool<phantom BaseAsset, phantom QuoteAsset> has key {
@@ -865,6 +866,7 @@ public fun add_deep_price_point<BaseAsset, QuoteAsset, ReferenceBaseAsset, Refer
     } else {
         reference_pool_price
     };
+    assert!(deep_per_reference_other_price > 0, EInvalidDeepPrice);
 
     // For USDC/SUI pool, reference_other_is_target_base is true, add price
     // point to deep per base

--- a/packages/deepbook/tests/pool_tests.move
+++ b/packages/deepbook/tests/pool_tests.move
@@ -912,6 +912,74 @@ fun test_using_unregistered_as_reference() {
     end(test);
 }
 
+#[test, expected_failure(abort_code = ::deepbook::pool::EInvalidDeepPrice)]
+fun add_deep_price_point_aborts_on_zero_rate() {
+    let mut test = begin(OWNER);
+    let registry_id = setup_test(OWNER, &mut test);
+    let balance_manager_id = create_acct_and_share_with_funds(
+        ALICE,
+        1_000_000 * constants::float_scaling(),
+        &mut test,
+    );
+
+    let target_pool_id = setup_pool_with_default_fees<SUI, USDC>(
+        OWNER,
+        registry_id,
+        false,
+        false,
+        &mut test,
+    );
+    let reference_pool_id = setup_pool_with_default_fees<DEEP, SUI>(
+        OWNER,
+        registry_id,
+        true,
+        false,
+        &mut test,
+    );
+
+    // mid_price = 2e18 → math::div(1e9, 2e18) = 1e18 / 2e18 = 0 (floors).
+    let huge_price: u64 = 2_000_000_000_000_000_000;
+    let tick = constants::tick_size();
+    place_limit_order<DEEP, SUI>(
+        ALICE,
+        reference_pool_id,
+        balance_manager_id,
+        1,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        huge_price - tick,
+        constants::min_size(),
+        true,
+        true,
+        constants::max_u64(),
+        &mut test,
+    );
+    place_limit_order<DEEP, SUI>(
+        ALICE,
+        reference_pool_id,
+        balance_manager_id,
+        2,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        huge_price + tick,
+        constants::min_size(),
+        false,
+        true,
+        constants::max_u64(),
+        &mut test,
+    );
+
+    set_time(0, &mut test);
+    add_deep_price_point<SUI, USDC, DEEP, SUI>(
+        ALICE,
+        target_pool_id,
+        reference_pool_id,
+        &mut test,
+    );
+
+    abort
+}
+
 #[test, expected_failure(abort_code = ::deepbook::pool::EPoolCannotBeBothWhitelistedAndStable)]
 fun test_create_pool_e() {
     test_create_pool(true, true);


### PR DESCRIPTION
## Summary
- Assert `deep_per_reference_other_price > 0` in `pool.move::add_deep_price_point` before storing the point, using new error `EInvalidDeepPrice` (code 21).
- A zero derived rate is never a sensible oracle value; this closes the edge case defensively.

## Key decisions
- Guard goes at the oracle insertion site rather than at any fee-path call site — rejecting at ingress is the narrowest surface and leaves every downstream consumer of `OrderDeepPrice` unchanged.
- Both branches of the derivation are covered by the single assert (floor-to-zero from the `math::div` branch and a zero `mid_price` from the pass-through branch).

## Test plan
- [x] `sui move build`
- [x] `sui move test --gas-limit 100000000000` — 361/361 existing tests pass
- [x] New expected-failure test `add_deep_price_point_aborts_on_zero_rate` in `pool_tests.move` constructs a whitelisted reference pool with a mid_price that floors the derived rate, and asserts the abort
- [x] `bunx prettier-move -c packages/deepbook/sources/pool.move packages/deepbook/tests/pool_tests.move --write`

Closes DBU-369