### PR TITLE
[predict] use derived objects

### DIFF
--- a/packages/predict/simulations/src/runtime.ts
+++ b/packages/predict/simulations/src/runtime.ts
@@ -1,5 +1,7 @@
+import { bcs } from "@mysten/sui/bcs";
 import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
 import { Transaction } from "@mysten/sui/transactions";
+import { deriveObjectID } from "@mysten/sui/utils";
 
 import {
   ADMIN_CAP_ID,
@@ -250,8 +252,38 @@ export function supplyTx(predictId: string, amount: bigint): Transaction {
 
 export function createManagerTx(): Transaction {
   const tx = new Transaction();
-  tx.moveCall({ target: target("predict", "create_manager") });
+  tx.moveCall({
+    target: target("registry", "create_and_share_manager"),
+    arguments: [tx.object(REGISTRY_ID)],
+  });
   return tx;
+}
+
+// === Derived object IDs ===
+
+// Fieldless struct → compiler-injected `dummy_field: bool = false` (one 0-byte).
+const PREDICT_KEY_BCS = new Uint8Array([0]);
+
+export function derivePredictId(quoteType: string = DUSDC_TYPE): string {
+  return deriveObjectID(
+    REGISTRY_ID,
+    `${PACKAGE_ID}::predict::PredictKey<${quoteType}>`,
+    PREDICT_KEY_BCS
+  );
+}
+
+const PredictManagerKeyBcs = bcs.struct("PredictManagerKey", {
+  pos0: bcs.Address,
+  pos1: bcs.u64(),
+});
+
+export function deriveManagerId(owner: string, index: bigint = 0n): string {
+  const key = PredictManagerKeyBcs.serialize({ pos0: owner, pos1: index }).toBytes();
+  return deriveObjectID(
+    REGISTRY_ID,
+    `${PACKAGE_ID}::predict_manager::PredictManagerKey`,
+    key
+  );
 }
 
 export function depositToManagerTx(managerId: string, amount: bigint): Transaction {

--- a/packages/predict/simulations/src/sim.ts
+++ b/packages/predict/simulations/src/sim.ts
@@ -21,6 +21,8 @@ import {
   createOracleTx,
   createPredictTx,
   depositToManagerTx,
+  derivePredictId,
+  deriveManagerId,
   execute,
   executeAndWait,
   finalizeDusdcCurrencyRegistrationTx,
@@ -114,9 +116,8 @@ async function setupSimulation(): Promise<SimState> {
   const dusdcCurrencyId: string = dusdcCurrencyChange.objectId;
   console.log(`[${ts()}]   DUSDC Currency: ${dusdcCurrencyId}`);
 
-  result = await executeAndWait(createPredictTx(dusdcCurrencyId), "create_predict");
-  const predictEvent = result.events.find((event: any) => event.type.includes("PredictCreated"));
-  const predictId: string = predictEvent.parsedJson.predict_id;
+  const predictId = derivePredictId();
+  await executeAndWait(createPredictTx(dusdcCurrencyId), "create_predict");
   console.log(`[${ts()}]   Predict: ${predictId}`);
 
   result = await executeAndWait(createOracleCapTx(address), "create_oracle_cap");
@@ -155,9 +156,8 @@ async function setupSimulation(): Promise<SimState> {
   await executeAndWait(supplyTx(predictId, vaultSeed), "supply");
   console.log(`[${ts()}]   Vault funded: ${vaultSeed / DUSDC_DECIMALS} DUSDC`);
 
-  result = await executeAndWait(createManagerTx(), "create_manager");
-  const managerEvent = result.events.find((event: any) => event.type.includes("ManagerCreated"));
-  const managerId: string = managerEvent.parsedJson.manager_id;
+  const managerId = deriveManagerId(address);
+  await executeAndWait(createManagerTx(), "create_manager");
   console.log(`[${ts()}]   Manager: ${managerId}`);
 
   const userFunds = 500_000n * DUSDC_DECIMALS;

--- a/packages/predict/sources/predict.move
+++ b/packages/predict/sources/predict.move
@@ -16,7 +16,7 @@ use deepbook_predict::{
     oracle::{Self, OracleSVI, OracleSVICap},
     oracle_config::{Self, OracleConfig},
     plp::PLP,
-    predict_manager::{Self, PredictManager},
+    predict_manager::PredictManager,
     pricing_config::{Self, PricingConfig},
     range_key::RangeKey,
     rate_limiter::{Self, RateLimiter},
@@ -29,6 +29,7 @@ use sui::{
     clock::Clock,
     coin::{Self, Coin, TreasuryCap},
     coin_registry::Currency,
+    derived_object,
     event,
     vec_set::VecSet
 };
@@ -45,13 +46,9 @@ const EAskPriceOutOfBounds: u64 = 7;
 const EAskBoundLooserThanGlobal: u64 = 8;
 const EOracleNotSettled: u64 = 9;
 const EStaleOracleMtm: u64 = 10;
+const EPredictAlreadyCreated: u64 = 11;
 
 // === Events ===
-
-public struct ManagerCreated has copy, drop, store {
-    manager_id: ID,
-    owner: address,
-}
 
 public struct PositionMinted has copy, drop, store {
     predict_id: ID,
@@ -217,17 +214,9 @@ public struct Predict has key {
     trading_paused: bool,
 }
 
-// === Public Functions ===
+public struct PredictKey<phantom T>() has copy, drop, store;
 
-/// Create a new PredictManager for the caller.
-public fun create_manager(ctx: &mut TxContext): ID {
-    let manager_id = predict_manager::new(ctx);
-    event::emit(ManagerCreated {
-        manager_id,
-        owner: ctx.sender(),
-    });
-    manager_id
-}
+// === Public Functions ===
 
 /// Get the amounts for mint/redeem (for UI/preview).
 /// Returns (mint_cost, redeem_payout).
@@ -540,13 +529,15 @@ public fun withdraw<Quote>(
 
 /// Create and share the Predict object. Returns its ID.
 public(package) fun create<Quote>(
+    registry_uid: &mut UID,
     currency: &Currency<Quote>,
     treasury_cap: TreasuryCap<PLP>,
     clock: &Clock,
     ctx: &mut TxContext,
-): ID {
+) {
+    assert!(!derived_object::exists(registry_uid, PredictKey<Quote>()), EPredictAlreadyCreated);
     let mut predict = Predict {
-        id: object::new(ctx),
+        id: derived_object::claim(registry_uid, PredictKey<Quote>()),
         vault: vault::new(ctx),
         treasury_cap,
         pricing_config: pricing_config::new(),
@@ -562,10 +553,7 @@ public(package) fun create<Quote>(
         trading_paused: false,
     };
     predict.enable_quote_asset<Quote>(currency);
-    let predict_id = object::id(&predict);
     transfer::share_object(predict);
-
-    predict_id
 }
 
 public(package) fun enable_quote_asset<Quote>(predict: &mut Predict, currency: &Currency<Quote>) {

--- a/packages/predict/sources/predict_manager.move
+++ b/packages/predict/sources/predict_manager.move
@@ -11,19 +11,16 @@ module deepbook_predict::predict_manager;
 
 use deepbook::balance_manager::{Self, BalanceManager, DepositCap, WithdrawCap};
 use deepbook_predict::{market_key::MarketKey, range_key::RangeKey};
-use sui::{coin::Coin, event, table::{Self, Table}};
+use sui::{coin::Coin, derived_object, table::{Self, Table}};
 
 // === Errors ===
 const EInvalidOwner: u64 = 0;
 const EInsufficientPosition: u64 = 1;
 const EInsufficientRangePosition: u64 = 2;
 
-// === Events ===
-
-public struct PredictManagerCreated has copy, drop, store {
-    manager_id: ID,
-    owner: address,
-}
+/// The key for deriving predict manager. u64 is optional for
+/// supporting multiple managers per address. Defaults to 0 in v1.
+public struct PredictManagerKey(address, u64) has copy, drop, store;
 
 // === Structs ===
 
@@ -41,6 +38,9 @@ public struct PredictManager has key {
 }
 
 // === Public Functions ===
+public fun share(self: PredictManager) {
+    transfer::share_object(self);
+}
 
 /// Get the owner of the PredictManager.
 public fun owner(self: &PredictManager): address {
@@ -85,15 +85,15 @@ public fun withdraw<T>(self: &mut PredictManager, amount: u64, ctx: &mut TxConte
 // === Public-Package Functions ===
 
 /// Create a new PredictManager and share it.
-public(package) fun new(ctx: &mut TxContext): ID {
-    let id = object::new(ctx);
+public(package) fun new(registry_uid: &mut UID, ctx: &mut TxContext): PredictManager {
+    let id = derived_object::claim(registry_uid, PredictManagerKey(ctx.sender(), 0));
     let owner = ctx.sender();
 
     let mut balance_manager = balance_manager::new(ctx);
     let deposit_cap = balance_manager.mint_deposit_cap(ctx);
     let withdraw_cap = balance_manager.mint_withdraw_cap(ctx);
 
-    let manager = PredictManager {
+    PredictManager {
         id,
         owner,
         balance_manager,
@@ -101,16 +101,7 @@ public(package) fun new(ctx: &mut TxContext): ID {
         withdraw_cap,
         positions: table::new(ctx),
         range_positions: table::new(ctx),
-    };
-    let manager_id = object::id(&manager);
-    transfer::share_object(manager);
-
-    event::emit(PredictManagerCreated {
-        manager_id,
-        owner,
-    });
-
-    manager_id
+    }
 }
 
 /// Deposit protocol payouts without requiring the manager owner as sender.

--- a/packages/predict/sources/registry.move
+++ b/packages/predict/sources/registry.move
@@ -20,10 +20,13 @@ use sui::{
     clock::Clock,
     coin::TreasuryCap,
     coin_registry::Currency,
-    dynamic_field,
+    dynamic_field as df,
     event,
     table::{Self, Table}
 };
+
+use fun df::exists_ as UID.exists_;
+use fun df::add as UID.add;
 
 // === Errors ===
 const EPredictAlreadyCreated: u64 = 0;
@@ -84,8 +87,8 @@ entry fun create_predict<Quote>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    assert!(!dynamic_field::exists_(&registry.id, PredictCreated()), EPredictAlreadyCreated);
-    dynamic_field::add(&mut registry.id, PredictCreated(), type_name::with_defining_ids<Quote>());
+    assert!(!registry.id.exists_(PredictCreated()), EPredictAlreadyCreated);
+    registry.id.add(PredictCreated(), type_name::with_defining_ids<Quote>());
     predict::create<Quote>(&mut registry.id, currency, treasury_cap, clock, ctx);
 }
 

--- a/packages/predict/sources/registry.move
+++ b/packages/predict/sources/registry.move
@@ -12,10 +12,18 @@ use deepbook_predict::{
     constants,
     oracle::{Self, OracleSVICap, OracleSVI},
     plp::PLP,
-    predict::{Self, Predict}
+    predict::{Self, Predict},
+    predict_manager::{Self, PredictManager}
 };
-use std::string::String;
-use sui::{clock::Clock, coin::TreasuryCap, coin_registry::Currency, event, table::{Self, Table}};
+use std::{string::String, type_name};
+use sui::{
+    clock::Clock,
+    coin::TreasuryCap,
+    coin_registry::Currency,
+    dynamic_field,
+    event,
+    table::{Self, Table}
+};
 
 // === Errors ===
 const EPredictAlreadyCreated: u64 = 0;
@@ -24,10 +32,6 @@ const EInvalidStrikeGrid: u64 = 2;
 const EFeedIdOverflow: u64 = 3;
 
 // === Events ===
-
-public struct PredictCreated has copy, drop, store {
-    predict_id: ID,
-}
 
 public struct OracleCreated has copy, drop, store {
     oracle_id: ID,
@@ -50,18 +54,15 @@ public struct AdminCap has key, store {
 /// Shared object tracking global state.
 public struct Registry has key {
     id: UID,
-    /// ID of the Predict object (None if not yet created)
-    predict_id: Option<ID>,
     /// OracleSVICap ID -> vector of oracle IDs created by that cap
     oracle_ids: Table<ID, vector<ID>>,
 }
 
-// === Public Functions ===
+/// DF marker on `Registry.id` enforcing the V1 single-Predict invariant.
+/// Stored value is the chosen `Quote` `TypeName`.
+public struct PredictCreated() has copy, drop, store;
 
-/// Get the Predict ID (None if not yet created).
-public fun predict_id(registry: &Registry): Option<ID> {
-    registry.predict_id
-}
+// === Public Functions ===
 
 /// Get oracle IDs created by a given OracleSVICap.
 public fun oracle_ids(registry: &Registry, cap_id: ID): vector<ID> {
@@ -72,24 +73,20 @@ public fun oracle_ids(registry: &Registry, cap_id: ID): vector<ID> {
     }
 }
 
-/// Create the Predict shared object. Can only be called once.
-/// Quote is the collateral asset (e.g., USDC).
-public fun create_predict<Quote>(
+/// Create the Predict shared object for `Quote`. V1 allows exactly one
+/// Predict total via the `PredictCreated` marker; the per-`Quote` lock in
+/// `predict::create` would take over if that guard is ever dropped.
+entry fun create_predict<Quote>(
     registry: &mut Registry,
     _admin_cap: &AdminCap,
     currency: &Currency<Quote>,
     treasury_cap: TreasuryCap<PLP>,
     clock: &Clock,
     ctx: &mut TxContext,
-): ID {
-    assert!(registry.predict_id.is_none(), EPredictAlreadyCreated);
-
-    let predict_id = predict::create<Quote>(currency, treasury_cap, clock, ctx);
-    registry.predict_id = option::some(predict_id);
-
-    event::emit(PredictCreated { predict_id });
-
-    predict_id
+) {
+    assert!(!dynamic_field::exists_(&registry.id, PredictCreated()), EPredictAlreadyCreated);
+    dynamic_field::add(&mut registry.id, PredictCreated(), type_name::with_defining_ids<Quote>());
+    predict::create<Quote>(&mut registry.id, currency, treasury_cap, clock, ctx);
 }
 
 /// Register an additional OracleSVICap as authorized to update an oracle.
@@ -331,6 +328,15 @@ public fun set_asset_feed_id(
     predict.set_asset_feed_id(asset, pyth_lazer_feed_id);
 }
 
+/// Create a new PredictManager for the caller, allowing composability.
+public fun create_manager(registry: &mut Registry, ctx: &mut TxContext): PredictManager {
+    predict_manager::new(&mut registry.id, ctx)
+}
+
+entry fun create_and_share_manager(registry: &mut Registry, ctx: &mut TxContext) {
+    create_manager(registry, ctx).share();
+}
+
 // === Private Functions ===
 
 /// Package initializer - creates Registry and AdminCap.
@@ -367,7 +373,6 @@ fun new_registry_and_admin_cap(ctx: &mut TxContext): (Registry, AdminCap) {
     (
         Registry {
             id: object::new(ctx),
-            predict_id: option::none(),
             oracle_ids: table::new(ctx),
         },
         AdminCap {


### PR DESCRIPTION
- Use derived objects for `Predict` creation, remove unneeded events
- Use derived objects for `PredictManager` creation, and move it to `registry` as it's global to the system
- Enforce 1 manager per user (for phase 1) -- keep a u64 index in case we want to allow N in the future
- Make the manager creation composable to allow us to batch operations in the creation ptb
- Update TS to use the new stuff