### PR TITLE
predict: add cap revocation, self-revocation, and destroy

### DIFF
--- a/packages/predict/sources/oracle.move
+++ b/packages/predict/sources/oracle.move
@@ -35,6 +35,7 @@ const EOracleStale: u64 = 21;
 const EOracleInactive: u64 = 22;
 const ELazerAuthoritativeAtExpiry: u64 = 23;
 const ELazerStaleAtExpiry: u64 = 24;
+const ECapNotRegistered: u64 = 25;
 
 // Pre-expiry oracle that has not been activated yet.
 const STATUS_INACTIVE: u8 = 0;
@@ -688,6 +689,30 @@ public(package) fun register_cap(oracle: &mut OracleSVI, cap: &OracleSVICap) {
     oracle.authorized_caps.insert(cap.id.to_inner());
 }
 
+/// Admin-side revocation. Takes `cap_id` by value so lost or compromised
+/// caps can still be revoked without the cap object.
+public(package) fun unregister_cap(oracle: &mut OracleSVI, cap_id: ID) {
+    assert!(oracle.authorized_caps.contains(&cap_id), ECapNotRegistered);
+    oracle.authorized_caps.remove(&cap_id);
+}
+
+/// Cap-holder self-revocation. Requires possession of the cap object so
+/// pushers can deregister during graceful shutdown without going through
+/// admin.
+public(package) fun self_unregister_cap(oracle: &mut OracleSVI, cap: &OracleSVICap) {
+    let cap_id = cap.id.to_inner();
+    assert!(oracle.authorized_caps.contains(&cap_id), ECapNotRegistered);
+    oracle.authorized_caps.remove(&cap_id);
+}
+
+/// Destroy a cap the holder no longer needs (key rotation, pod retirement).
+/// Does not touch `authorized_caps` on any oracle — `self_unregister_cap`
+/// first if on-chain cleanup is wanted.
+public(package) fun destroy_oracle_cap(cap: OracleSVICap) {
+    let OracleSVICap { id } = cap;
+    id.delete();
+}
+
 /// Abort unless `cap` is authorized to operate on this oracle.
 public(package) fun assert_authorized_cap(oracle: &OracleSVI, cap: &OracleSVICap) {
     assert!(oracle.authorized_caps.contains(&cap.id.to_inner()), EInvalidOracleCap);
@@ -1011,4 +1036,42 @@ fun compute_nd2(oracle: &OracleSVI, strike: u64): u64 {
     let d2 = d2.neg();
 
     predict_math::normal_cdf(&d2)
+}
+
+// === Test Functions ===
+
+#[test_only]
+public(package) fun create_test_oracle(ctx: &mut TxContext): OracleSVI {
+    let bounds = new_oracle_bounds(
+        tuning_constants::default_spot_staleness_threshold_ms!(),
+        tuning_constants::default_basis_staleness_threshold_ms!(),
+        tuning_constants::default_lazer_authoritative_threshold_ms!(),
+        tuning_constants::default_lazer_settlement_authoritative_threshold_ms!(),
+        tuning_constants::default_max_spot_deviation!(),
+        tuning_constants::default_max_basis_deviation!(),
+        tuning_constants::default_min_basis!(),
+        tuning_constants::default_max_basis!(),
+    );
+    OracleSVI {
+        id: object::new(ctx),
+        authorized_caps: vec_set::empty(),
+        underlying_asset: b"BTC".to_string(),
+        pyth_lazer_feed_id: 1,
+        expiry: 0,
+        active: false,
+        prices: PriceData { spot: 0, basis: 0 },
+        svi: SVIParams {
+            a: 0,
+            b: 0,
+            rho: i64::zero(),
+            m: i64::zero(),
+            sigma: 0,
+        },
+        spot_timestamp_ms: 0,
+        lazer_spot_timestamp_ms: 0,
+        basis_timestamp_ms: 0,
+        lazer_published_at_us: 0,
+        bounds,
+        settlement_price: option::none(),
+    }
 }

--- a/packages/predict/sources/registry.move
+++ b/packages/predict/sources/registry.move
@@ -44,6 +44,16 @@ public struct OracleCreated has copy, drop, store {
     tick_size: u64,
 }
 
+public struct CapRegistered has copy, drop, store {
+    oracle_id: ID,
+    cap_id: ID,
+}
+
+public struct CapUnregistered has copy, drop, store {
+    oracle_id: ID,
+    cap_id: ID,
+}
+
 /// Capability for admin operations.
 /// Created during package init, transferred to deployer (multisig).
 public struct AdminCap has key, store {
@@ -77,6 +87,28 @@ entry fun create_predict<Quote>(
     assert!(!registry.id.exists_(PredictCreated()), EPredictAlreadyCreated);
     registry.id.add(PredictCreated(), type_name::with_defining_ids<Quote>());
     predict::create<Quote>(&mut registry.id, currency, treasury_cap, clock, ctx);
+}
+
+/// Revoke an OracleSVICap's authorization on an oracle. Takes `cap_id` so the
+/// admin can revoke caps that are no longer held (e.g. lost or compromised).
+public fun unregister_oracle_cap(oracle: &mut OracleSVI, _admin_cap: &AdminCap, cap_id: ID) {
+    oracle::unregister_cap(oracle, cap_id);
+    event::emit(CapUnregistered { oracle_id: object::id(oracle), cap_id });
+}
+
+/// Cap holder voluntarily removes its own cap from an oracle's authorized
+/// set. No AdminCap needed — possession of the cap is the authorization.
+public fun self_unregister_oracle_cap(oracle: &mut OracleSVI, cap: &OracleSVICap) {
+    let cap_id = object::id(cap);
+    oracle::self_unregister_cap(oracle, cap);
+    event::emit(CapUnregistered { oracle_id: object::id(oracle), cap_id });
+}
+
+/// Destroy an OracleSVICap the holder no longer needs. Does not touch any
+/// oracle's authorized set — self_unregister_oracle_cap first if cleanup is
+/// wanted.
+public fun destroy_oracle_cap(cap: OracleSVICap) {
+    oracle::destroy_oracle_cap(cap);
 }
 
 /// Create a new OracleSVICap. Transferred to Block Scholes operator.
@@ -141,6 +173,7 @@ public fun create_oracle(
 /// Register an additional OracleSVICap as authorized to update an oracle.
 public fun register_oracle_cap(oracle: &mut OracleSVI, _admin_cap: &AdminCap, cap: &OracleSVICap) {
     oracle::register_cap(oracle, cap);
+    event::emit(CapRegistered { oracle_id: object::id(oracle), cap_id: object::id(cap) });
 }
 
 /// Enable a quote asset for new supply and mint inflows.

--- a/packages/predict/tests/helper/oracle_cap_tests.move
+++ b/packages/predict/tests/helper/oracle_cap_tests.move
@@ -1,0 +1,104 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module deepbook_predict::oracle_cap_tests;
+
+use deepbook_predict::oracle;
+use std::unit_test::destroy;
+
+#[test]
+fun unregister_removes_authorization() {
+    let ctx = &mut tx_context::dummy();
+    let mut o = oracle::create_test_oracle(ctx);
+    let cap = oracle::create_oracle_cap(ctx);
+
+    oracle::register_cap(&mut o, &cap);
+    oracle::assert_authorized_cap(&o, &cap);
+
+    oracle::unregister_cap(&mut o, object::id(&cap));
+
+    destroy(o);
+    destroy(cap);
+}
+
+#[test, expected_failure(abort_code = oracle::EInvalidOracleCap)]
+fun unregistered_cap_fails_authorization_check() {
+    let ctx = &mut tx_context::dummy();
+    let mut o = oracle::create_test_oracle(ctx);
+    let cap = oracle::create_oracle_cap(ctx);
+
+    oracle::register_cap(&mut o, &cap);
+    oracle::unregister_cap(&mut o, object::id(&cap));
+    oracle::assert_authorized_cap(&o, &cap);
+
+    abort 999
+}
+
+#[test, expected_failure(abort_code = oracle::ECapNotRegistered)]
+fun unregister_unknown_cap_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let mut o = oracle::create_test_oracle(ctx);
+    let cap = oracle::create_oracle_cap(ctx);
+
+    oracle::unregister_cap(&mut o, object::id(&cap));
+
+    abort 999
+}
+
+#[test, expected_failure(abort_code = oracle::ECapNotRegistered)]
+fun double_unregister_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let mut o = oracle::create_test_oracle(ctx);
+    let cap = oracle::create_oracle_cap(ctx);
+
+    oracle::register_cap(&mut o, &cap);
+    oracle::unregister_cap(&mut o, object::id(&cap));
+    oracle::unregister_cap(&mut o, object::id(&cap));
+
+    abort 999
+}
+
+#[test]
+fun self_unregister_removes_authorization() {
+    let ctx = &mut tx_context::dummy();
+    let mut o = oracle::create_test_oracle(ctx);
+    let cap = oracle::create_oracle_cap(ctx);
+
+    oracle::register_cap(&mut o, &cap);
+    oracle::self_unregister_cap(&mut o, &cap);
+
+    destroy(o);
+    destroy(cap);
+}
+
+#[test, expected_failure(abort_code = oracle::EInvalidOracleCap)]
+fun self_unregistered_cap_fails_authorization_check() {
+    let ctx = &mut tx_context::dummy();
+    let mut o = oracle::create_test_oracle(ctx);
+    let cap = oracle::create_oracle_cap(ctx);
+
+    oracle::register_cap(&mut o, &cap);
+    oracle::self_unregister_cap(&mut o, &cap);
+    oracle::assert_authorized_cap(&o, &cap);
+
+    abort 999
+}
+
+#[test, expected_failure(abort_code = oracle::ECapNotRegistered)]
+fun self_unregister_unknown_cap_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let mut o = oracle::create_test_oracle(ctx);
+    let cap = oracle::create_oracle_cap(ctx);
+
+    oracle::self_unregister_cap(&mut o, &cap);
+
+    abort 999
+}
+
+#[test]
+fun destroy_oracle_cap_consumes_cap() {
+    let ctx = &mut tx_context::dummy();
+    let cap = oracle::create_oracle_cap(ctx);
+    oracle::destroy_oracle_cap(cap);
+}


