### PR TITLE
scripts: add disableDeepbookPool sweep for all 6 margin-enabled pools

### DIFF
--- a/scripts/transactions/disableDeepbookPool.ts
+++ b/scripts/transactions/disableDeepbookPool.ts
@@ -1,0 +1,40 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+import { Transaction } from "@mysten/sui/transactions";
+import { prepareMultisigTx } from "../utils/utils.js";
+import { adminCapOwner, marginAdminCapID } from "../config/constants.js";
+import { deepbook } from "@mysten/deepbook-v3";
+import { SuiGrpcClient } from "@mysten/sui/grpc";
+
+(async () => {
+  // Update constant for env
+  const env = "mainnet";
+  const poolKeys = [
+    "SUI_USDC",
+    "WAL_USDC",
+    "DEEP_USDC",
+    "SUIUSDE_USDC",
+    "SUI_SUIUSDE",
+    "XBTC_USDC",
+  ];
+
+  const client = new SuiGrpcClient({
+    baseUrl: "https://sui-mainnet.mystenlabs.com",
+    network: "mainnet",
+  }).$extend(
+    deepbook({
+      address: adminCapOwner[env],
+      marginAdminCap: marginAdminCapID[env],
+    }),
+  );
+
+  const tx = new Transaction();
+
+  for (const poolKey of poolKeys) {
+    client.deepbook.marginAdmin.disableDeepbookPool(poolKey)(tx);
+  }
+
+  let res = await prepareMultisigTx(tx, env, adminCapOwner[env]);
+
+  console.dir(res, { depth: null });
+})();


### PR DESCRIPTION
## Summary
- Adds `scripts/transactions/disableDeepbookPool.ts` covering every margin-enabled DeepBook pool (SUI_USDC, WAL_USDC, DEEP_USDC, SUIUSDE_USDC, SUI_SUIUSDE, XBTC_USDC).
- Each entry calls `margin_registry::disable_deepbook_pool`, flipping `PoolConfig.enabled` off. After the PTB lands, `pool_proxy::place_limit_order` / `place_market_order` and `margin_manager::borrow_base` / `borrow_quote` for these pools abort with `EPoolNotEnabledForMarginTrading`. Reduce-only paths, cancels, and withdraw-settled remain available so existing managers can wind down.

## Test plan
- [ ] Dry-run the PTB against mainnet with a real `GAS_OBJECT` and inspect each `disableDeepbookPool` call in the serialized output.
- [ ] Confirm `prepareMultisigTx` writes `tx/tx-data.txt` cleanly.
- [ ] After execution, verify each pool's `PoolConfig.enabled == false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)