### PR TITLE
scripts: add marketMakerID and create two BMs owned by market maker

### DIFF
--- a/scripts/config/constants.ts
+++ b/scripts/config/constants.ts
@@ -75,3 +75,8 @@ export const supplierCapID = {
   mainnet: "0xe0e64f2b0037304e29647fd5ef2c5ea758828a8e5aea73bb0bd5f227c1c20204",
   testnet: "",
 };
+
+export const marketMakerID = {
+  mainnet: "0x30be3610c00673c0c5a60d0f3606eb58f8da7828692d0a06ae1d4f7af952c2b4",
+  testnet: "",
+};

--- a/scripts/transactions/prepBalanceManager.ts
+++ b/scripts/transactions/prepBalanceManager.ts
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Transaction } from "@mysten/sui/transactions";
 import { prepareMultisigTx } from "../utils/utils.js";
-import { adminCapOwner, adminCapID } from "../config/constants.js";
+import {
+  adminCapOwner,
+  adminCapID,
+  marketMakerID,
+} from "../config/constants.js";
 import { deepbook } from "@mysten/deepbook-v3";
 import { SuiGrpcClient } from "@mysten/sui/grpc";
 
@@ -28,42 +32,21 @@ import { SuiGrpcClient } from "@mysten/sui/grpc";
     },
   };
 
-  // const MANAGER_3_TRADER =
-  //   "0x3bb9c84c818748cccdd8d68e3069bd688ee97006ca1695e54419aa42e335d594";
-
   const client = new SuiGrpcClient({
     baseUrl: "https://sui-mainnet.mystenlabs.com",
     network: "mainnet",
   }).$extend(
     deepbook({
-      address: adminCapOwner[env],
-      // adminCap: adminCapID[env],
+      address: marketMakerID[env],
       balanceManagers,
     }),
   );
 
   const tx = new Transaction();
+  client.deepbook.balanceManager.createAndShareBalanceManager()(tx);
+  client.deepbook.balanceManager.createAndShareBalanceManager()(tx);
 
-  // const tradeCap3 =
-  //   client.deepbook.balanceManager.mintTradeCap("BALANCE_MANAGER_3")(tx);
-  // tx.transferObjects([tradeCap3], MANAGER_3_TRADER);
-
-  // client.deepbook.balanceManager.depositIntoManager(
-  //   "BALANCE_MANAGER_1",
-  //   "DEEP",
-  //   110000,
-  // )(tx);
-
-  client.deepbook.balanceManager.depositIntoManager(
-    "BALANCE_MANAGER_3",
-    "USDC",
-    6000,
-  )(tx);
-
-  // client.deepbook.balanceManager.createAndShareBalanceManager()(tx);
-  // client.deepbook.balanceManager.createAndShareBalanceManager()(tx);
-
-  const res = await prepareMultisigTx(tx, env, adminCapOwner[env]);
+  const res = await prepareMultisigTx(tx, env, marketMakerID[env]);
 
   console.dir(res, { depth: null });
 })();


### PR DESCRIPTION
## Summary
- Add `marketMakerID` constant in `scripts/config/constants.ts` (mainnet `0x30be3610c00673c0c5a60d0f3606eb58f8da7828692d0a06ae1d4f7af952c2b4`, testnet empty).
- In `scripts/transactions/prepBalanceManager.ts`, switch the deepbook client `address` and the multisig signer to `marketMakerID[env]`, and call `createAndShareBalanceManager()` twice.

## Key decisions
- The two new balance managers are created and shared with the market maker as the owner (i.e. the multisig signer is the market maker), not the admin cap owner.

## Test plan
- [ ] Run \`GAS_OBJECT=0x... pnpm tsx transactions/prepBalanceManager.ts\` from \`scripts/\` and verify the dry run succeeds and \`tx/tx-data.txt\` is produced.
- [ ] Multisig-execute the transaction on mainnet and confirm two new shared \`BalanceManager\` objects are created with the market maker as owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)