### PR TITLE
[predict] gate Lazer settlement on update freshness (DBU-389)

### DIFF
--- a/packages/predict/sources/oracle.move
+++ b/packages/predict/sources/oracle.move
@@ -42,6 +42,7 @@ const EBasisOutOfRange: u64 = 20;
 const EOracleStale: u64 = 21;
 const EOracleInactive: u64 = 22;
 const ELazerAuthoritativeAtExpiry: u64 = 23;
+const ELazerStaleAtExpiry: u64 = 24;
 
 // Pre-expiry oracle that has not been activated yet.
 const STATUS_INACTIVE: u8 = 0;
@@ -824,8 +825,21 @@ fun apply_lazer_spot(oracle: &mut OracleSVI, spot: u64, lazer_published_at_us: u
     let oracle_id = oracle.id.to_inner();
 
     // Lazer is the authoritative level source at expiry, so freeze the
-    // normalized Lazer spot as the settlement price.
+    // normalized Lazer spot as the settlement price — but only if this
+    // update's publish time falls inside the settlement-authoritative
+    // window. Otherwise the last stale-but-still-signed Lazer update could
+    // be submitted by anyone after Lazer stalls to lock in an outdated
+    // settlement price before the operator fallback engages. Once Lazer
+    // is stale beyond the window, `update_prices` is the settlement
+    // fallback (gated by the mirror-image `ELazerAuthoritativeAtExpiry`
+    // check on that path).
     if (oracle_status == status_pending_settlement()) {
+        let lazer_published_at_ms = lazer_published_at_us / 1000;
+        assert!(
+            now <= lazer_published_at_ms
+                + oracle.bounds.lazer_settlement_authoritative_threshold_ms,
+            ELazerStaleAtExpiry,
+        );
         oracle.settlement_price = option::some(spot);
         oracle.active = false;
         oracle.lazer_published_at_us = lazer_published_at_us;
@@ -834,7 +848,7 @@ fun apply_lazer_spot(oracle: &mut OracleSVI, spot: u64, lazer_published_at_us: u
             oracle_id,
             expiry: oracle.expiry,
             settlement_price: spot,
-            spot_timestamp_ms: lazer_published_at_us / 1000,
+            spot_timestamp_ms: lazer_published_at_ms,
         });
         return
     };


### PR DESCRIPTION
## Summary
- Fixes a High-severity finding from the security scan on #970 (commit `8fb8361a`): the permissionless `update_spot_from_lazer` → `apply_lazer_spot` path settled the oracle whenever `status == PENDING_SETTLEMENT`, without checking whether the incoming Lazer update was actually fresh. If Lazer stalls, anyone could replay the last still-signed Lazer update past expiry and lock in an outdated settlement price before the operator fallback engages.
- Adds a freshness gate in the Lazer settlement branch: `now_ms ≤ lazer_published_at_us/1000 + lazer_settlement_authoritative_threshold_ms`. New error `ELazerStaleAtExpiry = 24`.
- Linear: [DBU-389](https://linear.app/mysten-labs/issue/DBU-389/predict-stale-lazer-updates-can-still-settle-oracle-at-expiry).

## Key decisions
- **Check publish time, not on-chain landing time.** The attacker's whole lever is submitting an old-but-still-signed update, so we have to gate on what they can't forge: Lazer's signed `publish_time_us`. Checking `lazer_spot_timestamp_ms` (on-chain landing) wouldn't help — the attack *is* a fresh landing of old data.
- **Mirror the operator-path gate.** `update_prices` already aborts with `ELazerAuthoritativeAtExpiry` while Lazer is fresh. This PR adds the dual: `update_spot_from_lazer` aborts with `ELazerStaleAtExpiry` once Lazer is stale. Together they ensure exactly one source drives settlement and the oracle can't get stuck.
- **Settlement branch only — pre-expiry stays as-is.** Pre-expiry Lazer writes are overwritable by the next push, so a stale push is self-correcting. Settlement is irreversible. Widening the guard to the pre-expiry path is a reasonable defense-in-depth follow-up but out of scope here (noted on DBU-389).
- **New error code, not reused.** Semantically different from `ELazerAuthoritativeAtExpiry` ("operator can't settle while Lazer owns it") → `ELazerStaleAtExpiry` ("this specific Lazer update is too old to own settlement"). Distinct code keeps on-chain debuggability clean.
- **Ms-precision comparison.** Dividing `lazer_published_at_us / 1000` loses at most 1ms of resolution — negligible against the 60s default threshold.

## Test plan
- [x] `cd packages/predict && sui move build && sui move test --gas-limit 100000000000` — 34/34 passing.
- [x] `cd packages/deepbook_margin && sui move build` and `cd packages/margin_liquidation && sui move build` — dependents clean.
- [x] `bunx prettier-move -c packages/predict/sources/oracle.move --write` — formatted.
- [ ] Move-side negative test for `ELazerStaleAtExpiry` — rolled into the broader settlement-gate test batch tracked on DBU-389 (there is no oracle unit-test harness yet; the whole batch of circuit-breaker and settlement-gate tests was deferred from #970).

🤖 Generated with [Claude Code](https://claude.com/claude-code)