### PR TITLE
predict/sim: widen BTC basis bounds to admin ceiling

### DIFF
--- a/packages/predict/simulations/src/runtime.ts
+++ b/packages/predict/simulations/src/runtime.ts
@@ -161,6 +161,30 @@ export function setAssetFeedIdTx(
   return tx;
 }
 
+export function setAssetBasisBoundsTx(
+  predictId: string,
+  asset: string,
+  maxSpotDeviation: bigint,
+  maxBasisDeviation: bigint,
+  minBasis: bigint,
+  maxBasis: bigint
+): Transaction {
+  const tx = new Transaction();
+  tx.moveCall({
+    target: target("registry", "set_asset_basis_bounds"),
+    arguments: [
+      tx.object(predictId),
+      tx.object(ADMIN_CAP_ID),
+      tx.pure.string(asset),
+      tx.pure.u64(maxSpotDeviation),
+      tx.pure.u64(maxBasisDeviation),
+      tx.pure.u64(minBasis),
+      tx.pure.u64(maxBasis),
+    ],
+  });
+  return tx;
+}
+
 export function activateOracleTx(oracleId: string, oracleCapId: string): Transaction {
   const tx = new Transaction();
   tx.moveCall({

--- a/packages/predict/simulations/src/sim.ts
+++ b/packages/predict/simulations/src/sim.ts
@@ -28,6 +28,7 @@ import {
   finalizeDusdcCurrencyRegistrationTx,
   mintTx,
   refreshOracleAndMintTx,
+  setAssetBasisBoundsTx,
   setAssetFeedIdTx,
   supplyTx,
   updateBasisTx,
@@ -129,6 +130,22 @@ async function setupSimulation(): Promise<SimState> {
 
   await executeAndWait(setAssetFeedIdTx(predictId, "BTC", 1n), "set_asset_feed_id");
   console.log(`[${ts()}]   Feed id registered: BTC -> 1`);
+
+  // Scenario CSV has historical spot moves up to ~8% between consecutive
+  // update_prices rows. Default per-push bounds (2%) would trip the circuit
+  // breaker; widen to the admin ceiling (10%) so the sim replays the trace.
+  await executeAndWait(
+    setAssetBasisBoundsTx(
+      predictId,
+      "BTC",
+      100_000_000n,
+      100_000_000n,
+      900_000_000n,
+      1_100_000_000n
+    ),
+    "set_asset_basis_bounds"
+  );
+  console.log(`[${ts()}]   Basis bounds widened for BTC`);
 
   result = await executeAndWait(
     createOracleTx({


### PR DESCRIPTION
## Summary
- Fixes the Predict Gas Benchmark CI failure on main. Every push to main since #970 has failed with `sim exited with code 1`; PRs pass because they slice to `max_rows=200` and the first violation lands just past that cutoff.
- Root cause: #970 added a per-push circuit breaker in `validate_basis_push` with a 2% default `max_spot_deviation`. The scenario CSV (`scenario_mar6_1000mints.csv`) has consecutive `update_prices` rows with spot moves up to ~8%, first violating at ~row 192 with a 6.5% jump — full-row runs abort with `EBasisSpotDeviationTooLarge`.
- Registers per-asset basis bounds for `BTC` at the 10% admin ceiling before `create_oracle` so `OracleSVI.bounds` snapshots the wider envelope and the sim can replay the trace.

## Key decisions
- Widened via `registry::set_asset_basis_bounds` rather than tuning the CSV. The CSV is a historical trace; rewriting it would hide the fact that the benchmark exists to measure gas on realistic price paths.
- Bumped both `max_spot_deviation` and `max_basis_deviation` to the 10% ceiling (`max_basis_deviation_ceiling!()`). Data max spot jump is ~8.15%; basis deviation per push is well under 2% but the headroom is free.
- Left absolute basis bounds at the defaults `[0.9, 1.1]` — trace basis sits in `[0.994, 1.008]`, no reason to widen.
- Applied the bounds before `create_oracle` so they flow through the snapshot onto `OracleSVI.bounds`. The setter docstring explicitly warns it does not retroactively update existing oracles.

## Test plan
- [x] `cd packages/predict/simulations && SIM_MAX_ROWS=250 bash run.sh --skip-analysis` — 83 mints complete, previously aborted around mint 65 on the 6.5% jump.
- [ ] Predict Gas Benchmark CI green on this branch (full trace, no `max_rows` on main but PR run uses 200 — the real regression test is the post-merge run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)