### PR TITLE
Standardize Predict Move style

### DIFF
--- a/packages/predict/sources/config/pricing_config.move
+++ b/packages/predict/sources/config/pricing_config.move
@@ -7,12 +7,9 @@ module deepbook_predict::pricing_config;
 use deepbook::math;
 use deepbook_predict::{constants, math as predict_math};
 
-// === Errors ===
 const EInvalidSpread: u64 = 0;
 const EFairPriceAlreadySettled: u64 = 1;
 const EInvalidAskBound: u64 = 2;
-
-// === Structs ===
 
 public struct PricingConfig has store {
     /// Base spread multiplier for Bernoulli scaling.
@@ -105,6 +102,8 @@ public(package) fun quote_spread_from_fair_price(
 
     spread
 }
+
+// === Private Functions ===
 
 fun utilization_spread(config: &PricingConfig, liability: u64, balance: u64): u64 {
     if (balance == 0 || liability == 0) return 0;

--- a/packages/predict/sources/config/pricing_config.move
+++ b/packages/predict/sources/config/pricing_config.move
@@ -11,6 +11,7 @@ const EInvalidSpread: u64 = 0;
 const EFairPriceAlreadySettled: u64 = 1;
 const EInvalidAskBound: u64 = 2;
 
+/// Spread and ask-bound parameters used when quoting Predict markets.
 public struct PricingConfig has store {
     /// Base spread multiplier for Bernoulli scaling.
     /// Effective spread = base_spread * √(price * (1 - price))
@@ -28,28 +29,34 @@ public struct PricingConfig has store {
 
 // === Public Functions ===
 
+/// Return the base spread multiplier.
 public fun base_spread(config: &PricingConfig): u64 {
     config.base_spread
 }
 
+/// Return the minimum spread floor.
 public fun min_spread(config: &PricingConfig): u64 {
     config.min_spread
 }
 
+/// Return the utilization multiplier.
 public fun utilization_multiplier(config: &PricingConfig): u64 {
     config.utilization_multiplier
 }
 
+/// Return the global minimum allowed post-spread ask price.
 public fun min_ask_price(config: &PricingConfig): u64 {
     config.min_ask_price
 }
 
+/// Return the global maximum allowed post-spread ask price.
 public fun max_ask_price(config: &PricingConfig): u64 {
     config.max_ask_price
 }
 
 // === Public-Package Functions ===
 
+/// Create pricing config seeded from protocol defaults.
 public(package) fun new(): PricingConfig {
     PricingConfig {
         base_spread: constants::default_base_spread!(),
@@ -60,31 +67,40 @@ public(package) fun new(): PricingConfig {
     }
 }
 
+/// Set the base spread multiplier.
 public(package) fun set_base_spread(config: &mut PricingConfig, spread: u64) {
     assert!(spread > 0 && spread <= constants::float_scaling!(), EInvalidSpread);
     config.base_spread = spread;
 }
 
+/// Set the minimum spread floor.
 public(package) fun set_min_spread(config: &mut PricingConfig, spread: u64) {
     assert!(spread <= constants::float_scaling!(), EInvalidSpread);
     config.min_spread = spread;
 }
 
+/// Set the utilization multiplier.
 public(package) fun set_utilization_multiplier(config: &mut PricingConfig, multiplier: u64) {
     config.utilization_multiplier = multiplier;
 }
 
+/// Set the global minimum allowed post-spread ask price.
 public(package) fun set_min_ask_price(config: &mut PricingConfig, value: u64) {
     assert!(value < config.max_ask_price, EInvalidAskBound);
     config.min_ask_price = value;
 }
 
+/// Set the global maximum allowed post-spread ask price.
 public(package) fun set_max_ask_price(config: &mut PricingConfig, value: u64) {
     assert!(value > config.min_ask_price, EInvalidAskBound);
     assert!(value < constants::float_scaling!(), EInvalidAskBound);
     config.max_ask_price = value;
 }
 
+/// Quote the spread to add around a live fair price.
+///
+/// Uses Bernoulli variance scaling plus utilization pressure. Settled prices
+/// at exactly 0 or 1 are rejected because no live spread should be applied.
 public(package) fun quote_spread_from_fair_price(
     config: &PricingConfig,
     fair_price: u64,
@@ -105,6 +121,7 @@ public(package) fun quote_spread_from_fair_price(
 
 // === Private Functions ===
 
+/// Compute spread pressure from current liability utilization.
 fun utilization_spread(config: &PricingConfig, liability: u64, balance: u64): u64 {
     if (balance == 0 || liability == 0) return 0;
 

--- a/packages/predict/sources/config/risk_config.move
+++ b/packages/predict/sources/config/risk_config.move
@@ -9,6 +9,7 @@ use deepbook_predict::constants;
 const EExceedsMaxPct: u64 = 0;
 const EInvalidMtmFreshnessMs: u64 = 1;
 
+/// Vault risk limits enforced by the Predict orchestrator.
 public struct RiskConfig has store {
     /// Max total liability as % of balance (e.g., 800_000_000 = 80%)
     max_total_exposure_pct: u64,
@@ -18,16 +19,19 @@ public struct RiskConfig has store {
 
 // === Public Functions ===
 
+/// Return the maximum total exposure percentage.
 public fun max_total_exposure_pct(config: &RiskConfig): u64 {
     config.max_total_exposure_pct
 }
 
+/// Return the maximum allowed cached MTM age in milliseconds.
 public fun mtm_freshness_ms(config: &RiskConfig): u64 {
     config.mtm_freshness_ms
 }
 
 // === Public-Package Functions ===
 
+/// Create risk config seeded from protocol defaults.
 public(package) fun new(): RiskConfig {
     RiskConfig {
         max_total_exposure_pct: constants::default_max_total_exposure_pct!(),
@@ -35,11 +39,13 @@ public(package) fun new(): RiskConfig {
     }
 }
 
+/// Set the maximum total exposure percentage.
 public(package) fun set_max_total_exposure_pct(config: &mut RiskConfig, pct: u64) {
     assert!(pct > 0 && pct <= constants::float_scaling!(), EExceedsMaxPct);
     config.max_total_exposure_pct = pct;
 }
 
+/// Set the maximum allowed cached MTM age in milliseconds.
 public(package) fun set_mtm_freshness_ms(config: &mut RiskConfig, value: u64) {
     assert!(value > 0, EInvalidMtmFreshnessMs);
     config.mtm_freshness_ms = value;

--- a/packages/predict/sources/config/risk_config.move
+++ b/packages/predict/sources/config/risk_config.move
@@ -6,11 +6,8 @@ module deepbook_predict::risk_config;
 
 use deepbook_predict::constants;
 
-// === Errors ===
 const EExceedsMaxPct: u64 = 0;
 const EInvalidMtmFreshnessMs: u64 = 1;
-
-// === Structs ===
 
 public struct RiskConfig has store {
     /// Max total liability as % of balance (e.g., 800_000_000 = 80%)

--- a/packages/predict/sources/config/treasury_config.move
+++ b/packages/predict/sources/config/treasury_config.move
@@ -16,6 +16,7 @@ const ECoinAlreadyAccepted: u64 = 0;
 const EQuoteAssetNotAccepted: u64 = 1;
 const EInvalidQuoteDecimals: u64 = 2;
 
+/// Quote-asset whitelist state.
 public struct TreasuryConfig has copy, drop, store {
     /// Quote asset types currently enabled for new treasury inflows
     accepted_quotes: VecSet<TypeName>,
@@ -23,10 +24,12 @@ public struct TreasuryConfig has copy, drop, store {
 
 // === Public Functions ===
 
+/// Return the accepted quote asset type set.
 public fun accepted_quotes(config: &TreasuryConfig): &VecSet<TypeName> {
     &config.accepted_quotes
 }
 
+/// Return whether `Quote` is accepted for new treasury inflows.
 public fun is_quote_asset<Quote>(config: &TreasuryConfig): bool {
     let quote_type = type_name::with_defining_ids<Quote>();
     config.accepted_quotes.contains(&quote_type)
@@ -34,12 +37,14 @@ public fun is_quote_asset<Quote>(config: &TreasuryConfig): bool {
 
 // === Public-Package Functions ===
 
+/// Create an empty treasury config.
 public(package) fun new(): TreasuryConfig {
     TreasuryConfig {
         accepted_quotes: vec_set::empty(),
     }
 }
 
+/// Add a quote asset after validating its decimal precision.
 public(package) fun add_quote_asset<Quote>(
     config: &mut TreasuryConfig,
     currency: &Currency<Quote>,
@@ -50,12 +55,14 @@ public(package) fun add_quote_asset<Quote>(
     config.accepted_quotes.insert(quote_type);
 }
 
+/// Remove a quote asset from the accepted set.
 public(package) fun remove_quote_asset<Quote>(config: &mut TreasuryConfig) {
     let quote_type = type_name::with_defining_ids<Quote>();
     assert!(config.accepted_quotes.contains(&quote_type), EQuoteAssetNotAccepted);
     config.accepted_quotes.remove(&quote_type);
 }
 
+/// Abort unless `Quote` is currently accepted.
 public(package) fun assert_quote_asset<Quote>(config: &TreasuryConfig) {
     assert!(config.is_quote_asset<Quote>(), EQuoteAssetNotAccepted);
 }

--- a/packages/predict/sources/config/treasury_config.move
+++ b/packages/predict/sources/config/treasury_config.move
@@ -1,6 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/// Treasury configuration for accepted quote assets.
+///
+/// This module owns the whitelist of quote asset types that can be used for
+/// new Predict treasury inflows and validates each asset's decimal precision
+/// before it is enabled.
 module deepbook_predict::treasury_config;
 
 use deepbook_predict::constants;
@@ -16,6 +21,8 @@ public struct TreasuryConfig has copy, drop, store {
     accepted_quotes: VecSet<TypeName>,
 }
 
+// === Public Functions ===
+
 public fun accepted_quotes(config: &TreasuryConfig): &VecSet<TypeName> {
     &config.accepted_quotes
 }
@@ -24,6 +31,8 @@ public fun is_quote_asset<Quote>(config: &TreasuryConfig): bool {
     let quote_type = type_name::with_defining_ids<Quote>();
     config.accepted_quotes.contains(&quote_type)
 }
+
+// === Public-Package Functions ===
 
 public(package) fun new(): TreasuryConfig {
     TreasuryConfig {

--- a/packages/predict/sources/helper/i64.move
+++ b/packages/predict/sources/helper/i64.move
@@ -10,6 +10,7 @@ use deepbook_predict::constants;
 const EOverflow: u64 = 0;
 const EZeroDivisor: u64 = 1;
 
+/// Signed integer represented as magnitude plus sign.
 public struct I64 has copy, drop, store {
     magnitude: u64,
     is_negative: bool,
@@ -17,18 +18,22 @@ public struct I64 has copy, drop, store {
 
 // === Public Functions ===
 
+/// Return the absolute magnitude.
 public fun magnitude(value: &I64): u64 {
     value.magnitude
 }
 
+/// Return whether the value is negative.
 public fun is_negative(value: &I64): bool {
     value.is_negative
 }
 
+/// Return whether the value is normalized zero.
 public fun is_zero(value: &I64): bool {
     value.magnitude == 0
 }
 
+/// Return normalized zero.
 public fun zero(): I64 {
     I64 {
         magnitude: 0,
@@ -36,6 +41,7 @@ public fun zero(): I64 {
     }
 }
 
+/// Create a nonnegative value from `u64`.
 public fun from_u64(value: u64): I64 {
     I64 {
         magnitude: value,
@@ -43,6 +49,7 @@ public fun from_u64(value: u64): I64 {
     }
 }
 
+/// Create a value from magnitude and sign, normalizing zero to nonnegative.
 public fun from_parts(magnitude: u64, is_negative: bool): I64 {
     if (magnitude == 0) {
         zero()
@@ -54,6 +61,7 @@ public fun from_parts(magnitude: u64, is_negative: bool): I64 {
     }
 }
 
+/// Return the negated value, preserving normalized zero.
 public fun neg(value: &I64): I64 {
     if (value.magnitude == 0) {
         zero()
@@ -65,6 +73,7 @@ public fun neg(value: &I64): I64 {
     }
 }
 
+/// Add two signed values, aborting on magnitude overflow.
 public fun add(a: &I64, b: &I64): I64 {
     if (a.is_negative == b.is_negative) {
         assert!(a.magnitude <= max_u64() - b.magnitude, EOverflow);
@@ -76,6 +85,7 @@ public fun add(a: &I64, b: &I64): I64 {
     }
 }
 
+/// Subtract `b` from `a`.
 public fun sub(a: &I64, b: &I64): I64 {
     let neg_b = neg(b);
     add(a, &neg_b)
@@ -89,6 +99,7 @@ public fun mul_scaled(a: &I64, b: &I64): I64 {
     from_parts((product as u64), a.is_negative != b.is_negative)
 }
 
+/// Divide two FLOAT_SCALING fixed-point signed values.
 public fun div_scaled(a: &I64, b: &I64): I64 {
     assert!(b.magnitude > 0, EZeroDivisor);
     let quotient =
@@ -97,6 +108,7 @@ public fun div_scaled(a: &I64, b: &I64): I64 {
     from_parts((quotient as u64), a.is_negative != b.is_negative)
 }
 
+/// Square a FLOAT_SCALING fixed-point signed value and return a nonnegative result.
 public fun square_scaled(value: &I64): u64 {
     mul_scaled(value, value).magnitude
 }

--- a/packages/predict/sources/helper/i64.move
+++ b/packages/predict/sources/helper/i64.move
@@ -15,6 +15,8 @@ public struct I64 has copy, drop, store {
     is_negative: bool,
 }
 
+// === Public Functions ===
+
 public fun magnitude(value: &I64): u64 {
     value.magnitude
 }

--- a/packages/predict/sources/helper/lazer_helper.move
+++ b/packages/predict/sources/helper/lazer_helper.move
@@ -16,8 +16,6 @@ use pyth_lazer::{
     update::Update as LazerUpdate
 };
 
-// === Errors ===
-
 const ELazerFeedNotFound: u64 = 0;
 const ELazerPriceUnavailable: u64 = 1;
 const ELazerNegativePrice: u64 = 2;

--- a/packages/predict/sources/helper/math.move
+++ b/packages/predict/sources/helper/math.move
@@ -72,9 +72,7 @@ const INV_9_U128: u128 = 111_111_111;
 const INV_11_U128: u128 = 90_909_091;
 const INV_13_U128: u128 = 76_923_077;
 
-// ============================================================
-// Public API
-// ============================================================
+// === Public Functions ===
 
 /// Natural logarithm of x (in FLOAT_SCALING 1e9).
 /// Returns a signed fixed-point result.
@@ -125,9 +123,33 @@ public fun sqrt(x: u64, precision: u64): u64 {
     (sqrt_u128(scaled) / multiplier) as u64
 }
 
-// ============================================================
-// u128 internal functions
-// ============================================================
+/// (a * b) / c using u128 intermediate for full precision. Rounds down.
+public fun mul_div_round_down(a: u64, b: u64, c: u64): u64 {
+    ((a as u128) * (b as u128) / (c as u128)) as u64
+}
+
+/// (a * b) / c using u128 intermediate for full precision. Rounds up.
+public fun mul_div_round_up(a: u64, b: u64, c: u64): u64 {
+    let numerator = (a as u128) * (b as u128);
+    let denominator = c as u128;
+    let result = numerator / denominator;
+    let round = if (numerator % denominator == 0) 0 else 1;
+    (result + round) as u64
+}
+
+/// 10^n for small non-negative n. Capped at 18 because 10^19 overflows u64.
+public fun pow10(n: u64): u64 {
+    assert!(n <= 18, EPow10ExponentTooLarge);
+    let mut result: u64 = 1;
+    let mut i = 0;
+    while (i < n) {
+        result = result * 10;
+        i = i + 1;
+    };
+    result
+}
+
+// === Private Functions ===
 
 /// ln(y) where y is normalized to [F, 2F) and n is the shift count.
 /// Computes: n * ln(2) + 2 * (z + z³/3 + z⁵/5 + ... + z¹³/13)
@@ -239,10 +261,6 @@ fun normal_cdf_u128(x: u128, x_negative: bool): u128 {
     }
 }
 
-// ============================================================
-// u64 helpers
-// ============================================================
-
 /// Normalize x into [FLOAT_SCALING, 2*FLOAT_SCALING) via binary search.
 /// Returns (y, n) where x = y * 2^n.
 fun normalize(x: u64): (u64, u64) {
@@ -290,30 +308,4 @@ fun sqrt_initial_guess_u128(x: u128): u128 {
     if (val >= 1u128 << 2) { val = val >> 2; bits = bits + 2; };
     if (val >= 1u128 << 1) { bits = bits + 1; };
     1u128 << (((bits + 1) / 2) as u8)
-}
-
-/// (a * b) / c using u128 intermediate for full precision. Rounds down.
-public fun mul_div_round_down(a: u64, b: u64, c: u64): u64 {
-    ((a as u128) * (b as u128) / (c as u128)) as u64
-}
-
-/// (a * b) / c using u128 intermediate for full precision. Rounds up.
-public fun mul_div_round_up(a: u64, b: u64, c: u64): u64 {
-    let numerator = (a as u128) * (b as u128);
-    let denominator = c as u128;
-    let result = numerator / denominator;
-    let round = if (numerator % denominator == 0) 0 else 1;
-    (result + round) as u64
-}
-
-/// 10^n for small non-negative n. Capped at 18 because 10^19 overflows u64.
-public fun pow10(n: u64): u64 {
-    assert!(n <= 18, EPow10ExponentTooLarge);
-    let mut result: u64 = 1;
-    let mut i = 0;
-    while (i < n) {
-        result = result * 10;
-        i = i + 1;
-    };
-    result
 }

--- a/packages/predict/sources/helper/math.move
+++ b/packages/predict/sources/helper/math.move
@@ -278,10 +278,12 @@ fun normalize(x: u64): (u64, u64) {
     (y, n)
 }
 
+/// Multiply two 1e9-scaled values using a u128 intermediate.
 fun mul_scaled_u128(x: u128, y: u128): u128 {
     x * y / F
 }
 
+/// Integer square root for u128 values.
 fun sqrt_u128(x: u128): u128 {
     if (x == 0) return 0;
     if (x < 4) return 1;
@@ -297,6 +299,7 @@ fun sqrt_u128(x: u128): u128 {
     g
 }
 
+/// Initial power-of-two guess for Newton square root.
 fun sqrt_initial_guess_u128(x: u128): u128 {
     let mut bits: u8 = 0;
     let mut val = x;

--- a/packages/predict/sources/helper/rate_limiter.move
+++ b/packages/predict/sources/helper/rate_limiter.move
@@ -13,13 +13,9 @@ module deepbook_predict::rate_limiter;
 
 use sui::clock::Clock;
 
-// === Errors ===
-
 const EExceedsCapacity: u64 = 0;
 const EInsufficientWithdrawalBudget: u64 = 1;
 const EInvalidConfig: u64 = 2;
-
-// === Structs ===
 
 public struct RateLimiter has store {
     /// Current available tokens in the bucket.
@@ -32,38 +28,6 @@ public struct RateLimiter has store {
     refill_rate_per_ms: u64,
     /// Whether the rate limiter is active.
     enabled: bool,
-}
-
-// === Public-Package View Functions ===
-
-public(package) fun is_enabled(self: &RateLimiter): bool {
-    self.enabled
-}
-
-public(package) fun capacity(self: &RateLimiter): u64 {
-    self.capacity
-}
-
-public(package) fun refill_rate_per_ms(self: &RateLimiter): u64 {
-    self.refill_rate_per_ms
-}
-
-public(package) fun available(self: &RateLimiter): u64 {
-    self.available
-}
-
-/// Returns the currently available withdrawal amount (read-only).
-public(package) fun available_withdrawal(self: &RateLimiter, clock: &Clock): u64 {
-    if (!self.enabled) return std::u64::max_value!();
-
-    let elapsed = elapsed_ms(self.last_updated_ms, clock);
-    // u128 needed: elapsed (u64) * refill_rate_per_ms (u64) can overflow u64
-    // when large time gaps accumulate (e.g. 1M seconds × 16667 rate = 1.6e13,
-    // plus available up to 5e12, sum can approach u64::MAX).
-    let refill_amount = (elapsed as u128) * (self.refill_rate_per_ms as u128);
-    let new_available = (self.available as u128) + refill_amount;
-
-    new_available.min(self.capacity as u128) as u64
 }
 
 // === Public-Package Functions ===
@@ -135,7 +99,37 @@ public(package) fun update_config(
     };
 }
 
-// === Internal Functions ===
+public(package) fun is_enabled(self: &RateLimiter): bool {
+    self.enabled
+}
+
+public(package) fun capacity(self: &RateLimiter): u64 {
+    self.capacity
+}
+
+public(package) fun refill_rate_per_ms(self: &RateLimiter): u64 {
+    self.refill_rate_per_ms
+}
+
+public(package) fun available(self: &RateLimiter): u64 {
+    self.available
+}
+
+/// Returns the currently available withdrawal amount (read-only).
+public(package) fun available_withdrawal(self: &RateLimiter, clock: &Clock): u64 {
+    if (!self.enabled) return std::u64::max_value!();
+
+    let elapsed = elapsed_ms(self.last_updated_ms, clock);
+    // u128 needed: elapsed (u64) * refill_rate_per_ms (u64) can overflow u64
+    // when large time gaps accumulate (e.g. 1M seconds × 16667 rate = 1.6e13,
+    // plus available up to 5e12, sum can approach u64::MAX).
+    let refill_amount = (elapsed as u128) * (self.refill_rate_per_ms as u128);
+    let new_available = (self.available as u128) + refill_amount;
+
+    new_available.min(self.capacity as u128) as u64
+}
+
+// === Private Functions ===
 
 /// Refill the bucket based on time elapsed since last update.
 fun refill(self: &mut RateLimiter, clock: &Clock) {
@@ -160,7 +154,7 @@ fun elapsed_ms(last_updated_ms: u64, clock: &Clock): u64 {
     }
 }
 
-// === Test-only Functions ===
+// === Test-Only Functions ===
 
 #[test_only]
 public fun destroy_for_testing(self: RateLimiter) {

--- a/packages/predict/sources/helper/rate_limiter.move
+++ b/packages/predict/sources/helper/rate_limiter.move
@@ -17,6 +17,7 @@ const EExceedsCapacity: u64 = 0;
 const EInsufficientWithdrawalBudget: u64 = 1;
 const EInvalidConfig: u64 = 2;
 
+/// Token bucket state used to limit withdrawals over time.
 public struct RateLimiter has store {
     /// Current available tokens in the bucket.
     available: u64,
@@ -99,18 +100,22 @@ public(package) fun update_config(
     };
 }
 
+/// Return whether the limiter is currently enabled.
 public(package) fun is_enabled(self: &RateLimiter): bool {
     self.enabled
 }
 
+/// Return the maximum burst capacity.
 public(package) fun capacity(self: &RateLimiter): u64 {
     self.capacity
 }
 
+/// Return the number of tokens refilled per millisecond.
 public(package) fun refill_rate_per_ms(self: &RateLimiter): u64 {
     self.refill_rate_per_ms
 }
 
+/// Return the currently stored bucket balance without applying time refill.
 public(package) fun available(self: &RateLimiter): u64 {
     self.available
 }
@@ -157,11 +162,13 @@ fun elapsed_ms(last_updated_ms: u64, clock: &Clock): u64 {
 // === Test-Only Functions ===
 
 #[test_only]
+/// Destroy a test-only limiter value.
 public fun destroy_for_testing(self: RateLimiter) {
     let RateLimiter { available: _, last_updated_ms: _, capacity: _, refill_rate_per_ms: _, enabled: _ } = self;
 }
 
 #[test_only]
+/// Create a test-only limiter with explicit state.
 public fun new_for_testing(
     capacity: u64,
     refill_rate_per_ms: u64,

--- a/packages/predict/sources/helper/strike_matrix.move
+++ b/packages/predict/sources/helper/strike_matrix.move
@@ -1,65 +1,64 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// This module stores one oracle's exposure on a fixed strike grid.
-//
-// It serves two different queries:
-// 1. MTM against a sampled live-price curve
-// 2. exact worst-case settled payout (`max_payout`)
-//
-// MTM needs fast strike-range reads. For that, each page stores directional
-// aggregates so a segment can recover exact `qty` and `qty * strike` without
-// scanning every strike in the range.
-//
-// Exact `max_payout` is a different problem. For a settlement boundary `s`:
-// - UP wins for strikes `< s`
-// - DN wins for strikes `>= s`
-//
-// So:
-//     payout(s) = sum_up_below(s) + sum_dn_at_or_above(s)
-//               = total_q_dn + prefix_sum(q_up - q_dn)
-//
-// That means exact `max_payout` is the maximum prefix score over strikes in
-// sorted order. A single total is not enough; after each update we need enough
-// structure to recover the best prefix over the whole book.
-//
-// The layout is therefore hybrid:
-// - `pages` is a `Table<u64, vector<StrikeNode>>`, with one dynamic-field lookup
-//   per 512-strike page instead of one lookup per strike.
-// - Each `StrikeNode` stores exact `q_up` / `q_dn` plus page-local aggregates
-//   used by MTM range reads.
-// - `page_tree` is an inline vector-backed tree of page summaries. Each summary
-//   keeps:
-//     * `total_q_up`
-//     * `total_q_dn`
-//     * the best prefix in that page/range, encoded as
-//       `(best_prefix_up, best_prefix_dn)`
-//
-// The best prefix is stored as an unsigned pair instead of a signed scalar
-// because Move has no native signed integers.
-//
-// Update algorithm:
-// - rewrite the touched 512-slot page
-// - recompute that page's summary
-// - merge summaries up the inline tree
-//
-// Merge rule:
-// - totals add componentwise
-// - the best prefix of `left + right` is either:
-//     * the best prefix entirely inside `left`, or
-//     * all of `left` plus the best prefix of `right`
-//
-// After that path is rebuilt, the root summary is enough to answer the raw
-// binary-combination peak:
-//     root.total_q_dn + root.best_prefix_up - root.best_prefix_dn
-// `max_payout()` then applies the stored range cash offset to recover the
-// actual vault liability peak.
-//
-// So the design is intentionally asymmetric:
-// - page-local aggregates optimize MTM
-// - the inline summary tree optimizes exact `max_payout`
-// - dynamic-field pressure stays bounded because only leaf pages live in `Table`
-
+/// Fixed strike-grid exposure store for one oracle.
+///
+/// This module serves two different queries:
+/// 1. MTM against a sampled live-price curve
+/// 2. exact worst-case settled payout (`max_payout`)
+///
+/// MTM needs fast strike-range reads. For that, each page stores directional
+/// aggregates so a segment can recover exact `qty` and `qty * strike` without
+/// scanning every strike in the range.
+///
+/// Exact `max_payout` is a different problem. For a settlement boundary `s`:
+/// - UP wins for strikes `< s`
+/// - DN wins for strikes `>= s`
+///
+/// So:
+///     payout(s) = sum_up_below(s) + sum_dn_at_or_above(s)
+///               = total_q_dn + prefix_sum(q_up - q_dn)
+///
+/// That means exact `max_payout` is the maximum prefix score over strikes in
+/// sorted order. A single total is not enough; after each update we need enough
+/// structure to recover the best prefix over the whole book.
+///
+/// The layout is therefore hybrid:
+/// - `pages` is a `Table<u64, vector<StrikeNode>>`, with one dynamic-field lookup
+///   per 512-strike page instead of one lookup per strike.
+/// - Each `StrikeNode` stores exact `q_up` / `q_dn` plus page-local aggregates
+///   used by MTM range reads.
+/// - `page_tree` is an inline vector-backed tree of page summaries. Each summary
+///   keeps:
+///     * `total_q_up`
+///     * `total_q_dn`
+///     * the best prefix in that page/range, encoded as
+///       `(best_prefix_up, best_prefix_dn)`
+///
+/// The best prefix is stored as an unsigned pair instead of a signed scalar
+/// because Move has no native signed integers.
+///
+/// Update algorithm:
+/// - rewrite the touched 512-slot page
+/// - recompute that page's summary
+/// - merge summaries up the inline tree
+///
+/// Merge rule:
+/// - totals add componentwise
+/// - the best prefix of `left + right` is either:
+///     * the best prefix entirely inside `left`, or
+///     * all of `left` plus the best prefix of `right`
+///
+/// After that path is rebuilt, the root summary is enough to answer the raw
+/// binary-combination peak:
+///     root.total_q_dn + root.best_prefix_up - root.best_prefix_dn
+/// `max_payout()` then applies the stored range cash offset to recover the
+/// actual vault liability peak.
+///
+/// So the design is intentionally asymmetric:
+/// - page-local aggregates optimize MTM
+/// - the inline summary tree optimizes exact `max_payout`
+/// - dynamic-field pressure stays bounded because only leaf pages live in `Table`
 module deepbook_predict::strike_matrix;
 
 use deepbook::{constants::max_u64, math};
@@ -75,7 +74,6 @@ const EInsufficientQuantity: u64 = 2;
 const ENonMonotoneCurve: u64 = 3;
 const EInvalidCurveRange: u64 = 4;
 
-// === Structs ===
 /// Dense strike-indexed book with page-level summaries stored in an inline tree.
 public struct StrikeMatrix has store {
     pages: Table<u64, vector<StrikeNode>>,
@@ -115,6 +113,7 @@ public struct PageSummary has copy, drop, store {
 }
 
 // === Public-Package Functions ===
+
 /// Allocate all strike pages for the oracle grid and a zeroed page-summary tree.
 public(package) fun new(
     ctx: &mut TxContext,
@@ -370,6 +369,7 @@ public(package) fun into_settled_totals(matrix: StrikeMatrix, settlement: u64): 
 }
 
 // === Private Functions ===
+
 /// Apply a vertical range `(lower, higher)` as `long UP@lower + long DN@higher`
 /// plus a `qty` range_qty delta. The matrix writes are byte-identical to two
 /// separate longs; `range_qty` is the algebraic constant from the dominance

--- a/packages/predict/sources/helper/strike_matrix.move
+++ b/packages/predict/sources/helper/strike_matrix.move
@@ -155,10 +155,12 @@ public(package) fun new(
     }
 }
 
+/// Insert one UP or DOWN position quantity at `strike`.
 public(package) fun insert(matrix: &mut StrikeMatrix, strike: u64, qty: u64, is_up: bool) {
     apply_position(matrix, strike, qty, is_up, true);
 }
 
+/// Remove one UP or DOWN position quantity at `strike`.
 public(package) fun remove(matrix: &mut StrikeMatrix, strike: u64, qty: u64, is_up: bool) {
     apply_position(matrix, strike, qty, is_up, false);
 }
@@ -252,6 +254,7 @@ public(package) fun evaluate(matrix: &StrikeMatrix, curve: &vector<CurvePoint>):
     value
 }
 
+/// Evaluate exact settled liability for a concrete settlement price.
 public(package) fun evaluate_settled(matrix: &StrikeMatrix, settlement: u64): u64 {
     if (matrix.minted_max_strike < matrix.minted_min_strike) return 0;
 
@@ -285,6 +288,7 @@ public(package) fun evaluate_settled(matrix: &StrikeMatrix, settlement: u64): u6
     value
 }
 
+/// Return the exact worst-case settled payout across all settlement prices.
 public(package) fun max_payout(matrix: &StrikeMatrix): u64 {
     let root = matrix.page_tree[0];
     root.total_q_dn + root.best_prefix_up - root.best_prefix_dn - matrix.range_qty
@@ -397,6 +401,7 @@ fun apply_position(matrix: &mut StrikeMatrix, strike: u64, qty: u64, is_up: bool
     recompute_page_tree_path(matrix, page_index);
 }
 
+/// Apply an unchecked add/remove quantity delta.
 fun apply_delta(value: &mut u64, qty: u64, add: bool) {
     if (add) {
         *value = *value + qty;
@@ -405,6 +410,7 @@ fun apply_delta(value: &mut u64, qty: u64, add: bool) {
     };
 }
 
+/// Apply a quantity delta, aborting before underflow on removal.
 fun apply_exact_delta(value: &mut u64, qty: u64, add: bool) {
     if (!add) assert!(*value >= qty, EInsufficientQuantity);
     apply_delta(value, qty, add);
@@ -591,6 +597,7 @@ fun recompute_page_tree_path(matrix: &mut StrikeMatrix, page_index: u64) {
     };
 }
 
+/// Return a zeroed dense page.
 fun empty_page(): vector<StrikeNode> {
     vector::tabulate!(
         PAGE_SLOTS,
@@ -605,6 +612,7 @@ fun empty_page(): vector<StrikeNode> {
     )
 }
 
+/// Return a zeroed page summary.
 fun empty_summary(): PageSummary {
     PageSummary {
         total_q_up: 0,

--- a/packages/predict/sources/market_key/market_key.move
+++ b/packages/predict/sources/market_key/market_key.move
@@ -10,11 +10,8 @@
 /// - direction: UP (0) or DOWN (1)
 module deepbook_predict::market_key;
 
-// === Constants ===
 const DIRECTION_UP: u8 = 0;
 const DIRECTION_DOWN: u8 = 1;
-
-// === Structs ===
 
 /// Key for a market position used to identify positions in PredictManager and Vault.
 public struct MarketKey has copy, drop, store {

--- a/packages/predict/sources/market_key/range_key.move
+++ b/packages/predict/sources/market_key/range_key.move
@@ -9,10 +9,7 @@
 /// share the same RangeKey row.
 module deepbook_predict::range_key;
 
-// === Errors ===
 const EInvalidStrikes: u64 = 0;
-
-// === Structs ===
 
 /// Key for a vertical range position used in PredictManager and Vault.
 public struct RangeKey has copy, drop, store {

--- a/packages/predict/sources/oracle.move
+++ b/packages/predict/sources/oracle.move
@@ -10,13 +10,7 @@
 module deepbook_predict::oracle;
 
 use deepbook::math;
-use deepbook_predict::{
-    constants,
-    i64,
-    lazer_helper,
-    math as predict_math,
-    tuning_constants
-};
+use deepbook_predict::{constants, i64, lazer_helper, math as predict_math, tuning_constants};
 use pyth_lazer::update::Update as LazerUpdate;
 use std::string::String;
 use sui::{clock::Clock, event, vec_set::{Self, VecSet}};

--- a/packages/predict/sources/oracle.move
+++ b/packages/predict/sources/oracle.move
@@ -21,8 +21,6 @@ use pyth_lazer::update::Update as LazerUpdate;
 use std::string::String;
 use sui::{clock::Clock, event, vec_set::{Self, VecSet}};
 
-// === Errors ===
-
 const EInvalidOracleCap: u64 = 0;
 const EOracleAlreadyActive: u64 = 1;
 const EOracleExpired: u64 = 2;
@@ -52,8 +50,6 @@ const STATUS_ACTIVE: u8 = 1;
 const STATUS_PENDING_SETTLEMENT: u8 = 2;
 // Oracle with a frozen settlement price.
 const STATUS_SETTLED: u8 = 3;
-
-// === Events ===
 
 public struct OracleActivated has copy, drop, store {
     oracle_id: ID,
@@ -123,8 +119,6 @@ public struct OracleBoundsUpdated has copy, drop, store {
     min_basis: u64,
     max_basis: u64,
 }
-
-// === Structs ===
 
 /// SVI volatility surface parameters.
 /// All values scaled by FLOAT_SCALING (1e9).
@@ -255,6 +249,11 @@ public struct OracleSVICap has key, store {
 }
 
 // === Public Functions ===
+
+/// Create a new SVIParams struct.
+public fun new_svi_params(a: u64, b: u64, rho: i64::I64, m: i64::I64, sigma: u64): SVIParams {
+    SVIParams { a, b, rho, m, sigma }
+}
 
 /// Activate the oracle. Must be called before oracle can be used for pricing.
 public fun activate(oracle: &mut OracleSVI, cap: &OracleSVICap, clock: &Clock) {
@@ -416,181 +415,6 @@ public fun update_svi(oracle: &mut OracleSVI, cap: &OracleSVICap, svi: SVIParams
     });
 }
 
-/// Get the oracle ID.
-public fun id(oracle: &OracleSVI): ID {
-    oracle.id.to_inner()
-}
-
-/// Get the underlying asset name.
-public fun underlying_asset(oracle: &OracleSVI): String {
-    oracle.underlying_asset
-}
-
-/// Get the current spot price.
-public fun spot_price(oracle: &OracleSVI): u64 {
-    oracle.prices.spot
-}
-
-/// Get the forward price for this expiry. Derived as `spot * basis` from the
-/// cached `PriceData`; not a stored field.
-public fun forward_price(oracle: &OracleSVI): u64 {
-    math::mul(oracle.prices.spot, oracle.prices.basis)
-}
-
-/// Get the cached basis ratio (forward / spot) from the most recent
-/// `update_prices`. Zero until the first operator push lands.
-public(package) fun basis(oracle: &OracleSVI): u64 {
-    oracle.prices.basis
-}
-
-/// Get the price data.
-public fun prices(oracle: &OracleSVI): PriceData {
-    oracle.prices
-}
-
-/// Get the SVI parameters.
-public fun svi(oracle: &OracleSVI): SVIParams {
-    oracle.svi
-}
-
-/// Get the SVI `a` parameter.
-public fun svi_a(svi: &SVIParams): u64 {
-    svi.a
-}
-
-/// Get the SVI `b` parameter.
-public fun svi_b(svi: &SVIParams): u64 {
-    svi.b
-}
-
-/// Get the signed SVI `rho` parameter.
-public fun svi_rho(svi: &SVIParams): i64::I64 {
-    svi.rho
-}
-
-/// Get the signed SVI `m` parameter.
-public fun svi_m(svi: &SVIParams): i64::I64 {
-    svi.m
-}
-
-/// Get the SVI `sigma` parameter.
-public fun svi_sigma(svi: &SVIParams): u64 {
-    svi.sigma
-}
-
-/// Get the expiry timestamp.
-public fun expiry(oracle: &OracleSVI): u64 {
-    oracle.expiry
-}
-
-/// Get the on-chain clock ms of the most recent master-spot update.
-public(package) fun spot_timestamp_ms(oracle: &OracleSVI): u64 {
-    oracle.spot_timestamp_ms
-}
-
-/// Get the on-chain clock ms of the most recent successful Lazer spot push.
-public(package) fun lazer_spot_timestamp_ms(oracle: &OracleSVI): u64 {
-    oracle.lazer_spot_timestamp_ms
-}
-
-/// Get the on-chain clock ms of the most recent `update_prices` call.
-public(package) fun basis_timestamp_ms(oracle: &OracleSVI): u64 {
-    oracle.basis_timestamp_ms
-}
-
-/// Get the Pyth Lazer publisher's microsecond timestamp from the most
-/// recent Lazer push (source-data time, not on-chain landing time).
-public(package) fun lazer_published_at_us(oracle: &OracleSVI): u64 {
-    oracle.lazer_published_at_us
-}
-
-/// Get the Pyth Lazer feed id that this oracle tracks.
-public(package) fun pyth_lazer_feed_id(oracle: &OracleSVI): u32 {
-    oracle.pyth_lazer_feed_id
-}
-
-/// Get the per-oracle staleness thresholds and basis circuit-breaker bounds.
-public(package) fun bounds(oracle: &OracleSVI): OracleBounds {
-    oracle.bounds
-}
-
-public(package) fun bounds_spot_staleness_threshold_ms(bounds: &OracleBounds): u64 {
-    bounds.spot_staleness_threshold_ms
-}
-
-public(package) fun bounds_basis_staleness_threshold_ms(bounds: &OracleBounds): u64 {
-    bounds.basis_staleness_threshold_ms
-}
-
-public(package) fun bounds_lazer_authoritative_threshold_ms(bounds: &OracleBounds): u64 {
-    bounds.lazer_authoritative_threshold_ms
-}
-
-public(package) fun bounds_max_spot_deviation(bounds: &OracleBounds): u64 {
-    bounds.max_spot_deviation
-}
-
-public(package) fun bounds_max_basis_deviation(bounds: &OracleBounds): u64 {
-    bounds.max_basis_deviation
-}
-
-public(package) fun bounds_min_basis(bounds: &OracleBounds): u64 {
-    bounds.min_basis
-}
-
-public(package) fun bounds_max_basis(bounds: &OracleBounds): u64 {
-    bounds.max_basis
-}
-
-/// Get the settlement price (only valid after settlement).
-public fun settlement_price(oracle: &OracleSVI): Option<u64> {
-    oracle.settlement_price
-}
-
-/// Check if the oracle has been settled.
-public fun is_settled(oracle: &OracleSVI): bool {
-    oracle.settlement_price.is_some()
-}
-
-/// Check if the oracle is active.
-public fun is_active(oracle: &OracleSVI): bool {
-    oracle.active
-}
-
-/// Return the lifecycle status implied by the oracle's state and the current clock.
-public fun status(oracle: &OracleSVI, clock: &Clock): u8 {
-    if (oracle.is_settled()) {
-        STATUS_SETTLED
-    } else if (clock.timestamp_ms() >= oracle.expiry) {
-        STATUS_PENDING_SETTLEMENT
-    } else if (!oracle.active) {
-        STATUS_INACTIVE
-    } else {
-        STATUS_ACTIVE
-    }
-}
-
-public fun status_inactive(): u8 {
-    STATUS_INACTIVE
-}
-
-public fun status_active(): u8 {
-    STATUS_ACTIVE
-}
-
-public fun status_pending_settlement(): u8 {
-    STATUS_PENDING_SETTLEMENT
-}
-
-public fun status_settled(): u8 {
-    STATUS_SETTLED
-}
-
-/// Create a new SVIParams struct.
-public fun new_svi_params(a: u64, b: u64, rho: i64::I64, m: i64::I64, sigma: u64): SVIParams {
-    SVIParams { a, b, rho, m, sigma }
-}
-
 /// Tune the spot-staleness halt-gate threshold. Authorized by `OracleSVICap`.
 /// Bounded by `tuning_constants::max_staleness_threshold_ms!()` (60s) — beyond that
 /// the liveness gate stops meaningfully protecting quoting.
@@ -663,67 +487,116 @@ public fun set_basis_bounds(
     oracle.emit_bounds_updated();
 }
 
-/// Compute the conditional UP price within one binary pair.
-/// Settled oracles return exactly `1.0` if UP wins and `0` otherwise. Live
-/// oracles return `N(d2)` from the SVI surface.
-public(package) fun compute_price(oracle: &OracleSVI, strike: u64): u64 {
-    if (oracle.settlement_price.is_some()) {
-        let settlement_price = oracle.settlement_price.destroy_some();
-        if (settlement_price > strike) {
-            constants::float_scaling!()
-        } else {
-            0
-        }
+/// Get the oracle ID.
+public fun id(oracle: &OracleSVI): ID {
+    oracle.id.to_inner()
+}
+
+/// Get the underlying asset name.
+public fun underlying_asset(oracle: &OracleSVI): String {
+    oracle.underlying_asset
+}
+
+/// Get the current spot price.
+public fun spot_price(oracle: &OracleSVI): u64 {
+    oracle.prices.spot
+}
+
+/// Get the forward price for this expiry. Derived as `spot * basis` from the
+/// cached `PriceData`; not a stored field.
+public fun forward_price(oracle: &OracleSVI): u64 {
+    math::mul(oracle.prices.spot, oracle.prices.basis)
+}
+
+/// Get the price data.
+public fun prices(oracle: &OracleSVI): PriceData {
+    oracle.prices
+}
+
+/// Get the SVI parameters.
+public fun svi(oracle: &OracleSVI): SVIParams {
+    oracle.svi
+}
+
+/// Get the SVI `a` parameter.
+public fun svi_a(svi: &SVIParams): u64 {
+    svi.a
+}
+
+/// Get the SVI `b` parameter.
+public fun svi_b(svi: &SVIParams): u64 {
+    svi.b
+}
+
+/// Get the signed SVI `rho` parameter.
+public fun svi_rho(svi: &SVIParams): i64::I64 {
+    svi.rho
+}
+
+/// Get the signed SVI `m` parameter.
+public fun svi_m(svi: &SVIParams): i64::I64 {
+    svi.m
+}
+
+/// Get the SVI `sigma` parameter.
+public fun svi_sigma(svi: &SVIParams): u64 {
+    svi.sigma
+}
+
+/// Get the expiry timestamp.
+public fun expiry(oracle: &OracleSVI): u64 {
+    oracle.expiry
+}
+
+/// Get the settlement price (only valid after settlement).
+public fun settlement_price(oracle: &OracleSVI): Option<u64> {
+    oracle.settlement_price
+}
+
+/// Check if the oracle has been settled.
+public fun is_settled(oracle: &OracleSVI): bool {
+    oracle.settlement_price.is_some()
+}
+
+/// Check if the oracle is active.
+public fun is_active(oracle: &OracleSVI): bool {
+    oracle.active
+}
+
+/// Return the lifecycle status implied by the oracle's state and the current clock.
+public fun status(oracle: &OracleSVI, clock: &Clock): u8 {
+    if (oracle.is_settled()) {
+        STATUS_SETTLED
+    } else if (clock.timestamp_ms() >= oracle.expiry) {
+        STATUS_PENDING_SETTLEMENT
+    } else if (!oracle.active) {
+        STATUS_INACTIVE
     } else {
-        compute_nd2(oracle, strike)
+        STATUS_ACTIVE
     }
 }
 
-/// Return the exact fair prices for both sides of a binary market.
-/// The live parity invariant is `UP + DN = 1`.
-public(package) fun binary_price_pair(oracle: &OracleSVI, strike: u64, _clock: &Clock): (u64, u64) {
-    let up_price = oracle.compute_price(strike);
-    (up_price, float_scaling!() - up_price)
+public fun status_inactive(): u8 {
+    STATUS_INACTIVE
+}
+
+public fun status_active(): u8 {
+    STATUS_ACTIVE
+}
+
+public fun status_pending_settlement(): u8 {
+    STATUS_PENDING_SETTLEMENT
+}
+
+public fun status_settled(): u8 {
+    STATUS_SETTLED
 }
 
 // === Public-Package Functions ===
 
-/// Register an additional cap as authorized to update an oracle.
-public(package) fun register_cap(oracle: &mut OracleSVI, cap: &OracleSVICap) {
-    oracle.authorized_caps.insert(cap.id.to_inner());
-}
-
 /// Create a new OracleCap. Called by registry during setup.
 public(package) fun create_oracle_cap(ctx: &mut TxContext): OracleSVICap {
     OracleSVICap { id: object::new(ctx) }
-}
-
-public(package) fun assert_authorized_cap(oracle: &OracleSVI, cap: &OracleSVICap) {
-    assert!(oracle.authorized_caps.contains(&cap.id.to_inner()), EInvalidOracleCap);
-}
-
-/// Assert that an oracle can still be used for actions that require live
-/// pricing. The oracle must be `ACTIVE` and fresh; `INACTIVE`,
-/// `PENDING_SETTLEMENT`, `SETTLED`, and stale oracles are rejected.
-public(package) fun assert_live_oracle(oracle: &OracleSVI, clock: &Clock) {
-    let oracle_status = oracle.status(clock);
-    assert!(oracle_status != STATUS_SETTLED, EOracleSettled);
-    assert!(oracle_status != STATUS_PENDING_SETTLEMENT, EOracleExpired);
-    assert!(oracle_status != STATUS_INACTIVE, EOracleInactive);
-    oracle.assert_fresh(clock);
-}
-
-/// Assert that an oracle can still be used for actions that accept either live
-/// pricing or a finalized settlement price. `SETTLED` oracles are allowed
-/// immediately; otherwise the oracle must still be `ACTIVE` and fresh.
-/// `PENDING_SETTLEMENT` is intentionally rejected to freeze the
-/// expired-but-unsettled gap.
-public(package) fun assert_quoteable_oracle(oracle: &OracleSVI, clock: &Clock) {
-    let oracle_status = oracle.status(clock);
-    if (oracle_status == STATUS_SETTLED) return;
-    assert!(oracle_status != STATUS_PENDING_SETTLEMENT, EOracleExpired);
-    assert!(oracle_status != STATUS_INACTIVE, EOracleInactive);
-    oracle.assert_fresh(clock);
 }
 
 /// Create a new SVI Oracle for an underlying + expiry. Returns the oracle ID.
@@ -806,6 +679,127 @@ public(package) fun new_oracle_bounds(
         min_basis,
         max_basis,
     }
+}
+
+/// Register an additional cap as authorized to update an oracle.
+public(package) fun register_cap(oracle: &mut OracleSVI, cap: &OracleSVICap) {
+    oracle.authorized_caps.insert(cap.id.to_inner());
+}
+
+public(package) fun assert_authorized_cap(oracle: &OracleSVI, cap: &OracleSVICap) {
+    assert!(oracle.authorized_caps.contains(&cap.id.to_inner()), EInvalidOracleCap);
+}
+
+/// Assert that an oracle can still be used for actions that require live
+/// pricing. The oracle must be `ACTIVE` and fresh; `INACTIVE`,
+/// `PENDING_SETTLEMENT`, `SETTLED`, and stale oracles are rejected.
+public(package) fun assert_live_oracle(oracle: &OracleSVI, clock: &Clock) {
+    let oracle_status = oracle.status(clock);
+    assert!(oracle_status != STATUS_SETTLED, EOracleSettled);
+    assert!(oracle_status != STATUS_PENDING_SETTLEMENT, EOracleExpired);
+    assert!(oracle_status != STATUS_INACTIVE, EOracleInactive);
+    oracle.assert_fresh(clock);
+}
+
+/// Assert that an oracle can still be used for actions that accept either live
+/// pricing or a finalized settlement price. `SETTLED` oracles are allowed
+/// immediately; otherwise the oracle must still be `ACTIVE` and fresh.
+/// `PENDING_SETTLEMENT` is intentionally rejected to freeze the
+/// expired-but-unsettled gap.
+public(package) fun assert_quoteable_oracle(oracle: &OracleSVI, clock: &Clock) {
+    let oracle_status = oracle.status(clock);
+    if (oracle_status == STATUS_SETTLED) return;
+    assert!(oracle_status != STATUS_PENDING_SETTLEMENT, EOracleExpired);
+    assert!(oracle_status != STATUS_INACTIVE, EOracleInactive);
+    oracle.assert_fresh(clock);
+}
+
+/// Compute the conditional UP price within one binary pair.
+/// Settled oracles return exactly `1.0` if UP wins and `0` otherwise. Live
+/// oracles return `N(d2)` from the SVI surface.
+public(package) fun compute_price(oracle: &OracleSVI, strike: u64): u64 {
+    if (oracle.settlement_price.is_some()) {
+        let settlement_price = oracle.settlement_price.destroy_some();
+        if (settlement_price > strike) {
+            constants::float_scaling!()
+        } else {
+            0
+        }
+    } else {
+        compute_nd2(oracle, strike)
+    }
+}
+
+/// Return the exact fair prices for both sides of a binary market.
+/// The live parity invariant is `UP + DN = 1`.
+public(package) fun binary_price_pair(oracle: &OracleSVI, strike: u64, _clock: &Clock): (u64, u64) {
+    let up_price = oracle.compute_price(strike);
+    (up_price, float_scaling!() - up_price)
+}
+
+/// Get the cached basis ratio (forward / spot) from the most recent
+/// `update_prices`. Zero until the first operator push lands.
+public(package) fun basis(oracle: &OracleSVI): u64 {
+    oracle.prices.basis
+}
+
+/// Get the on-chain clock ms of the most recent master-spot update.
+public(package) fun spot_timestamp_ms(oracle: &OracleSVI): u64 {
+    oracle.spot_timestamp_ms
+}
+
+/// Get the on-chain clock ms of the most recent successful Lazer spot push.
+public(package) fun lazer_spot_timestamp_ms(oracle: &OracleSVI): u64 {
+    oracle.lazer_spot_timestamp_ms
+}
+
+/// Get the on-chain clock ms of the most recent `update_prices` call.
+public(package) fun basis_timestamp_ms(oracle: &OracleSVI): u64 {
+    oracle.basis_timestamp_ms
+}
+
+/// Get the Pyth Lazer publisher's microsecond timestamp from the most
+/// recent Lazer push (source-data time, not on-chain landing time).
+public(package) fun lazer_published_at_us(oracle: &OracleSVI): u64 {
+    oracle.lazer_published_at_us
+}
+
+/// Get the Pyth Lazer feed id that this oracle tracks.
+public(package) fun pyth_lazer_feed_id(oracle: &OracleSVI): u32 {
+    oracle.pyth_lazer_feed_id
+}
+
+/// Get the per-oracle staleness thresholds and basis circuit-breaker bounds.
+public(package) fun bounds(oracle: &OracleSVI): OracleBounds {
+    oracle.bounds
+}
+
+public(package) fun bounds_spot_staleness_threshold_ms(bounds: &OracleBounds): u64 {
+    bounds.spot_staleness_threshold_ms
+}
+
+public(package) fun bounds_basis_staleness_threshold_ms(bounds: &OracleBounds): u64 {
+    bounds.basis_staleness_threshold_ms
+}
+
+public(package) fun bounds_lazer_authoritative_threshold_ms(bounds: &OracleBounds): u64 {
+    bounds.lazer_authoritative_threshold_ms
+}
+
+public(package) fun bounds_max_spot_deviation(bounds: &OracleBounds): u64 {
+    bounds.max_spot_deviation
+}
+
+public(package) fun bounds_max_basis_deviation(bounds: &OracleBounds): u64 {
+    bounds.max_basis_deviation
+}
+
+public(package) fun bounds_min_basis(bounds: &OracleBounds): u64 {
+    bounds.min_basis
+}
+
+public(package) fun bounds_max_basis(bounds: &OracleBounds): u64 {
+    bounds.max_basis
 }
 
 // === Private Functions ===

--- a/packages/predict/sources/oracle.move
+++ b/packages/predict/sources/oracle.move
@@ -11,7 +11,7 @@ module deepbook_predict::oracle;
 
 use deepbook::math;
 use deepbook_predict::{
-    constants::{Self, float_scaling},
+    constants,
     i64,
     lazer_helper,
     math as predict_math,
@@ -743,7 +743,7 @@ public(package) fun compute_price(oracle: &OracleSVI, strike: u64): u64 {
 /// The live parity invariant is `UP + DN = 1`.
 public(package) fun binary_price_pair(oracle: &OracleSVI, strike: u64, _clock: &Clock): (u64, u64) {
     let up_price = oracle.compute_price(strike);
-    (up_price, float_scaling!() - up_price)
+    (up_price, constants::float_scaling!() - up_price)
 }
 
 /// Get the cached basis ratio (forward / spot) from the most recent

--- a/packages/predict/sources/oracle.move
+++ b/packages/predict/sources/oracle.move
@@ -51,6 +51,7 @@ const STATUS_PENDING_SETTLEMENT: u8 = 2;
 // Oracle with a frozen settlement price.
 const STATUS_SETTLED: u8 = 3;
 
+/// Emitted when an oracle is activated for live pricing.
 public struct OracleActivated has copy, drop, store {
     oracle_id: ID,
     expiry: u64,
@@ -69,6 +70,7 @@ public struct OracleSettled has copy, drop, store {
     spot_timestamp_ms: u64,
 }
 
+/// Emitted when the operator refreshes spot and basis with `update_prices`.
 public struct OraclePricesUpdated has copy, drop, store {
     oracle_id: ID,
     spot: u64,
@@ -77,6 +79,7 @@ public struct OraclePricesUpdated has copy, drop, store {
     spot_timestamp_ms: u64,
 }
 
+/// Emitted when SVI parameters are updated.
 public struct OracleSVIUpdated has copy, drop, store {
     oracle_id: ID,
     a: u64,
@@ -87,6 +90,7 @@ public struct OracleSVIUpdated has copy, drop, store {
     timestamp: u64,
 }
 
+/// Emitted when a Pyth Lazer push refreshes the oracle spot.
 public struct OracleSpotUpdatedFromLazer has copy, drop, store {
     oracle_id: ID,
     spot: u64,
@@ -576,18 +580,22 @@ public fun status(oracle: &OracleSVI, clock: &Clock): u8 {
     }
 }
 
+/// Return the inactive status code.
 public fun status_inactive(): u8 {
     STATUS_INACTIVE
 }
 
+/// Return the active status code.
 public fun status_active(): u8 {
     STATUS_ACTIVE
 }
 
+/// Return the expired-but-unsettled status code.
 public fun status_pending_settlement(): u8 {
     STATUS_PENDING_SETTLEMENT
 }
 
+/// Return the settled status code.
 public fun status_settled(): u8 {
     STATUS_SETTLED
 }
@@ -686,6 +694,7 @@ public(package) fun register_cap(oracle: &mut OracleSVI, cap: &OracleSVICap) {
     oracle.authorized_caps.insert(cap.id.to_inner());
 }
 
+/// Abort unless `cap` is authorized to operate on this oracle.
 public(package) fun assert_authorized_cap(oracle: &OracleSVI, cap: &OracleSVICap) {
     assert!(oracle.authorized_caps.contains(&cap.id.to_inner()), EInvalidOracleCap);
 }
@@ -774,30 +783,37 @@ public(package) fun bounds(oracle: &OracleSVI): OracleBounds {
     oracle.bounds
 }
 
+/// Return the spot-staleness threshold from an `OracleBounds` snapshot.
 public(package) fun bounds_spot_staleness_threshold_ms(bounds: &OracleBounds): u64 {
     bounds.spot_staleness_threshold_ms
 }
 
+/// Return the basis-staleness threshold from an `OracleBounds` snapshot.
 public(package) fun bounds_basis_staleness_threshold_ms(bounds: &OracleBounds): u64 {
     bounds.basis_staleness_threshold_ms
 }
 
+/// Return the Lazer-authoritative threshold from an `OracleBounds` snapshot.
 public(package) fun bounds_lazer_authoritative_threshold_ms(bounds: &OracleBounds): u64 {
     bounds.lazer_authoritative_threshold_ms
 }
 
+/// Return the maximum allowed spot deviation from an `OracleBounds` snapshot.
 public(package) fun bounds_max_spot_deviation(bounds: &OracleBounds): u64 {
     bounds.max_spot_deviation
 }
 
+/// Return the maximum allowed basis deviation from an `OracleBounds` snapshot.
 public(package) fun bounds_max_basis_deviation(bounds: &OracleBounds): u64 {
     bounds.max_basis_deviation
 }
 
+/// Return the minimum allowed basis from an `OracleBounds` snapshot.
 public(package) fun bounds_min_basis(bounds: &OracleBounds): u64 {
     bounds.min_basis
 }
 
+/// Return the maximum allowed basis from an `OracleBounds` snapshot.
 public(package) fun bounds_max_basis(bounds: &OracleBounds): u64 {
     bounds.max_basis
 }
@@ -916,6 +932,7 @@ fun validate_basis_push(oracle: &OracleSVI, new_spot: u64, new_basis: u64) {
     };
 }
 
+/// Validate a per-oracle staleness threshold.
 fun validate_staleness_ms(value: u64) {
     assert!(
         value > 0 && value <= tuning_constants::max_staleness_threshold_ms!(),
@@ -923,6 +940,7 @@ fun validate_staleness_ms(value: u64) {
     );
 }
 
+/// Validate basis circuit-breaker inputs before storing them.
 fun validate_basis_bounds_inputs(
     max_spot_deviation: u64,
     max_basis_deviation: u64,
@@ -950,6 +968,7 @@ fun within_deviation(prev: u64, next: u64, max_deviation: u64): bool {
     diff <= max_allowed
 }
 
+/// Emit the full current bounds snapshot for indexers.
 fun emit_bounds_updated(oracle: &OracleSVI) {
     let b = &oracle.bounds;
     event::emit(OracleBoundsUpdated {

--- a/packages/predict/sources/oracle_config.move
+++ b/packages/predict/sources/oracle_config.move
@@ -33,6 +33,7 @@ const EInvalidStalenessThreshold: u64 = 8;
 const EInvalidBasisBounds: u64 = 9;
 const EFeedIdNotConfigured: u64 = 10;
 
+/// Strike grid metadata attached to one oracle.
 public struct OracleGrid has copy, drop, store {
     min_strike: u64,
     max_strike: u64,
@@ -58,6 +59,7 @@ public struct BasisBounds has copy, drop, store {
     max_basis: u64,
 }
 
+/// Predict-owned oracle configuration and per-oracle metadata.
 public struct OracleConfig has store {
     oracle_grids: Table<ID, OracleGrid>,
     /// Per-oracle ask-bound overrides; presence in this table means an override
@@ -176,18 +178,22 @@ public(package) fun resolve_feed_id(oracle_config: &OracleConfig, asset: String)
     oracle_config.asset_feed_ids[asset]
 }
 
+/// Return the maximum allowed operator spot deviation.
 public(package) fun basis_bounds_max_spot_deviation(bounds: &BasisBounds): u64 {
     bounds.max_spot_deviation
 }
 
+/// Return the maximum allowed basis deviation.
 public(package) fun basis_bounds_max_basis_deviation(bounds: &BasisBounds): u64 {
     bounds.max_basis_deviation
 }
 
+/// Return the minimum allowed basis ratio.
 public(package) fun basis_bounds_min_basis(bounds: &BasisBounds): u64 {
     bounds.min_basis
 }
 
+/// Return the maximum allowed basis ratio.
 public(package) fun basis_bounds_max_basis(bounds: &BasisBounds): u64 {
     bounds.max_basis
 }
@@ -513,6 +519,7 @@ fun resolve_basis_bounds(
     }
 }
 
+/// Validate an admin-tuned staleness threshold.
 fun validate_staleness_ms(value: u64) {
     assert!(
         value > 0 && value <= tuning_constants::max_staleness_threshold_ms!(),
@@ -520,6 +527,7 @@ fun validate_staleness_ms(value: u64) {
     );
 }
 
+/// Validate per-asset basis circuit-breaker inputs before storing them.
 fun validate_basis_bounds_inputs(
     max_spot_deviation: u64,
     max_basis_deviation: u64,

--- a/packages/predict/sources/oracle_config.move
+++ b/packages/predict/sources/oracle_config.move
@@ -21,7 +21,6 @@ use deepbook_predict::{
 use std::string::String;
 use sui::table::{Self, Table};
 
-// === Errors ===
 const EMarketKeyOracleMismatch: u64 = 0;
 const EMarketKeyExpiryMismatch: u64 = 1;
 const EInvalidStrike: u64 = 2;
@@ -98,6 +97,8 @@ public struct CurvePoint has copy, drop, store {
     up_price: u64,
 }
 
+// === Public Functions ===
+
 /// Create a curve sample point from exact strike and UP price.
 public fun new_curve_point(strike: u64, up_price: u64): CurvePoint {
     CurvePoint {
@@ -117,6 +118,8 @@ public fun ask_bounds_min(bounds: &AskBounds): u64 { bounds.min_ask_price }
 
 /// Return the maximum ask price stored in an `AskBounds`.
 public fun ask_bounds_max(bounds: &AskBounds): u64 { bounds.max_ask_price }
+
+// === Public-Package Functions ===
 
 /// Admin-tuned spot staleness threshold (ms) used to seed new oracles.
 public(package) fun spot_staleness_threshold_ms(oracle_config: &OracleConfig): u64 {
@@ -461,6 +464,8 @@ public(package) fun build_curve(
 
     points
 }
+
+// === Private Functions ===
 
 /// Assert that a requested curve range is valid on the oracle's configured grid.
 fun assert_build_curve(

--- a/packages/predict/sources/predict.move
+++ b/packages/predict/sources/predict.move
@@ -47,6 +47,7 @@ const EOracleNotSettled: u64 = 9;
 const EStaleOracleMtm: u64 = 10;
 const EPredictAlreadyCreated: u64 = 11;
 
+/// Emitted when a binary UP/DOWN position is minted.
 public struct PositionMinted has copy, drop, store {
     predict_id: ID,
     manager_id: ID,
@@ -61,6 +62,7 @@ public struct PositionMinted has copy, drop, store {
     ask_price: u64,
 }
 
+/// Emitted when a binary UP/DOWN position is redeemed.
 public struct PositionRedeemed has copy, drop, store {
     predict_id: ID,
     manager_id: ID,
@@ -77,6 +79,7 @@ public struct PositionRedeemed has copy, drop, store {
     is_settled: bool,
 }
 
+/// Emitted when a vertical range position is minted.
 public struct RangeMinted has copy, drop, store {
     predict_id: ID,
     manager_id: ID,
@@ -91,6 +94,7 @@ public struct RangeMinted has copy, drop, store {
     ask_price: u64,
 }
 
+/// Emitted when a vertical range position is redeemed.
 public struct RangeRedeemed has copy, drop, store {
     predict_id: ID,
     manager_id: ID,
@@ -107,11 +111,13 @@ public struct RangeRedeemed has copy, drop, store {
     is_settled: bool,
 }
 
+/// Emitted when global trading pause state changes.
 public struct TradingPauseUpdated has copy, drop, store {
     predict_id: ID,
     paused: bool,
 }
 
+/// Emitted when pricing configuration changes.
 public struct PricingConfigUpdated has copy, drop, store {
     predict_id: ID,
     base_spread: u64,
@@ -121,6 +127,7 @@ public struct PricingConfigUpdated has copy, drop, store {
     max_ask_price: u64,
 }
 
+/// Emitted when a per-oracle ask-bound override is set.
 public struct OracleAskBoundsSet has copy, drop, store {
     predict_id: ID,
     oracle_id: ID,
@@ -128,27 +135,32 @@ public struct OracleAskBoundsSet has copy, drop, store {
     max_ask_price: u64,
 }
 
+/// Emitted when a per-oracle ask-bound override is cleared.
 public struct OracleAskBoundsCleared has copy, drop, store {
     predict_id: ID,
     oracle_id: ID,
 }
 
+/// Emitted when risk configuration changes.
 public struct RiskConfigUpdated has copy, drop, store {
     predict_id: ID,
     max_total_exposure_pct: u64,
     mtm_freshness_ms: u64,
 }
 
+/// Emitted when a quote asset is enabled for new inflows.
 public struct QuoteAssetEnabled has copy, drop, store {
     predict_id: ID,
     quote_asset: TypeName,
 }
 
+/// Emitted when a quote asset is disabled for new inflows.
 public struct QuoteAssetDisabled has copy, drop, store {
     predict_id: ID,
     quote_asset: TypeName,
 }
 
+/// Emitted when LP capital is supplied to the vault.
 public struct Supplied has copy, drop, store {
     predict_id: ID,
     supplier: address,
@@ -157,6 +169,7 @@ public struct Supplied has copy, drop, store {
     shares_minted: u64,
 }
 
+/// Emitted when LP capital is withdrawn from the vault.
 public struct Withdrawn has copy, drop, store {
     predict_id: ID,
     withdrawer: address,
@@ -165,6 +178,7 @@ public struct Withdrawn has copy, drop, store {
     shares_burned: u64,
 }
 
+/// Emitted when admin-tuned oracle staleness thresholds change.
 public struct OracleStalenessConfigUpdated has copy, drop, store {
     predict_id: ID,
     spot_staleness_threshold_ms: u64,
@@ -173,6 +187,7 @@ public struct OracleStalenessConfigUpdated has copy, drop, store {
     lazer_settlement_authoritative_threshold_ms: u64,
 }
 
+/// Emitted when per-asset oracle basis bounds change.
 public struct OracleBasisBoundsUpdated has copy, drop, store {
     predict_id: ID,
     asset: String,
@@ -182,6 +197,7 @@ public struct OracleBasisBoundsUpdated has copy, drop, store {
     max_basis: u64,
 }
 
+/// Emitted when an asset is bound to a Pyth Lazer feed id.
 public struct OracleFeedIdSet has copy, drop, store {
     predict_id: ID,
     asset: String,
@@ -209,6 +225,7 @@ public struct Predict has key {
     trading_paused: bool,
 }
 
+/// Derived-object key for the singleton Predict shared object per quote type.
 public struct PredictKey<phantom T>() has copy, drop, store;
 
 // === Public Functions ===
@@ -524,6 +541,7 @@ public fun get_range_trade_amounts(
     (math::mul(ask, quantity), math::mul(bid, quantity))
 }
 
+/// Return oracle IDs whose unsettled exposure must be refreshed before LP flows.
 public fun unsettled_exposed_oracles(predict: &Predict): &vector<ID> {
     predict.vault.unsettled_exposed_oracles()
 }
@@ -593,8 +611,6 @@ public(package) fun create<Quote>(
         risk_config: risk_config::new(),
         treasury_config: treasury_config::new(),
         oracle_config: oracle_config::new(ctx),
-        // Withdrawal rate limiter starts disabled. Admin must configure
-        // capacity and refill rate based on the actual quote asset value
         // Withdrawal rate limiter starts disabled. Admin must call
         // update_withdrawal_limiter() then enable_withdrawal_limiter()
         // to activate, configuring capacity and rate for the quote asset.
@@ -605,6 +621,7 @@ public(package) fun create<Quote>(
     transfer::share_object(predict);
 }
 
+/// Enable a quote asset for new Predict inflows.
 public(package) fun enable_quote_asset<Quote>(predict: &mut Predict, currency: &Currency<Quote>) {
     predict.treasury_config.add_quote_asset<Quote>(currency);
     event::emit(QuoteAssetEnabled {
@@ -613,6 +630,7 @@ public(package) fun enable_quote_asset<Quote>(predict: &mut Predict, currency: &
     });
 }
 
+/// Disable a quote asset for new Predict inflows.
 public(package) fun disable_quote_asset<Quote>(predict: &mut Predict) {
     predict.treasury_config.remove_quote_asset<Quote>();
     event::emit(QuoteAssetDisabled {
@@ -621,6 +639,7 @@ public(package) fun disable_quote_asset<Quote>(predict: &mut Predict) {
     });
 }
 
+/// Register an oracle strike grid and initialize its vault matrix.
 public(package) fun add_oracle_grid(
     predict: &mut Predict,
     oracle_id: ID,
@@ -835,6 +854,7 @@ public(package) fun resolve_feed_id(predict: &Predict, asset: String): u64 {
 
 // === Private Functions ===
 
+/// Assert every unsettled exposed oracle has a fresh cached MTM for LP flows.
 fun assert_total_mtm_fresh(predict: &Predict, clock: &Clock) {
     // MTM freshness is enforced only for LP supply/withdraw. Trade quoting
     // still relies on cached aggregate `vault.total_mtm()` and refreshes the
@@ -853,6 +873,7 @@ fun assert_total_mtm_fresh(predict: &Predict, clock: &Clock) {
     }
 }
 
+/// Shared binary-position redemption path.
 fun redeem_internal<Quote>(
     predict: &mut Predict,
     manager: &mut PredictManager,
@@ -905,6 +926,7 @@ fun redeem_internal<Quote>(
     payout_coin
 }
 
+/// Shared vertical-range redemption path.
 fun redeem_range_internal<Quote>(
     predict: &mut Predict,
     manager: &mut PredictManager,
@@ -968,6 +990,7 @@ fun shares_to_amount(predict: &Predict, shares: u64, vault_value: u64): u64 {
     mul_div_round_down(shares, vault_value, total)
 }
 
+/// Emit the full current pricing-config snapshot.
 fun emit_pricing_config_updated(predict: &Predict) {
     event::emit(PricingConfigUpdated {
         predict_id: object::id(predict),
@@ -979,6 +1002,7 @@ fun emit_pricing_config_updated(predict: &Predict) {
     });
 }
 
+/// Emit the full current risk-config snapshot.
 fun emit_risk_config_updated(predict: &Predict) {
     event::emit(RiskConfigUpdated {
         predict_id: object::id(predict),
@@ -987,6 +1011,7 @@ fun emit_risk_config_updated(predict: &Predict) {
     });
 }
 
+/// Emit the full current oracle-staleness config snapshot.
 fun emit_oracle_staleness_config_updated(predict: &Predict) {
     event::emit(OracleStalenessConfigUpdated {
         predict_id: object::id(predict),
@@ -1100,11 +1125,13 @@ fun resolve_ask_bounds(predict: &Predict, oracle_id: ID): (u64, u64) {
     }
 }
 
+/// Assert a mint ask price fits the resolved global/per-oracle bounds.
 fun assert_mintable_ask(predict: &Predict, oracle_id: ID, ask_price: u64) {
     let (min_ask, max_ask) = predict.resolve_ask_bounds(oracle_id);
     assert!(ask_price >= min_ask && ask_price <= max_ask, EAskPriceOutOfBounds);
 }
 
+/// Refresh one oracle's cached risk metrics in the vault.
 fun refresh_oracle_risk(predict: &mut Predict, oracle: &OracleSVI, clock: &Clock) {
     let oracle_id = oracle.id();
     let (min_strike, max_strike) = predict.vault.oracle_strike_range(oracle_id);
@@ -1153,21 +1180,25 @@ public(package) fun create_test_predict<Quote>(
 }
 
 #[test_only]
+/// Return mutable vault access for tests.
 public(package) fun vault_mut(predict: &mut Predict): &mut Vault {
     &mut predict.vault
 }
 
 #[test_only]
+/// Return oracle config access for tests.
 public(package) fun oracle_config(predict: &Predict): &OracleConfig {
     &predict.oracle_config
 }
 
 #[test_only]
+/// Return treasury config access for tests.
 public(package) fun treasury_config(predict: &Predict): &TreasuryConfig {
     &predict.treasury_config
 }
 
 #[test_only]
+/// Return aggregate vault balance for tests.
 public(package) fun vault_balance(predict: &Predict): u64 {
     predict.vault.balance()
 }

--- a/packages/predict/sources/predict.move
+++ b/packages/predict/sources/predict.move
@@ -34,7 +34,6 @@ use sui::{
     vec_set::VecSet
 };
 
-// === Errors ===
 const ETradingPaused: u64 = 0;
 const ENotOwner: u64 = 1;
 const EWithdrawExceedsAvailable: u64 = 2;
@@ -47,8 +46,6 @@ const EAskBoundLooserThanGlobal: u64 = 8;
 const EOracleNotSettled: u64 = 9;
 const EStaleOracleMtm: u64 = 10;
 const EPredictAlreadyCreated: u64 = 11;
-
-// === Events ===
 
 public struct PositionMinted has copy, drop, store {
     predict_id: ID,
@@ -191,8 +188,6 @@ public struct OracleFeedIdSet has copy, drop, store {
     pyth_lazer_feed_id: u64,
 }
 
-// === Structs ===
-
 /// Main shared object for the DeepBook Predict protocol.
 public struct Predict has key {
     id: UID,
@@ -217,29 +212,6 @@ public struct Predict has key {
 public struct PredictKey<phantom T>() has copy, drop, store;
 
 // === Public Functions ===
-
-/// Get the amounts for mint/redeem (for UI/preview).
-/// Returns (mint_cost, redeem_payout).
-public fun get_trade_amounts(
-    predict: &Predict,
-    oracle: &OracleSVI,
-    key: MarketKey,
-    quantity: u64,
-    clock: &Clock,
-): (u64, u64) {
-    let (ask, bid) = predict.trade_prices(oracle, key, clock);
-    (math::mul(ask, quantity), math::mul(bid, quantity))
-}
-
-public fun unsettled_exposed_oracles(predict: &Predict): &vector<ID> {
-    predict.vault.unsettled_exposed_oracles()
-}
-
-/// Resolved ask-price bounds for an oracle, after intersecting any per-oracle
-/// override with the global default. Exposed for UI/preview.
-public fun ask_bounds(predict: &Predict, oracle_id: ID): (u64, u64) {
-    predict.resolve_ask_bounds(oracle_id)
-}
 
 /// Buy a position using an enabled quote asset.
 /// Cost is withdrawn from the PredictManager's balance.
@@ -338,20 +310,6 @@ public fun redeem_permissionless<Quote>(
     assert!(oracle.is_settled(), EOracleNotSettled);
     let payout_coin = redeem_internal<Quote>(predict, manager, oracle, key, quantity, clock, ctx);
     manager.deposit_permissionless(payout_coin, ctx);
-}
-
-/// Get the amounts for range mint/redeem (for UI/preview).
-/// Returns (mint_cost, redeem_payout). Bull-call and bear-put ranges with the
-/// same strikes price identically — direction is not part of `RangeKey`.
-public fun get_range_trade_amounts(
-    predict: &Predict,
-    oracle: &OracleSVI,
-    key: RangeKey,
-    quantity: u64,
-    clock: &Clock,
-): (u64, u64) {
-    let (ask, bid) = predict.range_trade_prices(oracle, key, clock);
-    (math::mul(ask, quantity), math::mul(bid, quantity))
 }
 
 /// Mint a vertical range `(lower, higher)` priced as a single instrument.
@@ -525,6 +483,97 @@ public fun withdraw<Quote>(
     predict.vault.dispense_payout<Quote>(amount).into_coin(ctx)
 }
 
+/// Keeper/ops hook for syncing one oracle's cached MTM into the vault. This is
+/// used to keep LP supply/withdraw accounting fresh across unsettled exposed
+/// oracles; trade paths still refresh only the touched oracle inline.
+public fun refresh_oracle_mtm(predict: &mut Predict, oracle: &OracleSVI, clock: &Clock) {
+    if (oracle.is_settled() && predict.vault.has_settled_oracle(oracle.id())) return;
+    if (!oracle.is_settled()) {
+        oracle.assert_live_oracle(clock);
+    };
+    predict.refresh_oracle_risk(oracle, clock);
+    if (oracle.is_settled()) {
+        predict.vault.remove_unsettled_exposed_oracle(oracle.id(), true);
+    };
+}
+
+/// Get the amounts for mint/redeem (for UI/preview).
+/// Returns (mint_cost, redeem_payout).
+public fun get_trade_amounts(
+    predict: &Predict,
+    oracle: &OracleSVI,
+    key: MarketKey,
+    quantity: u64,
+    clock: &Clock,
+): (u64, u64) {
+    let (ask, bid) = predict.trade_prices(oracle, key, clock);
+    (math::mul(ask, quantity), math::mul(bid, quantity))
+}
+
+/// Get the amounts for range mint/redeem (for UI/preview).
+/// Returns (mint_cost, redeem_payout). Bull-call and bear-put ranges with the
+/// same strikes price identically — direction is not part of `RangeKey`.
+public fun get_range_trade_amounts(
+    predict: &Predict,
+    oracle: &OracleSVI,
+    key: RangeKey,
+    quantity: u64,
+    clock: &Clock,
+): (u64, u64) {
+    let (ask, bid) = predict.range_trade_prices(oracle, key, clock);
+    (math::mul(ask, quantity), math::mul(bid, quantity))
+}
+
+public fun unsettled_exposed_oracles(predict: &Predict): &vector<ID> {
+    predict.vault.unsettled_exposed_oracles()
+}
+
+/// Resolved ask-price bounds for an oracle, after intersecting any per-oracle
+/// override with the global default. Exposed for UI/preview.
+public fun ask_bounds(predict: &Predict, oracle_id: ID): (u64, u64) {
+    predict.resolve_ask_bounds(oracle_id)
+}
+
+/// Whether trading is currently paused.
+public fun trading_paused(predict: &Predict): bool {
+    predict.trading_paused
+}
+
+/// Get the base spread.
+public fun base_spread(predict: &Predict): u64 {
+    predict.pricing_config.base_spread()
+}
+
+/// Get the accepted quote asset whitelist.
+public fun accepted_quotes(predict: &Predict): &VecSet<TypeName> {
+    predict.treasury_config.accepted_quotes()
+}
+
+/// Get the min spread.
+public fun min_spread(predict: &Predict): u64 {
+    predict.pricing_config.min_spread()
+}
+
+/// Get the utilization multiplier.
+public fun utilization_multiplier(predict: &Predict): u64 {
+    predict.pricing_config.utilization_multiplier()
+}
+
+/// Get the max total exposure percentage.
+public fun max_total_exposure_pct(predict: &Predict): u64 {
+    predict.risk_config.max_total_exposure_pct()
+}
+
+/// Get the MTM freshness threshold used for LP supply/withdraw gating.
+public fun mtm_freshness_ms(predict: &Predict): u64 {
+    predict.risk_config.mtm_freshness_ms()
+}
+
+/// Returns the currently available withdrawal amount.
+public fun available_withdrawal(predict: &Predict, clock: &Clock): u64 {
+    predict.withdrawal_limiter.available_withdrawal(clock)
+}
+
 // === Public-Package Functions ===
 
 /// Create and share the Predict object. Returns its ID.
@@ -583,70 +632,6 @@ public(package) fun add_oracle_grid(
     predict.oracle_config.add_oracle_grid(oracle_id, min_strike, tick_size);
     let max_strike = min_strike + tick_size * constants::oracle_strike_grid_ticks!();
     predict.vault.init_oracle_matrix(oracle_id, min_strike, max_strike, tick_size, clock, ctx);
-}
-
-/// Keeper/ops hook for syncing one oracle's cached MTM into the vault. This is
-/// used to keep LP supply/withdraw accounting fresh across unsettled exposed
-/// oracles; trade paths still refresh only the touched oracle inline.
-public fun refresh_oracle_mtm(predict: &mut Predict, oracle: &OracleSVI, clock: &Clock) {
-    if (oracle.is_settled() && predict.vault.has_settled_oracle(oracle.id())) return;
-    if (!oracle.is_settled()) {
-        oracle.assert_live_oracle(clock);
-    };
-    predict.refresh_oracle_risk(oracle, clock);
-    if (oracle.is_settled()) {
-        predict.vault.remove_unsettled_exposed_oracle(oracle.id(), true);
-    };
-}
-
-/// Snapshot the admin-tuned oracle bounds (staleness thresholds + per-asset
-/// basis bounds) for `asset` at `create_oracle` time.
-public(package) fun build_oracle_bounds(predict: &Predict, asset: String): oracle::OracleBounds {
-    predict.oracle_config.build_oracle_bounds(asset)
-}
-
-/// Resolve the admin-registered Pyth Lazer feed id for `asset`. Aborts with
-/// `oracle_config::EFeedIdNotConfigured` if no entry exists — admin must call
-/// `set_asset_feed_id` at least once per underlying before its first oracle
-/// can be created. Returned as `u64` for type consistency with the rest of
-/// the admin-config surface; narrowed to `u32` at `registry::create_oracle`.
-public(package) fun resolve_feed_id(predict: &Predict, asset: String): u64 {
-    predict.oracle_config.resolve_feed_id(asset)
-}
-
-/// Whether trading is currently paused.
-public fun trading_paused(predict: &Predict): bool {
-    predict.trading_paused
-}
-
-/// Get the base spread.
-public fun base_spread(predict: &Predict): u64 {
-    predict.pricing_config.base_spread()
-}
-
-/// Get the accepted quote asset whitelist.
-public fun accepted_quotes(predict: &Predict): &VecSet<TypeName> {
-    predict.treasury_config.accepted_quotes()
-}
-
-/// Get the min spread.
-public fun min_spread(predict: &Predict): u64 {
-    predict.pricing_config.min_spread()
-}
-
-/// Get the utilization multiplier.
-public fun utilization_multiplier(predict: &Predict): u64 {
-    predict.pricing_config.utilization_multiplier()
-}
-
-/// Get the max total exposure percentage.
-public fun max_total_exposure_pct(predict: &Predict): u64 {
-    predict.risk_config.max_total_exposure_pct()
-}
-
-/// Get the MTM freshness threshold used for LP supply/withdraw gating.
-public fun mtm_freshness_ms(predict: &Predict): u64 {
-    predict.risk_config.mtm_freshness_ms()
 }
 
 /// Set trading pause state.
@@ -833,53 +818,19 @@ public(package) fun disable_withdrawal_limiter(predict: &mut Predict) {
     predict.withdrawal_limiter.disable();
 }
 
-/// Returns the currently available withdrawal amount.
-public fun available_withdrawal(predict: &Predict, clock: &Clock): u64 {
-    predict.withdrawal_limiter.available_withdrawal(clock)
+/// Snapshot the admin-tuned oracle bounds (staleness thresholds + per-asset
+/// basis bounds) for `asset` at `create_oracle` time.
+public(package) fun build_oracle_bounds(predict: &Predict, asset: String): oracle::OracleBounds {
+    predict.oracle_config.build_oracle_bounds(asset)
 }
 
-#[test_only]
-/// Create a Predict object for testing without sharing it.
-public(package) fun create_test_predict<Quote>(
-    currency: &Currency<Quote>,
-    ctx: &mut TxContext,
-): Predict {
-    let treasury_cap = coin::create_treasury_cap_for_testing<PLP>(ctx);
-    let clock = sui::clock::create_for_testing(ctx);
-    let mut predict = Predict {
-        id: object::new(ctx),
-        vault: vault::new(ctx),
-        treasury_cap,
-        pricing_config: pricing_config::new(),
-        risk_config: risk_config::new(),
-        treasury_config: treasury_config::new(),
-        oracle_config: oracle_config::new(ctx),
-        withdrawal_limiter: rate_limiter::new(&clock),
-        trading_paused: false,
-    };
-    predict.enable_quote_asset<Quote>(currency);
-    clock.destroy_for_testing();
-    predict
-}
-
-#[test_only]
-public(package) fun vault_mut(predict: &mut Predict): &mut Vault {
-    &mut predict.vault
-}
-
-#[test_only]
-public(package) fun oracle_config(predict: &Predict): &OracleConfig {
-    &predict.oracle_config
-}
-
-#[test_only]
-public(package) fun treasury_config(predict: &Predict): &TreasuryConfig {
-    &predict.treasury_config
-}
-
-#[test_only]
-public(package) fun vault_balance(predict: &Predict): u64 {
-    predict.vault.balance()
+/// Resolve the admin-registered Pyth Lazer feed id for `asset`. Aborts with
+/// `oracle_config::EFeedIdNotConfigured` if no entry exists — admin must call
+/// `set_asset_feed_id` at least once per underlying before its first oracle
+/// can be created. Returned as `u64` for type consistency with the rest of
+/// the admin-config surface; narrowed to `u32` at `registry::create_oracle`.
+public(package) fun resolve_feed_id(predict: &Predict, asset: String): u64 {
+    predict.oracle_config.resolve_feed_id(asset)
 }
 
 // === Private Functions ===
@@ -1173,4 +1124,50 @@ fun refresh_oracle_risk(predict: &mut Predict, oracle: &OracleSVI, clock: &Clock
     };
     let curve = predict.oracle_config.build_curve(oracle, min_strike, max_strike);
     predict.vault.set_mtm_with_curve(oracle_id, &curve, clock);
+}
+
+// === Test-Only Functions ===
+
+#[test_only]
+/// Create a Predict object for testing without sharing it.
+public(package) fun create_test_predict<Quote>(
+    currency: &Currency<Quote>,
+    ctx: &mut TxContext,
+): Predict {
+    let treasury_cap = coin::create_treasury_cap_for_testing<PLP>(ctx);
+    let clock = sui::clock::create_for_testing(ctx);
+    let mut predict = Predict {
+        id: object::new(ctx),
+        vault: vault::new(ctx),
+        treasury_cap,
+        pricing_config: pricing_config::new(),
+        risk_config: risk_config::new(),
+        treasury_config: treasury_config::new(),
+        oracle_config: oracle_config::new(ctx),
+        withdrawal_limiter: rate_limiter::new(&clock),
+        trading_paused: false,
+    };
+    predict.enable_quote_asset<Quote>(currency);
+    clock.destroy_for_testing();
+    predict
+}
+
+#[test_only]
+public(package) fun vault_mut(predict: &mut Predict): &mut Vault {
+    &mut predict.vault
+}
+
+#[test_only]
+public(package) fun oracle_config(predict: &Predict): &OracleConfig {
+    &predict.oracle_config
+}
+
+#[test_only]
+public(package) fun treasury_config(predict: &Predict): &TreasuryConfig {
+    &predict.treasury_config
+}
+
+#[test_only]
+public(package) fun vault_balance(predict: &Predict): u64 {
+    predict.vault.balance()
 }

--- a/packages/predict/sources/predict_manager.move
+++ b/packages/predict/sources/predict_manager.move
@@ -36,6 +36,7 @@ public struct PredictManager has key {
 
 // === Public Functions ===
 
+/// Share a newly created PredictManager object.
 public fun share(self: PredictManager) {
     transfer::share_object(self);
 }

--- a/packages/predict/sources/predict_manager.move
+++ b/packages/predict/sources/predict_manager.move
@@ -13,7 +13,6 @@ use deepbook::balance_manager::{Self, BalanceManager, DepositCap, WithdrawCap};
 use deepbook_predict::{market_key::MarketKey, range_key::RangeKey};
 use sui::{coin::Coin, derived_object, table::{Self, Table}};
 
-// === Errors ===
 const EInvalidOwner: u64 = 0;
 const EInsufficientPosition: u64 = 1;
 const EInsufficientRangePosition: u64 = 2;
@@ -21,8 +20,6 @@ const EInsufficientRangePosition: u64 = 2;
 /// The key for deriving predict manager. u64 is optional for
 /// supporting multiple managers per address. Defaults to 0 in v1.
 public struct PredictManagerKey(address, u64) has copy, drop, store;
-
-// === Structs ===
 
 /// PredictManager wraps a BalanceManager and tracks positions.
 public struct PredictManager has key {
@@ -38,8 +35,21 @@ public struct PredictManager has key {
 }
 
 // === Public Functions ===
+
 public fun share(self: PredictManager) {
     transfer::share_object(self);
+}
+
+/// Deposit coins into the PredictManager.
+public fun deposit<T>(self: &mut PredictManager, coin: Coin<T>, ctx: &TxContext) {
+    assert!(ctx.sender() == self.owner, EInvalidOwner);
+    self.balance_manager.deposit_with_cap(&self.deposit_cap, coin, ctx);
+}
+
+/// Withdraw coins from the PredictManager.
+public fun withdraw<T>(self: &mut PredictManager, amount: u64, ctx: &mut TxContext): Coin<T> {
+    assert!(ctx.sender() == self.owner, EInvalidOwner);
+    self.balance_manager.withdraw_with_cap(&self.withdraw_cap, amount, ctx)
 }
 
 /// Get the owner of the PredictManager.
@@ -68,18 +78,6 @@ public fun range_position(self: &PredictManager, key: RangeKey): u64 {
 /// Get the balance of a specific coin type in the PredictManager.
 public fun balance<T>(self: &PredictManager): u64 {
     self.balance_manager.balance<T>()
-}
-
-/// Deposit coins into the PredictManager.
-public fun deposit<T>(self: &mut PredictManager, coin: Coin<T>, ctx: &TxContext) {
-    assert!(ctx.sender() == self.owner, EInvalidOwner);
-    self.balance_manager.deposit_with_cap(&self.deposit_cap, coin, ctx);
-}
-
-/// Withdraw coins from the PredictManager.
-public fun withdraw<T>(self: &mut PredictManager, amount: u64, ctx: &mut TxContext): Coin<T> {
-    assert!(ctx.sender() == self.owner, EInvalidOwner);
-    self.balance_manager.withdraw_with_cap(&self.withdraw_cap, amount, ctx)
 }
 
 // === Public-Package Functions ===

--- a/packages/predict/sources/registry.move
+++ b/packages/predict/sources/registry.move
@@ -28,13 +28,10 @@ use sui::{
 use fun df::exists_ as UID.exists_;
 use fun df::add as UID.add;
 
-// === Errors ===
 const EPredictAlreadyCreated: u64 = 0;
 const EInvalidTickSize: u64 = 1;
 const EInvalidStrikeGrid: u64 = 2;
 const EFeedIdOverflow: u64 = 3;
-
-// === Events ===
 
 public struct OracleCreated has copy, drop, store {
     oracle_id: ID,
@@ -45,8 +42,6 @@ public struct OracleCreated has copy, drop, store {
     min_strike: u64,
     tick_size: u64,
 }
-
-// === Structs ===
 
 /// Capability for admin operations.
 /// Created during package init, transferred to deployer (multisig).
@@ -67,15 +62,6 @@ public struct PredictCreated() has copy, drop, store;
 
 // === Public Functions ===
 
-/// Get oracle IDs created by a given OracleSVICap.
-public fun oracle_ids(registry: &Registry, cap_id: ID): vector<ID> {
-    if (registry.oracle_ids.contains(cap_id)) {
-        registry.oracle_ids[cap_id]
-    } else {
-        vector[]
-    }
-}
-
 /// Create the Predict shared object for `Quote`. V1 allows exactly one
 /// Predict total via the `PredictCreated` marker; the per-`Quote` lock in
 /// `predict::create` would take over if that guard is ever dropped.
@@ -90,11 +76,6 @@ entry fun create_predict<Quote>(
     assert!(!registry.id.exists_(PredictCreated()), EPredictAlreadyCreated);
     registry.id.add(PredictCreated(), type_name::with_defining_ids<Quote>());
     predict::create<Quote>(&mut registry.id, currency, treasury_cap, clock, ctx);
-}
-
-/// Register an additional OracleSVICap as authorized to update an oracle.
-public fun register_oracle_cap(oracle: &mut OracleSVI, _admin_cap: &AdminCap, cap: &OracleSVICap) {
-    oracle::register_cap(oracle, cap);
 }
 
 /// Create a new OracleSVICap. Transferred to Block Scholes operator.
@@ -154,6 +135,11 @@ public fun create_oracle(
     });
 
     oracle_id
+}
+
+/// Register an additional OracleSVICap as authorized to update an oracle.
+public fun register_oracle_cap(oracle: &mut OracleSVI, _admin_cap: &AdminCap, cap: &OracleSVICap) {
+    oracle::register_cap(oracle, cap);
 }
 
 /// Enable a quote asset for new supply and mint inflows.
@@ -340,6 +326,15 @@ entry fun create_and_share_manager(registry: &mut Registry, ctx: &mut TxContext)
     create_manager(registry, ctx).share();
 }
 
+/// Get oracle IDs created by a given OracleSVICap.
+public fun oracle_ids(registry: &Registry, cap_id: ID): vector<ID> {
+    if (registry.oracle_ids.contains(cap_id)) {
+        registry.oracle_ids[cap_id]
+    } else {
+        vector[]
+    }
+}
+
 // === Private Functions ===
 
 /// Package initializer - creates Registry and AdminCap.
@@ -356,7 +351,20 @@ fun assert_valid_strike_grid(min_strike: u64, tick_size: u64) {
     assert!(min_strike % tick_size == 0, EInvalidStrikeGrid);
 }
 
-// === Test Functions ===
+fun new_registry_and_admin_cap(ctx: &mut TxContext): (Registry, AdminCap) {
+    (
+        Registry {
+            id: object::new(ctx),
+            oracle_ids: table::new(ctx),
+        },
+        AdminCap {
+            id: object::new(ctx),
+        },
+    )
+}
+
+// === Test-Only Functions ===
+
 #[test_only]
 public fun init_for_testing(ctx: &mut TxContext): ID {
     let (registry, admin_cap) = new_registry_and_admin_cap(ctx);
@@ -370,16 +378,4 @@ public fun init_for_testing(ctx: &mut TxContext): ID {
 #[test_only]
 public fun create_admin_cap_for_testing(ctx: &mut TxContext): AdminCap {
     AdminCap { id: object::new(ctx) }
-}
-
-fun new_registry_and_admin_cap(ctx: &mut TxContext): (Registry, AdminCap) {
-    (
-        Registry {
-            id: object::new(ctx),
-            oracle_ids: table::new(ctx),
-        },
-        AdminCap {
-            id: object::new(ctx),
-        },
-    )
 }

--- a/packages/predict/sources/registry.move
+++ b/packages/predict/sources/registry.move
@@ -33,6 +33,7 @@ const EInvalidTickSize: u64 = 1;
 const EInvalidStrikeGrid: u64 = 2;
 const EFeedIdOverflow: u64 = 3;
 
+/// Emitted when an oracle and its strike grid are registered.
 public struct OracleCreated has copy, drop, store {
     oracle_id: ID,
     oracle_cap_id: ID,
@@ -322,6 +323,7 @@ public fun create_manager(registry: &mut Registry, ctx: &mut TxContext): Predict
     predict_manager::new(&mut registry.id, ctx)
 }
 
+/// Create and share a new PredictManager for the caller.
 entry fun create_and_share_manager(registry: &mut Registry, ctx: &mut TxContext) {
     create_manager(registry, ctx).share();
 }
@@ -344,6 +346,7 @@ fun init(ctx: &mut TxContext) {
     transfer::transfer(admin_cap, ctx.sender());
 }
 
+/// Validate the initial oracle strike grid supplied by the operator.
 fun assert_valid_strike_grid(min_strike: u64, tick_size: u64) {
     assert!(tick_size > 0, EInvalidTickSize);
     assert!(tick_size % constants::oracle_tick_size_unit!() == 0, EInvalidTickSize);
@@ -351,6 +354,7 @@ fun assert_valid_strike_grid(min_strike: u64, tick_size: u64) {
     assert!(min_strike % tick_size == 0, EInvalidStrikeGrid);
 }
 
+/// Construct registry and admin cap during package init or tests.
 fun new_registry_and_admin_cap(ctx: &mut TxContext): (Registry, AdminCap) {
     (
         Registry {
@@ -366,6 +370,7 @@ fun new_registry_and_admin_cap(ctx: &mut TxContext): (Registry, AdminCap) {
 // === Test-Only Functions ===
 
 #[test_only]
+/// Initialize registry and admin cap for tests, returning the registry ID.
 public fun init_for_testing(ctx: &mut TxContext): ID {
     let (registry, admin_cap) = new_registry_and_admin_cap(ctx);
     let registry_id = object::id(&registry);
@@ -376,6 +381,7 @@ public fun init_for_testing(ctx: &mut TxContext): ID {
 }
 
 #[test_only]
+/// Create an admin cap for tests.
 public fun create_admin_cap_for_testing(ctx: &mut TxContext): AdminCap {
     AdminCap { id: object::new(ctx) }
 }

--- a/packages/predict/sources/vault/plp.move
+++ b/packages/predict/sources/vault/plp.move
@@ -7,10 +7,12 @@ module deepbook_predict::plp;
 
 use sui::coin_registry;
 
+/// One-time witness type for Predict LP token registration.
 public struct PLP has drop {}
 
 // === Private Functions ===
 
+/// Register PLP metadata and treasury cap on package publish.
 fun init(witness: PLP, ctx: &mut TxContext) {
     let (initializer, treasury_cap) = coin_registry::new_currency_with_otw(
         witness,
@@ -29,6 +31,7 @@ fun init(witness: PLP, ctx: &mut TxContext) {
 // === Test-Only Functions ===
 
 #[test_only]
+/// Register PLP in tests.
 public fun init_for_testing(ctx: &mut TxContext) {
     init(PLP {}, ctx);
 }

--- a/packages/predict/sources/vault/plp.move
+++ b/packages/predict/sources/vault/plp.move
@@ -9,6 +9,8 @@ use sui::coin_registry;
 
 public struct PLP has drop {}
 
+// === Private Functions ===
+
 fun init(witness: PLP, ctx: &mut TxContext) {
     let (initializer, treasury_cap) = coin_registry::new_currency_with_otw(
         witness,
@@ -23,6 +25,8 @@ fun init(witness: PLP, ctx: &mut TxContext) {
     transfer::public_transfer(metadata_cap, ctx.sender());
     transfer::public_transfer(treasury_cap, ctx.sender());
 }
+
+// === Test-Only Functions ===
 
 #[test_only]
 public fun init_for_testing(ctx: &mut TxContext) {

--- a/packages/predict/sources/vault/vault.move
+++ b/packages/predict/sources/vault/vault.move
@@ -26,11 +26,13 @@ const EAssetNotInVault: u64 = 4;
 /// Dynamic bag key for storing a concrete asset balance by type.
 public struct BalanceKey<phantom T> has copy, drop, store {}
 
+/// Compact settled-oracle liability state after a dense matrix is removed.
 public struct SettledOracleState has copy, drop, store {
     remaining_quantity: u64,
     remaining_liability: u64,
 }
 
+/// Vault state for balances, exposure matrices, and aggregate liability.
 public struct Vault has store {
     /// Concrete balances stored per accepted quote asset type.
     balances: Bag,
@@ -52,10 +54,12 @@ public struct Vault has store {
 
 // === Public Functions ===
 
+/// Return the aggregate vault balance across accepted quote assets.
 public fun balance(vault: &Vault): u64 {
     vault.balance
 }
 
+/// Return the concrete balance for asset type `T`, or zero if absent.
 public fun asset_balance<T>(vault: &Vault): u64 {
     let key = BalanceKey<T> {};
     if (vault.balances.contains(key)) {
@@ -66,21 +70,25 @@ public fun asset_balance<T>(vault: &Vault): u64 {
     }
 }
 
+/// Return cached total mark-to-market liability.
 public fun total_mtm(vault: &Vault): u64 {
     vault.total_mtm
 }
 
+/// Return balance net of cached mark-to-market liability.
 public fun vault_value(vault: &Vault): u64 {
     assert!(vault.balance >= vault.total_mtm, EMtmExceedsBalance);
     vault.balance - vault.total_mtm
 }
 
+/// Return cached total worst-case payout liability.
 public fun total_max_payout(vault: &Vault): u64 {
     vault.total_max_payout
 }
 
 // === Public-Package Functions ===
 
+/// Create an empty vault.
 public(package) fun new(ctx: &mut TxContext): Vault {
     Vault {
         balances: bag::new(ctx),
@@ -196,6 +204,7 @@ public(package) fun assert_total_exposure(vault: &Vault, max_total_pct: u64) {
     assert!(vault.total_mtm <= math::mul(vault.balance, max_total_pct), EExceedsMaxTotalExposure);
 }
 
+/// Recompute and cache live MTM for one oracle using a sampled curve.
 public(package) fun set_mtm_with_curve(
     vault: &mut Vault,
     oracle_id: ID,
@@ -213,6 +222,7 @@ public(package) fun set_mtm_with_curve(
     vault.total_mtm = vault.total_mtm + new_mtm - old_mtm;
 }
 
+/// Recompute and cache settled MTM for one oracle.
 public(package) fun set_mtm_with_settlement(
     vault: &mut Vault,
     oracle_id: ID,
@@ -230,6 +240,7 @@ public(package) fun set_mtm_with_settlement(
     vault.total_mtm = vault.total_mtm + new_mtm - old_mtm;
 }
 
+/// Overwrite cached MTM for one oracle and update the aggregate total.
 public(package) fun set_mtm(vault: &mut Vault, oracle_id: ID, mtm: u64, clock: &Clock) {
     assert!(vault.oracle_matrices.contains(oracle_id), EOracleExposureNotFound);
 
@@ -238,6 +249,7 @@ public(package) fun set_mtm(vault: &mut Vault, oracle_id: ID, mtm: u64, clock: &
     vault.total_mtm = vault.total_mtm + mtm - old_mtm;
 }
 
+/// Track an oracle whose unsettled exposure must be fresh before LP flows.
 public(package) fun add_unsettled_exposed_oracle(vault: &mut Vault, oracle_id: ID) {
     let mut i = 0;
     while (i < vault.unsettled_exposed_oracles.length()) {
@@ -247,6 +259,7 @@ public(package) fun add_unsettled_exposed_oracle(vault: &mut Vault, oracle_id: I
     vault.unsettled_exposed_oracles.push_back(oracle_id);
 }
 
+/// Remove an oracle from the unsettled-exposure refresh set when safe.
 public(package) fun remove_unsettled_exposed_oracle(
     vault: &mut Vault,
     oracle_id: ID,
@@ -268,6 +281,7 @@ public(package) fun remove_unsettled_exposed_oracle(
     };
 }
 
+/// Compact a settled oracle's dense matrix into fixed-size liability state.
 public(package) fun compact_settled_oracle_if_needed(
     vault: &mut Vault,
     oracle_id: ID,
@@ -302,6 +316,7 @@ public(package) fun compact_settled_oracle_if_needed(
         );
 }
 
+/// Apply a settled redemption against compact settled-oracle liability.
 public(package) fun redeem_settled_position(
     vault: &mut Vault,
     oracle_id: ID,
@@ -318,6 +333,7 @@ public(package) fun redeem_settled_position(
     // entirely or retained as zeroed records.
 }
 
+/// Return oracle IDs requiring fresh MTM before LP supply/withdraw.
 public(package) fun unsettled_exposed_oracles(vault: &Vault): &vector<ID> {
     &vault.unsettled_exposed_oracles
 }
@@ -330,10 +346,12 @@ public(package) fun oracle_strike_range(vault: &Vault, oracle_id: ID): (u64, u64
     matrix.minted_strike_range()
 }
 
+/// Return whether compact settled state exists for an oracle.
 public(package) fun has_settled_oracle(vault: &Vault, oracle_id: ID): bool {
     vault.settled_oracles.contains(oracle_id)
 }
 
+/// Return the cached MTM update timestamp for an oracle.
 public(package) fun get_last_mtm_update(vault: &Vault, oracle_id: ID): u64 {
     assert!(vault.oracle_matrices.contains(oracle_id), EOracleExposureNotFound);
     vault.oracle_matrices[oracle_id].last_mtm_update()
@@ -346,6 +364,7 @@ fun net_max_payout(matrix: &StrikeMatrix): u64 {
     matrix.max_payout() - matrix.range_qty()
 }
 
+/// Join a concrete asset balance into its bag entry, creating it if needed.
 fun deposit_balance<T>(vault: &mut Vault, payment: Balance<T>) {
     let key = BalanceKey<T> {};
     if (vault.balances.contains(key)) {
@@ -356,6 +375,7 @@ fun deposit_balance<T>(vault: &mut Vault, payment: Balance<T>) {
     }
 }
 
+/// Split a concrete asset balance from its bag entry.
 fun withdraw_balance<T>(vault: &mut Vault, amount: u64): Balance<T> {
     let key = BalanceKey<T> {};
     assert!(vault.balances.contains(key), EAssetNotInVault);

--- a/packages/predict/sources/vault/vault.move
+++ b/packages/predict/sources/vault/vault.move
@@ -17,14 +17,11 @@ use deepbook::math;
 use deepbook_predict::{oracle_config::CurvePoint, strike_matrix::{Self, StrikeMatrix}};
 use sui::{bag::{Self, Bag}, balance::Balance, clock::Clock, table::{Self, Table}};
 
-// === Errors ===
 const EInsufficientBalance: u64 = 0;
 const EExceedsMaxTotalExposure: u64 = 1;
 const EOracleExposureNotFound: u64 = 2;
 const EMtmExceedsBalance: u64 = 3;
 const EAssetNotInVault: u64 = 4;
-
-// === Structs ===
 
 /// Dynamic bag key for storing a concrete asset balance by type.
 public struct BalanceKey<phantom T> has copy, drop, store {}
@@ -80,10 +77,6 @@ public fun vault_value(vault: &Vault): u64 {
 
 public fun total_max_payout(vault: &Vault): u64 {
     vault.total_max_payout
-}
-
-public(package) fun unsettled_exposed_oracles(vault: &Vault): &vector<ID> {
-    &vault.unsettled_exposed_oracles
 }
 
 // === Public-Package Functions ===
@@ -203,18 +196,6 @@ public(package) fun assert_total_exposure(vault: &Vault, max_total_pct: u64) {
     assert!(vault.total_mtm <= math::mul(vault.balance, max_total_pct), EExceedsMaxTotalExposure);
 }
 
-/// Return the historical minted strike bounds for this oracle's matrix.
-/// These bounds expand on insert and do not shrink after positions are removed.
-public(package) fun oracle_strike_range(vault: &Vault, oracle_id: ID): (u64, u64) {
-    assert!(vault.oracle_matrices.contains(oracle_id), EOracleExposureNotFound);
-    let matrix = &vault.oracle_matrices[oracle_id];
-    matrix.minted_strike_range()
-}
-
-public(package) fun has_settled_oracle(vault: &Vault, oracle_id: ID): bool {
-    vault.settled_oracles.contains(oracle_id)
-}
-
 public(package) fun set_mtm_with_curve(
     vault: &mut Vault,
     oracle_id: ID,
@@ -255,11 +236,6 @@ public(package) fun set_mtm(vault: &mut Vault, oracle_id: ID, mtm: u64, clock: &
     let old_mtm = vault.oracle_matrices[oracle_id].mtm();
     vault.oracle_matrices[oracle_id].set_mtm(mtm, clock);
     vault.total_mtm = vault.total_mtm + mtm - old_mtm;
-}
-
-public(package) fun get_last_mtm_update(vault: &Vault, oracle_id: ID): u64 {
-    assert!(vault.oracle_matrices.contains(oracle_id), EOracleExposureNotFound);
-    vault.oracle_matrices[oracle_id].last_mtm_update()
 }
 
 public(package) fun add_unsettled_exposed_oracle(vault: &mut Vault, oracle_id: ID) {
@@ -341,6 +317,29 @@ public(package) fun redeem_settled_position(
     // TODO: Decide whether fully redeemed settled oracles should be removed
     // entirely or retained as zeroed records.
 }
+
+public(package) fun unsettled_exposed_oracles(vault: &Vault): &vector<ID> {
+    &vault.unsettled_exposed_oracles
+}
+
+/// Return the historical minted strike bounds for this oracle's matrix.
+/// These bounds expand on insert and do not shrink after positions are removed.
+public(package) fun oracle_strike_range(vault: &Vault, oracle_id: ID): (u64, u64) {
+    assert!(vault.oracle_matrices.contains(oracle_id), EOracleExposureNotFound);
+    let matrix = &vault.oracle_matrices[oracle_id];
+    matrix.minted_strike_range()
+}
+
+public(package) fun has_settled_oracle(vault: &Vault, oracle_id: ID): bool {
+    vault.settled_oracles.contains(oracle_id)
+}
+
+public(package) fun get_last_mtm_update(vault: &Vault, oracle_id: ID): u64 {
+    assert!(vault.oracle_matrices.contains(oracle_id), EOracleExposureNotFound);
+    vault.oracle_matrices[oracle_id].last_mtm_update()
+}
+
+// === Private Functions ===
 
 /// Per-matrix max payout net of the range quantity contributed by range mints.
 fun net_max_payout(matrix: &StrikeMatrix): u64 {


### PR DESCRIPTION
## Summary
- Standardize function ordering and section layout for production Predict Move modules.
- Add module, struct, and function docs for core production code surfaces.
- Normalize Predict constant macro access to module-qualified `constants::...` calls.

## Key decisions
- Kept this PR behavior-neutral: reordered and documented production source files without touching tests or simulation stubs.
- Built the PR branch from current `origin/main` and cherry-picked only the cleanup commits so unrelated local spec commits stay out.

## Test plan
- [x] `pnpm exec prettier -w --ignore-unknown packages/predict/sources`
- [x] `git diff --check -- packages/predict/sources`
- [x] `sui move test --path packages/predict --gas-limit 100000000000`