### PR TITLE
predict: inventory-aware mid shift

### DIFF
--- a/packages/predict/sources/config/pricing_config.move
+++ b/packages/predict/sources/config/pricing_config.move
@@ -174,22 +174,37 @@ public(package) fun quote_fee_rate_from_fair_price(
     fee
 }
 
-/// Post-shift `(mint_price, redeem_price)` for a fair UP price (or any
-/// `[0, 1]`-bounded fair price like a vertical-range premium). Applies a
-/// symmetric `fee` around the inventory-shifted mid, then clamps:
-/// `mint_price >= fair_price` and `redeem_price <= fair_price`. The
-/// zero-edge floor guarantees the LP never sells below or buys above fair.
-public(package) fun compute_up_quote(
+/// Post-shift `(mint_price, redeem_price)` for the range `(L, H]` whose
+/// per-strike UP probabilities are `p_up_lower = p_up(L)` and
+/// `p_up_higher = p_up(H)`, and whose unshifted fair is
+/// `fair_range = p_up_lower - p_up_higher`.
+///
+/// Both boundaries are shifted independently by `shifted_up_strike_mid`
+/// using the same oracle-level `aggregate`. The range mid is then
+/// `m(L) - m(H)`, preserving the binary invariant
+/// `mint_up + mint_dn == FS + 2·spread` and
+/// `redeem_up + redeem_dn == FS - 2·spread` for any aggregate sign:
+/// shifting UP up by Δ shifts DN down by Δ, since DN's mid is
+/// `m(neg_inf) - m(K) = FS - m(K)`.
+///
+/// No zero-edge floor: under heavy imbalance the LP intentionally takes a
+/// worse-than-fair fill on rebalancing trades — `mint < fair_range` on the
+/// side the vault wants to grow, `redeem > fair_range` on the side the
+/// vault wants to shrink. The only clamps are `[0, FS]` on the resulting
+/// prices.
+public(package) fun compute_range_quote(
     config: &PricingConfig,
-    fair_price: u64,
+    fair_range: u64,
+    p_up_lower: u64,
+    p_up_higher: u64,
     aggregate: &I64,
     liability: u64,
     balance: u64,
     tte_ms: u64,
 ): (u64, u64) {
-    let fee = config.quote_fee_rate_from_fair_price(fair_price, liability, balance);
-    let shifted_mid = shifted_up_mid(
-        fair_price,
+    let fee = config.quote_fee_rate_from_fair_price(fair_range, liability, balance);
+    let m_lower = shifted_up_strike_mid(
+        p_up_lower,
         aggregate,
         balance,
         tte_ms,
@@ -197,10 +212,26 @@ public(package) fun compute_up_quote(
         config.reference_tte_ms,
         config.min_tte_ms,
     );
+    let m_higher = shifted_up_strike_mid(
+        p_up_higher,
+        aggregate,
+        balance,
+        tte_ms,
+        config.depth_multiplier,
+        config.reference_tte_ms,
+        config.min_tte_ms,
+    );
+    // Both boundaries use the same oracle-level ratio, and `shifted_up_strike_mid`
+    // is monotonically non-decreasing in `p_up`, so `m_lower >= m_higher`
+    // whenever `p_up_lower >= p_up_higher`. Caller-side invariant; no abort
+    // because the strike-matrix range invariant `lower < higher` and SVI
+    // monotonicity guarantee it.
+    let shifted_mid = m_lower - m_higher;
 
-    let mint_price = (shifted_mid + fee).max(fair_price).min(constants::float_scaling!());
+    let fs = constants::float_scaling!();
+    let mint_price = (shifted_mid + fee).min(fs);
     let redeem_price = if (shifted_mid > fee) {
-        (shifted_mid - fee).min(fair_price)
+        shifted_mid - fee
     } else {
         0
     };
@@ -228,15 +259,23 @@ fun utilization_fee(config: &PricingConfig, liability: u64, balance: u64): u64 {
     )
 }
 
-/// Inventory-shifted UP mid in FLOAT_SCALING. The shift is
+/// Inventory-shifted UP probability at a single strike, in FLOAT_SCALING.
+/// Operates on a per-strike `p_up`, not on a range fair: `compute_range_quote`
+/// shifts each boundary independently and takes the difference.
+///
+/// Sentinel boundaries (`p_up == 0` for `+∞` or `p_up == FS` for `−∞`) are
+/// inert: the range never has positions at infinity, so the directional
+/// aggregate's accounting at sentinel weight `0` must be matched by leaving
+/// the boundary mid at the sentinel value. Without this short-circuit, a
+/// positive `ratio` at `p_up = 0` would produce `m = ratio · FS` (room is the
+/// full `[0,1]`), breaking the symmetry and the `UP+DN=$1` invariant.
+///
+/// Otherwise the shift is
 /// `clamp(aggregate · tte_factor / (balance · depth_multiplier), −1, +1)`
-/// scaled by the per-strike "room" to the binary boundary: `(1 − p)` for a
-/// positive ratio (vault net short UP — push the mid up) or `p` for a
-/// negative ratio (vault net long UP — push the mid down). Result is always
-/// in `[0, FLOAT_SCALING]` because the room scaling caps each direction at
-/// the binary bound.
-fun shifted_up_mid(
-    fair_price: u64,
+/// scaled by `room(p_up)`: `(1 − p_up)` for a positive ratio (push mid up)
+/// or `p_up` for a negative ratio (push mid down). Result is in `[0, FS]`.
+fun shifted_up_strike_mid(
+    p_up: u64,
     aggregate: &I64,
     balance: u64,
     tte_ms: u64,
@@ -244,29 +283,30 @@ fun shifted_up_mid(
     reference_tte_ms: u64,
     min_tte_ms: u64,
 ): u64 {
-    if (aggregate.is_zero() || balance == 0 || depth_multiplier == 0) return fair_price;
-
     let fs = constants::float_scaling!();
+    if (p_up == 0 || p_up == fs) return p_up;
+    if (aggregate.is_zero() || balance == 0 || depth_multiplier == 0) return p_up;
+
     let clamped_tte = tte_ms.max(min_tte_ms);
     let tte_ratio = predict_math::mul_div_round_down(reference_tte_ms, fs, clamped_tte);
     let tte_factor = predict_math::sqrt(tte_ratio, fs);
 
     let denominator = math::mul(balance, depth_multiplier);
-    if (denominator == 0) return fair_price;
+    if (denominator == 0) return p_up;
 
     let num = aggregate.mul_scaled(&i64::from_u64(tte_factor));
     let ratio = num.div_scaled(&i64::from_u64(denominator));
     let ratio_mag = ratio.magnitude().min(fs);
-    if (ratio_mag == 0) return fair_price;
+    if (ratio_mag == 0) return p_up;
 
     let ratio_negative = ratio.is_negative();
-    let room = if (ratio_negative) fair_price else fs - fair_price;
+    let room = if (ratio_negative) p_up else fs - p_up;
     let shift = math::mul(ratio_mag, room);
 
     if (ratio_negative) {
-        fair_price - shift
+        p_up - shift
     } else {
-        fair_price + shift
+        p_up + shift
     }
 }
 

--- a/packages/predict/sources/config/pricing_config.move
+++ b/packages/predict/sources/config/pricing_config.move
@@ -5,11 +5,13 @@
 module deepbook_predict::pricing_config;
 
 use deepbook::math;
-use deepbook_predict::{constants, math as predict_math};
+use deepbook_predict::{constants, i64::{Self, I64}, math as predict_math};
 
 const EInvalidFee: u64 = 0;
 const EFairPriceAlreadySettled: u64 = 1;
 const EInvalidAskBound: u64 = 2;
+const EInvalidTteBound: u64 = 3;
+const EInvalidDepthMultiplier: u64 = 4;
 
 /// Fee and ask-bound parameters used when quoting Predict markets.
 /// The quoted fee is a per-unit absolute price increment, not a bps rate.
@@ -26,6 +28,18 @@ public struct PricingConfig has store {
     min_ask_price: u64,
     /// Global maximum allowed all-in mint price after adding the fee.
     max_ask_price: u64,
+    /// Depth multiplier for the inventory-aware mid shift, in FLOAT_SCALING.
+    /// `raw_ratio = aggregate · tte_factor / (balance · depth_multiplier)`,
+    /// so lower values produce larger shifts from the same directional inventory.
+    depth_multiplier: u64,
+    /// Reference time-to-expiry for the inventory-aware mid shift.
+    /// `tte_factor = √(reference_tte_ms / max(tte_ms, min_tte_ms))`, so
+    /// `tte_factor == 1` exactly when `tte_ms == reference_tte_ms`.
+    reference_tte_ms: u64,
+    /// Minimum TTE floor used to cap near-expiry amplification of `tte_factor`.
+    /// Once `tte_ms < min_tte_ms`, further time decay no longer amplifies the
+    /// inventory shift.
+    min_tte_ms: u64,
 }
 
 // === Public Functions ===
@@ -55,6 +69,21 @@ public fun max_ask_price(config: &PricingConfig): u64 {
     config.max_ask_price
 }
 
+/// Return the depth multiplier for the inventory-aware mid shift.
+public fun depth_multiplier(config: &PricingConfig): u64 {
+    config.depth_multiplier
+}
+
+/// Return the reference time-to-expiry for the inventory-aware mid shift.
+public fun reference_tte_ms(config: &PricingConfig): u64 {
+    config.reference_tte_ms
+}
+
+/// Return the minimum TTE floor for the inventory-aware mid shift.
+public fun min_tte_ms(config: &PricingConfig): u64 {
+    config.min_tte_ms
+}
+
 // === Public-Package Functions ===
 
 /// Create pricing config seeded from protocol defaults.
@@ -65,6 +94,9 @@ public(package) fun new(): PricingConfig {
         utilization_multiplier: constants::default_utilization_multiplier!(),
         min_ask_price: constants::default_min_ask_price!(),
         max_ask_price: constants::default_max_ask_price!(),
+        depth_multiplier: constants::default_depth_multiplier!(),
+        reference_tte_ms: constants::default_reference_tte_ms!(),
+        min_tte_ms: constants::default_min_tte_ms!(),
     }
 }
 
@@ -98,6 +130,28 @@ public(package) fun set_max_ask_price(config: &mut PricingConfig, value: u64) {
     config.max_ask_price = value;
 }
 
+/// Set the depth multiplier. Zero is rejected: silently disabling the
+/// inventory shift via admin error is a defense-in-depth gap.
+public(package) fun set_depth_multiplier(config: &mut PricingConfig, multiplier: u64) {
+    assert!(multiplier > 0, EInvalidDepthMultiplier);
+    config.depth_multiplier = multiplier;
+}
+
+/// Set the reference TTE. Must be at least the current `min_tte_ms` so the
+/// invariant `min_tte_ms <= reference_tte_ms` is preserved.
+public(package) fun set_reference_tte_ms(config: &mut PricingConfig, value: u64) {
+    assert!(value >= config.min_tte_ms, EInvalidTteBound);
+    config.reference_tte_ms = value;
+}
+
+/// Set the minimum TTE floor. Must be positive (zero would let `tte_factor`
+/// amplification grow without bound) and not exceed the current
+/// `reference_tte_ms`.
+public(package) fun set_min_tte_ms(config: &mut PricingConfig, value: u64) {
+    assert!(value > 0 && value <= config.reference_tte_ms, EInvalidTteBound);
+    config.min_tte_ms = value;
+}
+
 /// Quote the dynamic per-unit fee rate for a live fair price.
 ///
 /// Uses Bernoulli variance scaling plus utilization pressure. Settled prices
@@ -120,6 +174,40 @@ public(package) fun quote_fee_rate_from_fair_price(
     fee
 }
 
+/// Post-shift `(mint_price, redeem_price)` for a fair UP price (or any
+/// `[0, 1]`-bounded fair price like a vertical-range premium). Applies a
+/// symmetric `fee` around the inventory-shifted mid, then clamps:
+/// `mint_price >= fair_price` and `redeem_price <= fair_price`. The
+/// zero-edge floor guarantees the LP never sells below or buys above fair.
+public(package) fun compute_up_quote(
+    config: &PricingConfig,
+    fair_price: u64,
+    aggregate: &I64,
+    liability: u64,
+    balance: u64,
+    tte_ms: u64,
+): (u64, u64) {
+    let fee = config.quote_fee_rate_from_fair_price(fair_price, liability, balance);
+    let shifted_mid = shifted_up_mid(
+        fair_price,
+        aggregate,
+        balance,
+        tte_ms,
+        config.depth_multiplier,
+        config.reference_tte_ms,
+        config.min_tte_ms,
+    );
+
+    let mint_price = (shifted_mid + fee).max(fair_price).min(constants::float_scaling!());
+    let redeem_price = if (shifted_mid > fee) {
+        (shifted_mid - fee).min(fair_price)
+    } else {
+        0
+    };
+
+    (mint_price, redeem_price)
+}
+
 // === Private Functions ===
 
 /// Compute fee pressure from current liability utilization.
@@ -140,6 +228,48 @@ fun utilization_fee(config: &PricingConfig, liability: u64, balance: u64): u64 {
     )
 }
 
+/// Inventory-shifted UP mid in FLOAT_SCALING. The shift is
+/// `clamp(aggregate · tte_factor / (balance · depth_multiplier), −1, +1)`
+/// scaled by the per-strike "room" to the binary boundary: `(1 − p)` for a
+/// positive ratio (vault net short UP — push the mid up) or `p` for a
+/// negative ratio (vault net long UP — push the mid down). Result is always
+/// in `[0, FLOAT_SCALING]` because the room scaling caps each direction at
+/// the binary bound.
+fun shifted_up_mid(
+    fair_price: u64,
+    aggregate: &I64,
+    balance: u64,
+    tte_ms: u64,
+    depth_multiplier: u64,
+    reference_tte_ms: u64,
+    min_tte_ms: u64,
+): u64 {
+    if (aggregate.is_zero() || balance == 0 || depth_multiplier == 0) return fair_price;
+
+    let fs = constants::float_scaling!();
+    let clamped_tte = tte_ms.max(min_tte_ms);
+    let tte_ratio = predict_math::mul_div_round_down(reference_tte_ms, fs, clamped_tte);
+    let tte_factor = predict_math::sqrt(tte_ratio, fs);
+
+    let denominator = math::mul(balance, depth_multiplier);
+    if (denominator == 0) return fair_price;
+
+    let num = aggregate.mul_scaled(&i64::from_u64(tte_factor));
+    let ratio = num.div_scaled(&i64::from_u64(denominator));
+    let ratio_mag = ratio.magnitude().min(fs);
+    if (ratio_mag == 0) return fair_price;
+
+    let ratio_negative = ratio.is_negative();
+    let room = if (ratio_negative) fair_price else fs - fair_price;
+    let shift = math::mul(ratio_mag, room);
+
+    if (ratio_negative) {
+        fair_price - shift
+    } else {
+        fair_price + shift
+    }
+}
+
 #[test_only]
 public fun destroy_for_testing(config: PricingConfig) {
     let PricingConfig {
@@ -148,5 +278,8 @@ public fun destroy_for_testing(config: PricingConfig) {
         utilization_multiplier: _,
         min_ask_price: _,
         max_ask_price: _,
+        depth_multiplier: _,
+        reference_tte_ms: _,
+        min_tte_ms: _,
     } = config;
 }

--- a/packages/predict/sources/helper/constants.move
+++ b/packages/predict/sources/helper/constants.move
@@ -52,6 +52,21 @@ public macro fun default_min_ask_price(): u64 { 10_000_000 }
 /// Maximum all-in unit price the protocol will allow at mint (99% in FLOAT_SCALING)
 public macro fun default_max_ask_price(): u64 { 990_000_000 }
 
+/// Depth multiplier for the inventory-aware mid shift (1× in FLOAT_SCALING).
+/// `raw_ratio = aggregate · tte_factor / (balance · depth_multiplier)`, so
+/// lower values produce larger shifts from the same directional inventory.
+public macro fun default_depth_multiplier(): u64 { 1_000_000_000 }
+
+/// Reference time-to-expiry for the inventory-aware mid shift (7 days).
+/// `tte_factor = √(reference_tte_ms / max(tte_ms, min_tte_ms))`, so
+/// `tte_factor == 1` exactly when `tte_ms == reference_tte_ms`.
+public macro fun default_reference_tte_ms(): u64 { 604_800_000 }
+
+/// Minimum time-to-expiry floor used to cap near-expiry amplification of
+/// `tte_factor` (1 day). Once `tte_ms < min_tte_ms`, further time decay no
+/// longer increases the inventory shift.
+public macro fun default_min_tte_ms(): u64 { 86_400_000 }
+
 // === Time Constants ===
 
 public macro fun ms_per_year(): u64 { 31_536_000_000 }

--- a/packages/predict/sources/helper/math.move
+++ b/packages/predict/sources/helper/math.move
@@ -8,6 +8,7 @@
 /// - exp(x): exponential function for signed fixed-point inputs
 /// - sqrt(x, precision): fixed-point square root
 /// - normal_cdf(x): standard normal CDF for signed fixed-point inputs
+/// - normal_pdf(x): standard normal PDF for signed fixed-point inputs
 ///
 /// Public functions use `u64` for nonnegative values and `i64::I64` for signed
 /// fixed-point values. Internal math uses u128 to minimize truncation.
@@ -23,6 +24,8 @@ const EPow10ExponentTooLarge: u64 = 3;
 // u128 constants for internal math
 const F: u128 = 1_000_000_000;
 const LN2_U128: u128 = 693_147_180;
+// 1 / sqrt(2π) scaled by F = 1e9. Peak value of the standard normal PDF.
+const INV_SQRT_2PI: u128 = 398_942_280;
 
 // Max input for exp(x, false) before u64 overflow.
 // Derived: with LN2_U128=693_147_180, at x=23_638_153_700 the bit-shift
@@ -112,6 +115,19 @@ public fun normal_cdf(x: &i64::I64): u64 {
         return if (x_negative) { 0 } else { constants::float_scaling!() }
     };
     (normal_cdf_u128((x_mag as u128), x_negative) as u64)
+}
+
+/// Standard normal PDF `n(x) = exp(−x²/2) / √(2π)` in FLOAT_SCALING. Peaks at
+/// `x = 0` with value ≈ `0.3989` (≈ 398_942_280). Returns 0 outside the 8σ
+/// envelope where the true value is below 5e-15.
+public fun normal_pdf(x: &i64::I64): u64 {
+    let x_mag = x.magnitude() as u128;
+    if (x_mag > 8 * F) return 0;
+    let x_sq = x_mag * x_mag / F;
+    let half_x_sq = i64::from_u64((x_sq / 2) as u64);
+    let neg_half_x_sq = half_x_sq.neg();
+    let exp_val = exp(&neg_half_x_sq) as u128;
+    (exp_val * INV_SQRT_2PI / F) as u64
 }
 
 /// Fixed-point square root using a bit-length initial guess and

--- a/packages/predict/sources/helper/strike_matrix.move
+++ b/packages/predict/sources/helper/strike_matrix.move
@@ -59,7 +59,7 @@
 module deepbook_predict::strike_matrix;
 
 use deepbook::{constants::max_u64, math};
-use deepbook_predict::{constants, oracle_config::CurvePoint};
+use deepbook_predict::{constants, i64::{Self, I64}, oracle_config::CurvePoint};
 use sui::{clock::Clock, table::{Self, Table}};
 
 const PAGE_SLOTS: u64 = 512;
@@ -88,6 +88,11 @@ public struct StrikeMatrix has store {
     /// intervals. Live MTM values it at 1.0 until a finite end boundary turns
     /// it off.
     base_qty: u64,
+    /// Risk-weighted signed inventory `Σ (q_long_leg − q_short_leg) · n(d₂)`,
+    /// updated on every range insert/remove at the trade-time fair price of
+    /// each boundary. Read by `pricing_config::compute_up_quote` to gauge
+    /// directional inventory risk and shift the UP mid accordingly.
+    directional_aggregate: I64,
 }
 
 /// Exact per-strike inventory stored in dense page slots.
@@ -149,17 +154,41 @@ public(package) fun new(
         max_payout: 0,
         last_mtm_update: clock.timestamp_ms(),
         base_qty: 0,
+        directional_aggregate: i64::zero(),
     }
 }
 
 /// Insert interval quantity for `(lower, higher]`.
-public(package) fun insert_range(matrix: &mut StrikeMatrix, lower: u64, higher: u64, qty: u64) {
+///
+/// `lower_weight` and `higher_weight` are `n(d₂)` at the lower and higher
+/// strikes (in FLOAT_SCALING). The lower boundary is the long-UP leg
+/// (`+qty · lower_weight`) and the higher boundary is the short-UP leg
+/// (`−qty · higher_weight`); both are folded into `directional_aggregate`.
+public(package) fun insert_range(
+    matrix: &mut StrikeMatrix,
+    lower: u64,
+    higher: u64,
+    qty: u64,
+    lower_weight: u64,
+    higher_weight: u64,
+) {
     matrix.apply_range(lower, higher, qty, true);
+    apply_aggregate_delta(matrix, qty, lower_weight, true, true);
+    apply_aggregate_delta(matrix, qty, higher_weight, false, true);
 }
 
-/// Remove interval quantity for `(lower, higher]`.
-public(package) fun remove_range(matrix: &mut StrikeMatrix, lower: u64, higher: u64, qty: u64) {
+/// Remove interval quantity for `(lower, higher]`. Symmetric to `insert_range`.
+public(package) fun remove_range(
+    matrix: &mut StrikeMatrix,
+    lower: u64,
+    higher: u64,
+    qty: u64,
+    lower_weight: u64,
+    higher_weight: u64,
+) {
     matrix.apply_range(lower, higher, qty, false);
+    apply_aggregate_delta(matrix, qty, lower_weight, true, false);
+    apply_aggregate_delta(matrix, qty, higher_weight, false, false);
 }
 
 /// Return the exact worst-case settled payout across all settlement prices.
@@ -175,6 +204,13 @@ public(package) fun mtm(matrix: &StrikeMatrix): u64 {
 /// Timestamp of the last MTM update, used by the vault to decide when to refresh.
 public(package) fun last_mtm_update(matrix: &StrikeMatrix): u64 {
     matrix.last_mtm_update
+}
+
+/// Risk-weighted signed inventory accumulated over all live insert/remove
+/// operations at their trade-time fair prices. Read by the pricing layer to
+/// shift the UP mid in the direction the book is bleeding.
+public(package) fun directional_aggregate(matrix: &StrikeMatrix): I64 {
+    matrix.directional_aggregate
 }
 
 /// Refresh cached live risk values from a sampled curve.
@@ -221,6 +257,7 @@ public(package) fun into_settled_liability(matrix: StrikeMatrix, settlement: u64
         max_payout: _,
         last_mtm_update: _,
         base_qty,
+        directional_aggregate: _,
     } = matrix;
 
     let total_strikes = (max_strike - min_strike) / tick_size + 1;
@@ -379,6 +416,26 @@ fun apply_range(matrix: &mut StrikeMatrix, lower: u64, higher: u64, qty: u64, ad
     if (higher != constants::pos_inf!()) {
         matrix.apply_boundary_delta(higher, qty, false, add);
     };
+}
+
+/// Fold one boundary's risk-weighted quantity into the signed directional
+/// aggregate. Long-UP legs (the lower boundary of `(lower, higher]`) contribute
+/// positively; short-UP legs (the higher boundary) contribute negatively.
+/// `add = false` flips the contribution so an insert+remove pair cancels
+/// exactly when the per-leg weight is unchanged between the two operations.
+fun apply_aggregate_delta(
+    matrix: &mut StrikeMatrix,
+    qty: u64,
+    weight: u64,
+    is_long_leg: bool,
+    add: bool,
+) {
+    if (qty == 0 || weight == 0) return;
+    let magnitude = math::mul(qty, weight);
+    if (magnitude == 0) return;
+    let is_negative = if (add) !is_long_leg else is_long_leg;
+    let delta = i64::from_parts(magnitude, is_negative);
+    matrix.directional_aggregate = matrix.directional_aggregate.add(&delta);
 }
 
 /// Apply one finite boundary delta, refresh the touched page summary, then

--- a/packages/predict/sources/helper/strike_matrix.move
+++ b/packages/predict/sources/helper/strike_matrix.move
@@ -90,8 +90,8 @@ public struct StrikeMatrix has store {
     base_qty: u64,
     /// Risk-weighted signed inventory `Σ (q_long_leg − q_short_leg) · n(d₂)`,
     /// updated on every range insert/remove at the trade-time fair price of
-    /// each boundary. Read by `pricing_config::compute_up_quote` to gauge
-    /// directional inventory risk and shift the UP mid accordingly.
+    /// each boundary. Read by `pricing_config::compute_range_quote` to gauge
+    /// directional inventory risk and shift the per-strike UP mid accordingly.
     directional_aggregate: I64,
 }
 

--- a/packages/predict/sources/oracle.move
+++ b/packages/predict/sources/oracle.move
@@ -760,7 +760,7 @@ public(package) fun compute_price(oracle: &OracleSVI, strike: u64): u64 {
             0
         }
     } else {
-        compute_nd2(oracle, strike)
+        predict_math::normal_cdf(&compute_d2(oracle, strike))
     }
 }
 
@@ -769,6 +769,26 @@ public(package) fun compute_range_price(oracle: &OracleSVI, lower: u64, higher: 
     let lower_up_price = oracle.compute_price(lower);
     let higher_up_price = oracle.compute_price(higher);
     lower_up_price - higher_up_price
+}
+
+/// Per-strike risk weight `n(d₂)` for the inventory-aware mid shift. This is
+/// the strike-dependent part of the textbook binary delta
+/// `Δ = e^(−rτ) · n(d₂) / (S · σ · √τ)`; the constant factors are absorbed
+/// into the depth multiplier and the TTE factor in `pricing_config`.
+///
+/// Returns `0` for settled oracles, sentinel strikes, and strikes outside the
+/// SVI surface's well-defined region (e.g., zero forward) — at those points
+/// the directional risk has either been realized or is undefined, and either
+/// way contributes nothing to the live inventory aggregate.
+///
+/// Note: the weight is computed at trade time. If the SVI surface drifts
+/// between mint and redeem of the same position, the open and close legs
+/// won't fully cancel in the directional aggregate — a known approximation
+/// that avoids storing per-position weights.
+public(package) fun compute_risk_weight(oracle: &OracleSVI, strike: u64): u64 {
+    if (oracle.settlement_price.is_some()) return 0;
+    if (strike == constants::neg_inf!() || strike == constants::pos_inf!()) return 0;
+    predict_math::normal_pdf(&compute_d2(oracle, strike))
 }
 
 /// Get the cached basis ratio (forward / spot) from the most recent
@@ -1009,11 +1029,15 @@ fun emit_bounds_updated(oracle: &OracleSVI) {
     });
 }
 
-/// Binary pricing from SVI total variance:
+/// Compute `d₂` for a strike under the current SVI surface. Signed.
 /// - k = ln(strike / forward)
 /// - w(k) = a + b * (rho * (k - m) + sqrt((k - m)^2 + sigma^2))
 /// - d2 = -((k + w(k) / 2) / sqrt(w(k)))
-fun compute_nd2(oracle: &OracleSVI, strike: u64): u64 {
+///
+/// `compute_price` applies `normal_cdf(d₂)` for the binary UP price;
+/// `compute_risk_weight` applies `normal_pdf(d₂)` for the per-strike
+/// inventory weight. Both share the same SVI walk.
+fun compute_d2(oracle: &OracleSVI, strike: u64): i64::I64 {
     let forward = oracle.forward_price();
     assert!(forward > 0, EZeroForward);
 
@@ -1033,15 +1057,13 @@ fun compute_nd2(oracle: &OracleSVI, strike: u64): u64 {
     let total_var = svi.a + math::mul(svi.b, inner.magnitude());
     assert!(total_var > 0, EZeroVariance);
 
-    // d2 = -((k + total_var/2) / sqrt(total_var)), then N(±d2).
+    // d2 = -((k + total_var/2) / sqrt(total_var)).
     let sqrt_var = predict_math::sqrt(total_var, constants::float_scaling!());
     let sqrt_var_i64 = i64::from_u64(sqrt_var);
     let half_var_i64 = i64::from_u64(total_var / 2);
     let d2_numerator = k.add(&half_var_i64);
     let d2 = d2_numerator.div_scaled(&sqrt_var_i64);
-    let d2 = d2.neg();
-
-    predict_math::normal_cdf(&d2)
+    d2.neg()
 }
 
 // === Test Functions ===

--- a/packages/predict/sources/predict.move
+++ b/packages/predict/sources/predict.move
@@ -388,10 +388,12 @@ public fun compact_settled_oracle(
 ///
 /// Both prices are all-in unit prices in FLOAT_SCALING — `mint_price` is what
 /// a buyer pays per contract; `redeem_price` is what a redeemer receives.
-/// Under inventory skew the two are not symmetric around the SVI fair price
-/// and the gap need not equal `2 · fee` — the LP enforces a zero-edge floor
-/// (`mint_price >= fair`, `redeem_price <= fair`) so a heavily skewed book
-/// can pin one side at fair while the other widens.
+/// Under inventory skew the two are still symmetric around an inventory-shifted
+/// per-strike mid (gap = `2 · spread`), but the mid itself walks away from the
+/// SVI fair so paired UP+DN minting still costs `FS + 2 · spread`. There is no
+/// zero-edge floor: under heavy imbalance `mint_price` can sit below fair on the
+/// side the vault wants to grow, and `redeem_price` can sit above fair on the
+/// side the vault wants to shrink.
 public fun quote_unit_price(
     predict: &Predict,
     oracle: &OracleSVI,
@@ -1004,7 +1006,9 @@ fun quote_unit_pricing(
     predict.oracle_config.assert_range_key_matches(oracle, &key);
     oracle.assert_quoteable_oracle(clock);
 
-    let fair_price = oracle.compute_range_price(key.lower_strike(), key.higher_strike());
+    let p_up_lower = oracle.compute_price(key.lower_strike());
+    let p_up_higher = oracle.compute_price(key.higher_strike());
+    let fair_price = p_up_lower - p_up_higher;
     if (oracle.is_settled()) return (fair_price, fair_price, fair_price);
 
     // Fee + skew use the cached aggregate MTM. This path does not require
@@ -1013,8 +1017,10 @@ fun quote_unit_pricing(
     let aggregate = predict.vault.oracle_directional_aggregate(oracle.id());
     let (mint_price, redeem_price) = predict
         .pricing_config
-        .compute_up_quote(
+        .compute_range_quote(
             fair_price,
+            p_up_lower,
+            p_up_higher,
             &aggregate,
             predict.vault.total_mtm(),
             predict.vault.balance(),

--- a/packages/predict/sources/predict.move
+++ b/packages/predict/sources/predict.move
@@ -100,6 +100,9 @@ public struct PricingConfigUpdated has copy, drop, store {
     utilization_multiplier: u64,
     min_ask_price: u64,
     max_ask_price: u64,
+    depth_multiplier: u64,
+    reference_tte_ms: u64,
+    min_tte_ms: u64,
 }
 
 /// Emitted when fee reserve distribution shares change.
@@ -381,32 +384,22 @@ public fun compact_settled_oracle(
     predict.vault.compact_settled_oracle_if_needed(oracle.id(), settlement);
 }
 
-/// Per-unit `(fair_price, fee_rate)` quote for a position interval.
-/// `fee_rate` is an absolute price increment in FLOAT_SCALING, not bps.
+/// Per-unit `(mint_price, redeem_price)` quote for a position interval.
+///
+/// Both prices are all-in unit prices in FLOAT_SCALING — `mint_price` is what
+/// a buyer pays per contract; `redeem_price` is what a redeemer receives.
+/// Under inventory skew the two are not symmetric around the SVI fair price
+/// and the gap need not equal `2 · fee` — the LP enforces a zero-edge floor
+/// (`mint_price >= fair`, `redeem_price <= fair`) so a heavily skewed book
+/// can pin one side at fair while the other widens.
 public fun quote_unit_price(
     predict: &Predict,
     oracle: &OracleSVI,
     key: RangeKey,
     clock: &Clock,
 ): (u64, u64) {
-    predict.oracle_config.assert_range_key_matches(oracle, &key);
-    oracle.assert_quoteable_oracle(clock);
-
-    let fair_price = oracle.compute_range_price(key.lower_strike(), key.higher_strike());
-
-    if (oracle.is_settled()) return (fair_price, 0);
-
-    // Fee uses the cached aggregate MTM. This path does not require every
-    // exposed oracle to be freshly synced; trade mutations refresh the traded
-    // oracle inline before calling into pricing.
-    let fee_rate = predict
-        .pricing_config
-        .quote_fee_rate_from_fair_price(
-            fair_price,
-            predict.vault.total_mtm(),
-            predict.vault.balance(),
-        );
-    (fair_price, fee_rate)
+    let (_, mint_price, redeem_price) = predict.quote_unit_pricing(oracle, key, clock);
+    (mint_price, redeem_price)
 }
 
 /// Return oracle IDs whose unsettled exposure must be refreshed before LP flows.
@@ -619,6 +612,24 @@ public(package) fun set_min_ask_price(predict: &mut Predict, value: u64) {
 /// Set the global maximum allowed all-in mint price.
 public(package) fun set_max_ask_price(predict: &mut Predict, value: u64) {
     predict.pricing_config.set_max_ask_price(value);
+    predict.emit_pricing_config_updated();
+}
+
+/// Set the depth multiplier for the inventory-aware mid shift.
+public(package) fun set_depth_multiplier(predict: &mut Predict, multiplier: u64) {
+    predict.pricing_config.set_depth_multiplier(multiplier);
+    predict.emit_pricing_config_updated();
+}
+
+/// Set the reference time-to-expiry for the inventory-aware mid shift.
+public(package) fun set_reference_tte_ms(predict: &mut Predict, value: u64) {
+    predict.pricing_config.set_reference_tte_ms(value);
+    predict.emit_pricing_config_updated();
+}
+
+/// Set the minimum time-to-expiry floor for the inventory-aware mid shift.
+public(package) fun set_min_tte_ms(predict: &mut Predict, value: u64) {
+    predict.pricing_config.set_min_tte_ms(value);
     predict.emit_pricing_config_updated();
 }
 
@@ -928,8 +939,10 @@ fun apply_mint_delta<Quote>(
     let (min_strike, max_strike) = predict.vault.valuation_strike_range(oracle.id());
     let (min_strike, max_strike) = key.extend_strike_range(min_strike, max_strike);
     let curve = predict.oracle_config.build_curve(oracle, min_strike, max_strike);
+    let lower_weight = oracle.compute_risk_weight(key.lower_strike());
+    let higher_weight = oracle.compute_risk_weight(key.higher_strike());
     manager.increase_position(key, quantity);
-    predict.vault.insert_live_range(key, quantity, curve, clock);
+    predict.vault.insert_live_range(key, quantity, lower_weight, higher_weight, curve, clock);
 }
 
 /// Apply the position, vault, and risk-state delta for a live redeem before
@@ -949,8 +962,10 @@ fun apply_live_redeem_delta(
     let (min_strike, max_strike) = predict.vault.valuation_strike_range(oracle.id());
     let (min_strike, max_strike) = key.extend_strike_range(min_strike, max_strike);
     let curve = predict.oracle_config.build_curve(oracle, min_strike, max_strike);
+    let lower_weight = oracle.compute_risk_weight(key.lower_strike());
+    let higher_weight = oracle.compute_risk_weight(key.higher_strike());
     manager.decrease_position(key, quantity);
-    predict.vault.remove_live_range(key, quantity, curve, clock);
+    predict.vault.remove_live_range(key, quantity, lower_weight, higher_weight, curve, clock);
 }
 
 /// Apply the position, vault, and risk-state delta for a settled redeem before
@@ -968,8 +983,44 @@ fun apply_settled_redeem_delta(
     predict.oracle_config.assert_range_key_matches(oracle, &key);
     oracle.assert_quoteable_oracle(clock);
 
+    let lower_weight = oracle.compute_risk_weight(key.lower_strike());
+    let higher_weight = oracle.compute_risk_weight(key.higher_strike());
     manager.decrease_position(key, quantity);
-    predict.vault.remove_settled_range(key, quantity, settlement, clock);
+    predict
+        .vault
+        .remove_settled_range(key, quantity, lower_weight, higher_weight, settlement, clock);
+}
+
+/// Per-unit `(fair_price, mint_price, redeem_price)` for a position interval.
+/// Internal helper feeding both the public `quote_unit_price` and the trade-
+/// path accounting in `quote_mint_amounts` / `quote_live_redeem_amounts`.
+/// Settled oracles have no skew: mint and redeem both sit at the settled fair.
+fun quote_unit_pricing(
+    predict: &Predict,
+    oracle: &OracleSVI,
+    key: RangeKey,
+    clock: &Clock,
+): (u64, u64, u64) {
+    predict.oracle_config.assert_range_key_matches(oracle, &key);
+    oracle.assert_quoteable_oracle(clock);
+
+    let fair_price = oracle.compute_range_price(key.lower_strike(), key.higher_strike());
+    if (oracle.is_settled()) return (fair_price, fair_price, fair_price);
+
+    // Fee + skew use the cached aggregate MTM. This path does not require
+    // every exposed oracle to be freshly synced; trade mutations refresh the
+    // traded oracle inline before calling into pricing.
+    let aggregate = predict.vault.oracle_directional_aggregate(oracle.id());
+    let (mint_price, redeem_price) = predict
+        .pricing_config
+        .compute_up_quote(
+            fair_price,
+            &aggregate,
+            predict.vault.total_mtm(),
+            predict.vault.balance(),
+            time_to_expiry(key.expiry(), clock),
+        );
+    (fair_price, mint_price, redeem_price)
 }
 
 fun quote_mint_amounts(
@@ -979,11 +1030,12 @@ fun quote_mint_amounts(
     quantity: u64,
     clock: &Clock,
 ): (u64, u64) {
-    let (fair_price, fee_rate) = predict.quote_unit_price(oracle, key, clock);
-    predict.assert_mint_quote_allowed(oracle.id(), fair_price, fee_rate);
+    let (fair_price, mint_price, _) = predict.quote_unit_pricing(oracle, key, clock);
+    predict.assert_mint_quote_allowed(oracle.id(), mint_price);
 
     let principal_amount = math::mul(fair_price, quantity);
-    let fee_amount = math::mul(fee_rate, quantity);
+    let cost = math::mul(mint_price, quantity);
+    let fee_amount = cost - principal_amount;
 
     (principal_amount, fee_amount)
 }
@@ -995,13 +1047,18 @@ fun quote_live_redeem_amounts(
     quantity: u64,
     clock: &Clock,
 ): (u64, u64) {
-    let (fair_price, fee_rate) = predict.quote_unit_price(oracle, key, clock);
+    let (fair_price, _, redeem_price) = predict.quote_unit_pricing(oracle, key, clock);
 
     let principal_amount = math::mul(fair_price, quantity);
-    let fee_amount = math::mul(fee_rate, quantity);
-    let fee_amount = fee_amount.min(principal_amount);
+    let payout = math::mul(redeem_price, quantity);
+    let fee_amount = (principal_amount - payout).min(principal_amount);
 
     (principal_amount, fee_amount)
+}
+
+fun time_to_expiry(expiry_ms: u64, clock: &Clock): u64 {
+    let now = clock.timestamp_ms();
+    if (expiry_ms > now) expiry_ms - now else 0
 }
 
 /// Returns the USDC value of `shares` at the given vault value.
@@ -1060,6 +1117,9 @@ fun emit_pricing_config_updated(predict: &Predict) {
         utilization_multiplier: predict.pricing_config.utilization_multiplier(),
         min_ask_price: predict.pricing_config.min_ask_price(),
         max_ask_price: predict.pricing_config.max_ask_price(),
+        depth_multiplier: predict.pricing_config.depth_multiplier(),
+        reference_tte_ms: predict.pricing_config.reference_tte_ms(),
+        min_tte_ms: predict.pricing_config.min_tte_ms(),
     });
 }
 
@@ -1102,13 +1162,7 @@ fun resolve_ask_bounds(predict: &Predict, oracle_id: ID): (u64, u64) {
 }
 
 /// Assert a mint quote can be traded under the effective ask bounds.
-fun assert_mint_quote_allowed(
-    predict: &Predict,
-    oracle_id: ID,
-    fair_price: u64,
-    quoted_fee_rate: u64,
-) {
-    let mint_price = fair_price + quoted_fee_rate;
+fun assert_mint_quote_allowed(predict: &Predict, oracle_id: ID, mint_price: u64) {
     let (min_ask, max_ask) = predict.resolve_ask_bounds(oracle_id);
     assert!(mint_price >= min_ask && mint_price <= max_ask, EAskPriceOutOfBounds);
 }

--- a/packages/predict/sources/registry.move
+++ b/packages/predict/sources/registry.move
@@ -235,6 +235,21 @@ public fun set_max_ask_price(predict: &mut Predict, _admin_cap: &AdminCap, value
     predict.set_max_ask_price(value);
 }
 
+/// Set the depth multiplier for the inventory-aware mid shift.
+public fun set_depth_multiplier(predict: &mut Predict, _admin_cap: &AdminCap, multiplier: u64) {
+    predict.set_depth_multiplier(multiplier);
+}
+
+/// Set the reference time-to-expiry for the inventory-aware mid shift.
+public fun set_reference_tte_ms(predict: &mut Predict, _admin_cap: &AdminCap, value: u64) {
+    predict.set_reference_tte_ms(value);
+}
+
+/// Set the minimum time-to-expiry floor for the inventory-aware mid shift.
+public fun set_min_tte_ms(predict: &mut Predict, _admin_cap: &AdminCap, value: u64) {
+    predict.set_min_tte_ms(value);
+}
+
 /// Set a per-oracle ask-bound override. Authorized by the oracle's own cap;
 /// no `AdminCap` required. The override may only tighten the global bounds.
 public fun set_oracle_ask_bounds(

--- a/packages/predict/sources/vault/vault.move
+++ b/packages/predict/sources/vault/vault.move
@@ -16,6 +16,7 @@ module deepbook_predict::vault;
 
 use deepbook::math;
 use deepbook_predict::{
+    i64::I64,
     oracle_config::CurvePoint,
     range_key::RangeKey,
     strike_matrix::{Self, StrikeMatrix}
@@ -120,10 +121,16 @@ public(package) fun init_oracle_matrix(
 }
 
 /// Insert a live vertical range and refresh live risk accounting.
+///
+/// `lower_weight` and `higher_weight` are `n(d₂)` at the lower and higher
+/// strikes (in FLOAT_SCALING). They feed the matrix's directional aggregate
+/// used by the inventory-aware mid shift.
 public(package) fun insert_live_range(
     vault: &mut Vault,
     key: RangeKey,
     quantity: u64,
+    lower_weight: u64,
+    higher_weight: u64,
     curve: vector<CurvePoint>,
     clock: &Clock,
 ) {
@@ -132,7 +139,7 @@ public(package) fun insert_live_range(
     let higher = key.higher_strike();
     assert!(vault.oracle_matrices.contains(oracle_id), EOracleExposureNotFound);
     let matrix = &mut vault.oracle_matrices[oracle_id];
-    matrix.insert_range(lower, higher, quantity);
+    matrix.insert_range(lower, higher, quantity, lower_weight, higher_weight);
     vault.apply_live_valuation(oracle_id, curve, clock);
     vault.add_unsettled_exposed_oracle(oracle_id);
 }
@@ -142,6 +149,8 @@ public(package) fun remove_live_range(
     vault: &mut Vault,
     key: RangeKey,
     quantity: u64,
+    lower_weight: u64,
+    higher_weight: u64,
     curve: vector<CurvePoint>,
     clock: &Clock,
 ) {
@@ -150,16 +159,21 @@ public(package) fun remove_live_range(
     let higher = key.higher_strike();
     assert!(vault.oracle_matrices.contains(oracle_id), EOracleExposureNotFound);
     let matrix = &mut vault.oracle_matrices[oracle_id];
-    matrix.remove_range(lower, higher, quantity);
+    matrix.remove_range(lower, higher, quantity, lower_weight, higher_weight);
     vault.apply_live_valuation(oracle_id, curve, clock);
     vault.remove_unsettled_exposed_oracle_if_empty(oracle_id);
 }
 
-/// Remove a settled vertical range from dense matrix exposure or compacted liability.
+/// Remove a settled vertical range from dense matrix exposure or compacted
+/// liability. Weights pass through to the matrix unchanged from the live
+/// removal API; the directional aggregate is meaningless after settlement
+/// but the matrix accounts for the legs symmetrically.
 public(package) fun remove_settled_range(
     vault: &mut Vault,
     key: RangeKey,
     quantity: u64,
+    lower_weight: u64,
+    higher_weight: u64,
     settlement: u64,
     clock: &Clock,
 ) {
@@ -175,9 +189,16 @@ public(package) fun remove_settled_range(
     } else {
         assert!(vault.oracle_matrices.contains(oracle_id), EOracleExposureNotFound);
         let matrix = &mut vault.oracle_matrices[oracle_id];
-        matrix.remove_range(lower, higher, quantity);
+        matrix.remove_range(lower, higher, quantity, lower_weight, higher_weight);
         vault.apply_settled_oracle_valuation(oracle_id, settlement, clock);
     };
+}
+
+/// Return the per-oracle directional aggregate consumed by the pricing layer
+/// when computing the inventory-aware mid shift.
+public(package) fun oracle_directional_aggregate(vault: &Vault, oracle_id: ID): I64 {
+    assert!(vault.oracle_matrices.contains(oracle_id), EOracleExposureNotFound);
+    vault.oracle_matrices[oracle_id].directional_aggregate()
 }
 
 /// Accept payment into vault balance.

--- a/packages/predict/tests/config/inventory_skew_scenarios.move
+++ b/packages/predict/tests/config/inventory_skew_scenarios.move
@@ -4,8 +4,8 @@
 #[test_only]
 /// End-to-end scenario tests: drive a `StrikeMatrix` with realistic
 /// `insert_range` / `remove_range` calls, read the directional aggregate,
-/// feed it into `pricing_config::compute_up_quote`, and assert exact mint
-/// and redeem prices at each step.
+/// feed it into `pricing_config::compute_range_quote`, and assert exact
+/// mint and redeem prices at each step.
 ///
 /// This is the closest thing to an integration test for the inventory shift
 /// — without spinning up a full `Predict` object, it exercises the same
@@ -14,15 +14,13 @@
 /// post-trade aggregate).
 module deepbook_predict::inventory_skew_scenarios;
 
-use deepbook_predict::{constants, pricing_config, strike_matrix};
+use deepbook_predict::{constants, i64::I64, pricing_config::{Self, PricingConfig}, strike_matrix};
 use std::unit_test::{assert_eq, destroy};
 use sui::{clock, test_scenario};
 
 const FS: u64 = 1_000_000_000;
 const HALF: u64 = 500_000_000;
 
-// Compact grid keeps page allocation cheap for unit tests; the strike values
-// below are illustrative — the matrix uses them as keys, not as prices.
 const TICK_SIZE: u64 = 1_000_000;
 const MIN_STRIKE: u64 = 1_000_000;
 const MAX_STRIKE: u64 = 1_000_000_000;
@@ -30,10 +28,10 @@ const STRIKE_K: u64 = 500_000_000;
 const STRIKE_K_LOW: u64 = 250_000_000;
 const STRIKE_K_HIGH: u64 = 750_000_000;
 
-// Vault and pricing parameters, sized so each "buyer" produces an exact
-// ratio = 0.10. denom = balance · depth / FS = 1e10. ratio_FS =
-// aggregate · FS / denom. For ratio = 0.10 we want aggregate = 1e9, which
-// is `qty · weight / FS = 2.5e9 · 4e8 / FS = 1e9`. ✓
+// Sized so each "buyer" produces an exact ratio = 0.10 in our setup:
+//   denom = balance · depth / FS = 1e10
+//   aggregate_per_buyer = qty · weight / FS = 2.5e9 · 4e8 / FS = 1e9
+//   ratio = aggregate · FS / denom = 1e9 · FS / 1e10 = 0.10.
 const BALANCE: u64 = 10_000_000_000;
 const QTY_PER_BUYER: u64 = 2_500_000_000;
 const WEIGHT_AT_K: u64 = 400_000_000; // n(d₂) ≈ 0.4 (near ATM)
@@ -42,6 +40,12 @@ const WEIGHT_AT_K_LOW: u64 = 200_000_000; // 0.2 (deeper from ATM peak)
 const FEE_AT_HALF: u64 = 10_000_000; // 2% · √0.25 = 1%
 
 fun seven_days_ms(): u64 { constants::default_reference_tte_ms!() }
+
+/// Quote a single-strike UP leg at K with `p_up(K) = fair`. Range form
+/// `(K, +∞]` → `p_up_lower = fair`, `p_up_higher = 0`.
+fun up_leg(config: &PricingConfig, fair: u64, agg: &I64, balance: u64, tte: u64): (u64, u64) {
+    config.compute_range_quote(fair, fair, 0, agg, 0, balance, tte)
+}
 
 fun new_matrix(scenario: &mut test_scenario::Scenario): strike_matrix::StrikeMatrix {
     scenario.next_tx(@0xa);
@@ -63,20 +67,17 @@ fun two_sequential_up_buys_compound_skew_post_trade() {
     // they're quoted is computed *against this post-trade aggregate*.
     matrix.insert_range(STRIKE_K, constants::pos_inf!(), QTY_PER_BUYER, WEIGHT_AT_K, 0);
     let agg_after_a = matrix.directional_aggregate();
-    let (mint_a, _) = config.compute_up_quote(HALF, &agg_after_a, 0, BALANCE, seven_days_ms());
+    let (mint_a, _) = up_leg(&config, HALF, &agg_after_a, BALANCE, seven_days_ms());
 
-    // Buyer B mints the same size at the same strike. Aggregate now
-    // reflects A + B; B's quote sees both contributions.
+    // Buyer B mints the same size at the same strike.
     matrix.insert_range(STRIKE_K, constants::pos_inf!(), QTY_PER_BUYER, WEIGHT_AT_K, 0);
     let agg_after_b = matrix.directional_aggregate();
-    let (mint_b, _) = config.compute_up_quote(HALF, &agg_after_b, 0, BALANCE, seven_days_ms());
+    let (mint_b, _) = up_leg(&config, HALF, &agg_after_b, BALANCE, seven_days_ms());
 
-    // Each buyer's contribution drives ratio by 0.10 → shift = 0.05.
-    // mint_a = 0.5 + 0.05 + 1% = 0.56.
-    // mint_b = 0.5 + 0.10 + 1% = 0.61.
+    // ratio_a = 0.10 → m(K) = 0.55 → mint_a = 0.56.
+    // ratio_b = 0.20 → m(K) = 0.60 → mint_b = 0.61.
     assert_eq!(mint_a, 560_000_000);
     assert_eq!(mint_b, 610_000_000);
-    // The second buyer paid exactly 5¢ more — the cost of their own size.
     assert_eq!(mint_b - mint_a, 50_000_000);
 
     destroy(matrix);
@@ -84,7 +85,7 @@ fun two_sequential_up_buys_compound_skew_post_trade() {
     scenario.end();
 }
 
-// ── Three buyers: skew compounds linearly until the clamp engages ──────────
+// ── Three buyers: skew compounds linearly ──────────────────────────────────
 
 #[test]
 fun three_sequential_up_buys_compound_linearly() {
@@ -97,16 +98,15 @@ fun three_sequential_up_buys_compound_linearly() {
     while (i < 3) {
         matrix.insert_range(STRIKE_K, constants::pos_inf!(), QTY_PER_BUYER, WEIGHT_AT_K, 0);
         let agg = matrix.directional_aggregate();
-        let (mint, _) = config.compute_up_quote(HALF, &agg, 0, BALANCE, seven_days_ms());
+        let (mint, _) = up_leg(&config, HALF, &agg, BALANCE, seven_days_ms());
         prices.push_back(mint);
         i = i + 1;
     };
 
-    // ratios: 0.10, 0.20, 0.30 → shifts: 0.05, 0.10, 0.15.
+    // ratios: 0.10, 0.20, 0.30 → mints: 0.56, 0.61, 0.66.
     assert_eq!(prices[0], 560_000_000);
     assert_eq!(prices[1], 610_000_000);
     assert_eq!(prices[2], 660_000_000);
-    // Equal step size: each marginal buyer pays the same incremental premium.
     assert_eq!(prices[1] - prices[0], prices[2] - prices[1]);
 
     destroy(matrix);
@@ -122,18 +122,13 @@ fun up_buy_followed_by_dn_buy_at_same_strike_cancels_skew() {
     let mut matrix = new_matrix(&mut scenario);
     let config = pricing_config::new();
 
-    // UP@K is `(K, +∞]` with lower_weight = n(d₂(K)), higher_weight = 0
-    // (sentinel). DN@K is `(-∞, K]` — lower_weight = 0, higher_weight =
-    // n(d₂(K)). The two contributions have equal magnitude and opposite
-    // sign — the directional aggregate returns to zero.
     matrix.insert_range(STRIKE_K, constants::pos_inf!(), QTY_PER_BUYER, WEIGHT_AT_K, 0);
     matrix.insert_range(constants::neg_inf!(), STRIKE_K, QTY_PER_BUYER, 0, WEIGHT_AT_K);
 
     let agg = matrix.directional_aggregate();
     assert!(agg.is_zero());
 
-    let (mint, redeem) = config.compute_up_quote(HALF, &agg, 0, BALANCE, seven_days_ms());
-    // Back to symmetric quotes around fair.
+    let (mint, redeem) = up_leg(&config, HALF, &agg, BALANCE, seven_days_ms());
     assert_eq!(mint, HALF + FEE_AT_HALF);
     assert_eq!(redeem, HALF - FEE_AT_HALF);
 
@@ -150,20 +145,19 @@ fun partial_redeem_after_buy_shrinks_skew_proportionally() {
     let mut matrix = new_matrix(&mut scenario);
     let config = pricing_config::new();
 
-    // Buy 3× the unit qty (ratio = 0.30), then redeem 1× (ratio drops to 0.20).
     let three_x = 3 * QTY_PER_BUYER;
     matrix.insert_range(STRIKE_K, constants::pos_inf!(), three_x, WEIGHT_AT_K, 0);
     matrix.remove_range(STRIKE_K, constants::pos_inf!(), QTY_PER_BUYER, WEIGHT_AT_K, 0);
 
-    let (mint, _) = config.compute_up_quote(
+    let (mint, _) = up_leg(
+        &config,
         HALF,
         &matrix.directional_aggregate(),
-        0,
         BALANCE,
         seven_days_ms(),
     );
 
-    // Net ratio = 0.20 → shift = 0.10 → mint = 0.61.
+    // Net ratio = 0.20 → m(K) = 0.60 → mint = 0.61.
     assert_eq!(mint, 610_000_000);
 
     destroy(matrix);
@@ -171,7 +165,7 @@ fun partial_redeem_after_buy_shrinks_skew_proportionally() {
     scenario.end();
 }
 
-// ── UP buy then UP redeem at unchanged weights returns to flat ──────────────
+// ── UP buy then UP redeem at unchanged weights returns to flat ─────────────
 
 #[test]
 fun full_round_trip_at_same_weights_returns_book_to_flat() {
@@ -184,10 +178,10 @@ fun full_round_trip_at_same_weights_returns_book_to_flat() {
 
     assert!(matrix.directional_aggregate().is_zero());
 
-    let (mint, redeem) = config.compute_up_quote(
+    let (mint, redeem) = up_leg(
+        &config,
         HALF,
         &matrix.directional_aggregate(),
-        0,
         BALANCE,
         seven_days_ms(),
     );
@@ -199,7 +193,7 @@ fun full_round_trip_at_same_weights_returns_book_to_flat() {
     scenario.end();
 }
 
-// ── Range buy with K_high closer to ATM than K_low: aggregate goes negative ─
+// ── Range buy with K_high closer to ATM: aggregate goes negative ────────────
 
 #[test]
 fun range_buy_with_higher_weight_at_top_drives_aggregate_negative() {
@@ -207,19 +201,20 @@ fun range_buy_with_higher_weight_at_top_drives_aggregate_negative() {
     let mut matrix = new_matrix(&mut scenario);
     let config = pricing_config::new();
 
-    // Range `(K_low, K]` — lower deeper from ATM, upper at ATM.
-    // lower_weight = 0.2, higher_weight = 0.4.
-    // Aggregate += +qty·0.2 - qty·0.4 = -qty·0.2 → ratio = -0.05 in our setup.
+    // Range `(K_low, K]` — lower weight 0.2, higher weight 0.4.
+    // Aggregate += qty·(0.2 - 0.4) = -qty·0.2 → ratio = -0.05.
     matrix.insert_range(STRIKE_K_LOW, STRIKE_K, QTY_PER_BUYER, WEIGHT_AT_K_LOW, WEIGHT_AT_K);
     let agg = matrix.directional_aggregate();
     assert!(agg.is_negative());
 
-    let (mint, redeem) = config.compute_up_quote(HALF, &agg, 0, BALANCE, seven_days_ms());
+    // Quote a separate UP-K leg at fair=HALF against this oracle aggregate.
+    let (mint, redeem) = up_leg(&config, HALF, &agg, BALANCE, seven_days_ms());
 
-    // ratio = -0.05 → shift = 0.05 · 0.5 = 0.025 → shifted_mid = 0.475.
-    // shift > spread (= 0.01) → mint clamps at fair = 0.5.
-    // redeem = (0.475 - 0.01).min(0.5) = 0.465.
-    assert_eq!(mint, HALF);
+    // ratio = -0.05 → m(K) = 0.5 - 0.05·0.5 = 0.475.
+    // mint = 0.475 + 0.01 = 0.485 (now below fair — the discount that draws
+    // in the offsetting flow when the vault is long UP).
+    // redeem = 0.475 - 0.01 = 0.465.
+    assert_eq!(mint, 485_000_000);
     assert_eq!(redeem, 465_000_000);
 
     destroy(matrix);
@@ -227,7 +222,7 @@ fun range_buy_with_higher_weight_at_top_drives_aggregate_negative() {
     scenario.end();
 }
 
-// ── Range buy with K_low closer to ATM than K_high: aggregate goes positive ─
+// ── Range buy with K_low closer to ATM: aggregate goes positive ─────────────
 
 #[test]
 fun range_buy_with_higher_weight_at_bottom_drives_aggregate_positive() {
@@ -235,18 +230,16 @@ fun range_buy_with_higher_weight_at_bottom_drives_aggregate_positive() {
     let mut matrix = new_matrix(&mut scenario);
     let config = pricing_config::new();
 
-    // Range `(K, K_high]` — lower at ATM, upper deeper from ATM.
-    // lower_weight = 0.4, higher_weight = 0.2.
+    // Range `(K, K_high]` — lower weight 0.4, higher weight 0.2.
     matrix.insert_range(STRIKE_K, STRIKE_K_HIGH, QTY_PER_BUYER, WEIGHT_AT_K, WEIGHT_AT_K_LOW);
     let agg = matrix.directional_aggregate();
     assert!(!agg.is_negative());
 
-    let (mint, redeem) = config.compute_up_quote(HALF, &agg, 0, BALANCE, seven_days_ms());
+    let (mint, redeem) = up_leg(&config, HALF, &agg, BALANCE, seven_days_ms());
 
-    // ratio = +0.05 → shift = +0.025 → shifted_mid = 0.525.
-    // mint = 0.525 + 0.01 = 0.535. redeem clamps at fair.
+    // ratio = +0.05 → m(K) = 0.525 → mint = 0.535, redeem = 0.515.
     assert_eq!(mint, 535_000_000);
-    assert_eq!(redeem, HALF);
+    assert_eq!(redeem, 515_000_000);
 
     destroy(matrix);
     config.destroy_for_testing();
@@ -261,31 +254,29 @@ fun range_buy_followed_by_up_buy_combine_into_smaller_net_skew() {
     let mut matrix = new_matrix(&mut scenario);
     let config = pricing_config::new();
 
-    // Range `(K, K_high]` first: aggregate += qty·(0.4 − 0.2) = qty·0.2,
-    // which in raw units is 5e8 → ratio = 0.05.
+    // Range `(K, K_high]`: aggregate += qty·(0.4 − 0.2). ratio = +0.05.
     matrix.insert_range(STRIKE_K, STRIKE_K_HIGH, QTY_PER_BUYER, WEIGHT_AT_K, WEIGHT_AT_K_LOW);
-    let (_, redeem_after_range) = config.compute_up_quote(
+    let (_, redeem_after_range) = up_leg(
+        &config,
         HALF,
         &matrix.directional_aggregate(),
-        0,
         BALANCE,
         seven_days_ms(),
     );
 
-    // Then UP@K: aggregate += qty·0.4 = 1e9 → ratio jumps from 0.05 to 0.15.
-    // shift = 0.15 · 0.5 = 0.075 → mint = 0.5 + 0.075 + 1% = 0.585.
+    // Then UP@K: aggregate += qty·0.4 → ratio jumps from 0.05 to 0.15.
     matrix.insert_range(STRIKE_K, constants::pos_inf!(), QTY_PER_BUYER, WEIGHT_AT_K, 0);
-    let (mint_combined, _) = config.compute_up_quote(
+    let (mint_combined, _) = up_leg(
+        &config,
         HALF,
         &matrix.directional_aggregate(),
-        0,
         BALANCE,
         seven_days_ms(),
     );
 
-    // After-range alone: redeem clamps at fair (positive aggregate).
-    assert_eq!(redeem_after_range, HALF);
-    // Combined ratio reflects both legs.
+    // After-range alone: ratio=0.05 → m(K)=0.525 → redeem = 0.515.
+    assert_eq!(redeem_after_range, 515_000_000);
+    // Combined: ratio=0.15 → m(K) = 0.575 → mint = 0.585.
     assert_eq!(mint_combined, 585_000_000);
 
     destroy(matrix);
@@ -305,33 +296,37 @@ fun saturating_single_trade_drives_mint_to_one() {
     let whale_qty = 11 * QTY_PER_BUYER;
     matrix.insert_range(STRIKE_K, constants::pos_inf!(), whale_qty, WEIGHT_AT_K, 0);
 
-    let (mint, redeem) = config.compute_up_quote(
+    let (mint, redeem) = up_leg(
+        &config,
         HALF,
         &matrix.directional_aggregate(),
-        0,
         BALANCE,
         seven_days_ms(),
     );
 
-    // Saturation: shifted_mid = FS, mint clamps at FS, redeem clamps at fair.
+    // Saturation: m(K) = FS, mint clamps at FS, redeem = FS - spread.
     assert_eq!(mint, FS);
-    assert_eq!(redeem, HALF);
+    assert_eq!(redeem, FS - FEE_AT_HALF);
 
     destroy(matrix);
     config.destroy_for_testing();
     scenario.end();
 }
 
-// ── Splitting an order across many TXs: average cost matches the bulk price ─
+// ── Splitting an order across many TXs: bulk pays more total than split ─────
 
 #[test]
-fun ten_split_orders_pay_same_average_cost_as_one_bulk_order() {
+fun ten_split_orders_pay_less_than_one_bulk_order() {
     let mut scenario = test_scenario::begin(@0xa);
     let mut split_matrix = new_matrix(&mut scenario);
     let mut bulk_matrix = new_matrix(&mut scenario);
     let config = pricing_config::new();
 
-    // 10 buyers at QTY_PER_BUYER each, vs one buyer at 10×.
+    // 10 buyers at QTY_PER_BUYER each (ratios 0.10, 0.20, ..., 1.00 with the
+    // 10th saturating). Sum of premiums over fair+spread:
+    //   k=1..9: k·0.05·FS sum = 0.05·45·FS = 2.25e9
+    //   k=10: saturates at m(K)=FS → mint=FS → premium = 0.49·FS = 0.49e9
+    //   total = 2.74e9.
     let mut total_split_premium = 0u64;
     let mut i = 0;
     while (i < 10) {
@@ -342,21 +337,18 @@ fun ten_split_orders_pay_same_average_cost_as_one_bulk_order() {
             WEIGHT_AT_K,
             0,
         );
-        let (mint, _) = config.compute_up_quote(
+        let (mint, _) = up_leg(
+            &config,
             HALF,
             &split_matrix.directional_aggregate(),
-            0,
             BALANCE,
             seven_days_ms(),
         );
-        // Each split buyer's premium over fair+spread = (mint - HALF - FEE_AT_HALF).
         total_split_premium = total_split_premium + (mint - HALF - FEE_AT_HALF);
         i = i + 1;
     };
 
-    // Bulk: one trade of 10× qty saturates instantly (ratio = 1.0). Per-unit
-    // premium = (FS - HALF - FEE_AT_HALF) / 10. Compare totals (sum across 10
-    // contracts vs 10× for one bulk contract is the same denominator).
+    // Bulk: one trade of 10× qty saturates instantly.
     bulk_matrix.insert_range(
         STRIKE_K,
         constants::pos_inf!(),
@@ -364,23 +356,18 @@ fun ten_split_orders_pay_same_average_cost_as_one_bulk_order() {
         WEIGHT_AT_K,
         0,
     );
-    let (mint_bulk, _) = config.compute_up_quote(
+    let (mint_bulk, _) = up_leg(
+        &config,
         HALF,
         &bulk_matrix.directional_aggregate(),
-        0,
         BALANCE,
         seven_days_ms(),
     );
     let bulk_premium_per_buyer = mint_bulk - HALF - FEE_AT_HALF;
     let bulk_total_premium = 10 * bulk_premium_per_buyer;
 
-    // Split path: sum of (k · 0.05) for k = 1..10 = 0.05 · 55 = 2.75 → 275M units.
-    // Bulk path: 10 · (FS · 0.5 - 0.01 - HALF) = 10 · (1.0 - 0.5 - 0.01) = 4.90 → 4_900M units.
-    // Bulk total > split total — the bulk buyer overpays vs the split path
-    // *as a sum across contracts*, because the bulk hits saturation earlier.
-    // (The protocol-relevant comparison is per-contract cost; in a non-saturated
-    // regime split and bulk converge, but at saturation the bulk pays the
-    // capped premium on every contract.)
+    // Bulk total > split total — the bulk hits saturation on every contract,
+    // while the split path's first 9 buyers pay strictly less than the cap.
     assert!(bulk_total_premium > total_split_premium);
 
     destroy(split_matrix);
@@ -397,23 +384,19 @@ fun round_trip_with_weight_drift_matches_predicted_residual() {
     let mut matrix = new_matrix(&mut scenario);
     let config = pricing_config::new();
 
-    // Trader opens UP@K with `n(d₂)` at trade time = 0.40, then closes
-    // after the SVI surface drifts so the new `n(d₂)` at K is 0.30.
     let weight_open = WEIGHT_AT_K; // 0.40
     let weight_close = 300_000_000; // 0.30
 
     matrix.insert_range(STRIKE_K, constants::pos_inf!(), QTY_PER_BUYER, weight_open, 0);
     matrix.remove_range(STRIKE_K, constants::pos_inf!(), QTY_PER_BUYER, weight_close, 0);
 
-    // Residual aggregate = qty · (weight_open − weight_close) =
-    // 2.5e9 · (0.40 − 0.30) / FS = 2.5e8 (positive).
+    // Residual aggregate = qty · (weight_open − weight_close) = 2.5e8.
     let residual = matrix.directional_aggregate();
     assert_eq!(residual.magnitude(), 250_000_000);
     assert!(!residual.is_negative());
 
-    // The next quote sees this residual: ratio = 2.5e8 · FS / 1e10 = 2.5e7
-    // = 0.025 → shift = 0.0125 → mint = 0.5 + 0.0125 + 0.01 = 0.5225.
-    let (mint, _) = config.compute_up_quote(HALF, &residual, 0, BALANCE, seven_days_ms());
+    // ratio = 0.025 → m(K) = 0.5 + 0.025·0.5 = 0.5125 → mint = 0.5225.
+    let (mint, _) = up_leg(&config, HALF, &residual, BALANCE, seven_days_ms());
     assert_eq!(mint, 522_500_000);
 
     destroy(matrix);

--- a/packages/predict/tests/config/inventory_skew_scenarios.move
+++ b/packages/predict/tests/config/inventory_skew_scenarios.move
@@ -1,0 +1,422 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+/// End-to-end scenario tests: drive a `StrikeMatrix` with realistic
+/// `insert_range` / `remove_range` calls, read the directional aggregate,
+/// feed it into `pricing_config::compute_up_quote`, and assert exact mint
+/// and redeem prices at each step.
+///
+/// This is the closest thing to an integration test for the inventory shift
+/// — without spinning up a full `Predict` object, it exercises the same
+/// data path the protocol takes during `mint_internal` /
+/// `redeem_live_internal` (apply state delta first, then quote against the
+/// post-trade aggregate).
+module deepbook_predict::inventory_skew_scenarios;
+
+use deepbook_predict::{constants, pricing_config, strike_matrix};
+use std::unit_test::{assert_eq, destroy};
+use sui::{clock, test_scenario};
+
+const FS: u64 = 1_000_000_000;
+const HALF: u64 = 500_000_000;
+
+// Compact grid keeps page allocation cheap for unit tests; the strike values
+// below are illustrative — the matrix uses them as keys, not as prices.
+const TICK_SIZE: u64 = 1_000_000;
+const MIN_STRIKE: u64 = 1_000_000;
+const MAX_STRIKE: u64 = 1_000_000_000;
+const STRIKE_K: u64 = 500_000_000;
+const STRIKE_K_LOW: u64 = 250_000_000;
+const STRIKE_K_HIGH: u64 = 750_000_000;
+
+// Vault and pricing parameters, sized so each "buyer" produces an exact
+// ratio = 0.10. denom = balance · depth / FS = 1e10. ratio_FS =
+// aggregate · FS / denom. For ratio = 0.10 we want aggregate = 1e9, which
+// is `qty · weight / FS = 2.5e9 · 4e8 / FS = 1e9`. ✓
+const BALANCE: u64 = 10_000_000_000;
+const QTY_PER_BUYER: u64 = 2_500_000_000;
+const WEIGHT_AT_K: u64 = 400_000_000; // n(d₂) ≈ 0.4 (near ATM)
+const WEIGHT_AT_K_LOW: u64 = 200_000_000; // 0.2 (deeper from ATM peak)
+
+const FEE_AT_HALF: u64 = 10_000_000; // 2% · √0.25 = 1%
+
+fun seven_days_ms(): u64 { constants::default_reference_tte_ms!() }
+
+fun new_matrix(scenario: &mut test_scenario::Scenario): strike_matrix::StrikeMatrix {
+    scenario.next_tx(@0xa);
+    let clock = clock::create_for_testing(scenario.ctx());
+    let matrix = strike_matrix::new(scenario.ctx(), TICK_SIZE, MIN_STRIKE, MAX_STRIKE, &clock);
+    destroy(clock);
+    matrix
+}
+
+// ── Two buyers at the same strike: B pays more than A by exactly one shift ─
+
+#[test]
+fun two_sequential_up_buys_compound_skew_post_trade() {
+    let mut scenario = test_scenario::begin(@0xa);
+    let mut matrix = new_matrix(&mut scenario);
+    let config = pricing_config::new();
+
+    // Buyer A mints UP@K. The matrix now reflects A's order; the price
+    // they're quoted is computed *against this post-trade aggregate*.
+    matrix.insert_range(STRIKE_K, constants::pos_inf!(), QTY_PER_BUYER, WEIGHT_AT_K, 0);
+    let agg_after_a = matrix.directional_aggregate();
+    let (mint_a, _) = config.compute_up_quote(HALF, &agg_after_a, 0, BALANCE, seven_days_ms());
+
+    // Buyer B mints the same size at the same strike. Aggregate now
+    // reflects A + B; B's quote sees both contributions.
+    matrix.insert_range(STRIKE_K, constants::pos_inf!(), QTY_PER_BUYER, WEIGHT_AT_K, 0);
+    let agg_after_b = matrix.directional_aggregate();
+    let (mint_b, _) = config.compute_up_quote(HALF, &agg_after_b, 0, BALANCE, seven_days_ms());
+
+    // Each buyer's contribution drives ratio by 0.10 → shift = 0.05.
+    // mint_a = 0.5 + 0.05 + 1% = 0.56.
+    // mint_b = 0.5 + 0.10 + 1% = 0.61.
+    assert_eq!(mint_a, 560_000_000);
+    assert_eq!(mint_b, 610_000_000);
+    // The second buyer paid exactly 5¢ more — the cost of their own size.
+    assert_eq!(mint_b - mint_a, 50_000_000);
+
+    destroy(matrix);
+    config.destroy_for_testing();
+    scenario.end();
+}
+
+// ── Three buyers: skew compounds linearly until the clamp engages ──────────
+
+#[test]
+fun three_sequential_up_buys_compound_linearly() {
+    let mut scenario = test_scenario::begin(@0xa);
+    let mut matrix = new_matrix(&mut scenario);
+    let config = pricing_config::new();
+
+    let mut prices = vector[];
+    let mut i = 0;
+    while (i < 3) {
+        matrix.insert_range(STRIKE_K, constants::pos_inf!(), QTY_PER_BUYER, WEIGHT_AT_K, 0);
+        let agg = matrix.directional_aggregate();
+        let (mint, _) = config.compute_up_quote(HALF, &agg, 0, BALANCE, seven_days_ms());
+        prices.push_back(mint);
+        i = i + 1;
+    };
+
+    // ratios: 0.10, 0.20, 0.30 → shifts: 0.05, 0.10, 0.15.
+    assert_eq!(prices[0], 560_000_000);
+    assert_eq!(prices[1], 610_000_000);
+    assert_eq!(prices[2], 660_000_000);
+    // Equal step size: each marginal buyer pays the same incremental premium.
+    assert_eq!(prices[1] - prices[0], prices[2] - prices[1]);
+
+    destroy(matrix);
+    config.destroy_for_testing();
+    scenario.end();
+}
+
+// ── UP buy followed by DN buy at the same strike: aggregate cancels exactly ─
+
+#[test]
+fun up_buy_followed_by_dn_buy_at_same_strike_cancels_skew() {
+    let mut scenario = test_scenario::begin(@0xa);
+    let mut matrix = new_matrix(&mut scenario);
+    let config = pricing_config::new();
+
+    // UP@K is `(K, +∞]` with lower_weight = n(d₂(K)), higher_weight = 0
+    // (sentinel). DN@K is `(-∞, K]` — lower_weight = 0, higher_weight =
+    // n(d₂(K)). The two contributions have equal magnitude and opposite
+    // sign — the directional aggregate returns to zero.
+    matrix.insert_range(STRIKE_K, constants::pos_inf!(), QTY_PER_BUYER, WEIGHT_AT_K, 0);
+    matrix.insert_range(constants::neg_inf!(), STRIKE_K, QTY_PER_BUYER, 0, WEIGHT_AT_K);
+
+    let agg = matrix.directional_aggregate();
+    assert!(agg.is_zero());
+
+    let (mint, redeem) = config.compute_up_quote(HALF, &agg, 0, BALANCE, seven_days_ms());
+    // Back to symmetric quotes around fair.
+    assert_eq!(mint, HALF + FEE_AT_HALF);
+    assert_eq!(redeem, HALF - FEE_AT_HALF);
+
+    destroy(matrix);
+    config.destroy_for_testing();
+    scenario.end();
+}
+
+// ── UP buy then partial UP redeem: skew shrinks proportionally ─────────────
+
+#[test]
+fun partial_redeem_after_buy_shrinks_skew_proportionally() {
+    let mut scenario = test_scenario::begin(@0xa);
+    let mut matrix = new_matrix(&mut scenario);
+    let config = pricing_config::new();
+
+    // Buy 3× the unit qty (ratio = 0.30), then redeem 1× (ratio drops to 0.20).
+    let three_x = 3 * QTY_PER_BUYER;
+    matrix.insert_range(STRIKE_K, constants::pos_inf!(), three_x, WEIGHT_AT_K, 0);
+    matrix.remove_range(STRIKE_K, constants::pos_inf!(), QTY_PER_BUYER, WEIGHT_AT_K, 0);
+
+    let (mint, _) = config.compute_up_quote(
+        HALF,
+        &matrix.directional_aggregate(),
+        0,
+        BALANCE,
+        seven_days_ms(),
+    );
+
+    // Net ratio = 0.20 → shift = 0.10 → mint = 0.61.
+    assert_eq!(mint, 610_000_000);
+
+    destroy(matrix);
+    config.destroy_for_testing();
+    scenario.end();
+}
+
+// ── UP buy then UP redeem at unchanged weights returns to flat ──────────────
+
+#[test]
+fun full_round_trip_at_same_weights_returns_book_to_flat() {
+    let mut scenario = test_scenario::begin(@0xa);
+    let mut matrix = new_matrix(&mut scenario);
+    let config = pricing_config::new();
+
+    matrix.insert_range(STRIKE_K, constants::pos_inf!(), QTY_PER_BUYER, WEIGHT_AT_K, 0);
+    matrix.remove_range(STRIKE_K, constants::pos_inf!(), QTY_PER_BUYER, WEIGHT_AT_K, 0);
+
+    assert!(matrix.directional_aggregate().is_zero());
+
+    let (mint, redeem) = config.compute_up_quote(
+        HALF,
+        &matrix.directional_aggregate(),
+        0,
+        BALANCE,
+        seven_days_ms(),
+    );
+    assert_eq!(mint, HALF + FEE_AT_HALF);
+    assert_eq!(redeem, HALF - FEE_AT_HALF);
+
+    destroy(matrix);
+    config.destroy_for_testing();
+    scenario.end();
+}
+
+// ── Range buy with K_high closer to ATM than K_low: aggregate goes negative ─
+
+#[test]
+fun range_buy_with_higher_weight_at_top_drives_aggregate_negative() {
+    let mut scenario = test_scenario::begin(@0xa);
+    let mut matrix = new_matrix(&mut scenario);
+    let config = pricing_config::new();
+
+    // Range `(K_low, K]` — lower deeper from ATM, upper at ATM.
+    // lower_weight = 0.2, higher_weight = 0.4.
+    // Aggregate += +qty·0.2 - qty·0.4 = -qty·0.2 → ratio = -0.05 in our setup.
+    matrix.insert_range(STRIKE_K_LOW, STRIKE_K, QTY_PER_BUYER, WEIGHT_AT_K_LOW, WEIGHT_AT_K);
+    let agg = matrix.directional_aggregate();
+    assert!(agg.is_negative());
+
+    let (mint, redeem) = config.compute_up_quote(HALF, &agg, 0, BALANCE, seven_days_ms());
+
+    // ratio = -0.05 → shift = 0.05 · 0.5 = 0.025 → shifted_mid = 0.475.
+    // shift > spread (= 0.01) → mint clamps at fair = 0.5.
+    // redeem = (0.475 - 0.01).min(0.5) = 0.465.
+    assert_eq!(mint, HALF);
+    assert_eq!(redeem, 465_000_000);
+
+    destroy(matrix);
+    config.destroy_for_testing();
+    scenario.end();
+}
+
+// ── Range buy with K_low closer to ATM than K_high: aggregate goes positive ─
+
+#[test]
+fun range_buy_with_higher_weight_at_bottom_drives_aggregate_positive() {
+    let mut scenario = test_scenario::begin(@0xa);
+    let mut matrix = new_matrix(&mut scenario);
+    let config = pricing_config::new();
+
+    // Range `(K, K_high]` — lower at ATM, upper deeper from ATM.
+    // lower_weight = 0.4, higher_weight = 0.2.
+    matrix.insert_range(STRIKE_K, STRIKE_K_HIGH, QTY_PER_BUYER, WEIGHT_AT_K, WEIGHT_AT_K_LOW);
+    let agg = matrix.directional_aggregate();
+    assert!(!agg.is_negative());
+
+    let (mint, redeem) = config.compute_up_quote(HALF, &agg, 0, BALANCE, seven_days_ms());
+
+    // ratio = +0.05 → shift = +0.025 → shifted_mid = 0.525.
+    // mint = 0.525 + 0.01 = 0.535. redeem clamps at fair.
+    assert_eq!(mint, 535_000_000);
+    assert_eq!(redeem, HALF);
+
+    destroy(matrix);
+    config.destroy_for_testing();
+    scenario.end();
+}
+
+// ── Mixed sequence: range buy then UP buy combine partially ────────────────
+
+#[test]
+fun range_buy_followed_by_up_buy_combine_into_smaller_net_skew() {
+    let mut scenario = test_scenario::begin(@0xa);
+    let mut matrix = new_matrix(&mut scenario);
+    let config = pricing_config::new();
+
+    // Range `(K, K_high]` first: aggregate += qty·(0.4 − 0.2) = qty·0.2,
+    // which in raw units is 5e8 → ratio = 0.05.
+    matrix.insert_range(STRIKE_K, STRIKE_K_HIGH, QTY_PER_BUYER, WEIGHT_AT_K, WEIGHT_AT_K_LOW);
+    let (_, redeem_after_range) = config.compute_up_quote(
+        HALF,
+        &matrix.directional_aggregate(),
+        0,
+        BALANCE,
+        seven_days_ms(),
+    );
+
+    // Then UP@K: aggregate += qty·0.4 = 1e9 → ratio jumps from 0.05 to 0.15.
+    // shift = 0.15 · 0.5 = 0.075 → mint = 0.5 + 0.075 + 1% = 0.585.
+    matrix.insert_range(STRIKE_K, constants::pos_inf!(), QTY_PER_BUYER, WEIGHT_AT_K, 0);
+    let (mint_combined, _) = config.compute_up_quote(
+        HALF,
+        &matrix.directional_aggregate(),
+        0,
+        BALANCE,
+        seven_days_ms(),
+    );
+
+    // After-range alone: redeem clamps at fair (positive aggregate).
+    assert_eq!(redeem_after_range, HALF);
+    // Combined ratio reflects both legs.
+    assert_eq!(mint_combined, 585_000_000);
+
+    destroy(matrix);
+    config.destroy_for_testing();
+    scenario.end();
+}
+
+// ── Whale order: single trade that saturates the clamp instantly ────────────
+
+#[test]
+fun saturating_single_trade_drives_mint_to_one() {
+    let mut scenario = test_scenario::begin(@0xa);
+    let mut matrix = new_matrix(&mut scenario);
+    let config = pricing_config::new();
+
+    // 11× the unit qty drives ratio to 1.10 → clamps at 1.0.
+    let whale_qty = 11 * QTY_PER_BUYER;
+    matrix.insert_range(STRIKE_K, constants::pos_inf!(), whale_qty, WEIGHT_AT_K, 0);
+
+    let (mint, redeem) = config.compute_up_quote(
+        HALF,
+        &matrix.directional_aggregate(),
+        0,
+        BALANCE,
+        seven_days_ms(),
+    );
+
+    // Saturation: shifted_mid = FS, mint clamps at FS, redeem clamps at fair.
+    assert_eq!(mint, FS);
+    assert_eq!(redeem, HALF);
+
+    destroy(matrix);
+    config.destroy_for_testing();
+    scenario.end();
+}
+
+// ── Splitting an order across many TXs: average cost matches the bulk price ─
+
+#[test]
+fun ten_split_orders_pay_same_average_cost_as_one_bulk_order() {
+    let mut scenario = test_scenario::begin(@0xa);
+    let mut split_matrix = new_matrix(&mut scenario);
+    let mut bulk_matrix = new_matrix(&mut scenario);
+    let config = pricing_config::new();
+
+    // 10 buyers at QTY_PER_BUYER each, vs one buyer at 10×.
+    let mut total_split_premium = 0u64;
+    let mut i = 0;
+    while (i < 10) {
+        split_matrix.insert_range(
+            STRIKE_K,
+            constants::pos_inf!(),
+            QTY_PER_BUYER,
+            WEIGHT_AT_K,
+            0,
+        );
+        let (mint, _) = config.compute_up_quote(
+            HALF,
+            &split_matrix.directional_aggregate(),
+            0,
+            BALANCE,
+            seven_days_ms(),
+        );
+        // Each split buyer's premium over fair+spread = (mint - HALF - FEE_AT_HALF).
+        total_split_premium = total_split_premium + (mint - HALF - FEE_AT_HALF);
+        i = i + 1;
+    };
+
+    // Bulk: one trade of 10× qty saturates instantly (ratio = 1.0). Per-unit
+    // premium = (FS - HALF - FEE_AT_HALF) / 10. Compare totals (sum across 10
+    // contracts vs 10× for one bulk contract is the same denominator).
+    bulk_matrix.insert_range(
+        STRIKE_K,
+        constants::pos_inf!(),
+        10 * QTY_PER_BUYER,
+        WEIGHT_AT_K,
+        0,
+    );
+    let (mint_bulk, _) = config.compute_up_quote(
+        HALF,
+        &bulk_matrix.directional_aggregate(),
+        0,
+        BALANCE,
+        seven_days_ms(),
+    );
+    let bulk_premium_per_buyer = mint_bulk - HALF - FEE_AT_HALF;
+    let bulk_total_premium = 10 * bulk_premium_per_buyer;
+
+    // Split path: sum of (k · 0.05) for k = 1..10 = 0.05 · 55 = 2.75 → 275M units.
+    // Bulk path: 10 · (FS · 0.5 - 0.01 - HALF) = 10 · (1.0 - 0.5 - 0.01) = 4.90 → 4_900M units.
+    // Bulk total > split total — the bulk buyer overpays vs the split path
+    // *as a sum across contracts*, because the bulk hits saturation earlier.
+    // (The protocol-relevant comparison is per-contract cost; in a non-saturated
+    // regime split and bulk converge, but at saturation the bulk pays the
+    // capped premium on every contract.)
+    assert!(bulk_total_premium > total_split_premium);
+
+    destroy(split_matrix);
+    destroy(bulk_matrix);
+    config.destroy_for_testing();
+    scenario.end();
+}
+
+// ── Round-trip through a moving SVI surface: the residual is the drift cost ─
+
+#[test]
+fun round_trip_with_weight_drift_matches_predicted_residual() {
+    let mut scenario = test_scenario::begin(@0xa);
+    let mut matrix = new_matrix(&mut scenario);
+    let config = pricing_config::new();
+
+    // Trader opens UP@K with `n(d₂)` at trade time = 0.40, then closes
+    // after the SVI surface drifts so the new `n(d₂)` at K is 0.30.
+    let weight_open = WEIGHT_AT_K; // 0.40
+    let weight_close = 300_000_000; // 0.30
+
+    matrix.insert_range(STRIKE_K, constants::pos_inf!(), QTY_PER_BUYER, weight_open, 0);
+    matrix.remove_range(STRIKE_K, constants::pos_inf!(), QTY_PER_BUYER, weight_close, 0);
+
+    // Residual aggregate = qty · (weight_open − weight_close) =
+    // 2.5e9 · (0.40 − 0.30) / FS = 2.5e8 (positive).
+    let residual = matrix.directional_aggregate();
+    assert_eq!(residual.magnitude(), 250_000_000);
+    assert!(!residual.is_negative());
+
+    // The next quote sees this residual: ratio = 2.5e8 · FS / 1e10 = 2.5e7
+    // = 0.025 → shift = 0.0125 → mint = 0.5 + 0.0125 + 0.01 = 0.5225.
+    let (mint, _) = config.compute_up_quote(HALF, &residual, 0, BALANCE, seven_days_ms());
+    assert_eq!(mint, 522_500_000);
+
+    destroy(matrix);
+    config.destroy_for_testing();
+    scenario.end();
+}

--- a/packages/predict/tests/config/inventory_skew_tests.move
+++ b/packages/predict/tests/config/inventory_skew_tests.move
@@ -512,6 +512,236 @@ fun higher_per_strike_weight_pushes_mint_further_for_same_qty() {
     config.destroy_for_testing();
 }
 
+// ── tte_factor at known ratios ──────────────────────────────────────────────
+
+#[test]
+fun tte_factor_equals_one_when_tte_matches_reference() {
+    // At τ = ref_tte the time-amplification factor is exactly 1, so the
+    // shift is purely the raw aggregate ratio scaled by room.
+    let config = pricing_config::new();
+    let depth = constants::default_depth_multiplier!();
+    let agg = i64::from_parts(aggregate_for_ratio(100_000_000, BALANCE, depth), false);
+
+    let (mint, _) = config.compute_up_quote(HALF, &agg, 0, BALANCE, seven_days_ms());
+
+    // ratio = 0.10 → shift = 0.10 · 0.5 = 0.05 → mint = 0.5 + 0.05 + 1% = 0.56.
+    assert_eq!(mint, 560_000_000);
+
+    config.destroy_for_testing();
+}
+
+#[test]
+fun tte_factor_doubles_at_quarter_reference_tte() {
+    // tte_factor = √(ref_tte / τ). At τ = ref_tte/4 the factor is exactly 2.
+    let config = pricing_config::new();
+    let depth = constants::default_depth_multiplier!();
+    let agg = i64::from_parts(aggregate_for_ratio(100_000_000, BALANCE, depth), false);
+    let quarter_tte = constants::default_reference_tte_ms!() / 4;
+
+    let (mint, _) = config.compute_up_quote(HALF, &agg, 0, BALANCE, quarter_tte);
+
+    // ratio = 0.10 · 2 = 0.20 → shift = 0.20 · 0.5 = 0.10 → mint = 0.61.
+    assert_eq!(mint, 610_000_000);
+
+    config.destroy_for_testing();
+}
+
+#[test]
+fun tte_factor_halves_at_four_times_reference_tte() {
+    // tte_factor = √(ref_tte / (4·ref_tte)) = 0.5. Skew dampens for far-dated
+    // expiries because the binary delta is correspondingly smaller.
+    let config = pricing_config::new();
+    let depth = constants::default_depth_multiplier!();
+    let agg = i64::from_parts(aggregate_for_ratio(100_000_000, BALANCE, depth), false);
+    let four_x_tte = 4 * constants::default_reference_tte_ms!();
+
+    let (mint, _) = config.compute_up_quote(HALF, &agg, 0, BALANCE, four_x_tte);
+
+    // ratio = 0.10 · 0.5 = 0.05 → shift = 0.05 · 0.5 = 0.025 → mint = 0.535.
+    assert_eq!(mint, 535_000_000);
+
+    config.destroy_for_testing();
+}
+
+// ── Ratio clamp behavior at the saturation boundary ─────────────────────────
+
+#[test]
+fun ratio_at_exactly_one_saturates_to_full_room() {
+    // At raw ratio == 1.0 exactly the clamp is a no-op: shift = 1 · room.
+    let config = pricing_config::new();
+    let depth = constants::default_depth_multiplier!();
+    let agg = i64::from_parts(aggregate_for_ratio(FS, BALANCE, depth), false);
+
+    let (mint, redeem) = config.compute_up_quote(HALF, &agg, 0, BALANCE, seven_days_ms());
+
+    // shifted_mid = 0.5 + 1.0 · 0.5 = 1.0 → mint = FS, redeem clamps at fair.
+    assert_eq!(mint, FS);
+    assert_eq!(redeem, HALF);
+
+    config.destroy_for_testing();
+}
+
+#[test]
+fun ratio_just_below_one_does_not_quite_saturate() {
+    // ratio = 0.999 → shift = 0.999 · 0.5 = 0.4995, mid = 0.9995, mint = FS
+    // (clamped by .min(FS) at the end), but the mid is still strictly < FS.
+    // This isolates the difference between the ratio_mag.min(FS) clamp and
+    // the final mint_price.min(FS) clamp.
+    let config = pricing_config::new();
+    let depth = constants::default_depth_multiplier!();
+    let agg = i64::from_parts(aggregate_for_ratio(999_000_000, BALANCE, depth), false);
+
+    let (mint, redeem) = config.compute_up_quote(HALF, &agg, 0, BALANCE, seven_days_ms());
+
+    // shifted_mid = 0.5 + 0.999 · 0.5 = 0.9995, mint = (0.9995 + 0.01).min(FS) = FS.
+    assert_eq!(mint, FS);
+    // redeem = (0.9995 - 0.01).min(0.5) = 0.5 (still clamped at fair).
+    assert_eq!(redeem, HALF);
+
+    config.destroy_for_testing();
+}
+
+// ── Sub-spread shift: zero-edge floor doesn't engage ────────────────────────
+
+#[test]
+fun negative_aggregate_with_shift_below_spread_keeps_mint_above_fair_only() {
+    // Small negative aggregate: shift < spread, so `shifted_mid + spread`
+    // still exceeds fair on its own — the .max(fair) clamp is a no-op and
+    // mint sits between fair and (fair + spread).
+    let config = pricing_config::new();
+    let depth = constants::default_depth_multiplier!();
+    // ratio = -0.005 → shift = 0.005 · 0.5 = 0.0025; spread (1%) > shift.
+    let agg = i64::from_parts(aggregate_for_ratio(5_000_000, BALANCE, depth), true);
+
+    let (mint, _) = config.compute_up_quote(HALF, &agg, 0, BALANCE, seven_days_ms());
+
+    // shifted_mid = 0.5 - 0.0025 = 0.4975 → mint = 0.4975 + 0.01 = 0.5075.
+    // Above fair (= 0.5) but strictly below the unshifted mint (= 0.51).
+    assert_eq!(mint, 507_500_000);
+
+    config.destroy_for_testing();
+}
+
+#[test]
+fun positive_aggregate_with_shift_below_spread_keeps_redeem_below_fair_only() {
+    let config = pricing_config::new();
+    let depth = constants::default_depth_multiplier!();
+    let agg = i64::from_parts(aggregate_for_ratio(5_000_000, BALANCE, depth), false);
+
+    let (_, redeem) = config.compute_up_quote(HALF, &agg, 0, BALANCE, seven_days_ms());
+
+    // shifted_mid = 0.5025 → redeem = 0.5025 - 0.01 = 0.4925 (below fair, above 0).
+    assert_eq!(redeem, 492_500_000);
+
+    config.destroy_for_testing();
+}
+
+// ── Rejected fair prices (settled boundaries) ───────────────────────────────
+
+#[test, expected_failure(abort_code = pricing_config::EFairPriceAlreadySettled)]
+fun compute_up_quote_aborts_when_fair_price_is_one() {
+    // FS == 1.0 means the binary settled "yes". No live fee applies.
+    let config = pricing_config::new();
+    let agg = i64::zero();
+    let (_, _) = config.compute_up_quote(FS, &agg, 0, BALANCE, seven_days_ms());
+    abort 999
+}
+
+#[test, expected_failure(abort_code = pricing_config::EFairPriceAlreadySettled)]
+fun compute_up_quote_aborts_when_fair_price_is_zero() {
+    let config = pricing_config::new();
+    let agg = i64::zero();
+    let (_, _) = config.compute_up_quote(0, &agg, 0, BALANCE, seven_days_ms());
+    abort 999
+}
+
+// ── Round-trip cost without skew equals two spreads ─────────────────────────
+
+#[test]
+fun round_trip_cost_with_zero_aggregate_equals_two_spreads() {
+    // Round-trip cost = mint − redeem. With a flat book this is purely
+    // bid-ask, no inventory penalty.
+    let config = pricing_config::new();
+    let agg = i64::zero();
+
+    let (mint, redeem) = config.compute_up_quote(HALF, &agg, 0, BALANCE, seven_days_ms());
+
+    assert_eq!(mint - redeem, 2 * FEE_AT_HALF);
+
+    config.destroy_for_testing();
+}
+
+#[test]
+fun round_trip_cost_with_positive_aggregate_widens_by_shift() {
+    // After a one-sided buy, the round trip costs more by exactly `shift` —
+    // the buyer's own order pushed the mid against them, and the redeem
+    // side pinned at fair while mint widened.
+    let config = pricing_config::new();
+    let depth = constants::default_depth_multiplier!();
+    let agg = i64::from_parts(aggregate_for_ratio(100_000_000, BALANCE, depth), false);
+
+    let (mint, redeem) = config.compute_up_quote(HALF, &agg, 0, BALANCE, seven_days_ms());
+
+    // mint = 0.56, redeem clamps at 0.5 → cost = 0.06 = 6¢.
+    assert_eq!(mint, 560_000_000);
+    assert_eq!(redeem, HALF);
+    assert_eq!(mint - redeem, 60_000_000);
+
+    config.destroy_for_testing();
+}
+
+// ── Very small balance: aggregate saturates the clamp instantly ─────────────
+
+#[test]
+fun tiny_balance_relative_to_aggregate_saturates_immediately() {
+    // With balance ≪ aggregate, the raw ratio explodes past 1 and clamps.
+    // Models the worst-case behavior right after a high-leverage trade.
+    let config = pricing_config::new();
+    let agg = i64::from_parts(1_000_000_000_000, false); // 1e12, large
+    let tiny_balance = 1_000_000u64; // 1 USDC vault
+
+    let (mint, redeem) = config.compute_up_quote(
+        HALF,
+        &agg,
+        0,
+        tiny_balance,
+        seven_days_ms(),
+    );
+
+    assert_eq!(mint, FS);
+    assert_eq!(redeem, HALF);
+
+    config.destroy_for_testing();
+}
+
+// ── Asymmetric room exact boundaries ────────────────────────────────────────
+
+#[test]
+fun positive_skew_at_one_cent_fair_uses_full_room_to_one() {
+    // Far OTM (fair = 1¢): room for positive skew is 99¢, so the shift can
+    // dominate. spread at p=0.01: 2% · √(0.01·0.99) ≈ 2% · 0.0995 = 0.199%
+    // — but min_fee floor (0.5%) kicks in.
+    let config = pricing_config::new();
+    let depth = constants::default_depth_multiplier!();
+    let agg = i64::from_parts(aggregate_for_ratio(100_000_000, BALANCE, depth), false);
+
+    let (mint, redeem) = config.compute_up_quote(
+        10_000_000,
+        &agg,
+        0,
+        BALANCE,
+        seven_days_ms(),
+    );
+
+    // ratio = 0.10 → shift = 0.10 · (1 - 0.01) = 0.099 → mid = 0.109.
+    // spread floor = 0.5% (min_fee) → mint = 0.109 + 0.005 = 0.114.
+    assert_eq!(mint, 114_000_000);
+    // redeem = 0.109 - 0.005 = 0.104, but clamped at fair (0.01).
+    assert_eq!(redeem, 10_000_000);
+
+    config.destroy_for_testing();
+}
+
 // ── Defaults and getters ────────────────────────────────────────────────────
 
 #[test]

--- a/packages/predict/tests/config/inventory_skew_tests.move
+++ b/packages/predict/tests/config/inventory_skew_tests.move
@@ -4,7 +4,7 @@
 #[test_only]
 module deepbook_predict::inventory_skew_tests;
 
-use deepbook_predict::{constants, i64, pricing_config};
+use deepbook_predict::{constants, i64::{Self, I64}, pricing_config::{Self, PricingConfig}};
 use std::unit_test::assert_eq;
 
 const FS: u64 = 1_000_000_000;
@@ -32,6 +32,20 @@ fun aggregate_for_ratio(target_ratio_fs: u64, balance: u64, depth_multiplier: u6
 
 fun seven_days_ms(): u64 { constants::default_reference_tte_ms!() }
 
+/// Quote a single-strike UP leg at strike K with `p_up(K) = fair`.
+/// Range form: `(K, +∞]` → `p_up_lower = fair`, `p_up_higher = 0`,
+/// `fair_range = fair`.
+fun up_leg(config: &PricingConfig, fair: u64, agg: &I64, balance: u64, tte: u64): (u64, u64) {
+    config.compute_range_quote(fair, fair, 0, agg, 0, balance, tte)
+}
+
+/// Quote a single-strike DN leg at strike K with `p_up(K) = p_up_at_k`.
+/// Range form: `(−∞, K]` → `p_up_lower = FS` (sentinel), `p_up_higher = p_up_at_k`,
+/// `fair_range = FS − p_up_at_k`.
+fun dn_leg(config: &PricingConfig, p_up_at_k: u64, agg: &I64, balance: u64, tte: u64): (u64, u64) {
+    config.compute_range_quote(FS - p_up_at_k, FS, p_up_at_k, agg, 0, balance, tte)
+}
+
 // ── Baseline: zero aggregate produces symmetric quote ───────────────────────
 
 #[test]
@@ -39,13 +53,7 @@ fun zero_aggregate_keeps_quote_centered_on_fair() {
     let config = pricing_config::new();
     let agg = i64::zero();
 
-    let (mint_price, redeem_price) = config.compute_up_quote(
-        HALF,
-        &agg,
-        0,
-        BALANCE,
-        seven_days_ms(),
-    );
+    let (mint_price, redeem_price) = up_leg(&config, HALF, &agg, BALANCE, seven_days_ms());
 
     assert_eq!(mint_price, HALF + FEE_AT_HALF);
     assert_eq!(redeem_price, HALF - FEE_AT_HALF);
@@ -53,52 +61,119 @@ fun zero_aggregate_keeps_quote_centered_on_fair() {
     config.destroy_for_testing();
 }
 
-// ── Positive aggregate: vault is short UP, push mid up; redeem clamps at fair ─
+// ── Symmetric invariant: paired legs sum to FS ± 2·spread ───────────────────
 
 #[test]
-fun positive_aggregate_pushes_mint_up_and_clamps_redeem_at_fair() {
+fun positive_aggregate_pushes_up_leg_up_and_dn_leg_down() {
     let config = pricing_config::new();
     let depth = constants::default_depth_multiplier!();
-    // ratio = 0.4 → shifted_mid = 0.5 + 0.4 · (1 − 0.5) = 0.7.
-    let agg_mag = aggregate_for_ratio(400_000_000, BALANCE, depth);
-    let agg = i64::from_parts(agg_mag, false);
+    // ratio = 0.4 at p_up(K) = 0.5 → m(K) = 0.5 + 0.4 · 0.5 = 0.7.
+    let agg = i64::from_parts(aggregate_for_ratio(400_000_000, BALANCE, depth), false);
 
-    let (mint_price, redeem_price) = config.compute_up_quote(
-        HALF,
-        &agg,
-        0,
-        BALANCE,
-        seven_days_ms(),
-    );
+    let (mint_up, redeem_up) = up_leg(&config, HALF, &agg, BALANCE, seven_days_ms());
+    let (mint_dn, redeem_dn) = dn_leg(&config, HALF, &agg, BALANCE, seven_days_ms());
 
-    // mint = 0.7 + 1% = 0.71; redeem clamped at fair (zero-edge floor).
-    assert_eq!(mint_price, 710_000_000);
-    assert_eq!(redeem_price, HALF);
+    // UP leg: m(K) = 0.7. mint = 0.71. redeem = 0.69.
+    assert_eq!(mint_up, 710_000_000);
+    assert_eq!(redeem_up, 690_000_000);
+    // DN leg: shifted_mid = FS − 0.7 = 0.3. mint = 0.31. redeem = 0.29.
+    assert_eq!(mint_dn, 310_000_000);
+    assert_eq!(redeem_dn, 290_000_000);
+
+    // Symmetric invariant: paired-leg cost = FS + 2·spread, paid out = FS − 2·spread.
+    assert_eq!(mint_up + mint_dn, FS + 2 * FEE_AT_HALF);
+    assert_eq!(redeem_up + redeem_dn, FS - 2 * FEE_AT_HALF);
 
     config.destroy_for_testing();
 }
 
-// ── Negative aggregate: symmetric, mint clamped at fair, redeem pushed down ─
-
 #[test]
-fun negative_aggregate_pushes_redeem_down_and_clamps_mint_at_fair() {
+fun negative_aggregate_mirrors_with_up_dn_swap() {
     let config = pricing_config::new();
     let depth = constants::default_depth_multiplier!();
-    // ratio = −0.4 → shifted_mid = 0.5 − 0.4 · 0.5 = 0.3.
-    let agg_mag = aggregate_for_ratio(400_000_000, BALANCE, depth);
-    let agg = i64::from_parts(agg_mag, true);
+    // ratio = −0.4 → m(K) = 0.5 − 0.4 · 0.5 = 0.3.
+    let agg = i64::from_parts(aggregate_for_ratio(400_000_000, BALANCE, depth), true);
 
-    let (mint_price, redeem_price) = config.compute_up_quote(
-        HALF,
-        &agg,
-        0,
-        BALANCE,
-        seven_days_ms(),
-    );
+    let (mint_up, redeem_up) = up_leg(&config, HALF, &agg, BALANCE, seven_days_ms());
+    let (mint_dn, redeem_dn) = dn_leg(&config, HALF, &agg, BALANCE, seven_days_ms());
 
-    // redeem = 0.3 − 1% = 0.29; mint clamped at fair (zero-edge floor).
-    assert_eq!(mint_price, HALF);
-    assert_eq!(redeem_price, 290_000_000);
+    // UP leg: m(K) = 0.3. mint = 0.31. redeem = 0.29.
+    assert_eq!(mint_up, 310_000_000);
+    assert_eq!(redeem_up, 290_000_000);
+    // DN leg: shifted_mid = FS − 0.3 = 0.7. mint = 0.71. redeem = 0.69.
+    assert_eq!(mint_dn, 710_000_000);
+    assert_eq!(redeem_dn, 690_000_000);
+
+    assert_eq!(mint_up + mint_dn, FS + 2 * FEE_AT_HALF);
+    assert_eq!(redeem_up + redeem_dn, FS - 2 * FEE_AT_HALF);
+
+    config.destroy_for_testing();
+}
+
+#[test]
+fun paired_legs_sum_invariant_holds_across_aggregate_sweep() {
+    // For any non-saturating aggregate, mint_up + mint_dn = FS + 2·spread and
+    // redeem_up + redeem_dn = FS − 2·spread. The invariant only fails at the
+    // FS / 0 clamps; this sweep stays well inside the unsaturated regime.
+    let config = pricing_config::new();
+    let depth = constants::default_depth_multiplier!();
+
+    let cases = vector[
+        i64::zero(),
+        i64::from_parts(aggregate_for_ratio(50_000_000, BALANCE, depth), false),
+        i64::from_parts(aggregate_for_ratio(50_000_000, BALANCE, depth), true),
+        i64::from_parts(aggregate_for_ratio(300_000_000, BALANCE, depth), false),
+        i64::from_parts(aggregate_for_ratio(300_000_000, BALANCE, depth), true),
+        i64::from_parts(aggregate_for_ratio(600_000_000, BALANCE, depth), false),
+        i64::from_parts(aggregate_for_ratio(600_000_000, BALANCE, depth), true),
+    ];
+
+    let mut i = 0;
+    while (i < cases.length()) {
+        let (mint_up, redeem_up) = up_leg(&config, HALF, &cases[i], BALANCE, seven_days_ms());
+        let (mint_dn, redeem_dn) = dn_leg(&config, HALF, &cases[i], BALANCE, seven_days_ms());
+
+        assert_eq!(mint_up + mint_dn, FS + 2 * FEE_AT_HALF);
+        assert_eq!(redeem_up + redeem_dn, FS - 2 * FEE_AT_HALF);
+        i = i + 1;
+    };
+
+    config.destroy_for_testing();
+}
+
+// ── Above-fair redeem / below-fair mint allowed under heavy imbalance ───────
+
+#[test]
+fun positive_aggregate_lifts_up_leg_redeem_above_fair() {
+    // Heavy short-UP inventory: LP buys UP back from users at *above* fair to
+    // incentivise them to close. Old design floored redeem at fair; new design
+    // lets the mid walk.
+    let config = pricing_config::new();
+    let depth = constants::default_depth_multiplier!();
+    let agg = i64::from_parts(aggregate_for_ratio(800_000_000, BALANCE, depth), false);
+
+    let (_, redeem_up) = up_leg(&config, HALF, &agg, BALANCE, seven_days_ms());
+
+    // ratio = 0.8 → m(K) = 0.5 + 0.8 · 0.5 = 0.9. redeem = 0.9 − 0.01 = 0.89.
+    assert_eq!(redeem_up, 890_000_000);
+    assert!(redeem_up > HALF);
+
+    config.destroy_for_testing();
+}
+
+#[test]
+fun negative_aggregate_drops_up_leg_mint_below_fair() {
+    // Heavy long-UP inventory: LP sells UP to new users at *below* fair to
+    // attract offsetting flow.
+    let config = pricing_config::new();
+    let depth = constants::default_depth_multiplier!();
+    let agg = i64::from_parts(aggregate_for_ratio(800_000_000, BALANCE, depth), true);
+
+    let (mint_up, _) = up_leg(&config, HALF, &agg, BALANCE, seven_days_ms());
+
+    // ratio = −0.8 → m(K) = 0.1. mint = 0.11.
+    assert_eq!(mint_up, 110_000_000);
+    assert!(mint_up < HALF);
 
     config.destroy_for_testing();
 }
@@ -106,44 +181,32 @@ fun negative_aggregate_pushes_redeem_down_and_clamps_mint_at_fair() {
 // ── Saturation: ratio_mag clamps at 1.0; mid lands at the binary boundary ──
 
 #[test]
-fun saturated_positive_ratio_drives_mint_to_one() {
+fun saturated_positive_ratio_drives_up_leg_mid_to_one() {
     let config = pricing_config::new();
     let depth = constants::default_depth_multiplier!();
-    // raw ratio = 5.0 → clamps to 1.0 → shifted_mid = 0.5 + (1 − 0.5) = 1.0.
-    let agg_mag = aggregate_for_ratio(5 * FS, BALANCE, depth);
-    let agg = i64::from_parts(agg_mag, false);
+    // raw ratio = 5.0 → clamps to 1.0 → m(K) = 0.5 + 1 · 0.5 = 1.0.
+    let agg = i64::from_parts(aggregate_for_ratio(5 * FS, BALANCE, depth), false);
 
-    let (mint_price, redeem_price) = config.compute_up_quote(
-        HALF,
-        &agg,
-        0,
-        BALANCE,
-        seven_days_ms(),
-    );
+    let (mint_up, redeem_up) = up_leg(&config, HALF, &agg, BALANCE, seven_days_ms());
 
-    assert_eq!(mint_price, FS);
-    assert_eq!(redeem_price, HALF);
+    // mint = (FS + 0.01).min(FS) = FS. redeem = FS − 0.01 = 0.99.
+    assert_eq!(mint_up, FS);
+    assert_eq!(redeem_up, FS - FEE_AT_HALF);
 
     config.destroy_for_testing();
 }
 
 #[test]
-fun saturated_negative_ratio_drives_redeem_to_zero() {
+fun saturated_negative_ratio_drives_up_leg_mid_to_zero() {
     let config = pricing_config::new();
     let depth = constants::default_depth_multiplier!();
-    let agg_mag = aggregate_for_ratio(5 * FS, BALANCE, depth);
-    let agg = i64::from_parts(agg_mag, true);
+    let agg = i64::from_parts(aggregate_for_ratio(5 * FS, BALANCE, depth), true);
 
-    let (mint_price, redeem_price) = config.compute_up_quote(
-        HALF,
-        &agg,
-        0,
-        BALANCE,
-        seven_days_ms(),
-    );
+    let (mint_up, redeem_up) = up_leg(&config, HALF, &agg, BALANCE, seven_days_ms());
 
-    assert_eq!(mint_price, HALF);
-    assert_eq!(redeem_price, 0);
+    // m(K) = 0. mint = 0 + 0.01 = 0.01. redeem = 0.
+    assert_eq!(mint_up, FEE_AT_HALF);
+    assert_eq!(redeem_up, 0);
 
     config.destroy_for_testing();
 }
@@ -156,7 +219,7 @@ fun balance_zero_disables_skew() {
     let depth = constants::default_depth_multiplier!();
     let agg = i64::from_parts(aggregate_for_ratio(900_000_000, BALANCE, depth), false);
 
-    let (mint_price, redeem_price) = config.compute_up_quote(HALF, &agg, 0, 0, seven_days_ms());
+    let (mint_price, redeem_price) = up_leg(&config, HALF, &agg, 0, seven_days_ms());
 
     assert_eq!(mint_price, HALF + FEE_AT_HALF);
     assert_eq!(redeem_price, HALF - FEE_AT_HALF);
@@ -170,10 +233,94 @@ fun zero_aggregate_short_circuits_even_with_extreme_inputs() {
     config.set_min_tte_ms(1);
     let agg = i64::zero();
 
-    let (mint_price, redeem_price) = config.compute_up_quote(HALF, &agg, 0, 1, 0);
+    let (mint_price, redeem_price) = up_leg(&config, HALF, &agg, 1, 0);
 
     assert_eq!(mint_price, HALF + FEE_AT_HALF);
     assert_eq!(redeem_price, HALF - FEE_AT_HALF);
+
+    config.destroy_for_testing();
+}
+
+// ── Sentinel boundary inertness ─────────────────────────────────────────────
+
+#[test]
+fun sentinel_higher_boundary_contributes_zero_to_shift() {
+    // UP-K range `(K, +∞]`: m(+∞) must be exactly 0 regardless of aggregate.
+    // We assert this indirectly: at saturating positive ratio, the shifted_mid
+    // is exactly m(K) (not m(K) + ratio · 1). If `m(0) ≠ 0`, the shifted_mid
+    // would exceed FS and the .min(FS) clamp would kick in for both mint and
+    // redeem alike — but we observe redeem = m(K) − spread strictly below FS.
+    let config = pricing_config::new();
+    let depth = constants::default_depth_multiplier!();
+    // ratio = 0.6 → m(K) = 0.5 + 0.6 · 0.5 = 0.8. Sentinel m(0) = 0.
+    let agg = i64::from_parts(aggregate_for_ratio(600_000_000, BALANCE, depth), false);
+
+    let (mint_up, redeem_up) = up_leg(&config, HALF, &agg, BALANCE, seven_days_ms());
+
+    // shifted_mid = m(K) − m(+∞) = 0.8 − 0 = 0.8.
+    assert_eq!(mint_up, 810_000_000);
+    assert_eq!(redeem_up, 790_000_000);
+
+    config.destroy_for_testing();
+}
+
+#[test]
+fun sentinel_lower_boundary_holds_dn_mid_at_one_minus_strike_mid() {
+    // DN-K range `(−∞, K]`: m(−∞) must be exactly FS regardless of aggregate.
+    let config = pricing_config::new();
+    let depth = constants::default_depth_multiplier!();
+    // ratio = 0.6 → m(K) = 0.8. shifted_mid = FS − 0.8 = 0.2.
+    let agg = i64::from_parts(aggregate_for_ratio(600_000_000, BALANCE, depth), false);
+
+    let (mint_dn, redeem_dn) = dn_leg(&config, HALF, &agg, BALANCE, seven_days_ms());
+
+    // mint = 0.2 + 0.01 = 0.21. redeem = 0.2 − 0.01 = 0.19.
+    assert_eq!(mint_dn, 210_000_000);
+    assert_eq!(redeem_dn, 190_000_000);
+
+    config.destroy_for_testing();
+}
+
+// ── Range monotonicity guard ────────────────────────────────────────────────
+
+#[test]
+fun shifted_mid_does_not_underflow_for_valid_strike_ordering() {
+    // Range `(L, H]` with both finite: p_up(L) > p_up(H). Sweep aggregates of
+    // both signs near saturation and verify `compute_range_quote` does not
+    // arithmetic-underflow on `m_lower − m_higher`. (The bug this guards is a
+    // monotonicity break in `shifted_up_strike_mid` that would let the higher
+    // boundary's shifted mid exceed the lower boundary's.)
+    let config = pricing_config::new();
+    let depth = constants::default_depth_multiplier!();
+
+    let p_lower = 700_000_000; // p_up(L) = 0.7
+    let p_higher = 300_000_000; // p_up(H) = 0.3
+    let fair_range = p_lower - p_higher; // 0.4
+
+    let cases = vector[
+        i64::zero(),
+        i64::from_parts(aggregate_for_ratio(990_000_000, BALANCE, depth), false),
+        i64::from_parts(aggregate_for_ratio(990_000_000, BALANCE, depth), true),
+        i64::from_parts(aggregate_for_ratio(5 * FS, BALANCE, depth), false),
+        i64::from_parts(aggregate_for_ratio(5 * FS, BALANCE, depth), true),
+    ];
+
+    let mut i = 0;
+    while (i < cases.length()) {
+        let (mint, redeem) = config.compute_range_quote(
+            fair_range,
+            p_lower,
+            p_higher,
+            &cases[i],
+            0,
+            BALANCE,
+            seven_days_ms(),
+        );
+        // Sanity bounds: prices live in [0, FS]; redeem ≤ mint.
+        assert!(mint <= FS);
+        assert!(redeem <= mint);
+        i = i + 1;
+    };
 
     config.destroy_for_testing();
 }
@@ -186,19 +333,12 @@ fun shorter_tte_amplifies_skew_versus_reference_tte() {
     let depth = constants::default_depth_multiplier!();
     let agg = i64::from_parts(aggregate_for_ratio(100_000_000, BALANCE, depth), false);
 
-    let (mint_far, _) = config.compute_up_quote(HALF, &agg, 0, BALANCE, seven_days_ms());
-    let (mint_near, _) = config.compute_up_quote(
-        HALF,
-        &agg,
-        0,
-        BALANCE,
-        constants::default_min_tte_ms!(), // tte_factor = √(7d/1d) = √7
-    );
+    let (mint_far, _) = up_leg(&config, HALF, &agg, BALANCE, seven_days_ms());
+    let (mint_near, _) = up_leg(&config, HALF, &agg, BALANCE, constants::default_min_tte_ms!());
 
-    // ratio_far = 0.10, shifted_mid = 0.55, mint = 0.55 + 1% = 0.56.
+    // ratio_far = 0.10 → m(K) = 0.55 → mint = 0.56.
     assert_eq!(mint_far, 560_000_000);
-    // ratio_near = 0.10 · √7 > 0.10 · 2.6 = 0.26 → mid > 0.5 + 0.26·0.5 = 0.63
-    //   → mint > 0.63 + 0.01 = 0.64.
+    // ratio_near = 0.10 · √7 > 0.10 · 2.6 = 0.26 → m(K) > 0.63 → mint > 0.64.
     assert!(mint_near > 640_000_000);
 
     config.destroy_for_testing();
@@ -210,17 +350,10 @@ fun tte_below_min_clamps_to_min_tte_factor() {
     let depth = constants::default_depth_multiplier!();
     let agg = i64::from_parts(aggregate_for_ratio(100_000_000, BALANCE, depth), false);
 
-    let (mint_at_min, _) = config.compute_up_quote(
-        HALF,
-        &agg,
-        0,
-        BALANCE,
-        constants::default_min_tte_ms!(),
-    );
-    let (mint_below_min, _) = config.compute_up_quote(HALF, &agg, 0, BALANCE, 1);
-    let (mint_at_zero, _) = config.compute_up_quote(HALF, &agg, 0, BALANCE, 0);
+    let (mint_at_min, _) = up_leg(&config, HALF, &agg, BALANCE, constants::default_min_tte_ms!());
+    let (mint_below_min, _) = up_leg(&config, HALF, &agg, BALANCE, 1);
+    let (mint_at_zero, _) = up_leg(&config, HALF, &agg, BALANCE, 0);
 
-    // Anything ≤ min_tte_ms must produce the same shift.
     assert_eq!(mint_at_min, mint_below_min);
     assert_eq!(mint_at_min, mint_at_zero);
 
@@ -233,20 +366,16 @@ fun tte_below_min_clamps_to_min_tte_factor() {
 fun positive_skew_at_low_fair_price_has_full_room_to_one() {
     let config = pricing_config::new();
     let depth = constants::default_depth_multiplier!();
-    // Saturated positive ratio at fair = 0.20.
+    // Saturated positive ratio at p_up(K) = 0.20.
     let agg = i64::from_parts(aggregate_for_ratio(5 * FS, BALANCE, depth), false);
 
-    let (mint_price, redeem_price) = config.compute_up_quote(
-        TWENTY_CENT,
-        &agg,
-        0,
-        BALANCE,
-        seven_days_ms(),
-    );
+    let (mint_up, redeem_up) = up_leg(&config, TWENTY_CENT, &agg, BALANCE, seven_days_ms());
 
-    // shifted_mid = 0.20 + (1.0 − 0.20) = 1.0; mint clamps at FS.
-    assert_eq!(mint_price, FS);
-    assert_eq!(redeem_price, TWENTY_CENT);
+    // m(K) = 0.20 + 1.0 · (1 − 0.20) = 1.0; mint clamps at FS.
+    assert_eq!(mint_up, FS);
+    // spread at p=0.20: 2% · √(0.20·0.80) = 2% · 0.4 = 0.8%.
+    // redeem = FS − 0.008 = 0.992.
+    assert_eq!(redeem_up, 992_000_000);
 
     config.destroy_for_testing();
 }
@@ -257,17 +386,12 @@ fun negative_skew_at_high_fair_price_has_full_room_to_zero() {
     let depth = constants::default_depth_multiplier!();
     let agg = i64::from_parts(aggregate_for_ratio(5 * FS, BALANCE, depth), true);
 
-    let (mint_price, redeem_price) = config.compute_up_quote(
-        EIGHTY_CENT,
-        &agg,
-        0,
-        BALANCE,
-        seven_days_ms(),
-    );
+    let (mint_up, redeem_up) = up_leg(&config, EIGHTY_CENT, &agg, BALANCE, seven_days_ms());
 
-    // shifted_mid = 0.80 − 0.80 = 0; redeem floored at 0.
-    assert_eq!(mint_price, EIGHTY_CENT);
-    assert_eq!(redeem_price, 0);
+    // m(K) = 0.80 − 1.0 · 0.80 = 0; redeem floored at 0.
+    // mint = 0 + 0.008 = 0.008.
+    assert_eq!(mint_up, 8_000_000);
+    assert_eq!(redeem_up, 0);
 
     config.destroy_for_testing();
 }
@@ -278,22 +402,14 @@ fun negative_skew_at_high_fair_price_has_full_room_to_zero() {
 fun positive_skew_uses_room_to_one_at_twenty_cent_fair() {
     let config = pricing_config::new();
     let depth = constants::default_depth_multiplier!();
-    // ratio = 0.5 at fair = 0.20 → shift = 0.5 · (1 − 0.20) = 0.4 → mid = 0.60.
-    // fee at p=0.20: 2% · √0.16 = 0.8% = 8_000_000.
+    // ratio = 0.5 at p_up(K) = 0.20 → m(K) = 0.20 + 0.5 · 0.80 = 0.60.
     let agg = i64::from_parts(aggregate_for_ratio(500_000_000, BALANCE, depth), false);
 
-    let (mint_price, redeem_price) = config.compute_up_quote(
-        TWENTY_CENT,
-        &agg,
-        0,
-        BALANCE,
-        seven_days_ms(),
-    );
+    let (mint_up, redeem_up) = up_leg(&config, TWENTY_CENT, &agg, BALANCE, seven_days_ms());
 
-    // mint = 0.60 + 0.8% = 0.608.
-    assert_eq!(mint_price, 608_000_000);
-    // redeem = 0.60 − 0.8% = 0.592, but zero-edge floor caps at fair (0.20).
-    assert_eq!(redeem_price, TWENTY_CENT);
+    // mint = 0.60 + 0.008 = 0.608. redeem = 0.60 − 0.008 = 0.592.
+    assert_eq!(mint_up, 608_000_000);
+    assert_eq!(redeem_up, 592_000_000);
 
     config.destroy_for_testing();
 }
@@ -302,61 +418,14 @@ fun positive_skew_uses_room_to_one_at_twenty_cent_fair() {
 fun negative_skew_uses_room_to_zero_at_eighty_cent_fair() {
     let config = pricing_config::new();
     let depth = constants::default_depth_multiplier!();
-    // ratio = −0.5 at fair = 0.80 → shift = −0.5 · 0.80 = −0.4 → mid = 0.40.
+    // ratio = −0.5 at p_up(K) = 0.80 → m(K) = 0.80 − 0.5 · 0.80 = 0.40.
     let agg = i64::from_parts(aggregate_for_ratio(500_000_000, BALANCE, depth), true);
 
-    let (mint_price, redeem_price) = config.compute_up_quote(
-        EIGHTY_CENT,
-        &agg,
-        0,
-        BALANCE,
-        seven_days_ms(),
-    );
+    let (mint_up, redeem_up) = up_leg(&config, EIGHTY_CENT, &agg, BALANCE, seven_days_ms());
 
-    // mint floored at fair (0.80). redeem = 0.40 − 0.8% = 0.392.
-    assert_eq!(mint_price, EIGHTY_CENT);
-    assert_eq!(redeem_price, 392_000_000);
-
-    config.destroy_for_testing();
-}
-
-// ── Zero-edge floor invariant under all configurations ──────────────────────
-
-#[test]
-fun mint_never_below_fair_and_redeem_never_above_fair() {
-    let config = pricing_config::new();
-    let depth = constants::default_depth_multiplier!();
-
-    let cases = vector[
-        i64::zero(),
-        i64::from_parts(aggregate_for_ratio(50_000_000, BALANCE, depth), false),
-        i64::from_parts(aggregate_for_ratio(50_000_000, BALANCE, depth), true),
-        i64::from_parts(aggregate_for_ratio(990_000_000, BALANCE, depth), false),
-        i64::from_parts(aggregate_for_ratio(990_000_000, BALANCE, depth), true),
-        i64::from_parts(aggregate_for_ratio(5 * FS, BALANCE, depth), false),
-        i64::from_parts(aggregate_for_ratio(5 * FS, BALANCE, depth), true),
-    ];
-    let prices = vector[100_000_000u64, HALF, EIGHTY_CENT, 950_000_000u64];
-
-    let mut i = 0;
-    while (i < prices.length()) {
-        let p = prices[i];
-        let mut j = 0;
-        while (j < cases.length()) {
-            let (mint_price, redeem_price) = config.compute_up_quote(
-                p,
-                &cases[j],
-                0,
-                BALANCE,
-                seven_days_ms(),
-            );
-            assert!(mint_price >= p);
-            assert!(redeem_price <= p);
-            assert!(mint_price <= FS);
-            j = j + 1;
-        };
-        i = i + 1;
-    };
+    // mint = 0.40 + 0.008 = 0.408. redeem = 0.40 − 0.008 = 0.392.
+    assert_eq!(mint_up, 408_000_000);
+    assert_eq!(redeem_up, 392_000_000);
 
     config.destroy_for_testing();
 }
@@ -376,13 +445,7 @@ fun equal_and_opposite_aggregate_contributions_cancel() {
     let net = positive.add(&negative);
     assert!(net.is_zero());
 
-    let (mint_price, redeem_price) = config.compute_up_quote(
-        HALF,
-        &net,
-        0,
-        BALANCE,
-        seven_days_ms(),
-    );
+    let (mint_price, redeem_price) = up_leg(&config, HALF, &net, BALANCE, seven_days_ms());
     assert_eq!(mint_price, HALF + FEE_AT_HALF);
     assert_eq!(redeem_price, HALF - FEE_AT_HALF);
 
@@ -412,11 +475,6 @@ fun differing_open_and_close_weights_leave_a_residual() {
 
 #[test]
 fun mint_price_is_strictly_increasing_in_positive_aggregate() {
-    // Post-trade pricing (the protocol calls `apply_*_delta` before
-    // `quote_*_amounts`) means a buyer is quoted against the inventory
-    // their own order created. A 10× larger order should produce a 10×
-    // larger pre-clamp ratio and a strictly higher mint price (until the
-    // clamp at FS hits).
     let config = pricing_config::new();
     let depth = constants::default_depth_multiplier!();
 
@@ -424,9 +482,9 @@ fun mint_price_is_strictly_increasing_in_positive_aggregate() {
     let medium_agg = i64::from_parts(aggregate_for_ratio(100_000_000, BALANCE, depth), false);
     let large_agg = i64::from_parts(aggregate_for_ratio(500_000_000, BALANCE, depth), false);
 
-    let (mint_small, _) = config.compute_up_quote(HALF, &small_agg, 0, BALANCE, seven_days_ms());
-    let (mint_medium, _) = config.compute_up_quote(HALF, &medium_agg, 0, BALANCE, seven_days_ms());
-    let (mint_large, _) = config.compute_up_quote(HALF, &large_agg, 0, BALANCE, seven_days_ms());
+    let (mint_small, _) = up_leg(&config, HALF, &small_agg, BALANCE, seven_days_ms());
+    let (mint_medium, _) = up_leg(&config, HALF, &medium_agg, BALANCE, seven_days_ms());
+    let (mint_large, _) = up_leg(&config, HALF, &large_agg, BALANCE, seven_days_ms());
 
     assert!(mint_small < mint_medium);
     assert!(mint_medium < mint_large);
@@ -436,8 +494,6 @@ fun mint_price_is_strictly_increasing_in_positive_aggregate() {
 
 #[test]
 fun redeem_price_is_strictly_decreasing_in_negative_aggregate() {
-    // Symmetric: a redeemer who pushes the aggregate further negative gets
-    // a worse (lower) bid.
     let config = pricing_config::new();
     let depth = constants::default_depth_multiplier!();
 
@@ -445,15 +501,9 @@ fun redeem_price_is_strictly_decreasing_in_negative_aggregate() {
     let medium_agg = i64::from_parts(aggregate_for_ratio(100_000_000, BALANCE, depth), true);
     let large_agg = i64::from_parts(aggregate_for_ratio(500_000_000, BALANCE, depth), true);
 
-    let (_, redeem_small) = config.compute_up_quote(HALF, &small_agg, 0, BALANCE, seven_days_ms());
-    let (_, redeem_medium) = config.compute_up_quote(
-        HALF,
-        &medium_agg,
-        0,
-        BALANCE,
-        seven_days_ms(),
-    );
-    let (_, redeem_large) = config.compute_up_quote(HALF, &large_agg, 0, BALANCE, seven_days_ms());
+    let (_, redeem_small) = up_leg(&config, HALF, &small_agg, BALANCE, seven_days_ms());
+    let (_, redeem_medium) = up_leg(&config, HALF, &medium_agg, BALANCE, seven_days_ms());
+    let (_, redeem_large) = up_leg(&config, HALF, &large_agg, BALANCE, seven_days_ms());
 
     assert!(redeem_small > redeem_medium);
     assert!(redeem_medium > redeem_large);
@@ -464,18 +514,17 @@ fun redeem_price_is_strictly_decreasing_in_negative_aggregate() {
 #[test]
 fun doubling_aggregate_doubles_pre_clamp_shift() {
     // While the ratio is below 1.0, the shift is linear in the aggregate.
-    // ratio = 0.10 → shift = 0.05; ratio = 0.20 → shift = 0.10.
     let config = pricing_config::new();
     let depth = constants::default_depth_multiplier!();
 
     let agg = i64::from_parts(aggregate_for_ratio(100_000_000, BALANCE, depth), false);
     let agg_2x = i64::from_parts(aggregate_for_ratio(200_000_000, BALANCE, depth), false);
 
-    let (mint, _) = config.compute_up_quote(HALF, &agg, 0, BALANCE, seven_days_ms());
-    let (mint_2x, _) = config.compute_up_quote(HALF, &agg_2x, 0, BALANCE, seven_days_ms());
+    let (mint, _) = up_leg(&config, HALF, &agg, BALANCE, seven_days_ms());
+    let (mint_2x, _) = up_leg(&config, HALF, &agg_2x, BALANCE, seven_days_ms());
 
-    // mint   = 0.5 + 0.10·0.5 + fee = 0.55 + 1% = 0.56
-    // mint_2x = 0.5 + 0.20·0.5 + fee = 0.60 + 1% = 0.61
+    // ratio 0.10 → m(K) = 0.55 → mint = 0.56.
+    // ratio 0.20 → m(K) = 0.60 → mint = 0.61.
     assert_eq!(mint, 560_000_000);
     assert_eq!(mint_2x, 610_000_000);
     assert_eq!(mint_2x - HALF - FEE_AT_HALF, 2 * (mint - HALF - FEE_AT_HALF));
@@ -487,9 +536,6 @@ fun doubling_aggregate_doubles_pre_clamp_shift() {
 
 #[test]
 fun higher_per_strike_weight_pushes_mint_further_for_same_qty() {
-    // Two trades of the same size at different strikes. The one with bigger
-    // `n(d₂)` (closer to ATM) moves the aggregate more, so the resulting
-    // mint price is higher even though `quantity` is identical.
     let config = pricing_config::new();
     let depth = constants::default_depth_multiplier!();
 
@@ -497,15 +543,13 @@ fun higher_per_strike_weight_pushes_mint_further_for_same_qty() {
     let mag_otm = ((qty as u128) * 50_000_000u128 / (FS as u128)) as u64; // n ≈ 0.05
     let mag_atm = ((qty as u128) * 350_000_000u128 / (FS as u128)) as u64; // n ≈ 0.35
 
-    // Drive ratios to comparable levels by varying `balance` so the aggregate
-    // numerics stay representative without saturating the clamp.
     let agg_otm = i64::from_parts(mag_otm, false);
     let agg_atm = i64::from_parts(mag_atm, false);
-    let denom = (qty as u128) * (depth as u128) / (FS as u128); // pick balance so denom_fs = qty
+    let denom = (qty as u128) * (depth as u128) / (FS as u128);
     let balance = (denom * 1_000u128 / (depth as u128) * (FS as u128) / 1_000u128) as u64;
 
-    let (mint_otm, _) = config.compute_up_quote(HALF, &agg_otm, 0, balance, seven_days_ms());
-    let (mint_atm, _) = config.compute_up_quote(HALF, &agg_atm, 0, balance, seven_days_ms());
+    let (mint_otm, _) = up_leg(&config, HALF, &agg_otm, balance, seven_days_ms());
+    let (mint_atm, _) = up_leg(&config, HALF, &agg_atm, balance, seven_days_ms());
 
     assert!(mint_atm > mint_otm);
 
@@ -516,15 +560,13 @@ fun higher_per_strike_weight_pushes_mint_further_for_same_qty() {
 
 #[test]
 fun tte_factor_equals_one_when_tte_matches_reference() {
-    // At τ = ref_tte the time-amplification factor is exactly 1, so the
-    // shift is purely the raw aggregate ratio scaled by room.
     let config = pricing_config::new();
     let depth = constants::default_depth_multiplier!();
     let agg = i64::from_parts(aggregate_for_ratio(100_000_000, BALANCE, depth), false);
 
-    let (mint, _) = config.compute_up_quote(HALF, &agg, 0, BALANCE, seven_days_ms());
+    let (mint, _) = up_leg(&config, HALF, &agg, BALANCE, seven_days_ms());
 
-    // ratio = 0.10 → shift = 0.10 · 0.5 = 0.05 → mint = 0.5 + 0.05 + 1% = 0.56.
+    // ratio = 0.10 → m(K) = 0.55 → mint = 0.56.
     assert_eq!(mint, 560_000_000);
 
     config.destroy_for_testing();
@@ -538,9 +580,9 @@ fun tte_factor_doubles_at_quarter_reference_tte() {
     let agg = i64::from_parts(aggregate_for_ratio(100_000_000, BALANCE, depth), false);
     let quarter_tte = constants::default_reference_tte_ms!() / 4;
 
-    let (mint, _) = config.compute_up_quote(HALF, &agg, 0, BALANCE, quarter_tte);
+    let (mint, _) = up_leg(&config, HALF, &agg, BALANCE, quarter_tte);
 
-    // ratio = 0.10 · 2 = 0.20 → shift = 0.20 · 0.5 = 0.10 → mint = 0.61.
+    // ratio = 0.10 · 2 = 0.20 → m(K) = 0.60 → mint = 0.61.
     assert_eq!(mint, 610_000_000);
 
     config.destroy_for_testing();
@@ -548,16 +590,14 @@ fun tte_factor_doubles_at_quarter_reference_tte() {
 
 #[test]
 fun tte_factor_halves_at_four_times_reference_tte() {
-    // tte_factor = √(ref_tte / (4·ref_tte)) = 0.5. Skew dampens for far-dated
-    // expiries because the binary delta is correspondingly smaller.
     let config = pricing_config::new();
     let depth = constants::default_depth_multiplier!();
     let agg = i64::from_parts(aggregate_for_ratio(100_000_000, BALANCE, depth), false);
     let four_x_tte = 4 * constants::default_reference_tte_ms!();
 
-    let (mint, _) = config.compute_up_quote(HALF, &agg, 0, BALANCE, four_x_tte);
+    let (mint, _) = up_leg(&config, HALF, &agg, BALANCE, four_x_tte);
 
-    // ratio = 0.10 · 0.5 = 0.05 → shift = 0.05 · 0.5 = 0.025 → mint = 0.535.
+    // ratio = 0.10 · 0.5 = 0.05 → m(K) = 0.525 → mint = 0.535.
     assert_eq!(mint, 535_000_000);
 
     config.destroy_for_testing();
@@ -567,70 +607,61 @@ fun tte_factor_halves_at_four_times_reference_tte() {
 
 #[test]
 fun ratio_at_exactly_one_saturates_to_full_room() {
-    // At raw ratio == 1.0 exactly the clamp is a no-op: shift = 1 · room.
     let config = pricing_config::new();
     let depth = constants::default_depth_multiplier!();
     let agg = i64::from_parts(aggregate_for_ratio(FS, BALANCE, depth), false);
 
-    let (mint, redeem) = config.compute_up_quote(HALF, &agg, 0, BALANCE, seven_days_ms());
+    let (mint, redeem) = up_leg(&config, HALF, &agg, BALANCE, seven_days_ms());
 
-    // shifted_mid = 0.5 + 1.0 · 0.5 = 1.0 → mint = FS, redeem clamps at fair.
+    // m(K) = 0.5 + 1.0 · 0.5 = 1.0 → mint = FS, redeem = FS − 0.01.
     assert_eq!(mint, FS);
-    assert_eq!(redeem, HALF);
+    assert_eq!(redeem, FS - FEE_AT_HALF);
 
     config.destroy_for_testing();
 }
 
 #[test]
 fun ratio_just_below_one_does_not_quite_saturate() {
-    // ratio = 0.999 → shift = 0.999 · 0.5 = 0.4995, mid = 0.9995, mint = FS
-    // (clamped by .min(FS) at the end), but the mid is still strictly < FS.
-    // This isolates the difference between the ratio_mag.min(FS) clamp and
-    // the final mint_price.min(FS) clamp.
     let config = pricing_config::new();
     let depth = constants::default_depth_multiplier!();
     let agg = i64::from_parts(aggregate_for_ratio(999_000_000, BALANCE, depth), false);
 
-    let (mint, redeem) = config.compute_up_quote(HALF, &agg, 0, BALANCE, seven_days_ms());
+    let (mint, redeem) = up_leg(&config, HALF, &agg, BALANCE, seven_days_ms());
 
-    // shifted_mid = 0.5 + 0.999 · 0.5 = 0.9995, mint = (0.9995 + 0.01).min(FS) = FS.
+    // m(K) = 0.5 + 0.999 · 0.5 = 0.9995. mint = (0.9995 + 0.01).min(FS) = FS.
     assert_eq!(mint, FS);
-    // redeem = (0.9995 - 0.01).min(0.5) = 0.5 (still clamped at fair).
-    assert_eq!(redeem, HALF);
+    // redeem = 0.9995 − 0.01 = 0.9895.
+    assert_eq!(redeem, 989_500_000);
 
     config.destroy_for_testing();
 }
 
-// ── Sub-spread shift: zero-edge floor doesn't engage ────────────────────────
+// ── Sub-spread shift: shifted_mid stays close to fair, no underflow on redeem
 
 #[test]
-fun negative_aggregate_with_shift_below_spread_keeps_mint_above_fair_only() {
-    // Small negative aggregate: shift < spread, so `shifted_mid + spread`
-    // still exceeds fair on its own — the .max(fair) clamp is a no-op and
-    // mint sits between fair and (fair + spread).
+fun negative_aggregate_with_shift_below_spread_keeps_mint_above_fair() {
     let config = pricing_config::new();
     let depth = constants::default_depth_multiplier!();
-    // ratio = -0.005 → shift = 0.005 · 0.5 = 0.0025; spread (1%) > shift.
+    // ratio = -0.005 → m(K) = 0.4975; spread (1%) > shift (0.0025).
     let agg = i64::from_parts(aggregate_for_ratio(5_000_000, BALANCE, depth), true);
 
-    let (mint, _) = config.compute_up_quote(HALF, &agg, 0, BALANCE, seven_days_ms());
+    let (mint, _) = up_leg(&config, HALF, &agg, BALANCE, seven_days_ms());
 
-    // shifted_mid = 0.5 - 0.0025 = 0.4975 → mint = 0.4975 + 0.01 = 0.5075.
-    // Above fair (= 0.5) but strictly below the unshifted mint (= 0.51).
+    // mint = 0.4975 + 0.01 = 0.5075. Above fair because spread > shift.
     assert_eq!(mint, 507_500_000);
 
     config.destroy_for_testing();
 }
 
 #[test]
-fun positive_aggregate_with_shift_below_spread_keeps_redeem_below_fair_only() {
+fun positive_aggregate_with_shift_below_spread_keeps_redeem_below_fair() {
     let config = pricing_config::new();
     let depth = constants::default_depth_multiplier!();
     let agg = i64::from_parts(aggregate_for_ratio(5_000_000, BALANCE, depth), false);
 
-    let (_, redeem) = config.compute_up_quote(HALF, &agg, 0, BALANCE, seven_days_ms());
+    let (_, redeem) = up_leg(&config, HALF, &agg, BALANCE, seven_days_ms());
 
-    // shifted_mid = 0.5025 → redeem = 0.5025 - 0.01 = 0.4925 (below fair, above 0).
+    // m(K) = 0.5025 → redeem = 0.5025 − 0.01 = 0.4925.
     assert_eq!(redeem, 492_500_000);
 
     config.destroy_for_testing();
@@ -639,32 +670,30 @@ fun positive_aggregate_with_shift_below_spread_keeps_redeem_below_fair_only() {
 // ── Rejected fair prices (settled boundaries) ───────────────────────────────
 
 #[test, expected_failure(abort_code = pricing_config::EFairPriceAlreadySettled)]
-fun compute_up_quote_aborts_when_fair_price_is_one() {
+fun compute_range_quote_aborts_when_fair_range_is_one() {
     // FS == 1.0 means the binary settled "yes". No live fee applies.
     let config = pricing_config::new();
     let agg = i64::zero();
-    let (_, _) = config.compute_up_quote(FS, &agg, 0, BALANCE, seven_days_ms());
+    let (_, _) = config.compute_range_quote(FS, FS, 0, &agg, 0, BALANCE, seven_days_ms());
     abort 999
 }
 
 #[test, expected_failure(abort_code = pricing_config::EFairPriceAlreadySettled)]
-fun compute_up_quote_aborts_when_fair_price_is_zero() {
+fun compute_range_quote_aborts_when_fair_range_is_zero() {
     let config = pricing_config::new();
     let agg = i64::zero();
-    let (_, _) = config.compute_up_quote(0, &agg, 0, BALANCE, seven_days_ms());
+    let (_, _) = config.compute_range_quote(0, HALF, HALF, &agg, 0, BALANCE, seven_days_ms());
     abort 999
 }
 
-// ── Round-trip cost without skew equals two spreads ─────────────────────────
+// ── Round-trip cost: 2·spread regardless of skew ────────────────────────────
 
 #[test]
 fun round_trip_cost_with_zero_aggregate_equals_two_spreads() {
-    // Round-trip cost = mint − redeem. With a flat book this is purely
-    // bid-ask, no inventory penalty.
     let config = pricing_config::new();
     let agg = i64::zero();
 
-    let (mint, redeem) = config.compute_up_quote(HALF, &agg, 0, BALANCE, seven_days_ms());
+    let (mint, redeem) = up_leg(&config, HALF, &agg, BALANCE, seven_days_ms());
 
     assert_eq!(mint - redeem, 2 * FEE_AT_HALF);
 
@@ -672,20 +701,19 @@ fun round_trip_cost_with_zero_aggregate_equals_two_spreads() {
 }
 
 #[test]
-fun round_trip_cost_with_positive_aggregate_widens_by_shift() {
-    // After a one-sided buy, the round trip costs more by exactly `shift` —
-    // the buyer's own order pushed the mid against them, and the redeem
-    // side pinned at fair while mint widened.
+fun round_trip_cost_is_two_spreads_under_skew() {
+    // Symmetric design: mint = m(K) + spread, redeem = m(K) − spread, so a
+    // round-trip on the same leg always costs exactly 2·spread regardless of
+    // the inventory shift.
     let config = pricing_config::new();
     let depth = constants::default_depth_multiplier!();
     let agg = i64::from_parts(aggregate_for_ratio(100_000_000, BALANCE, depth), false);
 
-    let (mint, redeem) = config.compute_up_quote(HALF, &agg, 0, BALANCE, seven_days_ms());
+    let (mint, redeem) = up_leg(&config, HALF, &agg, BALANCE, seven_days_ms());
 
-    // mint = 0.56, redeem clamps at 0.5 → cost = 0.06 = 6¢.
     assert_eq!(mint, 560_000_000);
-    assert_eq!(redeem, HALF);
-    assert_eq!(mint - redeem, 60_000_000);
+    assert_eq!(redeem, 540_000_000);
+    assert_eq!(mint - redeem, 2 * FEE_AT_HALF);
 
     config.destroy_for_testing();
 }
@@ -694,22 +722,14 @@ fun round_trip_cost_with_positive_aggregate_widens_by_shift() {
 
 #[test]
 fun tiny_balance_relative_to_aggregate_saturates_immediately() {
-    // With balance ≪ aggregate, the raw ratio explodes past 1 and clamps.
-    // Models the worst-case behavior right after a high-leverage trade.
     let config = pricing_config::new();
-    let agg = i64::from_parts(1_000_000_000_000, false); // 1e12, large
-    let tiny_balance = 1_000_000u64; // 1 USDC vault
+    let agg = i64::from_parts(1_000_000_000_000, false);
+    let tiny_balance = 1_000_000u64;
 
-    let (mint, redeem) = config.compute_up_quote(
-        HALF,
-        &agg,
-        0,
-        tiny_balance,
-        seven_days_ms(),
-    );
+    let (mint, redeem) = up_leg(&config, HALF, &agg, tiny_balance, seven_days_ms());
 
     assert_eq!(mint, FS);
-    assert_eq!(redeem, HALF);
+    assert_eq!(redeem, FS - FEE_AT_HALF);
 
     config.destroy_for_testing();
 }
@@ -718,26 +738,19 @@ fun tiny_balance_relative_to_aggregate_saturates_immediately() {
 
 #[test]
 fun positive_skew_at_one_cent_fair_uses_full_room_to_one() {
-    // Far OTM (fair = 1¢): room for positive skew is 99¢, so the shift can
-    // dominate. spread at p=0.01: 2% · √(0.01·0.99) ≈ 2% · 0.0995 = 0.199%
-    // — but min_fee floor (0.5%) kicks in.
+    // Far OTM (fair = 1¢): room for positive skew is 99¢.
+    // spread at p=0.01: 2% · √(0.01·0.99) ≈ 0.199% — but min_fee floor (0.5%) kicks in.
     let config = pricing_config::new();
     let depth = constants::default_depth_multiplier!();
     let agg = i64::from_parts(aggregate_for_ratio(100_000_000, BALANCE, depth), false);
 
-    let (mint, redeem) = config.compute_up_quote(
-        10_000_000,
-        &agg,
-        0,
-        BALANCE,
-        seven_days_ms(),
-    );
+    let (mint, redeem) = up_leg(&config, 10_000_000, &agg, BALANCE, seven_days_ms());
 
-    // ratio = 0.10 → shift = 0.10 · (1 - 0.01) = 0.099 → mid = 0.109.
+    // ratio = 0.10 → m(K) = 0.01 + 0.10 · 0.99 = 0.109.
     // spread floor = 0.5% (min_fee) → mint = 0.109 + 0.005 = 0.114.
     assert_eq!(mint, 114_000_000);
-    // redeem = 0.109 - 0.005 = 0.104, but clamped at fair (0.01).
-    assert_eq!(redeem, 10_000_000);
+    // redeem = 0.109 − 0.005 = 0.104.
+    assert_eq!(redeem, 104_000_000);
 
     config.destroy_for_testing();
 }

--- a/packages/predict/tests/config/inventory_skew_tests.move
+++ b/packages/predict/tests/config/inventory_skew_tests.move
@@ -1,0 +1,556 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module deepbook_predict::inventory_skew_tests;
+
+use deepbook_predict::{constants, i64, pricing_config};
+use std::unit_test::assert_eq;
+
+const FS: u64 = 1_000_000_000;
+const HALF: u64 = 500_000_000;
+const TWENTY_CENT: u64 = 200_000_000;
+const EIGHTY_CENT: u64 = 800_000_000;
+
+const BALANCE: u64 = 1_000_000_000_000;
+
+// Hand-derived from the protocol defaults:
+// fee = max(default_base_fee · √(p·(1-p)), default_min_fee) at zero utilization.
+//   p = 0.5: 2% · √0.25 = 1%.
+const FEE_AT_HALF: u64 = 10_000_000;
+
+/// Build an aggregate magnitude that drives `raw_ratio` to `target_ratio_fs`
+/// (in FLOAT_SCALING) at the given depth_multiplier and tte_factor = 1.
+///
+/// `raw_ratio = aggregate · tte_factor / (balance · depth_multiplier)` where
+/// the multiplications are FS-scaled (so `denom_fs = balance · depth / FS`).
+/// Solve for `aggregate`: `aggregate = target_ratio_fs · denom_fs / FS`.
+fun aggregate_for_ratio(target_ratio_fs: u64, balance: u64, depth_multiplier: u64): u64 {
+    let denom = (balance as u128) * (depth_multiplier as u128) / (FS as u128);
+    ((target_ratio_fs as u128) * denom / (FS as u128)) as u64
+}
+
+fun seven_days_ms(): u64 { constants::default_reference_tte_ms!() }
+
+// ── Baseline: zero aggregate produces symmetric quote ───────────────────────
+
+#[test]
+fun zero_aggregate_keeps_quote_centered_on_fair() {
+    let config = pricing_config::new();
+    let agg = i64::zero();
+
+    let (mint_price, redeem_price) = config.compute_up_quote(
+        HALF,
+        &agg,
+        0,
+        BALANCE,
+        seven_days_ms(),
+    );
+
+    assert_eq!(mint_price, HALF + FEE_AT_HALF);
+    assert_eq!(redeem_price, HALF - FEE_AT_HALF);
+
+    config.destroy_for_testing();
+}
+
+// ── Positive aggregate: vault is short UP, push mid up; redeem clamps at fair ─
+
+#[test]
+fun positive_aggregate_pushes_mint_up_and_clamps_redeem_at_fair() {
+    let config = pricing_config::new();
+    let depth = constants::default_depth_multiplier!();
+    // ratio = 0.4 → shifted_mid = 0.5 + 0.4 · (1 − 0.5) = 0.7.
+    let agg_mag = aggregate_for_ratio(400_000_000, BALANCE, depth);
+    let agg = i64::from_parts(agg_mag, false);
+
+    let (mint_price, redeem_price) = config.compute_up_quote(
+        HALF,
+        &agg,
+        0,
+        BALANCE,
+        seven_days_ms(),
+    );
+
+    // mint = 0.7 + 1% = 0.71; redeem clamped at fair (zero-edge floor).
+    assert_eq!(mint_price, 710_000_000);
+    assert_eq!(redeem_price, HALF);
+
+    config.destroy_for_testing();
+}
+
+// ── Negative aggregate: symmetric, mint clamped at fair, redeem pushed down ─
+
+#[test]
+fun negative_aggregate_pushes_redeem_down_and_clamps_mint_at_fair() {
+    let config = pricing_config::new();
+    let depth = constants::default_depth_multiplier!();
+    // ratio = −0.4 → shifted_mid = 0.5 − 0.4 · 0.5 = 0.3.
+    let agg_mag = aggregate_for_ratio(400_000_000, BALANCE, depth);
+    let agg = i64::from_parts(agg_mag, true);
+
+    let (mint_price, redeem_price) = config.compute_up_quote(
+        HALF,
+        &agg,
+        0,
+        BALANCE,
+        seven_days_ms(),
+    );
+
+    // redeem = 0.3 − 1% = 0.29; mint clamped at fair (zero-edge floor).
+    assert_eq!(mint_price, HALF);
+    assert_eq!(redeem_price, 290_000_000);
+
+    config.destroy_for_testing();
+}
+
+// ── Saturation: ratio_mag clamps at 1.0; mid lands at the binary boundary ──
+
+#[test]
+fun saturated_positive_ratio_drives_mint_to_one() {
+    let config = pricing_config::new();
+    let depth = constants::default_depth_multiplier!();
+    // raw ratio = 5.0 → clamps to 1.0 → shifted_mid = 0.5 + (1 − 0.5) = 1.0.
+    let agg_mag = aggregate_for_ratio(5 * FS, BALANCE, depth);
+    let agg = i64::from_parts(agg_mag, false);
+
+    let (mint_price, redeem_price) = config.compute_up_quote(
+        HALF,
+        &agg,
+        0,
+        BALANCE,
+        seven_days_ms(),
+    );
+
+    assert_eq!(mint_price, FS);
+    assert_eq!(redeem_price, HALF);
+
+    config.destroy_for_testing();
+}
+
+#[test]
+fun saturated_negative_ratio_drives_redeem_to_zero() {
+    let config = pricing_config::new();
+    let depth = constants::default_depth_multiplier!();
+    let agg_mag = aggregate_for_ratio(5 * FS, BALANCE, depth);
+    let agg = i64::from_parts(agg_mag, true);
+
+    let (mint_price, redeem_price) = config.compute_up_quote(
+        HALF,
+        &agg,
+        0,
+        BALANCE,
+        seven_days_ms(),
+    );
+
+    assert_eq!(mint_price, HALF);
+    assert_eq!(redeem_price, 0);
+
+    config.destroy_for_testing();
+}
+
+// ── Short-circuit guards ────────────────────────────────────────────────────
+
+#[test]
+fun balance_zero_disables_skew() {
+    let config = pricing_config::new();
+    let depth = constants::default_depth_multiplier!();
+    let agg = i64::from_parts(aggregate_for_ratio(900_000_000, BALANCE, depth), false);
+
+    let (mint_price, redeem_price) = config.compute_up_quote(HALF, &agg, 0, 0, seven_days_ms());
+
+    assert_eq!(mint_price, HALF + FEE_AT_HALF);
+    assert_eq!(redeem_price, HALF - FEE_AT_HALF);
+
+    config.destroy_for_testing();
+}
+
+#[test]
+fun zero_aggregate_short_circuits_even_with_extreme_inputs() {
+    let mut config = pricing_config::new();
+    config.set_min_tte_ms(1);
+    let agg = i64::zero();
+
+    let (mint_price, redeem_price) = config.compute_up_quote(HALF, &agg, 0, 1, 0);
+
+    assert_eq!(mint_price, HALF + FEE_AT_HALF);
+    assert_eq!(redeem_price, HALF - FEE_AT_HALF);
+
+    config.destroy_for_testing();
+}
+
+// ── TTE amplification ───────────────────────────────────────────────────────
+
+#[test]
+fun shorter_tte_amplifies_skew_versus_reference_tte() {
+    let config = pricing_config::new();
+    let depth = constants::default_depth_multiplier!();
+    let agg = i64::from_parts(aggregate_for_ratio(100_000_000, BALANCE, depth), false);
+
+    let (mint_far, _) = config.compute_up_quote(HALF, &agg, 0, BALANCE, seven_days_ms());
+    let (mint_near, _) = config.compute_up_quote(
+        HALF,
+        &agg,
+        0,
+        BALANCE,
+        constants::default_min_tte_ms!(), // tte_factor = √(7d/1d) = √7
+    );
+
+    // ratio_far = 0.10, shifted_mid = 0.55, mint = 0.55 + 1% = 0.56.
+    assert_eq!(mint_far, 560_000_000);
+    // ratio_near = 0.10 · √7 > 0.10 · 2.6 = 0.26 → mid > 0.5 + 0.26·0.5 = 0.63
+    //   → mint > 0.63 + 0.01 = 0.64.
+    assert!(mint_near > 640_000_000);
+
+    config.destroy_for_testing();
+}
+
+#[test]
+fun tte_below_min_clamps_to_min_tte_factor() {
+    let config = pricing_config::new();
+    let depth = constants::default_depth_multiplier!();
+    let agg = i64::from_parts(aggregate_for_ratio(100_000_000, BALANCE, depth), false);
+
+    let (mint_at_min, _) = config.compute_up_quote(
+        HALF,
+        &agg,
+        0,
+        BALANCE,
+        constants::default_min_tte_ms!(),
+    );
+    let (mint_below_min, _) = config.compute_up_quote(HALF, &agg, 0, BALANCE, 1);
+    let (mint_at_zero, _) = config.compute_up_quote(HALF, &agg, 0, BALANCE, 0);
+
+    // Anything ≤ min_tte_ms must produce the same shift.
+    assert_eq!(mint_at_min, mint_below_min);
+    assert_eq!(mint_at_min, mint_at_zero);
+
+    config.destroy_for_testing();
+}
+
+// ── Asymmetric room at extreme fair prices ──────────────────────────────────
+
+#[test]
+fun positive_skew_at_low_fair_price_has_full_room_to_one() {
+    let config = pricing_config::new();
+    let depth = constants::default_depth_multiplier!();
+    // Saturated positive ratio at fair = 0.20.
+    let agg = i64::from_parts(aggregate_for_ratio(5 * FS, BALANCE, depth), false);
+
+    let (mint_price, redeem_price) = config.compute_up_quote(
+        TWENTY_CENT,
+        &agg,
+        0,
+        BALANCE,
+        seven_days_ms(),
+    );
+
+    // shifted_mid = 0.20 + (1.0 − 0.20) = 1.0; mint clamps at FS.
+    assert_eq!(mint_price, FS);
+    assert_eq!(redeem_price, TWENTY_CENT);
+
+    config.destroy_for_testing();
+}
+
+#[test]
+fun negative_skew_at_high_fair_price_has_full_room_to_zero() {
+    let config = pricing_config::new();
+    let depth = constants::default_depth_multiplier!();
+    let agg = i64::from_parts(aggregate_for_ratio(5 * FS, BALANCE, depth), true);
+
+    let (mint_price, redeem_price) = config.compute_up_quote(
+        EIGHTY_CENT,
+        &agg,
+        0,
+        BALANCE,
+        seven_days_ms(),
+    );
+
+    // shifted_mid = 0.80 − 0.80 = 0; redeem floored at 0.
+    assert_eq!(mint_price, EIGHTY_CENT);
+    assert_eq!(redeem_price, 0);
+
+    config.destroy_for_testing();
+}
+
+// ── Half-saturated skew at off-center fair prices ───────────────────────────
+
+#[test]
+fun positive_skew_uses_room_to_one_at_twenty_cent_fair() {
+    let config = pricing_config::new();
+    let depth = constants::default_depth_multiplier!();
+    // ratio = 0.5 at fair = 0.20 → shift = 0.5 · (1 − 0.20) = 0.4 → mid = 0.60.
+    // fee at p=0.20: 2% · √0.16 = 0.8% = 8_000_000.
+    let agg = i64::from_parts(aggregate_for_ratio(500_000_000, BALANCE, depth), false);
+
+    let (mint_price, redeem_price) = config.compute_up_quote(
+        TWENTY_CENT,
+        &agg,
+        0,
+        BALANCE,
+        seven_days_ms(),
+    );
+
+    // mint = 0.60 + 0.8% = 0.608.
+    assert_eq!(mint_price, 608_000_000);
+    // redeem = 0.60 − 0.8% = 0.592, but zero-edge floor caps at fair (0.20).
+    assert_eq!(redeem_price, TWENTY_CENT);
+
+    config.destroy_for_testing();
+}
+
+#[test]
+fun negative_skew_uses_room_to_zero_at_eighty_cent_fair() {
+    let config = pricing_config::new();
+    let depth = constants::default_depth_multiplier!();
+    // ratio = −0.5 at fair = 0.80 → shift = −0.5 · 0.80 = −0.4 → mid = 0.40.
+    let agg = i64::from_parts(aggregate_for_ratio(500_000_000, BALANCE, depth), true);
+
+    let (mint_price, redeem_price) = config.compute_up_quote(
+        EIGHTY_CENT,
+        &agg,
+        0,
+        BALANCE,
+        seven_days_ms(),
+    );
+
+    // mint floored at fair (0.80). redeem = 0.40 − 0.8% = 0.392.
+    assert_eq!(mint_price, EIGHTY_CENT);
+    assert_eq!(redeem_price, 392_000_000);
+
+    config.destroy_for_testing();
+}
+
+// ── Zero-edge floor invariant under all configurations ──────────────────────
+
+#[test]
+fun mint_never_below_fair_and_redeem_never_above_fair() {
+    let config = pricing_config::new();
+    let depth = constants::default_depth_multiplier!();
+
+    let cases = vector[
+        i64::zero(),
+        i64::from_parts(aggregate_for_ratio(50_000_000, BALANCE, depth), false),
+        i64::from_parts(aggregate_for_ratio(50_000_000, BALANCE, depth), true),
+        i64::from_parts(aggregate_for_ratio(990_000_000, BALANCE, depth), false),
+        i64::from_parts(aggregate_for_ratio(990_000_000, BALANCE, depth), true),
+        i64::from_parts(aggregate_for_ratio(5 * FS, BALANCE, depth), false),
+        i64::from_parts(aggregate_for_ratio(5 * FS, BALANCE, depth), true),
+    ];
+    let prices = vector[100_000_000u64, HALF, EIGHTY_CENT, 950_000_000u64];
+
+    let mut i = 0;
+    while (i < prices.length()) {
+        let p = prices[i];
+        let mut j = 0;
+        while (j < cases.length()) {
+            let (mint_price, redeem_price) = config.compute_up_quote(
+                p,
+                &cases[j],
+                0,
+                BALANCE,
+                seven_days_ms(),
+            );
+            assert!(mint_price >= p);
+            assert!(redeem_price <= p);
+            assert!(mint_price <= FS);
+            j = j + 1;
+        };
+        i = i + 1;
+    };
+
+    config.destroy_for_testing();
+}
+
+// ── Sign convention: signed delta cancels exactly across insert+remove ──────
+
+#[test]
+fun equal_and_opposite_aggregate_contributions_cancel() {
+    let config = pricing_config::new();
+
+    let qty = 1_000_000_000u64;
+    let weight = 250_000_000u64; // n(d₂) ≈ 0.25 (d ≈ ±0.95)
+    let mag = ((qty as u128) * (weight as u128) / (FS as u128)) as u64;
+
+    let positive = i64::from_parts(mag, false);
+    let negative = i64::from_parts(mag, true);
+    let net = positive.add(&negative);
+    assert!(net.is_zero());
+
+    let (mint_price, redeem_price) = config.compute_up_quote(
+        HALF,
+        &net,
+        0,
+        BALANCE,
+        seven_days_ms(),
+    );
+    assert_eq!(mint_price, HALF + FEE_AT_HALF);
+    assert_eq!(redeem_price, HALF - FEE_AT_HALF);
+
+    config.destroy_for_testing();
+}
+
+#[test]
+fun differing_open_and_close_weights_leave_a_residual() {
+    // Known approximation: weight is recomputed at trade time, so a position
+    // closed under a different SVI surface leaves a `qty · (w_open − w_close)`
+    // residual in the directional aggregate.
+    let qty = 1_000_000_000u64;
+    let w_open = 250_000_000u64;
+    let w_close = 200_000_000u64;
+    let mag_open = ((qty as u128) * (w_open as u128) / (FS as u128)) as u64;
+    let mag_close = ((qty as u128) * (w_close as u128) / (FS as u128)) as u64;
+
+    let opened = i64::from_parts(mag_open, false);
+    let closed_negation = i64::from_parts(mag_close, true);
+    let residual = opened.add(&closed_negation);
+
+    assert_eq!(residual.magnitude(), mag_open - mag_close);
+    assert!(!residual.is_negative());
+}
+
+// ── Order-size monotonicity: bigger aggregate → strictly worse mint price ──
+
+#[test]
+fun mint_price_is_strictly_increasing_in_positive_aggregate() {
+    // Post-trade pricing (the protocol calls `apply_*_delta` before
+    // `quote_*_amounts`) means a buyer is quoted against the inventory
+    // their own order created. A 10× larger order should produce a 10×
+    // larger pre-clamp ratio and a strictly higher mint price (until the
+    // clamp at FS hits).
+    let config = pricing_config::new();
+    let depth = constants::default_depth_multiplier!();
+
+    let small_agg = i64::from_parts(aggregate_for_ratio(10_000_000, BALANCE, depth), false);
+    let medium_agg = i64::from_parts(aggregate_for_ratio(100_000_000, BALANCE, depth), false);
+    let large_agg = i64::from_parts(aggregate_for_ratio(500_000_000, BALANCE, depth), false);
+
+    let (mint_small, _) = config.compute_up_quote(HALF, &small_agg, 0, BALANCE, seven_days_ms());
+    let (mint_medium, _) = config.compute_up_quote(HALF, &medium_agg, 0, BALANCE, seven_days_ms());
+    let (mint_large, _) = config.compute_up_quote(HALF, &large_agg, 0, BALANCE, seven_days_ms());
+
+    assert!(mint_small < mint_medium);
+    assert!(mint_medium < mint_large);
+
+    config.destroy_for_testing();
+}
+
+#[test]
+fun redeem_price_is_strictly_decreasing_in_negative_aggregate() {
+    // Symmetric: a redeemer who pushes the aggregate further negative gets
+    // a worse (lower) bid.
+    let config = pricing_config::new();
+    let depth = constants::default_depth_multiplier!();
+
+    let small_agg = i64::from_parts(aggregate_for_ratio(10_000_000, BALANCE, depth), true);
+    let medium_agg = i64::from_parts(aggregate_for_ratio(100_000_000, BALANCE, depth), true);
+    let large_agg = i64::from_parts(aggregate_for_ratio(500_000_000, BALANCE, depth), true);
+
+    let (_, redeem_small) = config.compute_up_quote(HALF, &small_agg, 0, BALANCE, seven_days_ms());
+    let (_, redeem_medium) = config.compute_up_quote(
+        HALF,
+        &medium_agg,
+        0,
+        BALANCE,
+        seven_days_ms(),
+    );
+    let (_, redeem_large) = config.compute_up_quote(HALF, &large_agg, 0, BALANCE, seven_days_ms());
+
+    assert!(redeem_small > redeem_medium);
+    assert!(redeem_medium > redeem_large);
+
+    config.destroy_for_testing();
+}
+
+#[test]
+fun doubling_aggregate_doubles_pre_clamp_shift() {
+    // While the ratio is below 1.0, the shift is linear in the aggregate.
+    // ratio = 0.10 → shift = 0.05; ratio = 0.20 → shift = 0.10.
+    let config = pricing_config::new();
+    let depth = constants::default_depth_multiplier!();
+
+    let agg = i64::from_parts(aggregate_for_ratio(100_000_000, BALANCE, depth), false);
+    let agg_2x = i64::from_parts(aggregate_for_ratio(200_000_000, BALANCE, depth), false);
+
+    let (mint, _) = config.compute_up_quote(HALF, &agg, 0, BALANCE, seven_days_ms());
+    let (mint_2x, _) = config.compute_up_quote(HALF, &agg_2x, 0, BALANCE, seven_days_ms());
+
+    // mint   = 0.5 + 0.10·0.5 + fee = 0.55 + 1% = 0.56
+    // mint_2x = 0.5 + 0.20·0.5 + fee = 0.60 + 1% = 0.61
+    assert_eq!(mint, 560_000_000);
+    assert_eq!(mint_2x, 610_000_000);
+    assert_eq!(mint_2x - HALF - FEE_AT_HALF, 2 * (mint - HALF - FEE_AT_HALF));
+
+    config.destroy_for_testing();
+}
+
+// ── Per-strike weight scales the impact: ATM weight bites harder than OTM ───
+
+#[test]
+fun higher_per_strike_weight_pushes_mint_further_for_same_qty() {
+    // Two trades of the same size at different strikes. The one with bigger
+    // `n(d₂)` (closer to ATM) moves the aggregate more, so the resulting
+    // mint price is higher even though `quantity` is identical.
+    let config = pricing_config::new();
+    let depth = constants::default_depth_multiplier!();
+
+    let qty = 1_000_000_000u64;
+    let mag_otm = ((qty as u128) * 50_000_000u128 / (FS as u128)) as u64; // n ≈ 0.05
+    let mag_atm = ((qty as u128) * 350_000_000u128 / (FS as u128)) as u64; // n ≈ 0.35
+
+    // Drive ratios to comparable levels by varying `balance` so the aggregate
+    // numerics stay representative without saturating the clamp.
+    let agg_otm = i64::from_parts(mag_otm, false);
+    let agg_atm = i64::from_parts(mag_atm, false);
+    let denom = (qty as u128) * (depth as u128) / (FS as u128); // pick balance so denom_fs = qty
+    let balance = (denom * 1_000u128 / (depth as u128) * (FS as u128) / 1_000u128) as u64;
+
+    let (mint_otm, _) = config.compute_up_quote(HALF, &agg_otm, 0, balance, seven_days_ms());
+    let (mint_atm, _) = config.compute_up_quote(HALF, &agg_atm, 0, balance, seven_days_ms());
+
+    assert!(mint_atm > mint_otm);
+
+    config.destroy_for_testing();
+}
+
+// ── Defaults and getters ────────────────────────────────────────────────────
+
+#[test]
+fun defaults_expose_skew_terms() {
+    let config = pricing_config::new();
+    assert_eq!(config.depth_multiplier(), constants::default_depth_multiplier!());
+    assert_eq!(config.reference_tte_ms(), constants::default_reference_tte_ms!());
+    assert_eq!(config.min_tte_ms(), constants::default_min_tte_ms!());
+    config.destroy_for_testing();
+}
+
+// ── Admin-setter abort guards ───────────────────────────────────────────────
+
+#[test, expected_failure(abort_code = pricing_config::EInvalidDepthMultiplier)]
+fun set_depth_multiplier_rejects_zero() {
+    let mut config = pricing_config::new();
+    config.set_depth_multiplier(0);
+    abort 999
+}
+
+#[test, expected_failure(abort_code = pricing_config::EInvalidTteBound)]
+fun set_min_tte_ms_rejects_zero() {
+    let mut config = pricing_config::new();
+    config.set_min_tte_ms(0);
+    abort 999
+}
+
+#[test, expected_failure(abort_code = pricing_config::EInvalidTteBound)]
+fun set_min_tte_ms_rejects_value_above_reference_tte() {
+    let mut config = pricing_config::new();
+    let above_ref = constants::default_reference_tte_ms!() + 1;
+    config.set_min_tte_ms(above_ref);
+    abort 999
+}
+
+#[test, expected_failure(abort_code = pricing_config::EInvalidTteBound)]
+fun set_reference_tte_ms_rejects_value_below_min_tte() {
+    let mut config = pricing_config::new();
+    let below_min = constants::default_min_tte_ms!() - 1;
+    config.set_reference_tte_ms(below_min);
+    abort 999
+}

--- a/packages/predict/tests/helper/normal_pdf_tests.move
+++ b/packages/predict/tests/helper/normal_pdf_tests.move
@@ -1,0 +1,74 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module deepbook_predict::normal_pdf_tests;
+
+use deepbook_predict::{i64, math};
+use std::unit_test::assert_eq;
+
+const FS: u64 = 1_000_000_000;
+
+fun assert_close(actual: u64, expected: u64, tol: u64) {
+    let diff = if (actual >= expected) actual - expected else expected - actual;
+    assert!(diff <= tol);
+}
+
+#[test]
+fun pdf_at_zero_equals_inv_sqrt_2pi() {
+    // n(0) = 1/√(2π) ≈ 0.398942280.
+    let zero = i64::zero();
+    assert_eq!(math::normal_pdf(&zero), 398_942_280);
+}
+
+#[test]
+fun pdf_is_symmetric_around_zero() {
+    let one = i64::from_u64(FS);
+    let neg_one = one.neg();
+    assert_eq!(math::normal_pdf(&one), math::normal_pdf(&neg_one));
+
+    let two = i64::from_u64(2 * FS);
+    let neg_two = two.neg();
+    assert_eq!(math::normal_pdf(&two), math::normal_pdf(&neg_two));
+}
+
+#[test]
+fun pdf_matches_textbook_at_one() {
+    // n(1) = exp(-0.5)/√(2π) ≈ 0.241970725 → 241_970_725.
+    let one = i64::from_u64(FS);
+    assert_close(math::normal_pdf(&one), 241_970_725, 200);
+}
+
+#[test]
+fun pdf_matches_textbook_at_two() {
+    // n(2) ≈ 0.053990967 → 53_990_967.
+    let two = i64::from_u64(2 * FS);
+    assert_close(math::normal_pdf(&two), 53_990_967, 200);
+}
+
+#[test]
+fun pdf_decays_to_zero_far_from_origin() {
+    // Beyond 8σ the PDF returns 0 to skip the exp call.
+    let nine = i64::from_u64(9 * FS);
+    assert_eq!(math::normal_pdf(&nine), 0);
+    assert_eq!(math::normal_pdf(&nine.neg()), 0);
+}
+
+#[test]
+fun pdf_is_strictly_decreasing_in_magnitude() {
+    let half = i64::from_u64(FS / 2);
+    let one = i64::from_u64(FS);
+    let two = i64::from_u64(2 * FS);
+    let four = i64::from_u64(4 * FS);
+
+    let p_zero = math::normal_pdf(&i64::zero());
+    let p_half = math::normal_pdf(&half);
+    let p_one = math::normal_pdf(&one);
+    let p_two = math::normal_pdf(&two);
+    let p_four = math::normal_pdf(&four);
+
+    assert!(p_zero > p_half);
+    assert!(p_half > p_one);
+    assert!(p_one > p_two);
+    assert!(p_two > p_four);
+}

--- a/packages/predict/tests/helper/risk_weight_tests.move
+++ b/packages/predict/tests/helper/risk_weight_tests.move
@@ -1,0 +1,39 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module deepbook_predict::risk_weight_tests;
+
+use deepbook_predict::{constants, oracle};
+use std::unit_test::{assert_eq, destroy};
+use sui::test_scenario;
+
+#[test]
+fun risk_weight_at_pos_inf_is_zero() {
+    // The +∞ sentinel is the unbounded upper boundary of `(K, +∞]`. The
+    // pricing layer must treat it as zero-weight so that the long-UP
+    // portion of a binary contributes only `qty · n(d₂(K))` to the
+    // directional aggregate (not `qty · (n(d₂(K)) − w_∞)` for some
+    // arbitrary `w_∞`).
+    let mut scenario = test_scenario::begin(@0xa);
+    let oracle = oracle::create_test_oracle(scenario.ctx());
+
+    assert_eq!(oracle.compute_risk_weight(constants::pos_inf!()), 0);
+
+    destroy(oracle);
+    scenario.end();
+}
+
+#[test]
+fun risk_weight_at_neg_inf_is_zero() {
+    // Symmetric for the −∞ boundary of `(−∞, K]`. Combined with the
+    // +∞ case, this means a binary on either side has exactly one
+    // weighted leg contributing to the aggregate.
+    let mut scenario = test_scenario::begin(@0xa);
+    let oracle = oracle::create_test_oracle(scenario.ctx());
+
+    assert_eq!(oracle.compute_risk_weight(constants::neg_inf!()), 0);
+
+    destroy(oracle);
+    scenario.end();
+}

--- a/packages/predict/tests/helper/strike_matrix_aggregate_tests.move
+++ b/packages/predict/tests/helper/strike_matrix_aggregate_tests.move
@@ -1,0 +1,304 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module deepbook_predict::strike_matrix_aggregate_tests;
+
+use deepbook_predict::{constants, i64, strike_matrix};
+use std::unit_test::{assert_eq, destroy};
+use sui::{clock, test_scenario};
+
+const FS: u64 = 1_000_000_000;
+const TICK_SIZE: u64 = 1_000_000;
+const MIN_STRIKE: u64 = 1_000_000;
+const MAX_STRIKE: u64 = 100_000_000;
+
+const QTY: u64 = 1_000_000;
+const STRIKE_LOW: u64 = 10_000_000;
+const STRIKE_HIGH: u64 = 50_000_000;
+
+// Hand-derived weights at two strikes (representative `n(d₂)` magnitudes,
+// not tied to any particular SVI surface — the matrix doesn't compute them,
+// it just folds them into the aggregate).
+const WEIGHT_LOW: u64 = 300_000_000; // 0.30
+const WEIGHT_HIGH: u64 = 100_000_000; // 0.10
+
+fun new_matrix(scenario: &mut test_scenario::Scenario): strike_matrix::StrikeMatrix {
+    scenario.next_tx(@0xa);
+    let clock = clock::create_for_testing(scenario.ctx());
+    let matrix = strike_matrix::new(scenario.ctx(), TICK_SIZE, MIN_STRIKE, MAX_STRIKE, &clock);
+    destroy(clock);
+    matrix
+}
+
+/// `qty · weight / FS` — the magnitude `apply_aggregate_delta` folds in.
+fun weighted_magnitude(qty: u64, weight: u64): u64 {
+    ((qty as u128) * (weight as u128) / (FS as u128)) as u64
+}
+
+// ── Fresh matrix has zero aggregate ─────────────────────────────────────────
+
+#[test]
+fun new_matrix_has_zero_aggregate() {
+    let mut scenario = test_scenario::begin(@0xa);
+    let matrix = new_matrix(&mut scenario);
+
+    let aggregate = matrix.directional_aggregate();
+    assert!(aggregate.is_zero());
+
+    destroy(matrix);
+    scenario.end();
+}
+
+// ── Insert range updates aggregate by qty·(lower_weight − higher_weight) ────
+
+#[test]
+fun insert_range_folds_lower_weight_positively_and_higher_weight_negatively() {
+    let mut scenario = test_scenario::begin(@0xa);
+    let mut matrix = new_matrix(&mut scenario);
+
+    matrix.insert_range(STRIKE_LOW, STRIKE_HIGH, QTY, WEIGHT_LOW, WEIGHT_HIGH);
+
+    let aggregate = matrix.directional_aggregate();
+    let expected = weighted_magnitude(QTY, WEIGHT_LOW) - weighted_magnitude(QTY, WEIGHT_HIGH);
+    assert_eq!(aggregate.magnitude(), expected);
+    assert!(!aggregate.is_negative());
+
+    destroy(matrix);
+    scenario.end();
+}
+
+#[test]
+fun insert_range_with_higher_weight_dominant_yields_negative_aggregate() {
+    let mut scenario = test_scenario::begin(@0xa);
+    let mut matrix = new_matrix(&mut scenario);
+
+    // Swap roles so higher leg's weight is bigger — net long DN portion
+    // (e.g., user is buying a range whose upper boundary is closer to ATM).
+    matrix.insert_range(STRIKE_LOW, STRIKE_HIGH, QTY, WEIGHT_HIGH, WEIGHT_LOW);
+
+    let aggregate = matrix.directional_aggregate();
+    let expected = weighted_magnitude(QTY, WEIGHT_LOW) - weighted_magnitude(QTY, WEIGHT_HIGH);
+    assert_eq!(aggregate.magnitude(), expected);
+    assert!(aggregate.is_negative());
+
+    destroy(matrix);
+    scenario.end();
+}
+
+// ── Round-trip cancels exactly when weights are unchanged ───────────────────
+
+#[test]
+fun insert_then_remove_with_same_weights_returns_aggregate_to_zero() {
+    let mut scenario = test_scenario::begin(@0xa);
+    let mut matrix = new_matrix(&mut scenario);
+
+    matrix.insert_range(STRIKE_LOW, STRIKE_HIGH, QTY, WEIGHT_LOW, WEIGHT_HIGH);
+    matrix.remove_range(STRIKE_LOW, STRIKE_HIGH, QTY, WEIGHT_LOW, WEIGHT_HIGH);
+
+    assert!(matrix.directional_aggregate().is_zero());
+
+    destroy(matrix);
+    scenario.end();
+}
+
+#[test]
+fun remove_at_different_weights_leaves_residual_in_aggregate() {
+    // Known approximation: when the SVI surface drifts between mint and redeem,
+    // the close leg's weight differs from the open leg's weight, so a residual
+    // `qty · (w_open − w_close)` remains.
+    let mut scenario = test_scenario::begin(@0xa);
+    let mut matrix = new_matrix(&mut scenario);
+
+    let w_open_lower = 300_000_000u64;
+    let w_open_higher = 100_000_000u64;
+    let w_close_lower = 250_000_000u64;
+    let w_close_higher = 80_000_000u64;
+
+    matrix.insert_range(STRIKE_LOW, STRIKE_HIGH, QTY, w_open_lower, w_open_higher);
+    matrix.remove_range(STRIKE_LOW, STRIKE_HIGH, QTY, w_close_lower, w_close_higher);
+
+    // Net = (w_open_lower − w_close_lower) − (w_open_higher − w_close_higher),
+    // weighted by qty / FS.
+    let lower_residual_mag = weighted_magnitude(QTY, w_open_lower - w_close_lower);
+    let higher_residual_mag = weighted_magnitude(QTY, w_open_higher - w_close_higher);
+    let expected = lower_residual_mag - higher_residual_mag;
+
+    let aggregate = matrix.directional_aggregate();
+    assert_eq!(aggregate.magnitude(), expected);
+    assert!(!aggregate.is_negative());
+
+    destroy(matrix);
+    scenario.end();
+}
+
+// ── Multiple inserts accumulate linearly ────────────────────────────────────
+
+#[test]
+fun sequential_inserts_accumulate_aggregate_linearly() {
+    let mut scenario = test_scenario::begin(@0xa);
+    let mut matrix = new_matrix(&mut scenario);
+
+    matrix.insert_range(STRIKE_LOW, STRIKE_HIGH, QTY, WEIGHT_LOW, WEIGHT_HIGH);
+    matrix.insert_range(STRIKE_LOW, STRIKE_HIGH, QTY, WEIGHT_LOW, WEIGHT_HIGH);
+    matrix.insert_range(STRIKE_LOW, STRIKE_HIGH, QTY, WEIGHT_LOW, WEIGHT_HIGH);
+
+    let single_delta =
+        weighted_magnitude(QTY, WEIGHT_LOW)
+        - weighted_magnitude(QTY, WEIGHT_HIGH);
+
+    assert_eq!(matrix.directional_aggregate().magnitude(), 3 * single_delta);
+
+    destroy(matrix);
+    scenario.end();
+}
+
+// ── Order-size monotonicity ─────────────────────────────────────────────────
+
+#[test]
+fun larger_qty_produces_proportionally_larger_aggregate_update() {
+    let mut scenario = test_scenario::begin(@0xa);
+    let mut small_matrix = new_matrix(&mut scenario);
+    let mut large_matrix = new_matrix(&mut scenario);
+
+    // Same fixture, two independent matrices.
+
+    small_matrix.insert_range(STRIKE_LOW, STRIKE_HIGH, QTY, WEIGHT_LOW, WEIGHT_HIGH);
+    // 10× the quantity at the same strikes/weights.
+    large_matrix.insert_range(STRIKE_LOW, STRIKE_HIGH, 10 * QTY, WEIGHT_LOW, WEIGHT_HIGH);
+
+    let small_mag = small_matrix.directional_aggregate().magnitude();
+    let large_mag = large_matrix.directional_aggregate().magnitude();
+
+    // Larger order moves aggregate by exactly 10× — same sign, same shape.
+    assert_eq!(large_mag, 10 * small_mag);
+
+    destroy(small_matrix);
+    destroy(large_matrix);
+    scenario.end();
+}
+
+// ── Sentinel boundaries treat the unbounded leg as zero-weight ──────────────
+
+#[test]
+fun upper_sentinel_range_contributes_only_lower_weight() {
+    // `(K, +∞]` is "user is long UP@K". Caller passes `higher_weight = 0`
+    // because `oracle::compute_risk_weight(pos_inf!()) == 0` — there's no
+    // strike-dependent risk at the +∞ boundary.
+    let mut scenario = test_scenario::begin(@0xa);
+    let mut matrix = new_matrix(&mut scenario);
+
+    matrix.insert_range(STRIKE_LOW, constants::pos_inf!(), QTY, WEIGHT_LOW, 0);
+
+    let aggregate = matrix.directional_aggregate();
+    assert_eq!(aggregate.magnitude(), weighted_magnitude(QTY, WEIGHT_LOW));
+    assert!(!aggregate.is_negative());
+
+    destroy(matrix);
+    scenario.end();
+}
+
+#[test]
+fun lower_sentinel_range_contributes_only_higher_weight_negatively() {
+    // `(-∞, K]` is "user is long DN@K" — `lower_weight = 0` at the −∞ boundary,
+    // and the K boundary is the short-UP leg (negative aggregate contribution).
+    let mut scenario = test_scenario::begin(@0xa);
+    let mut matrix = new_matrix(&mut scenario);
+
+    matrix.insert_range(constants::neg_inf!(), STRIKE_LOW, QTY, 0, WEIGHT_LOW);
+
+    let aggregate = matrix.directional_aggregate();
+    assert_eq!(aggregate.magnitude(), weighted_magnitude(QTY, WEIGHT_LOW));
+    assert!(aggregate.is_negative());
+
+    destroy(matrix);
+    scenario.end();
+}
+
+// ── No-op guards ────────────────────────────────────────────────────────────
+
+#[test]
+fun zero_qty_is_a_no_op_on_aggregate() {
+    let mut scenario = test_scenario::begin(@0xa);
+    let mut matrix = new_matrix(&mut scenario);
+
+    matrix.insert_range(STRIKE_LOW, STRIKE_HIGH, 0, WEIGHT_LOW, WEIGHT_HIGH);
+    assert!(matrix.directional_aggregate().is_zero());
+
+    destroy(matrix);
+    scenario.end();
+}
+
+#[test]
+fun zero_weights_are_a_no_op_on_aggregate() {
+    let mut scenario = test_scenario::begin(@0xa);
+    let mut matrix = new_matrix(&mut scenario);
+
+    matrix.insert_range(STRIKE_LOW, STRIKE_HIGH, QTY, 0, 0);
+    assert!(matrix.directional_aggregate().is_zero());
+
+    destroy(matrix);
+    scenario.end();
+}
+
+// ── Per-matrix isolation (analog of per-oracle isolation in the vault) ──────
+
+#[test]
+fun two_matrices_track_independent_aggregates() {
+    let mut scenario = test_scenario::begin(@0xa);
+    let mut matrix_a = new_matrix(&mut scenario);
+    let matrix_b = new_matrix(&mut scenario);
+
+    matrix_a.insert_range(STRIKE_LOW, STRIKE_HIGH, QTY, WEIGHT_LOW, WEIGHT_HIGH);
+    // matrix_b stays untouched.
+
+    let agg_a = matrix_a.directional_aggregate();
+    let agg_b = matrix_b.directional_aggregate();
+
+    assert!(!agg_a.is_zero());
+    assert!(agg_b.is_zero());
+
+    destroy(matrix_a);
+    destroy(matrix_b);
+    scenario.end();
+}
+
+// ── Sign convention: insert + opposing-side insert net to zero magnitude ───
+
+#[test]
+fun insert_up_then_insert_dn_at_same_strike_cancel() {
+    // Going long UP at K via `(K, pos_inf]` and short UP at K via `(-inf, K]`
+    // (a user buying both sides of a binary) leaves zero directional inventory.
+    let mut scenario = test_scenario::begin(@0xa);
+    let mut matrix = new_matrix(&mut scenario);
+
+    matrix.insert_range(STRIKE_LOW, constants::pos_inf!(), QTY, WEIGHT_LOW, 0);
+    matrix.insert_range(constants::neg_inf!(), STRIKE_LOW, QTY, 0, WEIGHT_LOW);
+
+    assert!(matrix.directional_aggregate().is_zero());
+
+    destroy(matrix);
+    scenario.end();
+}
+
+// ── Smoke: matrix's aggregate type is non-droppable; explicit destroy works ─
+
+#[test]
+fun aggregate_value_is_copyable_for_external_reads() {
+    let mut scenario = test_scenario::begin(@0xa);
+    let mut matrix = new_matrix(&mut scenario);
+
+    matrix.insert_range(STRIKE_LOW, STRIKE_HIGH, QTY, WEIGHT_LOW, WEIGHT_HIGH);
+
+    // Two reads return values that compare equal — the I64 value is `copy`,
+    // so external pricing layers can stash it without mutating the matrix.
+    let a = matrix.directional_aggregate();
+    let b = matrix.directional_aggregate();
+    assert_eq!(a.magnitude(), b.magnitude());
+    assert!(a.is_negative() == b.is_negative());
+    let _zero_check = i64::add(&a, &b.neg());
+    assert!(_zero_check.is_zero());
+
+    destroy(matrix);
+    scenario.end();
+}


### PR DESCRIPTION
## Summary

- Skews the per-strike UP mid by the vault's signed directional inventory and applies the shift symmetrically across UP and DN legs. When the vault is net short UP, UP-mint widens *and DN-mint cheapens by the same amount*, so paired UP+DN mint cost stays at `1 + 2·spread` and the discount on the offsetting side actively pulls in the rebalancing flow.
- Per-strike weight is `n(d₂(K))` — the strike-dependent part of the textbook binary delta `Δ = e^(−rτ)·n(d₂)/(S·σ·√τ)`. The aggregate `Σ (q_long_leg − q_short_leg) · n(d₂)` is updated at every range insert/remove at the trade-time fair price. Time scaling uses `√(ref_tte / max(tte, min_tte))`, which amplifies the shift near expiry to track the binary delta's `1/√τ` growth.
- Pricing is **post-trade**: `apply_*_delta` runs before `quote_*_amounts`, so a buyer is quoted against the inventory their own order created. Larger orders pay strictly more (tested).
- **No zero-edge floor.** Under heavy imbalance, `mint_price` can sit below fair on the side the vault wants to grow, and `redeem_price` can sit above fair on the side the vault wants to shrink. The LP intentionally takes a worse-than-fair fill on rebalancing trades — this is what closes the loop on inventory normalisation.

## Key decisions

- **Symmetric per-strike mid.** Range pricing shifts each boundary's UP probability independently (`m(L)` and `m(H)` via `shifted_up_strike_mid`) and uses `m(L) − m(H)` as the range mid. This means a single oracle-level shift moves UP and DN in opposite directions — the textbook arrangement that preserves `1 UP + 1 DN = $1` across any aggregate sign. Sentinel boundaries (`p_up = 0` for `+∞`, `p_up = FS` for `−∞`) short-circuit to themselves so single-strike UP `(K, +∞]` and DN `(−∞, K]` collapse to the natural `m(K)` and `FS − m(K)` respectively.
- **Public API**: `quote_unit_price` returns `(mint_price, redeem_price)`. The internal helper `quote_unit_pricing` returns `(fair, mint, redeem)` for the trade-path accounting (so `quote_mint_amounts` can split principal vs fee).
- **Aggregate lives on `StrikeMatrix`** as a single signed `I64`, updated at the two range boundaries with `lower_weight` (long-UP leg, +) and `higher_weight` (short-UP leg, −). One-sided binaries pass `0` for the sentinel boundary's weight.
- **No per-position weight storage**: the aggregate uses trade-time weights, so an SVI surface drift between mint and redeem leaves a `qty · (w_open − w_close)` residual. This is a deliberate trade-off — full accuracy would require per-position storage. Drift residual is bounded and tested explicitly.
- **Round-trip cost is exactly `2·spread` per leg, regardless of skew.** Because both `mint = m + spread` and `redeem = m − spread` walk together with the inventory shift, an immediate buy+redeem on the same leg always costs `2·spread`. The protection against toxic flow is the post-trade impact on the *first* trade, not a widened round-trip.

## Manipulation resistance

The "buy UP cheap, then arb the cheap DN" attack does not work — see test scenarios for the explicit traces:

- **Atomic post-trade pricing.** A 100k UP order against a flat book pays `m(K) = 0.70` (mint = 0.71), not `0.50` — the order's own state delta is applied to `directional_aggregate` *before* the price is computed.
- **The aggregate is one signed scalar.** The same buyer's follow-up DN order moves the aggregate back, so they don't capture the discount their UP order created. They pay `≈ 0.51` for DN, totalling `1.22` against a `$1` payout — strictly worse than a flat-book paired mint.
- **Per-oracle isolation.** Trading oracle A can't move oracle B's aggregate.
- **Round-trip cancellation.** `insert(K, qty, w) + remove(K, qty, w)` returns aggregate to zero exactly; the only residual is from genuine SVI drift.
- **Paired mint invariant.** As long as `m(K) ∈ (spread, 1−spread)`, `mint_UP + mint_DN = 1 + 2·spread` exactly. There is no inventory state where a paired mint costs less than two spreads.

The discount on the off-side (cheap DN when vault is short UP) is *captured by an arber, not by the buyer who created the imbalance* — and that's the intended mechanism. The arber's DN order rebalances the book; the LP pays the discount as a rebalancing inducement and avoids the much larger PnL hit of staying skewed.

## Known limitations

- `tte_factor` amplification can overflow `i64::mul_scaled` under aggressive admin configs. `set_min_tte_ms` only requires `value > 0`; tightening to e.g. 1 hour bounds the ratio. Follow-up.
- Aggregate drift across SVI surface changes is a known approximation, not a bug.
- `min_ask_price` / `max_ask_price` provide defense-in-depth bounds on `mint_price` regardless of inventory; admins should review these against the new behaviour where mint can drop below fair under negative aggregate.

## Files changed

- `helper/constants.move` — `default_depth_multiplier!`, `default_reference_tte_ms!`, `default_min_tte_ms!`
- `helper/math.move` — `normal_pdf(x: &I64): u64` (8σ cutoff, peak `1/√(2π)`)
- `oracle.move` — split `compute_nd2` into `compute_d2: I64` shared by `compute_price` (CDF) and `compute_risk_weight` (PDF, 0 at sentinels and after settlement)
- `helper/strike_matrix.move` — `directional_aggregate: I64` field, threaded weights through `insert_range`/`remove_range`, accessor
- `vault/vault.move` — forwarded weights through `insert_live_range`/`remove_live_range`/`remove_settled_range`; `oracle_directional_aggregate(oracle_id)` accessor
- `config/pricing_config.move` — three new fields + getters + admin setters; `compute_range_quote(fair_range, p_up_lower, p_up_higher, aggregate, ...)` returning `(mint, redeem)`; private `shifted_up_strike_mid` (per-strike, sentinel-inert)
- `predict.move` — threaded weights at all `apply_*_delta` sites; `quote_unit_pricing` derives `p_up_lower`/`p_up_higher` from `oracle.compute_price(...)` and feeds the new helper; `time_to_expiry`; extended `PricingConfigUpdated` event
- `registry.move` — admin entries for the three new pricing-config knobs

## Test coverage

**128/128 pass** (52 pre-existing + 76 new across three commits).

- `tests/config/inventory_skew_tests.move` — pricing-config-level coverage. Baseline (zero aggregate, sign correctness, saturation), short-circuits (balance=0, depth=0, aggregate=0), TTE amplification including known points (1× at ref_tte, 2× at ref_tte/4, 0.5× at 4·ref_tte), room asymmetry at off-center fair prices, ratio clamp at exactly 1.0 vs 0.999, sub-spread shift, settled-fair aborts, sentinel boundary inertness on both UP and DN legs, range monotonicity guard, paired-leg sum invariant sweep (`mint_up + mint_dn = FS + 2·spread`), above-fair redeem allowed, below-fair mint allowed, round-trip cost is `2·spread` regardless of skew, tiny balance saturation, 1¢ fair, defaults, admin-setter aborts.
- `tests/config/inventory_skew_scenarios.move` — drives a real `StrikeMatrix` with `insert_range`/`remove_range` and feeds the aggregate into `compute_range_quote` at each step. Closest thing to integration coverage. Cases: two and three sequential UP buys compound linearly, UP+DN at same strike cancels exactly, partial redeem shrinks skew proportionally, full round-trip at unchanged weights returns to flat, range buy with K_high near ATM drives aggregate negative and the resulting mint sits *below* fair (the discount that draws in offsetting flow), mirror case for K_low at ATM, mixed range+UP sequence with hand-derived combined ratio, whale order saturates the clamp, split (10·N) vs bulk (1·10N) shows splitting doesn't dodge skew, round-trip across SVI drift produces the predicted residual.
- `tests/helper/normal_pdf_tests.move` — textbook values at 0/±1/±2, symmetry, monotone decay, 8σ cutoff.
- `tests/helper/strike_matrix_aggregate_tests.move` — matrix-level aggregate accounting, sentinel boundaries, round-trip cancellation, surface-drift residual, sequential accumulation, qty-scale linearity, per-matrix isolation.
- `tests/helper/risk_weight_tests.move` — `compute_risk_weight` returns 0 at `pos_inf!()` and `neg_inf!()`.

## Test plan

- [x] `sui move build` clean, no warnings
- [x] `sui move test --gas-limit 100000000000` — 128/128 pass
- [x] `bunx prettier-move --write` clean
- [x] Predict simulation setup smoke test (`bash run.sh --setup --skip-analysis`) passes
- [x] Predict simulation end-to-end smoke test (`SIM_MAX_ROWS=1 bash run.sh --skip-analysis`) passes — note: Python sim still encodes the prior asymmetric formula, so end-to-end Move↔Python parity for the symmetric design will diverge until the Python side is updated (out of scope here)
- [ ] Manual review of `quote_unit_price` consumers for the new "mint can be below fair, redeem can be above fair under heavy imbalance" semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)