### PR TITLE
scripts: prep two new balance managers

### DIFF
--- a/scripts/transactions/prepBalanceManager.ts
+++ b/scripts/transactions/prepBalanceManager.ts
@@ -9,19 +9,19 @@ import { SuiGrpcClient } from "@mysten/sui/grpc";
 (async () => {
   // Update constant for env
   const env = "mainnet";
-  const balanceManagers = {
-    BALANCE_MANAGER_1: {
-      address:
-        "0xedd38a1faf45147923c4b020af940e1e09f0888d311e45267ed2bd05b5f648a8",
-    },
-    BALANCE_MANAGER_2: {
-      address:
-        "0xc915672c93be17e55a35455a24a600fccf81afe1beb81e9ca9e12d5dc49195e7",
-    },
-  };
+  // const balanceManagers = {
+  //   BALANCE_MANAGER_1: {
+  //     address:
+  //       "0xedd38a1faf45147923c4b020af940e1e09f0888d311e45267ed2bd05b5f648a8",
+  //   },
+  //   BALANCE_MANAGER_2: {
+  //     address:
+  //       "0xc915672c93be17e55a35455a24a600fccf81afe1beb81e9ca9e12d5dc49195e7",
+  //   },
+  // };
 
-  const receivingAddress =
-    "0x946a9773c1acfe7a20ac926f948ed4e6d77148b75e00d60f83ac10abae4ea9d7";
+  // const receivingAddress =
+  //   "0x946a9773c1acfe7a20ac926f948ed4e6d77148b75e00d60f83ac10abae4ea9d7";
 
   const client = new SuiGrpcClient({
     baseUrl: "https://sui-mainnet.mystenlabs.com",
@@ -30,33 +30,35 @@ import { SuiGrpcClient } from "@mysten/sui/grpc";
     deepbook({
       address: adminCapOwner[env],
       adminCap: adminCapID[env],
-      balanceManagers,
+      // balanceManagers,
     }),
   );
 
   const tx = new Transaction();
 
-  const tradeCap =
-    client.deepbook.balanceManager.mintTradeCap("BALANCE_MANAGER_2")(tx);
-  tx.transferObjects([tradeCap], receivingAddress);
+  // const tradeCap =
+  //   client.deepbook.balanceManager.mintTradeCap("BALANCE_MANAGER_2")(tx);
+  // tx.transferObjects([tradeCap], receivingAddress);
 
-  client.deepbook.balanceManager.depositIntoManager(
-    "BALANCE_MANAGER_1",
-    "DEEP",
-    110000,
-  )(tx);
+  // client.deepbook.balanceManager.depositIntoManager(
+  //   "BALANCE_MANAGER_1",
+  //   "DEEP",
+  //   110000,
+  // )(tx);
 
-  client.deepbook.balanceManager.depositIntoManager(
-    "BALANCE_MANAGER_2",
-    "DEEP",
-    30000,
-  )(tx);
+  // client.deepbook.balanceManager.depositIntoManager(
+  //   "BALANCE_MANAGER_2",
+  //   "DEEP",
+  //   30000,
+  // )(tx);
 
-  client.deepbook.balanceManager.depositIntoManager(
-    "BALANCE_MANAGER_2",
-    "USDC",
-    1000,
-  )(tx);
+  // client.deepbook.balanceManager.depositIntoManager(
+  //   "BALANCE_MANAGER_2",
+  //   "USDC",
+  //   1000,
+  // )(tx);
+  client.deepbook.balanceManager.createAndShareBalanceManager()(tx);
+  client.deepbook.balanceManager.createAndShareBalanceManager()(tx);
 
   const res = await prepareMultisigTx(tx, env, adminCapOwner[env]);
 


### PR DESCRIPTION
## Summary
- Comment out the existing balance manager mint/deposit logic in `prepBalanceManager.ts`
- Add two `createAndShareBalanceManager()` calls to mint two new balance managers

## Key decisions
- Existing logic is commented out rather than removed so it can be restored for future top-ups/trade cap mints

## Test plan
- [x] Dry run the multisig tx and confirm two new balance managers are created and shared