### PR TITLE
margin_pool: clamp decrease_supply_absolute to total_supply

### DIFF
--- a/packages/deepbook_margin/sources/margin_pool/margin_state.move
+++ b/packages/deepbook_margin/sources/margin_pool/margin_state.move
@@ -76,9 +76,12 @@ public(package) fun increase_supply_absolute(self: &mut State, amount: u64) {
 }
 
 /// Decrease the supply given an absolute amount. Used when the supply needs to be
-/// decreased without decreasing shares.
+/// decreased without decreasing shares. Clamped to `total_supply`: any excess
+/// represents bad debt that exceeds the supplier pool's absorptive capacity and
+/// is uncollectible by design (was never backed by vault cash).
 public(package) fun decrease_supply_absolute(self: &mut State, amount: u64) {
-    self.total_supply = self.total_supply - amount;
+    let decrease = amount.min(self.total_supply);
+    self.total_supply = self.total_supply - decrease;
 }
 
 /// Increase the borrow given an amount. Return the individual borrow shares

--- a/packages/deepbook_margin/tests/margin_pool/margin_state_tests.move
+++ b/packages/deepbook_margin/tests/margin_pool/margin_state_tests.move
@@ -83,6 +83,25 @@ fun margin_state_operations_work() {
 }
 
 #[test]
+fun decrease_supply_absolute_clamps_at_zero() {
+    let mut test = begin(test_constants::admin());
+    let clock = clock::create_for_testing(test.ctx());
+    let mut state = margin_state::default(&clock);
+
+    state.increase_supply_absolute(500);
+    assert_eq!(state.total_supply(), 500);
+
+    state.decrease_supply_absolute(600);
+    assert_eq!(state.total_supply(), 0);
+
+    state.decrease_supply_absolute(100);
+    assert_eq!(state.total_supply(), 0);
+
+    destroy(clock);
+    test.end();
+}
+
+#[test]
 fun margin_state_with_supply_and_borrow_accrues_interest() {
     let mut test = begin(test_constants::admin());
     let mut clock = clock::create_for_testing(test.ctx());


### PR DESCRIPTION
## Summary
- Clamp the subtraction in `margin_state::decrease_supply_absolute` at `total_supply`. Previously it could underflow (raw `arithmetic_error`) when `repay_liquidation` recorded bad debt larger than the current supplier pool.
- Add a unit test (`decrease_supply_absolute_clamps_at_zero`) asserting the clamp holds and repeated over-decrements stay at zero.

## Key decisions
- **Fix at the leaf, not the caller.** `decrease_supply_absolute` is a `public(package)` primitive; per the leaf-guard convention in `.claude/rules/move.md`, it should be self-consistent regardless of which sibling module reaches it. The only caller (`margin_pool::repay_liquidation`) was relying on a cross-module invariant (`bad_debt ≤ total_supply`) that isn't guaranteed — `total_supply` drifts below `total_borrow` over time because `update()` skims protocol spread only from the supply side. Rather than add caller-side math, the leaf now enforces its own bound.
- **No API change, no new error constant, no event.** Silent clamp is the minimal correct behavior: when bad debt exceeds `total_supply`, suppliers are already fully written down (worst case for them); the residual was never backed by vault cash so it's uncollectible by definition. The existing `default` return from `repay_liquidation` still reflects the economic shortfall, which remains accurate.
- **Not scoping in drift mitigation.** The `total_borrow` vs. `total_supply` drift from protocol spread is intentional (it's how the fee model works). This PR only fixes the bad-debt path's handling of the resulting state, not the drift itself.

## Test plan
- [x] `sui move test --gas-limit 100000000000` in `packages/deepbook_margin` — all 301 tests pass
- [x] New `decrease_supply_absolute_clamps_at_zero` test exercises over-decrement + follow-up decrement from zero
- [x] `bunx prettier-move -c` on modified files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)