### PR TITLE
admin inject capital: USDC pool default backfill + margin disable PTB

### DIFF
--- a/.github/workflows/deepbookv3-build-tx.yml
+++ b/.github/workflows/deepbookv3-build-tx.yml
@@ -32,6 +32,7 @@ on:
           - Margin Prep
           - Prep Balance Manager
           - Revoke Pausecap
+          - Admin Inject Capital
       sui_tools_image:
         description: "image reference of sui_tools"
         default: "mysten/sui-tools:mainnet"
@@ -469,6 +470,17 @@ jobs:
           RPC_URL: ${{ inputs.rpc }}
         run: |
           cd scripts && pnpm install && pnpm tsx transactions/revokePausecap.ts
+
+      - name: Admin Inject Capital
+        if: ${{ inputs.transaction_type == 'Admin Inject Capital' }}
+        env:
+          NODE_ENV: production
+          GAS_OBJECT: ${{ inputs.gas_object_id }}
+          NETWORK: mainnet
+          ORIGIN: gh_action
+          RPC_URL: ${{ inputs.rpc }}
+        run: |
+          cd scripts && pnpm install && pnpm tsx transactions/adminInjectCapital.ts
 
       - name: Prep Deepbook MVR
         if: ${{ inputs.transaction_type == 'Prep Deepbook MVR' }}

--- a/scripts/transactions/adminInjectCapital.ts
+++ b/scripts/transactions/adminInjectCapital.ts
@@ -19,7 +19,8 @@ declare const process: {
 
 const MAINNET = "mainnet";
 
-// Placeholder — replace with the real margin package id before signing.
+// Upgraded margin package (v4). Canonical v3 lives at
+// 0xfbd322126f1452fd4c89aedbaeb9fd0c44df9b5cedbe70d76bf80dc086031377.
 const MARGIN_PACKAGE =
   "0x7767428727629a08dfd196bd4fc00d8a060e30da33aa63f4087fb3271e615a98";
 
@@ -34,9 +35,10 @@ const DEEP_MARGIN_POOL_ID =
   "0x1d723c5cd113296868b55208f2ab5a905184950dd59c48eb7345607d6b5e6af7";
 const WAL_MARGIN_POOL_ID =
   "0x38decd3dbb62bd4723144349bf57bc403b393aee86a51596846a824a1e0c2c01";
-// TODO: fill these in before signing — not in the bundled SDK constants.
-const SUIUSDE_MARGIN_POOL_ID = "TODO_FILL_SUIUSDE_MARGIN_POOL_ID";
-const XBTC_MARGIN_POOL_ID = "TODO_FILL_XBTC_MARGIN_POOL_ID";
+const SUIUSDE_MARGIN_POOL_ID =
+  "0xbb990ca04a7743e6c0a25a7fb16f60fc6f6d8bf213624ff03a63f1bb04c3a12f";
+const XBTC_MARGIN_POOL_ID =
+  "0x14dfbf54400e0b97e892349310d392bef6d187c2b6709d9b246b8f41c9a13de4";
 
 const SUI_TYPE =
   "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI";
@@ -57,7 +59,13 @@ const XBTC_TYPE =
 // + 33,577,714,688 +  26,877,577,806 = 283,604,871,465 (≈ 283,604.871465 USDC).
 const USDC_INJECTION_AMOUNT = 283_604_871_465n;
 
-const MARGIN_VERSION_TO_ENABLE = 4;
+// Both v3 and v4 must be enabled in the registry: v3 so users with existing
+// margin managers can still call reduce-only / withdraw paths; v4 so the
+// admin disable + inject calls in this PTB resolve through the upgraded
+// package. enable_version aborts with EVersionAlreadyEnabled
+// (margin_registry.move:374) on a no-op — comment out the matching line if
+// either version is already enabled at sign time.
+const MARGIN_VERSIONS_TO_ENABLE = [3, 4];
 
 const ADMIN_INJECT_CAPITAL_TARGET = `${MARGIN_PACKAGE}::margin_pool::admin_inject_capital`;
 const DISABLE_DEEPBOOK_POOL_TARGET = `${MARGIN_PACKAGE}::margin_registry::disable_deepbook_pool`;
@@ -227,32 +235,22 @@ const LOAN_PAIRS_TO_DISABLE: {
   },
 ];
 
