### PR TITLE
scripts: lower SUI_USDC tick size to 0.00001

### DIFF
--- a/scripts/transactions/updatePoolTickSize.ts
+++ b/scripts/transactions/updatePoolTickSize.ts
@@ -22,7 +22,7 @@ import { SuiGrpcClient } from "@mysten/sui/grpc";
 
   const tx = new Transaction();
 
-  client.deepbook.deepBookAdmin.adjustTickSize("SUI_USDC", 0.0001)(tx);
+  client.deepbook.deepBookAdmin.adjustTickSize("SUI_USDC", 0.00001)(tx);
 
   let res = await prepareMultisigTx(tx, env, adminCapOwner[env]);
 


### PR DESCRIPTION
## Summary
- Update `updatePoolTickSize.ts` to set the SUI_USDC tick size to `0.00001` (from `0.0001`).

## Key decisions
- None.

## Test plan
- [ ] Review the multisig tx output before executing on-chain.