### PR DESCRIPTION
## Summary
- `registry::unregister_oracle_cap(oracle, admin_cap, cap_id)` — admin-gated revocation. Takes `cap_id` by value so admin can revoke caps they no longer physically hold (lost / compromised).
- `registry::self_unregister_oracle_cap(oracle, cap)` — holder voluntarily removes their own cap from an oracle. No AdminCap; possession of the cap is the authorization. Used by pushers during graceful shutdown.
- `registry::destroy_oracle_cap(cap)` — holder burns a cap they no longer need (key rotation, pod retirement).
- All three emit / use `CapUnregistered { oracle_id, cap_id }` where on-chain authorization state changes. `destroy_oracle_cap` emits nothing — no oracle state changes.
- Named error `ECapNotRegistered` on both unregister paths (no raw VM abort from `VecSet::remove`).
- 8 tests: register/unregister success, double-unregister, unknown-cap, post-unregister authorization checks, self-unregister equivalents, and cap destroy.

## Key decisions
- **Admin `unregister` takes `ID`, self-unregister takes `&OracleSVICap`.** Intentional asymmetry — the whole point of admin revocation is that it works without the cap object, while self-revocation requires proof of possession.
- **`destroy_oracle_cap` does not touch `authorized_caps`.** Leaves a dangling ID in any oracle the cap was registered on. That entry is inert (no one can mint a colliding cap ID), so it's a cleanliness issue not a correctness one. Documented recommendation: `self_unregister` from all oracles before destroying. Enforcing the order in Move would make graceful-shutdown paths more fragile.
- **No admin-forced burn.** Move ownership means only the cap holder can pass `OracleSVICap` by value. Admin still has authorization-level revocation via `unregister_oracle_cap`, which is sufficient.
- **Test helper `create_unshared_oracle_for_testing`** — `#[test_only]` helper in `oracle.move`. Explicitly named non-production per unit-tests rule 12. Avoids standing up a full Predict scenario for cap-authorization unit tests.

## Test plan
- [x] `sui move test` — 42 pass, 0 fail, 0 warnings
- [x] `bunx @mysten/prettier-plugin-move -c` clean on modified files
- [ ] Deploy + exercise each entrypoint on testnet: admin unregister, self-unregister, destroy. Confirm events fire and revoked caps fail `update_prices`.