-const assertNoPlaceholders = (): void => {
-  const todos = LOAN_PAIRS_TO_DISABLE.filter((p) =>
-    p.marginPoolId.startsWith("TODO"),
-  ).map((p) => p.label);
-  if (todos.length > 0) {
-    throw new Error(
-      `Refusing to build PTB — fill in TODO margin pool IDs first: ${todos.join(", ")}`,
-    );
-  }
-};
-
 (async () => {
-  assertNoPlaceholders();
-
   const tx = new Transaction();
 
-  // 1. Enable margin version 4 in the registry so the upgraded margin package
-  //    is callable for the disable + inject steps below.
-  tx.moveCall({
-    target: ENABLE_VERSION_TARGET,
-    arguments: [
-      tx.object(MARGIN_REGISTRY_ID),
-      tx.pure.u64(MARGIN_VERSION_TO_ENABLE),
-      tx.object(marginAdminCapID[MAINNET]),
-    ],
-  });
+  // 1. Enable both v3 (so existing margin managers stay callable for
+  //    reduce-only and withdraw paths) and v4 (so the disable + inject calls
+  //    below resolve through the upgraded margin package).
+  for (const version of MARGIN_VERSIONS_TO_ENABLE) {
+    tx.moveCall({
+      target: ENABLE_VERSION_TARGET,
+      arguments: [
+        tx.object(MARGIN_REGISTRY_ID),
+        tx.pure.u64(version),
+        tx.object(marginAdminCapID[MAINNET]),
+      ],
+    });
+  }
 
   // 2. Disable all DeepBook pools so no liquidation activity can race the
   //    capital injection inside the same multisig PTB. Built manually against
@@ -307,7 +305,7 @@ const assertNoPlaceholders = (): void => {
   });
 
   console.log({
-    marginVersionEnabled: MARGIN_VERSION_TO_ENABLE,
+    marginVersionsEnabled: MARGIN_VERSIONS_TO_ENABLE,
     poolKeysDisabled: POOLS_TO_DISABLE.map((p) => p.key),
     loanPairsDisabled: LOAN_PAIRS_TO_DISABLE.map((p) => p.label),
     usdcInjectionAmount: USDC_INJECTION_AMOUNT.toString(),

--- a/scripts/transactions/adminInjectCapital.ts
+++ b/scripts/transactions/adminInjectCapital.ts
@@ -1,0 +1,68 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+import { coinWithBalance, Transaction } from "@mysten/sui/transactions";
+import { prepareMultisigTx } from "../utils/utils.js";
+import { adminCapOwner, marginAdminCapID } from "../config/constants.js";
+
+declare const process: {
+  exitCode?: number;
+};
+
+const MAINNET = "mainnet";
+
+const MARGIN_PACKAGE =
+  "0xfbd322126f1452fd4c89aedbaeb9fd0c44df9b5cedbe70d76bf80dc086031377";
+
+const USDC_MARGIN_POOL_ID =
+  "0xba473d9ae278f10af75c50a8fa341e9c6a1c087dc91a3f23e8048baf67d0754f";
+
+const USDC_TYPE =
+  "0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC";
+
+// Sum of pool_default across the five MarginManagerLiquidated events from
+// digest 2e6RkQYWrhtKxRArGWUXGXQHreqr9GLfkxwJamvXmomw (USDC, 6 decimals):
+//   116,051,397,182 + 53,704,452,210 + 53,393,729,579
+// + 33,577,714,688 +  26,877,577,806 = 283,604,871,465 (≈ 283,604.871465 USDC).
+const USDC_INJECTION_AMOUNT = 283_604_871_465n;
+
+const ADMIN_INJECT_CAPITAL_TARGET = `${MARGIN_PACKAGE}::margin_pool::admin_inject_capital`;
+
+const buildInjectionTransaction = (): Transaction => {
+  const tx = new Transaction();
+
+  const usdcCoin = coinWithBalance({
+    type: USDC_TYPE,
+    balance: USDC_INJECTION_AMOUNT,
+  })(tx);
+
+  tx.moveCall({
+    target: ADMIN_INJECT_CAPITAL_TARGET,
+    arguments: [
+      tx.object(USDC_MARGIN_POOL_ID),
+      tx.object(marginAdminCapID[MAINNET]),
+      usdcCoin,
+      tx.object.clock(),
+    ],
+    typeArguments: [USDC_TYPE],
+  });
+
+  return tx;
+};
+
+const main = async () => {
+  const tx = buildInjectionTransaction();
+
+  console.log({
+    usdcInjectionAmount: USDC_INJECTION_AMOUNT.toString(),
+    usdcMarginPool: USDC_MARGIN_POOL_ID,
+    marginAdminCap: marginAdminCapID[MAINNET],
+  });
+
+  const res = await prepareMultisigTx(tx, MAINNET, adminCapOwner[MAINNET]);
+  console.dir(res, { depth: null });
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/transactions/adminInjectCapital.ts
+++ b/scripts/transactions/adminInjectCapital.ts
@@ -38,8 +38,11 @@ const XBTC_TYPE =
 // + 33,577,714,688 +  26,877,577,806 = 283,604,871,465 (≈ 283,604.871465 USDC).
 const USDC_INJECTION_AMOUNT = 283_604_871_465n;
 
+const MARGIN_VERSION_TO_ENABLE = 4;
+
 const ADMIN_INJECT_CAPITAL_TARGET = `${MARGIN_PACKAGE}::margin_pool::admin_inject_capital`;
 const DISABLE_DEEPBOOK_POOL_TARGET = `${MARGIN_PACKAGE}::margin_registry::disable_deepbook_pool`;
+const ENABLE_VERSION_TARGET = `${MARGIN_PACKAGE}::margin_registry::enable_version`;
 
 const POOLS_TO_DISABLE: {
   key: string;
@@ -94,7 +97,18 @@ const POOLS_TO_DISABLE: {
 (async () => {
   const tx = new Transaction();
 
-  // 1. Disable all DeepBook pools first so no liquidation activity can race the
+  // 1. Enable margin version 4 in the registry so the upgraded margin package
+  //    is callable for the disable + inject steps below.
+  tx.moveCall({
+    target: ENABLE_VERSION_TARGET,
+    arguments: [
+      tx.object(MARGIN_REGISTRY_ID),
+      tx.pure.u64(MARGIN_VERSION_TO_ENABLE),
+      tx.object(marginAdminCapID[MAINNET]),
+    ],
+  });
+
+  // 2. Disable all DeepBook pools so no liquidation activity can race the
   //    capital injection inside the same multisig PTB. Built manually against
   //    MARGIN_PACKAGE rather than the SDK so the package id can be pinned.
   for (const pool of POOLS_TO_DISABLE) {
@@ -110,7 +124,7 @@ const POOLS_TO_DISABLE: {
     });
   }
 
-  // 2. Inject the aggregate pool_default amount (283,604.871465 USDC) into the
+  // 3. Inject the aggregate pool_default amount (283,604.871465 USDC) into the
   //    USDC margin pool without minting supplier shares.
   const usdcCoin = coinWithBalance({
     type: USDC_TYPE,
@@ -129,6 +143,7 @@ const POOLS_TO_DISABLE: {
   });
 
   console.log({
+    marginVersionEnabled: MARGIN_VERSION_TO_ENABLE,
     poolKeysDisabled: POOLS_TO_DISABLE.map((p) => p.key),
     usdcInjectionAmount: USDC_INJECTION_AMOUNT.toString(),
     usdcMarginPool: USDC_MARGIN_POOL_ID,

--- a/scripts/transactions/adminInjectCapital.ts
+++ b/scripts/transactions/adminInjectCapital.ts
@@ -3,8 +3,6 @@
 import { coinWithBalance, Transaction } from "@mysten/sui/transactions";
 import { prepareMultisigTx } from "../utils/utils.js";
 import { adminCapOwner, marginAdminCapID } from "../config/constants.js";
-import { deepbook } from "@mysten/deepbook-v3";
-import { SuiGrpcClient } from "@mysten/sui/grpc";
 
 declare const process: {
   exitCode?: number;
@@ -12,14 +10,27 @@ declare const process: {
 
 const MAINNET = "mainnet";
 
-const MARGIN_PACKAGE =
-  "0xfbd322126f1452fd4c89aedbaeb9fd0c44df9b5cedbe70d76bf80dc086031377";
+// Placeholder — replace with the real margin package id before signing.
+const MARGIN_PACKAGE = "0x1234";
+
+const MARGIN_REGISTRY_ID =
+  "0x0e40998b359a9ccbab22a98ed21bd4346abf19158bc7980c8291908086b3a742";
 
 const USDC_MARGIN_POOL_ID =
   "0xba473d9ae278f10af75c50a8fa341e9c6a1c087dc91a3f23e8048baf67d0754f";
 
+const SUI_TYPE =
+  "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI";
 const USDC_TYPE =
   "0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC";
+const DEEP_TYPE =
+  "0xdeeb7a4662eec9f2f3def03fb937a663dddaa2e215b8078a284d026b7946c270::deep::DEEP";
+const WAL_TYPE =
+  "0x356a26eb9e012a68958082340d4c4116e7f55615cf27affcff209cf0ae544f59::wal::WAL";
+const SUIUSDE_TYPE =
+  "0x41d587e5336f1c86cad50d38a7136db99333bb9bda91cea4ba69115defeb1402::sui_usde::SUI_USDE";
+const XBTC_TYPE =
+  "0x876a4b7bce8aeaef60464c11f4026903e9afacab79b9b142686158aa86560b50::xbtc::XBTC";
 
 // Sum of pool_default across the five MarginManagerLiquidated events from
 // digest 2e6RkQYWrhtKxRArGWUXGXQHreqr9GLfkxwJamvXmomw (USDC, 6 decimals):
@@ -28,33 +39,75 @@ const USDC_TYPE =
 const USDC_INJECTION_AMOUNT = 283_604_871_465n;
 
 const ADMIN_INJECT_CAPITAL_TARGET = `${MARGIN_PACKAGE}::margin_pool::admin_inject_capital`;
+const DISABLE_DEEPBOOK_POOL_TARGET = `${MARGIN_PACKAGE}::margin_registry::disable_deepbook_pool`;
 
-const POOL_KEYS_TO_DISABLE = [
-  "SUI_USDC",
-  "WAL_USDC",
-  "DEEP_USDC",
-  "SUIUSDE_USDC",
-  "SUI_SUIUSDE",
-  "XBTC_USDC",
+const POOLS_TO_DISABLE: {
+  key: string;
+  address: string;
+  baseType: string;
+  quoteType: string;
+}[] = [
+  {
+    key: "SUI_USDC",
+    address:
+      "0xe05dafb5133bcffb8d59f4e12465dc0e9faeaa05e3e342a08fe135800e3e4407",
+    baseType: SUI_TYPE,
+    quoteType: USDC_TYPE,
+  },
+  {
+    key: "WAL_USDC",
+    address:
+      "0x56a1c985c1f1123181d6b881714793689321ba24301b3585eec427436eb1c76d",
+    baseType: WAL_TYPE,
+    quoteType: USDC_TYPE,
+  },
+  {
+    key: "DEEP_USDC",
+    address:
+      "0xf948981b806057580f91622417534f491da5f61aeaf33d0ed8e69fd5691c95ce",
+    baseType: DEEP_TYPE,
+    quoteType: USDC_TYPE,
+  },
+  {
+    key: "SUIUSDE_USDC",
+    address:
+      "0x0fac1cebf35bde899cd9ecdd4371e0e33f44ba83b8a2902d69186646afa3a94b",
+    baseType: SUIUSDE_TYPE,
+    quoteType: USDC_TYPE,
+  },
+  {
+    key: "SUI_SUIUSDE",
+    address:
+      "0x034f3a42e7348de2084406db7a725f9d9d132a56c68324713e6e623601fb4fd7",
+    baseType: SUI_TYPE,
+    quoteType: SUIUSDE_TYPE,
+  },
+  {
+    key: "XBTC_USDC",
+    address:
+      "0x20b9a3ec7a02d4f344aa1ebc5774b7b0ccafa9a5d76230662fdc0300bb215307",
+    baseType: XBTC_TYPE,
+    quoteType: USDC_TYPE,
+  },
 ];
 
 (async () => {
-  const client = new SuiGrpcClient({
-    baseUrl: "https://sui-mainnet.mystenlabs.com",
-    network: MAINNET,
-  }).$extend(
-    deepbook({
-      address: adminCapOwner[MAINNET],
-      marginAdminCap: marginAdminCapID[MAINNET],
-    }),
-  );
-
   const tx = new Transaction();
 
   // 1. Disable all DeepBook pools first so no liquidation activity can race the
-  //    capital injection inside the same multisig PTB.
-  for (const poolKey of POOL_KEYS_TO_DISABLE) {
-    client.deepbook.marginAdmin.disableDeepbookPool(poolKey)(tx);
+  //    capital injection inside the same multisig PTB. Built manually against
+  //    MARGIN_PACKAGE rather than the SDK so the package id can be pinned.
+  for (const pool of POOLS_TO_DISABLE) {
+    tx.moveCall({
+      target: DISABLE_DEEPBOOK_POOL_TARGET,
+      arguments: [
+        tx.object(MARGIN_REGISTRY_ID),
+        tx.object(marginAdminCapID[MAINNET]),
+        tx.object(pool.address),
+        tx.object.clock(),
+      ],
+      typeArguments: [pool.baseType, pool.quoteType],
+    });
   }
 
   // 2. Inject the aggregate pool_default amount (283,604.871465 USDC) into the
@@ -76,10 +129,11 @@ const POOL_KEYS_TO_DISABLE = [
   });
 
   console.log({
-    poolKeysDisabled: POOL_KEYS_TO_DISABLE,
+    poolKeysDisabled: POOLS_TO_DISABLE.map((p) => p.key),
     usdcInjectionAmount: USDC_INJECTION_AMOUNT.toString(),
     usdcMarginPool: USDC_MARGIN_POOL_ID,
     marginAdminCap: marginAdminCapID[MAINNET],
+    marginPackage: MARGIN_PACKAGE,
   });
 
   const res = await prepareMultisigTx(tx, MAINNET, adminCapOwner[MAINNET]);

--- a/scripts/transactions/adminInjectCapital.ts
+++ b/scripts/transactions/adminInjectCapital.ts
@@ -2,7 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 import { coinWithBalance, Transaction } from "@mysten/sui/transactions";
 import { prepareMultisigTx } from "../utils/utils.js";
-import { adminCapOwner, marginAdminCapID } from "../config/constants.js";
+import {
+  adminCapOwner,
+  deepMarginPoolCapID,
+  marginAdminCapID,
+  suiMarginPoolCapID,
+  suiUsdeMarginPoolCapID,
+  usdcMarginPoolCapID,
+  walMarginPoolCapID,
+  xbtcMarginPoolCapID,
+} from "../config/constants.js";
 
 declare const process: {
   exitCode?: number;
@@ -11,13 +20,23 @@ declare const process: {
 const MAINNET = "mainnet";
 
 // Placeholder — replace with the real margin package id before signing.
-const MARGIN_PACKAGE = "0x1234";
+const MARGIN_PACKAGE =
+  "0x7767428727629a08dfd196bd4fc00d8a060e30da33aa63f4087fb3271e615a98";
 
 const MARGIN_REGISTRY_ID =
   "0x0e40998b359a9ccbab22a98ed21bd4346abf19158bc7980c8291908086b3a742";
 
+const SUI_MARGIN_POOL_ID =
+  "0x53041c6f86c4782aabbfc1d4fe234a6d37160310c7ee740c915f0a01b7127344";
 const USDC_MARGIN_POOL_ID =
   "0xba473d9ae278f10af75c50a8fa341e9c6a1c087dc91a3f23e8048baf67d0754f";
+const DEEP_MARGIN_POOL_ID =
+  "0x1d723c5cd113296868b55208f2ab5a905184950dd59c48eb7345607d6b5e6af7";
+const WAL_MARGIN_POOL_ID =
+  "0x38decd3dbb62bd4723144349bf57bc403b393aee86a51596846a824a1e0c2c01";
+// TODO: fill these in before signing — not in the bundled SDK constants.
+const SUIUSDE_MARGIN_POOL_ID = "TODO_FILL_SUIUSDE_MARGIN_POOL_ID";
+const XBTC_MARGIN_POOL_ID = "TODO_FILL_XBTC_MARGIN_POOL_ID";
 
 const SUI_TYPE =
   "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI";
@@ -42,6 +61,7 @@ const MARGIN_VERSION_TO_ENABLE = 4;
 
 const ADMIN_INJECT_CAPITAL_TARGET = `${MARGIN_PACKAGE}::margin_pool::admin_inject_capital`;
 const DISABLE_DEEPBOOK_POOL_TARGET = `${MARGIN_PACKAGE}::margin_registry::disable_deepbook_pool`;
+const DISABLE_DEEPBOOK_POOL_FOR_LOAN_TARGET = `${MARGIN_PACKAGE}::margin_pool::disable_deepbook_pool_for_loan`;
 const ENABLE_VERSION_TARGET = `${MARGIN_PACKAGE}::margin_registry::enable_version`;
 
 const POOLS_TO_DISABLE: {
@@ -94,7 +114,133 @@ const POOLS_TO_DISABLE: {
   },
 ];
 
+// Mirrors the (deepbookPool, marginPool) pairs enabled in marginSetup.ts via
+// enableDeepbookPoolForLoan (USDSUI pairs intentionally excluded). For each,
+// we call disable_deepbook_pool_for_loan to flip MarginPool.allowed_deepbook_pools
+// off — defense in depth on top of the registry-side disable above.
+//
+// Aborts with EDeepbookPoolNotAllowed (margin_pool.move:207) if the pair was
+// already disabled on chain. If PR #22 already executed, comment out the
+// matching entries before signing.
+const LOAN_PAIRS_TO_DISABLE: {
+  label: string;
+  marginPoolId: string;
+  marginPoolCapId: string;
+  deepbookPoolId: string;
+  assetType: string;
+}[] = [
+  {
+    label: "SUI_USDC + USDC margin pool",
+    marginPoolId: USDC_MARGIN_POOL_ID,
+    marginPoolCapId: usdcMarginPoolCapID[MAINNET],
+    deepbookPoolId:
+      "0xe05dafb5133bcffb8d59f4e12465dc0e9faeaa05e3e342a08fe135800e3e4407",
+    assetType: USDC_TYPE,
+  },
+  {
+    label: "SUI_USDC + SUI margin pool",
+    marginPoolId: SUI_MARGIN_POOL_ID,
+    marginPoolCapId: suiMarginPoolCapID[MAINNET],
+    deepbookPoolId:
+      "0xe05dafb5133bcffb8d59f4e12465dc0e9faeaa05e3e342a08fe135800e3e4407",
+    assetType: SUI_TYPE,
+  },
+  {
+    label: "DEEP_USDC + USDC margin pool",
+    marginPoolId: USDC_MARGIN_POOL_ID,
+    marginPoolCapId: usdcMarginPoolCapID[MAINNET],
+    deepbookPoolId:
+      "0xf948981b806057580f91622417534f491da5f61aeaf33d0ed8e69fd5691c95ce",
+    assetType: USDC_TYPE,
+  },
+  {
+    label: "DEEP_USDC + DEEP margin pool",
+    marginPoolId: DEEP_MARGIN_POOL_ID,
+    marginPoolCapId: deepMarginPoolCapID[MAINNET],
+    deepbookPoolId:
+      "0xf948981b806057580f91622417534f491da5f61aeaf33d0ed8e69fd5691c95ce",
+    assetType: DEEP_TYPE,
+  },
+  {
+    label: "WAL_USDC + USDC margin pool",
+    marginPoolId: USDC_MARGIN_POOL_ID,
+    marginPoolCapId: usdcMarginPoolCapID[MAINNET],
+    deepbookPoolId:
+      "0x56a1c985c1f1123181d6b881714793689321ba24301b3585eec427436eb1c76d",
+    assetType: USDC_TYPE,
+  },
+  {
+    label: "WAL_USDC + WAL margin pool",
+    marginPoolId: WAL_MARGIN_POOL_ID,
+    marginPoolCapId: walMarginPoolCapID[MAINNET],
+    deepbookPoolId:
+      "0x56a1c985c1f1123181d6b881714793689321ba24301b3585eec427436eb1c76d",
+    assetType: WAL_TYPE,
+  },
+  {
+    label: "SUIUSDE_USDC + USDC margin pool",
+    marginPoolId: USDC_MARGIN_POOL_ID,
+    marginPoolCapId: usdcMarginPoolCapID[MAINNET],
+    deepbookPoolId:
+      "0x0fac1cebf35bde899cd9ecdd4371e0e33f44ba83b8a2902d69186646afa3a94b",
+    assetType: USDC_TYPE,
+  },
+  {
+    label: "SUIUSDE_USDC + SUIUSDE margin pool",
+    marginPoolId: SUIUSDE_MARGIN_POOL_ID,
+    marginPoolCapId: suiUsdeMarginPoolCapID[MAINNET],
+    deepbookPoolId:
+      "0x0fac1cebf35bde899cd9ecdd4371e0e33f44ba83b8a2902d69186646afa3a94b",
+    assetType: SUIUSDE_TYPE,
+  },
+  {
+    label: "SUI_SUIUSDE + SUI margin pool",
+    marginPoolId: SUI_MARGIN_POOL_ID,
+    marginPoolCapId: suiMarginPoolCapID[MAINNET],
+    deepbookPoolId:
+      "0x034f3a42e7348de2084406db7a725f9d9d132a56c68324713e6e623601fb4fd7",
+    assetType: SUI_TYPE,
+  },
+  {
+    label: "SUI_SUIUSDE + SUIUSDE margin pool",
+    marginPoolId: SUIUSDE_MARGIN_POOL_ID,
+    marginPoolCapId: suiUsdeMarginPoolCapID[MAINNET],
+    deepbookPoolId:
+      "0x034f3a42e7348de2084406db7a725f9d9d132a56c68324713e6e623601fb4fd7",
+    assetType: SUIUSDE_TYPE,
+  },
+  {
+    label: "XBTC_USDC + USDC margin pool",
+    marginPoolId: USDC_MARGIN_POOL_ID,
+    marginPoolCapId: usdcMarginPoolCapID[MAINNET],
+    deepbookPoolId:
+      "0x20b9a3ec7a02d4f344aa1ebc5774b7b0ccafa9a5d76230662fdc0300bb215307",
+    assetType: USDC_TYPE,
+  },
+  {
+    label: "XBTC_USDC + XBTC margin pool",
+    marginPoolId: XBTC_MARGIN_POOL_ID,
+    marginPoolCapId: xbtcMarginPoolCapID[MAINNET],
+    deepbookPoolId:
+      "0x20b9a3ec7a02d4f344aa1ebc5774b7b0ccafa9a5d76230662fdc0300bb215307",
+    assetType: XBTC_TYPE,
+  },
+];
+
+const assertNoPlaceholders = (): void => {
+  const todos = LOAN_PAIRS_TO_DISABLE.filter((p) =>
+    p.marginPoolId.startsWith("TODO"),
+  ).map((p) => p.label);
+  if (todos.length > 0) {
+    throw new Error(
+      `Refusing to build PTB — fill in TODO margin pool IDs first: ${todos.join(", ")}`,
+    );
+  }
+};
+
 (async () => {
+  assertNoPlaceholders();
+
   const tx = new Transaction();
 
   // 1. Enable margin version 4 in the registry so the upgraded margin package
@@ -124,7 +270,25 @@ const POOLS_TO_DISABLE: {
     });
   }
 
-  // 3. Inject the aggregate pool_default amount (283,604.871465 USDC) into the
+  // 3. Disable each (deepbook_pool, margin_pool) loan allowlist entry that was
+  //    enabled in marginSetup.ts (USDSUI pairs excluded). Belt-and-suspenders
+  //    on top of step 2: step 2 blocks pool_proxy::* trades, step 3 blocks
+  //    margin_manager::borrow_* at the margin-pool level.
+  for (const pair of LOAN_PAIRS_TO_DISABLE) {
+    tx.moveCall({
+      target: DISABLE_DEEPBOOK_POOL_FOR_LOAN_TARGET,
+      arguments: [
+        tx.object(pair.marginPoolId),
+        tx.object(MARGIN_REGISTRY_ID),
+        tx.pure.id(pair.deepbookPoolId),
+        tx.object(pair.marginPoolCapId),
+        tx.object.clock(),
+      ],
+      typeArguments: [pair.assetType],
+    });
+  }
+
+  // 4. Inject the aggregate pool_default amount (283,604.871465 USDC) into the
   //    USDC margin pool without minting supplier shares.
   const usdcCoin = coinWithBalance({
     type: USDC_TYPE,
@@ -145,6 +309,7 @@ const POOLS_TO_DISABLE: {
   console.log({
     marginVersionEnabled: MARGIN_VERSION_TO_ENABLE,
     poolKeysDisabled: POOLS_TO_DISABLE.map((p) => p.key),
+    loanPairsDisabled: LOAN_PAIRS_TO_DISABLE.map((p) => p.label),
     usdcInjectionAmount: USDC_INJECTION_AMOUNT.toString(),
     usdcMarginPool: USDC_MARGIN_POOL_ID,
     marginAdminCap: marginAdminCapID[MAINNET],

--- a/scripts/transactions/adminInjectCapital.ts
+++ b/scripts/transactions/adminInjectCapital.ts
@@ -3,6 +3,8 @@
 import { coinWithBalance, Transaction } from "@mysten/sui/transactions";
 import { prepareMultisigTx } from "../utils/utils.js";
 import { adminCapOwner, marginAdminCapID } from "../config/constants.js";
+import { deepbook } from "@mysten/deepbook-v3";
+import { SuiGrpcClient } from "@mysten/sui/grpc";
 
 declare const process: {
   exitCode?: number;
@@ -27,9 +29,36 @@ const USDC_INJECTION_AMOUNT = 283_604_871_465n;
 
 const ADMIN_INJECT_CAPITAL_TARGET = `${MARGIN_PACKAGE}::margin_pool::admin_inject_capital`;
 
-const buildInjectionTransaction = (): Transaction => {
+const POOL_KEYS_TO_DISABLE = [
+  "SUI_USDC",
+  "WAL_USDC",
+  "DEEP_USDC",
+  "SUIUSDE_USDC",
+  "SUI_SUIUSDE",
+  "XBTC_USDC",
+];
+
+(async () => {
+  const client = new SuiGrpcClient({
+    baseUrl: "https://sui-mainnet.mystenlabs.com",
+    network: MAINNET,
+  }).$extend(
+    deepbook({
+      address: adminCapOwner[MAINNET],
+      marginAdminCap: marginAdminCapID[MAINNET],
+    }),
+  );
+
   const tx = new Transaction();
 
+  // 1. Disable all DeepBook pools first so no liquidation activity can race the
+  //    capital injection inside the same multisig PTB.
+  for (const poolKey of POOL_KEYS_TO_DISABLE) {
+    client.deepbook.marginAdmin.disableDeepbookPool(poolKey)(tx);
+  }
+
+  // 2. Inject the aggregate pool_default amount (283,604.871465 USDC) into the
+  //    USDC margin pool without minting supplier shares.
   const usdcCoin = coinWithBalance({
     type: USDC_TYPE,
     balance: USDC_INJECTION_AMOUNT,
@@ -46,13 +75,8 @@ const buildInjectionTransaction = (): Transaction => {
     typeArguments: [USDC_TYPE],
   });
 
-  return tx;
-};
-
-const main = async () => {
-  const tx = buildInjectionTransaction();
-
   console.log({
+    poolKeysDisabled: POOL_KEYS_TO_DISABLE,
     usdcInjectionAmount: USDC_INJECTION_AMOUNT.toString(),
     usdcMarginPool: USDC_MARGIN_POOL_ID,
     marginAdminCap: marginAdminCapID[MAINNET],
@@ -60,9 +84,7 @@ const main = async () => {
 
   const res = await prepareMultisigTx(tx, MAINNET, adminCapOwner[MAINNET]);
   console.dir(res, { depth: null });
-};
-
-main().catch((error) => {
+})().catch((error) => {
   console.error(error);
   process.exitCode = 1;
 });


### PR DESCRIPTION
## Summary
- Adds `scripts/transactions/adminInjectCapital.ts` targeting `margin_pool::admin_inject_capital<USDC>` on the upgraded margin package, sized to the aggregate `pool_default` (283,604.871465 USDC).
- Prepends a full disable PTB so no pool activity can race the injection inside the same multisig transaction:
  1. `enable_version(3)` + `enable_version(4)` so existing managers stay callable for reduce-only / withdraw and the new admin calls resolve through the upgraded package.
  2. `disable_deepbook_pool` for all 6 margin-enabled DeepBook pools (SUI_USDC, WAL_USDC, DEEP_USDC, SUIUSDE_USDC, SUI_SUIUSDE, XBTC_USDC).
  3. `disable_deepbook_pool_for_loan` for every `(deepbook_pool, margin_pool)` pair enabled in `marginSetup.ts` (USDSUI pairs intentionally excluded) — belt-and-suspenders against `margin_manager::borrow_*`.
  4. `admin_inject_capital(USDC_MARGIN_POOL_ID, 283_604_871_465)`.
- Built via raw `tx.moveCall` against a pinned `MARGIN_PACKAGE` so the package id is stable in this script rather than inherited from SDK constants.
- Wires "Admin Inject Capital" into `.github/workflows/deepbookv3-build-tx.yml` next to the existing entries.

## Key decisions
- Pool/loan-pair entries left as commented in-line lists rather than imported helpers so a signer can comment out any pair that's already disabled at sign time. Aborts: `enable_version` on a no-op fires `EVersionAlreadyEnabled`; `disable_deepbook_pool_for_loan` on a no-op fires `EDeepbookPoolNotAllowed`.
- USDSUI deepbook pools intentionally excluded from the loan-pair sweep — those aren't enabled for margin.

## Test plan
- [ ] Dry-run with `GAS_OBJECT` and inspect each Move call's `typeArguments` + object refs.
- [ ] Confirm `prepareMultisigTx` produces clean `tx/tx-data.txt`.
- [ ] Verify `admin_inject_capital` post-state: `vault_balance` increased by 283,604.871465 USDC, `supply_shares` unchanged, `total_supply` bumped.
- [ ] Workflow lint: `gh workflow view deepbookv3-build-tx.yml` resolves cleanly after push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)