### PR TITLE
DBU-402: Add /rebates_v2 endpoint to deepbook-server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,13 @@ When creating a PR with `gh pr create`, always ask the user for a branch name be
 - [ ] <checklist items>
 ```
 
+## Linear
+
+The Linear API key is in `.env` as `LINEAR_API_KEY` — use it (via `source .env`) for issue creation/lookup against `https://api.linear.app/graphql`.
+
+- Repo's project: **Deepbook Maintenance** (id `1fa68715-f85f-4e4c-bdfe-38b9fbf7be40`) under team **DeFi** / key `DBU` (id `fa06ddc0-54b9-4a24-b1ed-06dee49e0c1b`).
+- To auto-link a PR to a Linear issue, include the issue identifier (e.g. `DBU-402`) in the branch name or PR title.
+
 ## Wrap Up
 
 When I say "wrap up", follow the instructions in `.claude/rules/wrap-up.md`.

--- a/crates/schema/src/models.rs
+++ b/crates/schema/src/models.rs
@@ -328,7 +328,7 @@ pub struct Rebates {
     pub claim_amount: i64,
 }
 
-#[derive(Queryable, Selectable, Insertable, Identifiable, Debug, FieldCount)]
+#[derive(Queryable, Selectable, Insertable, Identifiable, Debug, FieldCount, Serialize)]
 #[diesel(table_name = rebates_v2, primary_key(event_digest))]
 pub struct RebatesV2 {
     pub event_digest: String,

--- a/crates/server/src/reader.rs
+++ b/crates/server/src/reader.rs
@@ -6,8 +6,8 @@ use deepbook_schema::models::{
     InterestParamsUpdated, Liquidation, LoanBorrowed, LoanRepaid, MaintainerCapUpdated,
     MaintainerFeesWithdrawn, MarginManagerCreated, MarginManagerState, MarginPoolConfigUpdated,
     MarginPoolCreated, OrderFillSummary, OrderStatus, PauseCapUpdated, PoolCreated, Pools,
-    ProtocolFeesIncreasedEvent, ProtocolFeesWithdrawn, ReferralFeeEvent, ReferralFeesClaimedEvent,
-    SupplierCapMinted, SupplyReferralMinted,
+    ProtocolFeesIncreasedEvent, ProtocolFeesWithdrawn, RebatesV2, ReferralFeeEvent,
+    ReferralFeesClaimedEvent, SupplierCapMinted, SupplyReferralMinted,
 };
 use deepbook_schema::schema;
 use diesel::deserialize::FromSqlRow;
@@ -1005,6 +1005,25 @@ impl Reader {
             .filter(schema::referral_fee_events::pool_id.like(to_pattern(&pool_id_filter)))
             .filter(schema::referral_fee_events::referral_id.like(to_pattern(&referral_id_filter)))
             .order_by(schema::referral_fee_events::checkpoint_timestamp_ms.desc())
+            .limit(limit);
+
+        Ok(self.results(query).await?)
+    }
+
+    pub async fn get_rebates_v2(
+        &self,
+        start_time: i64,
+        end_time: i64,
+        limit: i64,
+        balance_manager_id_filter: String,
+    ) -> Result<Vec<RebatesV2>, DeepBookError> {
+        let query = schema::rebates_v2::table
+            .select(RebatesV2::as_select())
+            .filter(schema::rebates_v2::checkpoint_timestamp_ms.between(start_time, end_time))
+            .filter(
+                schema::rebates_v2::balance_manager_id.like(to_pattern(&balance_manager_id_filter)),
+            )
+            .order_by(schema::rebates_v2::checkpoint_timestamp_ms.desc())
             .limit(limit);
 
         Ok(self.results(query).await?)

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -15,8 +15,8 @@ use deepbook_schema::models::{
     InterestParamsUpdated, Liquidation, LoanBorrowed, LoanRepaid, MaintainerCapUpdated,
     MaintainerFeesWithdrawn, MarginManagerCreated, MarginManagerState, MarginPoolConfigUpdated,
     MarginPoolCreated, PauseCapUpdated, PoolCreated, Pools, ProtocolFeesIncreasedEvent,
-    ProtocolFeesWithdrawn, ReferralFeeEvent, ReferralFeesClaimedEvent, SupplierCapMinted,
-    SupplyReferralMinted,
+    ProtocolFeesWithdrawn, RebatesV2, ReferralFeeEvent, ReferralFeesClaimedEvent,
+    SupplierCapMinted, SupplyReferralMinted,
 };
 use deepbook_schema::*;
 use diesel::dsl::count_star;
@@ -111,6 +111,7 @@ pub const PAUSE_CAP_UPDATED_PATH: &str = "/pause_cap_updated";
 pub const PROTOCOL_FEES_INCREASED_PATH: &str = "/protocol_fees_increased";
 pub const REFERRAL_FEES_CLAIMED_PATH: &str = "/referral_fees_claimed";
 pub const REFERRAL_FEE_EVENTS_PATH: &str = "/referral_fee_events";
+pub const REBATES_V2_PATH: &str = "/rebates_v2";
 pub const DEEPBOOK_POOL_REGISTERED_PATH: &str = "/deepbook_pool_registered";
 pub const DEEPBOOK_POOL_UPDATED_REGISTRY_PATH: &str = "/deepbook_pool_updated_registry";
 pub const DEEPBOOK_POOL_CONFIG_UPDATED_PATH: &str = "/deepbook_pool_config_updated";
@@ -396,6 +397,7 @@ pub(crate) fn make_router(state: Arc<AppState>) -> Router {
         .route(PROTOCOL_FEES_INCREASED_PATH, get(protocol_fees_increased))
         .route(REFERRAL_FEES_CLAIMED_PATH, get(referral_fees_claimed))
         .route(REFERRAL_FEE_EVENTS_PATH, get(referral_fee_events))
+        .route(REBATES_V2_PATH, get(rebates_v2))
         .route(DEEPBOOK_POOL_REGISTERED_PATH, get(deepbook_pool_registered))
         .route(
             DEEPBOOK_POOL_UPDATED_REGISTRY_PATH,
@@ -2575,6 +2577,33 @@ async fn referral_fee_events(
             pool_id_filter,
             referral_id_filter,
         )
+        .await?;
+
+    Ok(Json(results))
+}
+
+async fn rebates_v2(
+    Query(params): Query<HashMap<String, String>>,
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<Vec<RebatesV2>>, DeepBookError> {
+    let start_time = params.start_time().unwrap_or(0);
+    let end_time = params
+        .get("end_time")
+        .and_then(|v| v.parse::<i64>().ok())
+        .map(|t| t * 1000)
+        .unwrap_or(i64::MAX);
+    let limit = params
+        .get("limit")
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or(10_000_000);
+    let balance_manager_id_filter = params
+        .get("balance_manager_id")
+        .cloned()
+        .unwrap_or_default();
+
+    let results = state
+        .reader
+        .get_rebates_v2(start_time, end_time, limit, balance_manager_id_filter)
         .await?;
 
     Ok(Json(results))


### PR DESCRIPTION
## Summary
- Add `GET /rebates_v2` to `deepbook-server`, returning rows from the indexed `rebates_v2` table.
- Query params (all optional): `balance_manager_id` (default no filter), `start_time` / `end_time` in seconds (default no time bound), `limit` (default `10_000_000`).
- Adds `Serialize` derive to `RebatesV2` so it can be returned as JSON.
- Document Linear API access in `CLAUDE.md` (env var location, Deepbook Maintenance project / DeFi team IDs, branch/PR auto-link convention).

## Key decisions
- Diverged from the existing `ParameterUtil::limit()` (default `1`) and `end_time()` (default "now") helpers because this endpoint needs no time bound and a much larger default limit. Inlined that handling rather than expanding the trait, since no other endpoint shares these defaults.
- Used the same `to_pattern` LIKE-style filter as sibling endpoints (`referral_fee_events`, etc.) so an empty `balance_manager_id` matches everything.
- Results ordered by `checkpoint_timestamp_ms DESC` to match other event-style endpoints.

## Test plan
- [ ] `cargo build -p deepbook-server` (verified locally)
- [ ] `curl '<host>/rebates_v2'` returns rows
- [ ] `curl '<host>/rebates_v2?balance_manager_id=<id>'` filters to that BM
- [ ] `curl '<host>/rebates_v2?start_time=<sec>&end_time=<sec>&limit=100'` respects bounds and limit

Closes DBU-402