### PR TITLE
margin v5: post-trade risk_ratio invariant on order placement

### DIFF
--- a/packages/deepbook_margin/Published.toml
+++ b/packages/deepbook_margin/Published.toml
@@ -4,9 +4,9 @@
 
 [published.mainnet]
 chain-id = "35834a8a"
-published-at = "0xfbd322126f1452fd4c89aedbaeb9fd0c44df9b5cedbe70d76bf80dc086031377"
+published-at = "0x7767428727629a08dfd196bd4fc00d8a060e30da33aa63f4087fb3271e615a98"
 original-id = "0x97d9473771b01f77b0940c589484184b49f6444627ec121314fae6a6d36fb86b"
-version = 3
+version = 4
 toolchain-version = "1.63.1"
 build-config = { flavor = "sui", edition = "2024" }
 upgrade-capability = "0xd57c7a41b31c0a1fab5e71d296a75daf2e9e09945df383d4745daa49f06d9c56"

--- a/packages/deepbook_margin/sources/helper/margin_constants.move
+++ b/packages/deepbook_margin/sources/helper/margin_constants.move
@@ -3,7 +3,7 @@
 
 module deepbook_margin::margin_constants;
 
-const MARGIN_VERSION: u64 = 4;
+const MARGIN_VERSION: u64 = 5;
 const MAX_RISK_RATIO: u64 = 1_000 * 1_000_000_000; // Risk ratio above 1000 will be considered as 1000
 const DEFAULT_USER_LIQUIDATION_REWARD: u64 = 10_000_000; // 1%
 const DEFAULT_POOL_LIQUIDATION_REWARD: u64 = 40_000_000; // 4%

--- a/packages/deepbook_margin/sources/margin_manager.move
+++ b/packages/deepbook_margin/sources/margin_manager.move
@@ -1823,24 +1823,6 @@ fun process_collected_orders_v2<BaseAsset, QuoteAsset>(
                 ctx,
             );
 
-            // Post-fill solvency check. Skip when manager has no debt.
-            if (self.borrowed_base_shares > 0
-                || self.borrowed_quote_shares > 0) {
-                let risk_ratio_after = self.risk_ratio(
-                    registry,
-                    base_oracle,
-                    quote_oracle,
-                    pool,
-                    base_margin_pool,
-                    quote_margin_pool,
-                    clock,
-                );
-                assert!(
-                    risk_ratio_after >= registry.min_borrow_risk_ratio(pool.id()),
-                    EInsufficientRiskRatioAfterTrade,
-                );
-            };
-
             order_infos.push_back(order_info);
             executed_ids.push_back(conditional_order_id);
         } else {
@@ -1857,7 +1839,32 @@ fun process_collected_orders_v2<BaseAsset, QuoteAsset>(
         };
 
         i = i + 1;
-    }
+    };
+
+    // Post-loop solvency check. Move PTBs are atomic, so checking once after
+    // all fills is functionally equivalent to checking after each fill — a
+    // breach of the invariant aborts the whole txn either way. Skipped when
+    // no fills landed (executed_ids empty) and skipped when manager has no
+    // debt (nothing to be insolvent against). Saves up to N-1 Pyth reads on
+    // the happy path versus per-fill checking.
+    if (
+        !executed_ids.is_empty()
+        && (self.borrowed_base_shares > 0 || self.borrowed_quote_shares > 0)
+    ) {
+        let risk_ratio_after = self.risk_ratio(
+            registry,
+            base_oracle,
+            quote_oracle,
+            pool,
+            base_margin_pool,
+            quote_margin_pool,
+            clock,
+        );
+        assert!(
+            risk_ratio_after >= registry.min_borrow_risk_ratio(pool.id()),
+            EInsufficientRiskRatioAfterTrade,
+        );
+    };
 }
 
 fun balance_manager_unsafe_mut<BaseAsset, QuoteAsset>(

--- a/packages/deepbook_margin/sources/margin_manager.move
+++ b/packages/deepbook_margin/sources/margin_manager.move
@@ -59,6 +59,14 @@ const EPoolNotEnabledForMarginTrading: u64 = 15;
 const EConditionalOrderNotFound: u64 = 16;
 const EOutstandingDebt: u64 = 17;
 const EOutstandingAsset: u64 = 18;
+/// A conditional-order fill in `execute_conditional_orders_v2` would drop the
+/// manager's `risk_ratio` below `min_borrow_risk_ratio`. The whole txn aborts
+/// — we don't allow partial fills that leave the manager in a state borrowing
+/// would have been forbidden from.
+const EInsufficientRiskRatioAfterTrade: u64 = 19;
+/// Deprecated v1 entry was called. Use the `_v2` variant which enforces a
+/// post-trade risk_ratio invariant.
+const EDeprecatedUseV2: u64 = 20;
 
 // === Structs ===
 /// Witness type for authorizing MarginManager to call protected features of the DeepBook
@@ -216,11 +224,38 @@ public fun cancel_conditional_order<BaseAsset, QuoteAsset>(
     self.take_profit_stop_loss.cancel_conditional_order(manager_id, conditional_order_id, clock);
 }
 
+/// DEPRECATED. Use `execute_conditional_orders_v2`.
+///
+/// The v1 entry preserves its on-chain signature so the v5 package upgrade
+/// type-checks against existing dependents, but the body is replaced with
+/// `abort EDeprecatedUseV2`. The v2 variant adds margin-pool + oracle params
+/// and enforces a post-fill `risk_ratio >= min_borrow_risk_ratio` invariant
+/// inside `process_collected_orders_v2`.
+public fun execute_conditional_orders<BaseAsset, QuoteAsset>(
+    _self: &mut MarginManager<BaseAsset, QuoteAsset>,
+    _pool: &mut Pool<BaseAsset, QuoteAsset>,
+    _base_price_info_object: &PriceInfoObject,
+    _quote_price_info_object: &PriceInfoObject,
+    _registry: &MarginRegistry,
+    _max_orders_to_execute: u64,
+    _clock: &Clock,
+    _ctx: &TxContext,
+): vector<OrderInfo> {
+    abort EDeprecatedUseV2
+}
+
 /// Execute conditional orders and return the order infos.
 /// This is a permissionless function that can be called by anyone.
-public fun execute_conditional_orders<BaseAsset, QuoteAsset>(
+///
+/// v2 adds `base_margin_pool` + `quote_margin_pool` parameters and enforces
+/// a post-fill `risk_ratio >= min_borrow_risk_ratio` invariant inside the
+/// inner loop. If any single triggered fill would breach that floor, the
+/// entire txn aborts — no partial-state landing.
+public fun execute_conditional_orders_v2<BaseAsset, QuoteAsset>(
     self: &mut MarginManager<BaseAsset, QuoteAsset>,
     pool: &mut Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
     base_price_info_object: &PriceInfoObject,
     quote_price_info_object: &PriceInfoObject,
     registry: &MarginRegistry,
@@ -275,9 +310,13 @@ public fun execute_conditional_orders<BaseAsset, QuoteAsset>(
     };
 
     // Process collected orders
-    self.process_collected_orders(
+    self.process_collected_orders_v2(
         pool,
         registry,
+        base_margin_pool,
+        quote_margin_pool,
+        base_price_info_object,
+        quote_price_info_object,
         orders_to_process,
         &mut order_infos,
         &mut executed_ids,
@@ -1556,7 +1595,7 @@ fun assets_in_debt_unit_unsafe<BaseAsset, QuoteAsset>(
     (assets_in_debt_unit, base_asset, quote_asset)
 }
 
-fun place_pending_order<BaseAsset, QuoteAsset>(
+fun place_pending_order_v2<BaseAsset, QuoteAsset>(
     self: &mut MarginManager<BaseAsset, QuoteAsset>,
     registry: &MarginRegistry,
     pool: &mut Pool<BaseAsset, QuoteAsset>,
@@ -1565,7 +1604,7 @@ fun place_pending_order<BaseAsset, QuoteAsset>(
     ctx: &TxContext,
 ): OrderInfo {
     if (pending_order.is_limit_order()) {
-        self.place_pending_limit_order<BaseAsset, QuoteAsset>(
+        self.place_pending_limit_order_v2<BaseAsset, QuoteAsset>(
             registry,
             pool,
             pending_order.client_order_id(),
@@ -1580,7 +1619,7 @@ fun place_pending_order<BaseAsset, QuoteAsset>(
             ctx,
         )
     } else {
-        self.place_market_order_conditional<BaseAsset, QuoteAsset>(
+        self.place_market_order_conditional_v2<BaseAsset, QuoteAsset>(
             registry,
             pool,
             pending_order.client_order_id(),
@@ -1595,7 +1634,9 @@ fun place_pending_order<BaseAsset, QuoteAsset>(
 }
 
 /// Only used for tpsl pending orders.
-fun place_pending_limit_order<BaseAsset, QuoteAsset>(
+/// The post-fill solvency invariant is enforced one level up in
+/// `process_collected_orders_v2`, where we have access to the margin pools.
+fun place_pending_limit_order_v2<BaseAsset, QuoteAsset>(
     self: &mut MarginManager<BaseAsset, QuoteAsset>,
     registry: &MarginRegistry,
     pool: &mut Pool<BaseAsset, QuoteAsset>,
@@ -1636,7 +1677,9 @@ fun place_pending_limit_order<BaseAsset, QuoteAsset>(
 
 /// Places a market order in the pool.
 /// Only used for tpsl pending orders.
-fun place_market_order_conditional<BaseAsset, QuoteAsset>(
+/// The post-fill solvency invariant is enforced one level up in
+/// `process_collected_orders_v2`, where we have access to the margin pools.
+fun place_market_order_conditional_v2<BaseAsset, QuoteAsset>(
     self: &mut MarginManager<BaseAsset, QuoteAsset>,
     registry: &MarginRegistry,
     pool: &mut Pool<BaseAsset, QuoteAsset>,
@@ -1667,11 +1710,22 @@ fun place_market_order_conditional<BaseAsset, QuoteAsset>(
     )
 }
 
-/// Helper function to process collected conditional orders
-fun process_collected_orders<BaseAsset, QuoteAsset>(
+/// Helper function to process collected conditional orders.
+///
+/// After each successful `place_pending_order_v2` call, recompute `risk_ratio`
+/// against Pyth via the public `risk_ratio` helper. If the manager has debt
+/// and the post-fill ratio is below `min_borrow_risk_ratio`, abort the entire
+/// txn with `EInsufficientRiskRatioAfterTrade`. We do not allow partial-fill
+/// landing — one bad fill reverts everything so the manager is never left in
+/// a state borrowing would have been forbidden from.
+fun process_collected_orders_v2<BaseAsset, QuoteAsset>(
     self: &mut MarginManager<BaseAsset, QuoteAsset>,
     pool: &mut Pool<BaseAsset, QuoteAsset>,
     registry: &MarginRegistry,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    base_oracle: &PriceInfoObject,
+    quote_oracle: &PriceInfoObject,
     orders: vector<ConditionalOrder>,
     order_infos: &mut vector<OrderInfo>,
     executed_ids: &mut vector<u64>,
@@ -1761,13 +1815,32 @@ fun process_collected_orders<BaseAsset, QuoteAsset>(
                 };
             };
 
-            let order_info = self.place_pending_order(
+            let order_info = self.place_pending_order_v2(
                 registry,
                 pool,
                 &pending_order,
                 clock,
                 ctx,
             );
+
+            // Post-fill solvency check. Skip when manager has no debt.
+            if (self.borrowed_base_shares > 0
+                || self.borrowed_quote_shares > 0) {
+                let risk_ratio_after = self.risk_ratio(
+                    registry,
+                    base_oracle,
+                    quote_oracle,
+                    pool,
+                    base_margin_pool,
+                    quote_margin_pool,
+                    clock,
+                );
+                assert!(
+                    risk_ratio_after >= registry.min_borrow_risk_ratio(pool.id()),
+                    EInsufficientRiskRatioAfterTrade,
+                );
+            };
+
             order_infos.push_back(order_info);
             executed_ids.push_back(conditional_order_id);
         } else {

--- a/packages/deepbook_margin/sources/pool_proxy.move
+++ b/packages/deepbook_margin/sources/pool_proxy.move
@@ -21,6 +21,17 @@ const EPoolNotEnabledForMarginTrading: u64 = 2;
 const ENotReduceOnlyOrder: u64 = 3;
 const EIncorrectDeepBookPool: u64 = 4;
 const ENoLiquidityInOrderbook: u64 = 5;
+/// Post-trade risk ratio dropped below `min_borrow_risk_ratio`.
+/// Raised by the v2 order placement entries when the manager would be left
+/// in a state borrowing would be forbidden from.
+const EInsufficientRiskRatioAfterTrade: u64 = 6;
+/// Reduce-only fill leaked value to the counterparty: the manager's
+/// risk_ratio after the trade is lower than before. Reduce-only orders must
+/// monotonically improve (or hold) solvency.
+const EReduceOnlyMustImproveRiskRatio: u64 = 7;
+/// Deprecated v1 entry was called. Use the `_v2` variant which enforces a
+/// post-trade risk_ratio invariant.
+const EDeprecatedUseV2: u64 = 8;
 
 // === Public Functions - Price Protection ===
 /// Updates the current price for a pool using safe oracle price calculation.
@@ -43,12 +54,108 @@ public fun update_current_price<BaseAsset, QuoteAsset>(
     registry.update_current_price(pool.id(), price, clock);
 }
 
-// === Public Proxy Functions - Trading ===
-/// Places a limit order in the pool.
+// === Public Proxy Functions - Trading (v1 — DEPRECATED) ===
+//
+// The v1 trading entries below preserve their on-chain signatures so the v5
+// package upgrade type-checks against existing dependents, but every body is
+// replaced with `abort EDeprecatedUseV2`. Callers must migrate to the `_v2`
+// variants further down, which add a post-trade `risk_ratio` invariant that
+// closes the wash-trade drain vector exploited in the v3/v4 incident.
+
+/// DEPRECATED. Use `place_limit_order_v2`.
 public fun place_limit_order<BaseAsset, QuoteAsset>(
+    _registry: &MarginRegistry,
+    _margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    _pool: &mut Pool<BaseAsset, QuoteAsset>,
+    _client_order_id: u64,
+    _order_type: u8,
+    _self_matching_option: u8,
+    _price: u64,
+    _quantity: u64,
+    _is_bid: bool,
+    _pay_with_deep: bool,
+    _expire_timestamp: u64,
+    _clock: &Clock,
+    _ctx: &TxContext,
+): OrderInfo {
+    abort EDeprecatedUseV2
+}
+
+/// DEPRECATED. Use `place_market_order_v2`.
+public fun place_market_order<BaseAsset, QuoteAsset>(
+    _registry: &MarginRegistry,
+    _margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    _pool: &mut Pool<BaseAsset, QuoteAsset>,
+    _client_order_id: u64,
+    _self_matching_option: u8,
+    _quantity: u64,
+    _is_bid: bool,
+    _pay_with_deep: bool,
+    _clock: &Clock,
+    _ctx: &TxContext,
+): OrderInfo {
+    abort EDeprecatedUseV2
+}
+
+/// DEPRECATED. Use `place_reduce_only_limit_order_v2`.
+public fun place_reduce_only_limit_order<BaseAsset, QuoteAsset, DebtAsset>(
+    _registry: &MarginRegistry,
+    _margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    _pool: &mut Pool<BaseAsset, QuoteAsset>,
+    _margin_pool: &MarginPool<DebtAsset>,
+    _client_order_id: u64,
+    _order_type: u8,
+    _self_matching_option: u8,
+    _price: u64,
+    _quantity: u64,
+    _is_bid: bool,
+    _pay_with_deep: bool,
+    _expire_timestamp: u64,
+    _clock: &Clock,
+    _ctx: &TxContext,
+): OrderInfo {
+    abort EDeprecatedUseV2
+}
+
+/// DEPRECATED. Use `place_reduce_only_market_order_v2`.
+public fun place_reduce_only_market_order<BaseAsset, QuoteAsset, DebtAsset>(
+    _registry: &MarginRegistry,
+    _margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    _pool: &mut Pool<BaseAsset, QuoteAsset>,
+    _margin_pool: &MarginPool<DebtAsset>,
+    _client_order_id: u64,
+    _self_matching_option: u8,
+    _quantity: u64,
+    _is_bid: bool,
+    _pay_with_deep: bool,
+    _clock: &Clock,
+    _ctx: &TxContext,
+): OrderInfo {
+    abort EDeprecatedUseV2
+}
+
+// === Public Proxy Functions - Trading (v2) ===
+//
+// Each v2 entry mirrors its v1 counterpart and additionally recomputes
+// `risk_ratio` after the order settles (using Pyth via the public
+// `MarginManager::risk_ratio` helper). For non-reduce-only entries the
+// post-trade ratio must be at least `min_borrow_risk_ratio` — same threshold
+// the borrow path enforces, so trading cannot push a manager below where
+// borrowing was already forbidden. Skipped when the manager has no debt
+// (nothing to be insolvent against). For reduce-only entries the post-trade
+// ratio must be `>= risk_ratio_before` (monotonic improvement); also skipped
+// when the manager has no debt because the reduce-only quantity predicate
+// already rejects every order in that case.
+
+/// Places a limit order in the pool.
+public fun place_limit_order_v2<BaseAsset, QuoteAsset>(
     registry: &MarginRegistry,
     margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
     pool: &mut Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    base_oracle: &PriceInfoObject,
+    quote_oracle: &PriceInfoObject,
     client_order_id: u64,
     order_type: u8,
     self_matching_option: u8,
@@ -68,7 +175,7 @@ public fun place_limit_order<BaseAsset, QuoteAsset>(
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
 
-    pool.place_limit_order(
+    let order_info = pool.place_limit_order(
         balance_manager,
         &trade_proof,
         client_order_id,
@@ -81,14 +188,31 @@ public fun place_limit_order<BaseAsset, QuoteAsset>(
         expire_timestamp,
         clock,
         ctx,
-    )
+    );
+
+    assert_post_trade_solvent(
+        margin_manager,
+        registry,
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        base_oracle,
+        quote_oracle,
+        clock,
+    );
+
+    order_info
 }
 
 /// Places a market order in the pool.
-public fun place_market_order<BaseAsset, QuoteAsset>(
+public fun place_market_order_v2<BaseAsset, QuoteAsset>(
     registry: &MarginRegistry,
     margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
     pool: &mut Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    base_oracle: &PriceInfoObject,
+    quote_oracle: &PriceInfoObject,
     client_order_id: u64,
     self_matching_option: u8,
     quantity: u64,
@@ -112,7 +236,7 @@ public fun place_market_order<BaseAsset, QuoteAsset>(
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
 
-    pool.place_market_order(
+    let order_info = pool.place_market_order(
         balance_manager,
         &trade_proof,
         client_order_id,
@@ -122,15 +246,32 @@ public fun place_market_order<BaseAsset, QuoteAsset>(
         pay_with_deep,
         clock,
         ctx,
-    )
+    );
+
+    assert_post_trade_solvent(
+        margin_manager,
+        registry,
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        base_oracle,
+        quote_oracle,
+        clock,
+    );
+
+    order_info
 }
 
 /// Places a reduce-only order in the pool. Used when margin trading is disabled.
-public fun place_reduce_only_limit_order<BaseAsset, QuoteAsset, DebtAsset>(
+public fun place_reduce_only_limit_order_v2<BaseAsset, QuoteAsset, DebtAsset>(
     registry: &MarginRegistry,
     margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
     pool: &mut Pool<BaseAsset, QuoteAsset>,
     margin_pool: &MarginPool<DebtAsset>,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    base_oracle: &PriceInfoObject,
+    quote_oracle: &PriceInfoObject,
     client_order_id: u64,
     order_type: u8,
     self_matching_option: u8,
@@ -161,10 +302,21 @@ public fun place_reduce_only_limit_order<BaseAsset, QuoteAsset, DebtAsset>(
         ENotReduceOnlyOrder,
     );
 
+    let risk_ratio_before = read_risk_ratio_if_indebted(
+        margin_manager,
+        registry,
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        base_oracle,
+        quote_oracle,
+        clock,
+    );
+
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
 
-    pool.place_limit_order(
+    let order_info = pool.place_limit_order(
         balance_manager,
         &trade_proof,
         client_order_id,
@@ -177,15 +329,33 @@ public fun place_reduce_only_limit_order<BaseAsset, QuoteAsset, DebtAsset>(
         expire_timestamp,
         clock,
         ctx,
-    )
+    );
+
+    assert_reduce_only_monotonic(
+        margin_manager,
+        registry,
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        base_oracle,
+        quote_oracle,
+        clock,
+        risk_ratio_before,
+    );
+
+    order_info
 }
 
 /// Places a reduce-only market order in the pool. Used when margin trading is disabled.
-public fun place_reduce_only_market_order<BaseAsset, QuoteAsset, DebtAsset>(
+public fun place_reduce_only_market_order_v2<BaseAsset, QuoteAsset, DebtAsset>(
     registry: &MarginRegistry,
     margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
     pool: &mut Pool<BaseAsset, QuoteAsset>,
     margin_pool: &MarginPool<DebtAsset>,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    base_oracle: &PriceInfoObject,
+    quote_oracle: &PriceInfoObject,
     client_order_id: u64,
     self_matching_option: u8,
     quantity: u64,
@@ -223,10 +393,21 @@ public fun place_reduce_only_market_order<BaseAsset, QuoteAsset, DebtAsset>(
 
     registry.assert_price(pool.id(), effective_price, is_bid, clock);
 
+    let risk_ratio_before = read_risk_ratio_if_indebted(
+        margin_manager,
+        registry,
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        base_oracle,
+        quote_oracle,
+        clock,
+    );
+
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
 
-    pool.place_market_order(
+    let order_info = pool.place_market_order(
         balance_manager,
         &trade_proof,
         client_order_id,
@@ -236,7 +417,21 @@ public fun place_reduce_only_market_order<BaseAsset, QuoteAsset, DebtAsset>(
         pay_with_deep,
         clock,
         ctx,
-    )
+    );
+
+    assert_reduce_only_monotonic(
+        margin_manager,
+        registry,
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        base_oracle,
+        quote_oracle,
+        clock,
+        risk_ratio_before,
+    );
+
+    order_info
 }
 
 /// Modifies an order
@@ -489,4 +684,101 @@ fun calculate_effective_price<BaseAsset, QuoteAsset>(
         assert!(base_used > 0, ENoLiquidityInOrderbook);
         (math::div(quote_out, base_used), quote_out)
     }
+}
+
+/// Reads the manager's `risk_ratio` only when there is outstanding debt.
+/// Returns `0` when the manager has no debt — callers must treat the sentinel
+/// as "no constraint to check" rather than as a real ratio.
+fun read_risk_ratio_if_indebted<BaseAsset, QuoteAsset>(
+    margin_manager: &MarginManager<BaseAsset, QuoteAsset>,
+    registry: &MarginRegistry,
+    pool: &Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    base_oracle: &PriceInfoObject,
+    quote_oracle: &PriceInfoObject,
+    clock: &Clock,
+): u64 {
+    if (
+        margin_manager.borrowed_base_shares() > 0
+        || margin_manager.borrowed_quote_shares() > 0
+    ) {
+        margin_manager.risk_ratio(
+            registry,
+            base_oracle,
+            quote_oracle,
+            pool,
+            base_margin_pool,
+            quote_margin_pool,
+            clock,
+        )
+    } else {
+        0
+    }
+}
+
+/// Asserts the manager remains above the borrow-floor risk ratio after a
+/// trade. Skipped when the manager has no debt (nothing to be insolvent
+/// against). Threshold reuses `min_borrow_risk_ratio` so trading cannot push
+/// a manager below the level borrowing is already gated at.
+fun assert_post_trade_solvent<BaseAsset, QuoteAsset>(
+    margin_manager: &MarginManager<BaseAsset, QuoteAsset>,
+    registry: &MarginRegistry,
+    pool: &Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    base_oracle: &PriceInfoObject,
+    quote_oracle: &PriceInfoObject,
+    clock: &Clock,
+) {
+    if (
+        margin_manager.borrowed_base_shares() == 0
+        && margin_manager.borrowed_quote_shares() == 0
+    ) {
+        return
+    };
+
+    let risk_ratio_after = margin_manager.risk_ratio(
+        registry,
+        base_oracle,
+        quote_oracle,
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        clock,
+    );
+    assert!(
+        risk_ratio_after >= registry.min_borrow_risk_ratio(pool.id()),
+        EInsufficientRiskRatioAfterTrade,
+    );
+}
+
+/// Asserts a reduce-only fill did not worsen the manager's risk ratio.
+/// `risk_ratio_before` is the sentinel returned by `read_risk_ratio_if_indebted`
+/// — a value of `0` means the manager had no debt at the entry, in which case
+/// the reduce-only quantity predicate would have already aborted any nonzero
+/// order, so there is nothing to compare.
+fun assert_reduce_only_monotonic<BaseAsset, QuoteAsset>(
+    margin_manager: &MarginManager<BaseAsset, QuoteAsset>,
+    registry: &MarginRegistry,
+    pool: &Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    base_oracle: &PriceInfoObject,
+    quote_oracle: &PriceInfoObject,
+    clock: &Clock,
+    risk_ratio_before: u64,
+) {
+    if (risk_ratio_before == 0) return;
+
+    let risk_ratio_after = margin_manager.risk_ratio(
+        registry,
+        base_oracle,
+        quote_oracle,
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        clock,
+    );
+    assert!(risk_ratio_after >= risk_ratio_before, EReduceOnlyMustImproveRiskRatio);
 }

--- a/packages/deepbook_margin/sources/pool_proxy.move
+++ b/packages/deepbook_margin/sources/pool_proxy.move
@@ -29,15 +29,9 @@ const EInsufficientRiskRatioAfterTrade: u64 = 6;
 /// risk_ratio after the trade is lower than before. Reduce-only orders must
 /// monotonically improve (or hold) solvency.
 const EReduceOnlyMustImproveRiskRatio: u64 = 7;
-/// Reduce-only entry called on a manager with no outstanding debt. Reduce-only
-/// is only meaningful when there is debt to reduce; without it the post-fill
-/// monotonic invariant has no `before` value to compare against. Raised
-/// explicitly so this no-op case is distinguishable from a malformed
-/// quantity / wrong-side reduce-only attempt (`ENotReduceOnlyOrder`).
-const ENoDebtToReduce: u64 = 8;
 /// Deprecated v1 entry was called. Use the `_v2` variant which enforces a
 /// post-trade risk_ratio invariant.
-const EDeprecatedUseV2: u64 = 9;
+const EDeprecatedUseV2: u64 = 8;
 
 // === Public Functions - Price Protection ===
 /// Updates the current price for a pool using safe oracle price calculation.
@@ -313,18 +307,18 @@ public fun place_reduce_only_limit_order_v2<BaseAsset, QuoteAsset, DebtAsset>(
         ENotReduceOnlyOrder,
     );
 
-    let risk_ratio_before_opt = read_risk_ratio_if_indebted(
-        margin_manager,
+    // The reduce-only quantity predicate above already guarantees the manager
+    // has debt on the relevant side, so `risk_ratio` is safe to compute (no
+    // divide-by-zero in `risk_ratio_int`).
+    let risk_ratio_before = margin_manager.risk_ratio(
         registry,
+        base_oracle,
+        quote_oracle,
         pool,
         base_margin_pool,
         quote_margin_pool,
-        base_oracle,
-        quote_oracle,
         clock,
     );
-    assert!(risk_ratio_before_opt.is_some(), ENoDebtToReduce);
-    let risk_ratio_before = risk_ratio_before_opt.destroy_some();
 
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
@@ -406,18 +400,18 @@ public fun place_reduce_only_market_order_v2<BaseAsset, QuoteAsset, DebtAsset>(
 
     registry.assert_price(pool.id(), effective_price, is_bid, clock);
 
-    let risk_ratio_before_opt = read_risk_ratio_if_indebted(
-        margin_manager,
+    // The reduce-only quantity predicate above already guarantees the manager
+    // has debt on the relevant side, so `risk_ratio` is safe to compute (no
+    // divide-by-zero in `risk_ratio_int`).
+    let risk_ratio_before = margin_manager.risk_ratio(
         registry,
+        base_oracle,
+        quote_oracle,
         pool,
         base_margin_pool,
         quote_margin_pool,
-        base_oracle,
-        quote_oracle,
         clock,
     );
-    assert!(risk_ratio_before_opt.is_some(), ENoDebtToReduce);
-    let risk_ratio_before = risk_ratio_before_opt.destroy_some();
 
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
@@ -737,43 +731,11 @@ fun assert_post_trade_solvent<BaseAsset, QuoteAsset>(
     );
 }
 
-/// Reads the manager's `risk_ratio` only when there is outstanding debt.
-/// Returns `option::none()` when the manager has no debt — using `Option`
-/// (not a `0` sentinel) so callers can't confuse "no debt" with a real
-/// `risk_ratio` of zero.
-fun read_risk_ratio_if_indebted<BaseAsset, QuoteAsset>(
-    margin_manager: &MarginManager<BaseAsset, QuoteAsset>,
-    registry: &MarginRegistry,
-    pool: &Pool<BaseAsset, QuoteAsset>,
-    base_margin_pool: &MarginPool<BaseAsset>,
-    quote_margin_pool: &MarginPool<QuoteAsset>,
-    base_oracle: &PriceInfoObject,
-    quote_oracle: &PriceInfoObject,
-    clock: &Clock,
-): Option<u64> {
-    if (
-        margin_manager.borrowed_base_shares() == 0
-        && margin_manager.borrowed_quote_shares() == 0
-    ) {
-        return option::none()
-    };
-
-    option::some(margin_manager.risk_ratio(
-        registry,
-        base_oracle,
-        quote_oracle,
-        pool,
-        base_margin_pool,
-        quote_margin_pool,
-        clock,
-    ))
-}
-
 /// Asserts a reduce-only fill did not worsen the manager's risk ratio.
-/// Caller is responsible for ensuring the manager had debt at the entry
-/// (`ENoDebtToReduce` is asserted in the public reduce-only entries before
-/// this helper is invoked), so `risk_ratio_before` is a real ratio rather
-/// than a sentinel.
+/// Caller is responsible for ensuring the manager had debt at the entry —
+/// the reduce-only quantity predicate (`base_debt > base_asset` or
+/// `quote_debt > quote_asset`) already aborts the txn for no-debt managers,
+/// so `risk_ratio_before` is always a real ratio by the time this fires.
 fun assert_reduce_only_monotonic<BaseAsset, QuoteAsset>(
     margin_manager: &MarginManager<BaseAsset, QuoteAsset>,
     registry: &MarginRegistry,

--- a/packages/deepbook_margin/sources/pool_proxy.move
+++ b/packages/deepbook_margin/sources/pool_proxy.move
@@ -60,7 +60,8 @@ public fun update_current_price<BaseAsset, QuoteAsset>(
 // package upgrade type-checks against existing dependents, but every body is
 // replaced with `abort EDeprecatedUseV2`. Callers must migrate to the `_v2`
 // variants further down, which add a post-trade `risk_ratio` invariant that
-// closes the wash-trade drain vector exploited in the v3/v4 incident.
+// prevents an order placement from leaving the manager in a state borrowing
+// would already be forbidden from.
 
 /// DEPRECATED. Use `place_limit_order_v2`.
 public fun place_limit_order<BaseAsset, QuoteAsset>(

--- a/packages/deepbook_margin/sources/pool_proxy.move
+++ b/packages/deepbook_margin/sources/pool_proxy.move
@@ -29,9 +29,15 @@ const EInsufficientRiskRatioAfterTrade: u64 = 6;
 /// risk_ratio after the trade is lower than before. Reduce-only orders must
 /// monotonically improve (or hold) solvency.
 const EReduceOnlyMustImproveRiskRatio: u64 = 7;
+/// Reduce-only entry called on a manager with no outstanding debt. Reduce-only
+/// is only meaningful when there is debt to reduce; without it the post-fill
+/// monotonic invariant has no `before` value to compare against. Raised
+/// explicitly so this no-op case is distinguishable from a malformed
+/// quantity / wrong-side reduce-only attempt (`ENotReduceOnlyOrder`).
+const ENoDebtToReduce: u64 = 8;
 /// Deprecated v1 entry was called. Use the `_v2` variant which enforces a
 /// post-trade risk_ratio invariant.
-const EDeprecatedUseV2: u64 = 8;
+const EDeprecatedUseV2: u64 = 9;
 
 // === Public Functions - Price Protection ===
 /// Updates the current price for a pool using safe oracle price calculation.
@@ -307,7 +313,7 @@ public fun place_reduce_only_limit_order_v2<BaseAsset, QuoteAsset, DebtAsset>(
         ENotReduceOnlyOrder,
     );
 
-    let risk_ratio_before = read_risk_ratio_if_indebted(
+    let risk_ratio_before_opt = read_risk_ratio_if_indebted(
         margin_manager,
         registry,
         pool,
@@ -317,6 +323,8 @@ public fun place_reduce_only_limit_order_v2<BaseAsset, QuoteAsset, DebtAsset>(
         quote_oracle,
         clock,
     );
+    assert!(risk_ratio_before_opt.is_some(), ENoDebtToReduce);
+    let risk_ratio_before = risk_ratio_before_opt.destroy_some();
 
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
@@ -398,7 +406,7 @@ public fun place_reduce_only_market_order_v2<BaseAsset, QuoteAsset, DebtAsset>(
 
     registry.assert_price(pool.id(), effective_price, is_bid, clock);
 
-    let risk_ratio_before = read_risk_ratio_if_indebted(
+    let risk_ratio_before_opt = read_risk_ratio_if_indebted(
         margin_manager,
         registry,
         pool,
@@ -408,6 +416,8 @@ public fun place_reduce_only_market_order_v2<BaseAsset, QuoteAsset, DebtAsset>(
         quote_oracle,
         clock,
     );
+    assert!(risk_ratio_before_opt.is_some(), ENoDebtToReduce);
+    let risk_ratio_before = risk_ratio_before_opt.destroy_some();
 
     let trade_proof = margin_manager.trade_proof(ctx);
     let balance_manager = margin_manager.balance_manager_trading_mut(ctx);
@@ -760,9 +770,10 @@ fun read_risk_ratio_if_indebted<BaseAsset, QuoteAsset>(
 }
 
 /// Asserts a reduce-only fill did not worsen the manager's risk ratio.
-/// `risk_ratio_before` is `option::none()` when the manager had no debt at
-/// the entry — in that case the reduce-only quantity predicate would have
-/// already aborted any nonzero order, so there is nothing to compare.
+/// Caller is responsible for ensuring the manager had debt at the entry
+/// (`ENoDebtToReduce` is asserted in the public reduce-only entries before
+/// this helper is invoked), so `risk_ratio_before` is a real ratio rather
+/// than a sentinel.
 fun assert_reduce_only_monotonic<BaseAsset, QuoteAsset>(
     margin_manager: &MarginManager<BaseAsset, QuoteAsset>,
     registry: &MarginRegistry,
@@ -772,14 +783,8 @@ fun assert_reduce_only_monotonic<BaseAsset, QuoteAsset>(
     base_oracle: &PriceInfoObject,
     quote_oracle: &PriceInfoObject,
     clock: &Clock,
-    risk_ratio_before: Option<u64>,
+    risk_ratio_before: u64,
 ) {
-    if (risk_ratio_before.is_none()) {
-        risk_ratio_before.destroy_none();
-        return
-    };
-
-    let before = risk_ratio_before.destroy_some();
     let risk_ratio_after = margin_manager.risk_ratio(
         registry,
         base_oracle,
@@ -789,5 +794,5 @@ fun assert_reduce_only_monotonic<BaseAsset, QuoteAsset>(
         quote_margin_pool,
         clock,
     );
-    assert!(risk_ratio_after >= before, EReduceOnlyMustImproveRiskRatio);
+    assert!(risk_ratio_after >= risk_ratio_before, EReduceOnlyMustImproveRiskRatio);
 }

--- a/packages/deepbook_margin/sources/pool_proxy.move
+++ b/packages/deepbook_margin/sources/pool_proxy.move
@@ -143,10 +143,14 @@ public fun place_reduce_only_market_order<BaseAsset, QuoteAsset, DebtAsset>(
 // post-trade ratio must be at least `min_borrow_risk_ratio` — same threshold
 // the borrow path enforces, so trading cannot push a manager below where
 // borrowing was already forbidden. Skipped when the manager has no debt
-// (nothing to be insolvent against). For reduce-only entries the post-trade
-// ratio must be `>= risk_ratio_before` (monotonic improvement); also skipped
-// when the manager has no debt because the reduce-only quantity predicate
-// already rejects every order in that case.
+// (nothing to be insolvent against).
+//
+// For reduce-only entries the post-trade ratio must be `>= risk_ratio_before`
+// (monotonic improvement). The borrow-floor check would trap users in the
+// 1.1–1.25 danger zone (between liquidation and borrow thresholds), who are
+// exactly the people who most need to wind down via reduce-only. Monotonic
+// avoids that trap and additionally catches within-band value leak that the
+// borrow-floor check allows.
 
 /// Places a limit order in the pool.
 public fun place_limit_order_v2<BaseAsset, QuoteAsset>(
@@ -687,37 +691,6 @@ fun calculate_effective_price<BaseAsset, QuoteAsset>(
     }
 }
 
-/// Reads the manager's `risk_ratio` only when there is outstanding debt.
-/// Returns `0` when the manager has no debt — callers must treat the sentinel
-/// as "no constraint to check" rather than as a real ratio.
-fun read_risk_ratio_if_indebted<BaseAsset, QuoteAsset>(
-    margin_manager: &MarginManager<BaseAsset, QuoteAsset>,
-    registry: &MarginRegistry,
-    pool: &Pool<BaseAsset, QuoteAsset>,
-    base_margin_pool: &MarginPool<BaseAsset>,
-    quote_margin_pool: &MarginPool<QuoteAsset>,
-    base_oracle: &PriceInfoObject,
-    quote_oracle: &PriceInfoObject,
-    clock: &Clock,
-): u64 {
-    if (
-        margin_manager.borrowed_base_shares() > 0
-        || margin_manager.borrowed_quote_shares() > 0
-    ) {
-        margin_manager.risk_ratio(
-            registry,
-            base_oracle,
-            quote_oracle,
-            pool,
-            base_margin_pool,
-            quote_margin_pool,
-            clock,
-        )
-    } else {
-        0
-    }
-}
-
 /// Asserts the manager remains above the borrow-floor risk ratio after a
 /// trade. Skipped when the manager has no debt (nothing to be insolvent
 /// against). Threshold reuses `min_borrow_risk_ratio` so trading cannot push
@@ -754,11 +727,42 @@ fun assert_post_trade_solvent<BaseAsset, QuoteAsset>(
     );
 }
 
+/// Reads the manager's `risk_ratio` only when there is outstanding debt.
+/// Returns `option::none()` when the manager has no debt — using `Option`
+/// (not a `0` sentinel) so callers can't confuse "no debt" with a real
+/// `risk_ratio` of zero.
+fun read_risk_ratio_if_indebted<BaseAsset, QuoteAsset>(
+    margin_manager: &MarginManager<BaseAsset, QuoteAsset>,
+    registry: &MarginRegistry,
+    pool: &Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    base_oracle: &PriceInfoObject,
+    quote_oracle: &PriceInfoObject,
+    clock: &Clock,
+): Option<u64> {
+    if (
+        margin_manager.borrowed_base_shares() == 0
+        && margin_manager.borrowed_quote_shares() == 0
+    ) {
+        return option::none()
+    };
+
+    option::some(margin_manager.risk_ratio(
+        registry,
+        base_oracle,
+        quote_oracle,
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        clock,
+    ))
+}
+
 /// Asserts a reduce-only fill did not worsen the manager's risk ratio.
-/// `risk_ratio_before` is the sentinel returned by `read_risk_ratio_if_indebted`
-/// — a value of `0` means the manager had no debt at the entry, in which case
-/// the reduce-only quantity predicate would have already aborted any nonzero
-/// order, so there is nothing to compare.
+/// `risk_ratio_before` is `option::none()` when the manager had no debt at
+/// the entry — in that case the reduce-only quantity predicate would have
+/// already aborted any nonzero order, so there is nothing to compare.
 fun assert_reduce_only_monotonic<BaseAsset, QuoteAsset>(
     margin_manager: &MarginManager<BaseAsset, QuoteAsset>,
     registry: &MarginRegistry,
@@ -768,10 +772,14 @@ fun assert_reduce_only_monotonic<BaseAsset, QuoteAsset>(
     base_oracle: &PriceInfoObject,
     quote_oracle: &PriceInfoObject,
     clock: &Clock,
-    risk_ratio_before: u64,
+    risk_ratio_before: Option<u64>,
 ) {
-    if (risk_ratio_before == 0) return;
+    if (risk_ratio_before.is_none()) {
+        risk_ratio_before.destroy_none();
+        return
+    };
 
+    let before = risk_ratio_before.destroy_some();
     let risk_ratio_after = margin_manager.risk_ratio(
         registry,
         base_oracle,
@@ -781,5 +789,5 @@ fun assert_reduce_only_monotonic<BaseAsset, QuoteAsset>(
         quote_margin_pool,
         clock,
     );
-    assert!(risk_ratio_after >= risk_ratio_before, EReduceOnlyMustImproveRiskRatio);
+    assert!(risk_ratio_after >= before, EReduceOnlyMustImproveRiskRatio);
 }

--- a/packages/deepbook_margin/tests/helper/test_helpers.move
+++ b/packages/deepbook_margin/tests/helper/test_helpers.move
@@ -323,7 +323,10 @@ public fun initialize_pool_price<BaseAsset, QuoteAsset>(
 }
 
 /// Build a price info object based on the asset type
-fun build_price_info_for_type<Asset>(scenario: &mut Scenario, clock: &Clock): PriceInfoObject {
+public fun build_price_info_for_type<Asset>(
+    scenario: &mut Scenario,
+    clock: &Clock,
+): PriceInfoObject {
     let type_name = std::type_name::with_defining_ids<Asset>();
     let type_string = type_name.into_string().into_bytes();
 
@@ -1201,4 +1204,210 @@ public fun setup_deep_price<BaseAsset, QuoteAsset>(
     return_shared(reference_pool);
 
     reference_pool_id
+}
+
+// === V2 trading wrappers ===
+//
+// The v2 entries on `pool_proxy` and `margin_manager` take additional
+// margin-pool and oracle parameters so they can enforce a post-trade
+// `risk_ratio` invariant. These wrappers fold the oracle build/destroy
+// dance into one call. Callers pass already-shared margin pool refs
+// (most tests already have them taken for borrow/withdraw setup).
+//
+// Signature shape: `(&mut scenario, &registry, &base_margin_pool,
+// &quote_margin_pool, &mut mm, &mut pool, /* original v1 trade args */,
+// &clock)`. The wrapper builds Pyth oracle objects for both assets,
+// invokes the v2 entry with `scenario.ctx()`, and destroys the oracles.
+
+public fun place_limit_order_v2_for_test<BaseAsset, QuoteAsset>(
+    scenario: &mut Scenario,
+    registry: &MarginRegistry,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    mm: &mut deepbook_margin::margin_manager::MarginManager<BaseAsset, QuoteAsset>,
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    client_order_id: u64,
+    order_type: u8,
+    self_matching_option: u8,
+    price: u64,
+    quantity: u64,
+    is_bid: bool,
+    pay_with_deep: bool,
+    expire_timestamp: u64,
+    clock: &Clock,
+): deepbook::order_info::OrderInfo {
+    let base_oracle = build_price_info_for_type<BaseAsset>(scenario, clock);
+    let quote_oracle = build_price_info_for_type<QuoteAsset>(scenario, clock);
+    let order_info = pool_proxy::place_limit_order_v2<BaseAsset, QuoteAsset>(
+        registry,
+        mm,
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        &base_oracle,
+        &quote_oracle,
+        client_order_id,
+        order_type,
+        self_matching_option,
+        price,
+        quantity,
+        is_bid,
+        pay_with_deep,
+        expire_timestamp,
+        clock,
+        scenario.ctx(),
+    );
+    destroy(base_oracle);
+    destroy(quote_oracle);
+    order_info
+}
+
+public fun place_market_order_v2_for_test<BaseAsset, QuoteAsset>(
+    scenario: &mut Scenario,
+    registry: &MarginRegistry,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    mm: &mut deepbook_margin::margin_manager::MarginManager<BaseAsset, QuoteAsset>,
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    client_order_id: u64,
+    self_matching_option: u8,
+    quantity: u64,
+    is_bid: bool,
+    pay_with_deep: bool,
+    clock: &Clock,
+): deepbook::order_info::OrderInfo {
+    let base_oracle = build_price_info_for_type<BaseAsset>(scenario, clock);
+    let quote_oracle = build_price_info_for_type<QuoteAsset>(scenario, clock);
+    let order_info = pool_proxy::place_market_order_v2<BaseAsset, QuoteAsset>(
+        registry,
+        mm,
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        &base_oracle,
+        &quote_oracle,
+        client_order_id,
+        self_matching_option,
+        quantity,
+        is_bid,
+        pay_with_deep,
+        clock,
+        scenario.ctx(),
+    );
+    destroy(base_oracle);
+    destroy(quote_oracle);
+    order_info
+}
+
+public fun place_reduce_only_limit_order_v2_for_test<BaseAsset, QuoteAsset, DebtAsset>(
+    scenario: &mut Scenario,
+    registry: &MarginRegistry,
+    debt_margin_pool: &MarginPool<DebtAsset>,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    mm: &mut deepbook_margin::margin_manager::MarginManager<BaseAsset, QuoteAsset>,
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    client_order_id: u64,
+    order_type: u8,
+    self_matching_option: u8,
+    price: u64,
+    quantity: u64,
+    is_bid: bool,
+    pay_with_deep: bool,
+    expire_timestamp: u64,
+    clock: &Clock,
+): deepbook::order_info::OrderInfo {
+    let base_oracle = build_price_info_for_type<BaseAsset>(scenario, clock);
+    let quote_oracle = build_price_info_for_type<QuoteAsset>(scenario, clock);
+    let order_info = pool_proxy::place_reduce_only_limit_order_v2<BaseAsset, QuoteAsset, DebtAsset>(
+        registry,
+        mm,
+        pool,
+        debt_margin_pool,
+        base_margin_pool,
+        quote_margin_pool,
+        &base_oracle,
+        &quote_oracle,
+        client_order_id,
+        order_type,
+        self_matching_option,
+        price,
+        quantity,
+        is_bid,
+        pay_with_deep,
+        expire_timestamp,
+        clock,
+        scenario.ctx(),
+    );
+    destroy(base_oracle);
+    destroy(quote_oracle);
+    order_info
+}
+
+public fun place_reduce_only_market_order_v2_for_test<BaseAsset, QuoteAsset, DebtAsset>(
+    scenario: &mut Scenario,
+    registry: &MarginRegistry,
+    debt_margin_pool: &MarginPool<DebtAsset>,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    mm: &mut deepbook_margin::margin_manager::MarginManager<BaseAsset, QuoteAsset>,
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    client_order_id: u64,
+    self_matching_option: u8,
+    quantity: u64,
+    is_bid: bool,
+    pay_with_deep: bool,
+    clock: &Clock,
+): deepbook::order_info::OrderInfo {
+    let base_oracle = build_price_info_for_type<BaseAsset>(scenario, clock);
+    let quote_oracle = build_price_info_for_type<QuoteAsset>(scenario, clock);
+    let order_info = pool_proxy::place_reduce_only_market_order_v2<
+        BaseAsset,
+        QuoteAsset,
+        DebtAsset,
+    >(
+        registry,
+        mm,
+        pool,
+        debt_margin_pool,
+        base_margin_pool,
+        quote_margin_pool,
+        &base_oracle,
+        &quote_oracle,
+        client_order_id,
+        self_matching_option,
+        quantity,
+        is_bid,
+        pay_with_deep,
+        clock,
+        scenario.ctx(),
+    );
+    destroy(base_oracle);
+    destroy(quote_oracle);
+    order_info
+}
+
+public fun execute_conditional_orders_v2_for_test<BaseAsset, QuoteAsset>(
+    scenario: &mut Scenario,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    mm: &mut deepbook_margin::margin_manager::MarginManager<BaseAsset, QuoteAsset>,
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    base_price_info_object: &PriceInfoObject,
+    quote_price_info_object: &PriceInfoObject,
+    registry: &MarginRegistry,
+    max_orders_to_execute: u64,
+    clock: &Clock,
+): vector<deepbook::order_info::OrderInfo> {
+    mm.execute_conditional_orders_v2<BaseAsset, QuoteAsset>(
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        base_price_info_object,
+        quote_price_info_object,
+        registry,
+        max_orders_to_execute,
+        clock,
+        scenario.ctx(),
+    )
 }

--- a/packages/deepbook_margin/tests/margin_manager_tests.move
+++ b/packages/deepbook_margin/tests/margin_manager_tests.move
@@ -29,6 +29,7 @@ use deepbook_margin::{
         setup_btc_usd_deepbook_margin,
         setup_usdc_usdt_deepbook_margin,
         setup_pool_proxy_test_env,
+        setup_orderbook_liquidity_stablecoin,
         destroy_2,
         destroy_3,
         return_shared_2,
@@ -37,7 +38,8 @@ use deepbook_margin::{
         advance_time,
         get_margin_pool_caps,
         return_to_sender_2
-    }
+    },
+    tpsl
 };
 use std::unit_test::destroy;
 use sui::test_scenario::return_shared;
@@ -3661,4 +3663,184 @@ fun locked_balance_reflects_open_orders() {
 
     return_shared_2!(mm, pool);
     cleanup_margin_test(registry, _admin_cap, _maintainer_cap, clock, scenario);
+}
+
+// === V1 deprecation regression test ===
+//
+// `execute_conditional_orders` (v1) preserves its on-chain ABI for upgrade
+// compatibility but the body is replaced with `abort EDeprecatedUseV2`. This
+// test asserts the abort fires, so a future refactor can't silently restore
+// the v1 path that lacks the post-fill `risk_ratio` invariant.
+#[test, expected_failure(abort_code = margin_manager::EDeprecatedUseV2)]
+fun execute_conditional_orders_v1_aborts() {
+    let (
+        mut scenario,
+        clock,
+        _admin_cap,
+        _maintainer_cap,
+        _b,
+        _q,
+        pool_id,
+        registry_id,
+    ) = setup_pool_proxy_test_env<USDC, USDT>();
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<USDC, USDT>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+
+    let _ = mm.execute_conditional_orders<USDC, USDT>(
+        &mut pool,
+        &usdc_price,
+        &usdt_price,
+        &registry,
+        10,
+        &clock,
+        scenario.ctx(),
+    );
+
+    abort 999
+}
+
+// === Conditional-orders post-loop solvency regression test ===
+//
+// Borrow against collateral right at the borrow floor (1.25), pre-register a
+// conditional order whose trigger fires when the oracle drops, with a pending
+// limit order whose fill matches the standard orderbook bid at $0.99. The
+// fill drops `risk_ratio` below 1.25; `process_collected_orders_v2`'s
+// post-loop check aborts the txn, no partial fill lands.
+#[test, expected_failure(abort_code = margin_manager::EInsufficientRiskRatioAfterTrade)]
+fun execute_conditional_orders_v2_post_loop_check_aborts() {
+    let (
+        mut scenario,
+        clock,
+        _admin_cap,
+        _maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+        registry_id,
+    ) = setup_pool_proxy_test_env<USDC, USDT>();
+    setup_orderbook_liquidity_stablecoin<USDC, USDT>(&mut scenario, pool_id, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let mut base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<USDC, USDT>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+
+    // 100 USDT collateral + 100 DEEP (for fees) + borrow 400 USDC
+    // Post-borrow: 100 USDT + 400 USDC = 500 USDC-equiv, debt 400 USDC,
+    // risk_ratio = 1.25 (exactly at borrow floor).
+    mm.deposit<USDC, USDT, USDT>(
+        &registry,
+        &usdc_price,
+        &usdt_price,
+        mint_coin<USDT>(100 * test_constants::usdt_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    mm.deposit<USDC, USDT, DEEP>(
+        &registry,
+        &usdc_price,
+        &usdt_price,
+        mint_coin<DEEP>(100 * test_constants::deep_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    mm.borrow_base<USDC, USDT>(
+        &registry,
+        &mut base_pool,
+        &usdc_price,
+        &usdt_price,
+        &pool,
+        400 * test_constants::usdc_multiplier(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    // Add conditional order while oracles are USDC=$1.0, USDT=$1.0 (ratio =
+    // 1.0). trigger_below = false (a "trigger above" order) requires
+    // trigger >= current at add time; we use trigger = $1.0 (equal). The
+    // pending order sells 100 USDC at 0.99 (matches resting bid).
+    let condition = tpsl::new_condition(false, 1_000_000_000);
+    let pending_order = tpsl::new_pending_limit_order(
+        1,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        990_000_000,
+        100 * test_constants::usdc_multiplier(),
+        false, // ask (sell USDC for USDT)
+        true, // pay_with_deep (fees from DEEP balance, not the trade)
+        constants::max_u64(),
+    );
+    mm.add_conditional_order<USDC, USDT>(
+        &pool,
+        &usdc_price,
+        &usdt_price,
+        &registry,
+        1,
+        condition,
+        pending_order,
+        &clock,
+        scenario.ctx(),
+    );
+    destroy_2!(usdc_price, usdt_price);
+
+    // Bump USDC Pyth price slightly above $1.00 so the live ratio
+    // (USDC/USDT = 1.01/1.00) exceeds the trigger ($1.00) and the
+    // trigger_above order fires. Critical: USDC rises (the asset we're
+    // selling becomes more valuable), so the trade loss isn't compensated by
+    // a cross-asset reval. Post-fill assets_in_debt_unit drops below the
+    // pre-trade value, dragging risk_ratio under 1.25.
+    let usdc_price_high = test_helpers::build_demo_usdc_price_info_object_with_price(
+        &mut scenario,
+        101 * test_constants::pyth_multiplier() / 100, // $1.01
+        &clock,
+    );
+    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+
+    let order_infos = test_helpers::execute_conditional_orders_v2_for_test<USDC, USDT>(
+        &mut scenario,
+        &base_pool,
+        &quote_pool,
+        &mut mm,
+        &mut pool,
+        &usdc_price_high,
+        &usdt_price,
+        &registry,
+        10,
+        &clock,
+    );
+
+    destroy(order_infos);
+    destroy_2!(usdc_price_high, usdt_price);
+    abort 999
 }

--- a/packages/deepbook_margin/tests/margin_manager_tests.move
+++ b/packages/deepbook_margin/tests/margin_manager_tests.move
@@ -158,7 +158,7 @@ fun test_btc_usd_deepbook_margin() {
         clock,
         admin_cap,
         maintainer_cap,
-        _btc_pool_id,
+        btc_pool_id,
         usdc_pool_id,
         _pool_id,
         registry_id,
@@ -1100,7 +1100,7 @@ fun test_liquidation_reward_calculations() {
         clock,
         admin_cap,
         maintainer_cap,
-        _btc_pool_id,
+        btc_pool_id,
         usdc_pool_id,
         _pool_id,
         registry_id,
@@ -1356,7 +1356,7 @@ fun test_risk_ratio_with_oracle_price_changes() {
         mut clock,
         admin_cap,
         maintainer_cap,
-        _btc_pool_id,
+        btc_pool_id,
         usdc_pool_id,
         _pool_id,
         registry_id,
@@ -1377,7 +1377,7 @@ fun test_risk_ratio_with_oracle_price_changes() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
-    let btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(_btc_pool_id);
+    let btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
     let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
     let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
@@ -2342,7 +2342,7 @@ fun test_liquidate_fails_with_too_low_repay_amount() {
         mut clock,
         _admin_cap,
         _maintainer_cap,
-        _btc_pool_id,
+        btc_pool_id,
         usdc_pool_id,
         _pool_id,
         registry_id,
@@ -2614,7 +2614,7 @@ fun test_borrow_quote_fails_when_pool_disabled() {
         clock,
         admin_cap,
         _maintainer_cap,
-        _btc_pool_id,
+        btc_pool_id,
         usdc_pool_id,
         _pool_id,
         registry_id,
@@ -2808,7 +2808,7 @@ fun test_unregister_margin_manager_fails_with_outstanding_quote_debt() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _btc_pool_id,
+        btc_pool_id,
         usdc_pool_id,
         _pool_id,
         registry_id,
@@ -2912,7 +2912,7 @@ fun liquidation_with_unsettled_maker_fills() {
         clock,
         admin_cap,
         maintainer_cap,
-        _btc_pool_id,
+        btc_pool_id,
         usdc_pool_id,
         _pool_id,
         registry_id,
@@ -2977,8 +2977,13 @@ fun liquidation_with_unsettled_maker_fills() {
     let bid_price = 500_000_000_000u64; // price in pool units (within 5% of oracle)
     let bid_quantity = btc_multiplier() / 10; // 0.1 BTC
 
-    deepbook_margin::pool_proxy::place_limit_order<BTC, USDC>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+    deepbook_margin::test_helpers::place_limit_order_v2_for_test<BTC, USDC>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
         1,
@@ -2986,12 +2991,15 @@ fun liquidation_with_unsettled_maker_fills() {
         constants::self_matching_allowed(),
         bid_price,
         bid_quantity,
-        true, // is_bid
-        false, // pay_with_deep
+        true,
+        // is_bid
+        false,
+        // pay_with_deep
         18446744073709551615,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
 
     destroy_2!(btc_price, usdc_price);
     return_shared_3!(mm, pool, registry);
@@ -3417,8 +3425,8 @@ fun get_account_order_details_returns_open_orders() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -3450,8 +3458,13 @@ fun get_account_order_details_returns_open_orders() {
     );
     destroy_2!(usdc_price, usdt_price);
 
-    let order_info = pool_proxy::place_limit_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let order_info = test_helpers::place_limit_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
         1,
@@ -3463,8 +3476,9 @@ fun get_account_order_details_returns_open_orders() {
         false,
         2000000,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
     let expected_order_id = order_info.order_id();
     destroy(order_info);
 
@@ -3485,8 +3499,8 @@ fun account_open_orders_returns_order_ids() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -3523,8 +3537,13 @@ fun account_open_orders_returns_order_ids() {
     assert!(open_orders.length() == 0);
 
     // Place two orders
-    let order1 = pool_proxy::place_limit_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let order1 = test_helpers::place_limit_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
         1,
@@ -3536,10 +3555,12 @@ fun account_open_orders_returns_order_ids() {
         false,
         2000000,
         &clock,
-        scenario.ctx(),
     );
-    let order2 = pool_proxy::place_limit_order<USDC, USDT>(
+    let order2 = test_helpers::place_limit_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
         2,
@@ -3551,8 +3572,9 @@ fun account_open_orders_returns_order_ids() {
         false,
         2000000,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
 
     let open_orders = mm.account_open_orders(&pool);
     assert!(open_orders.length() == 2);
@@ -3571,8 +3593,8 @@ fun locked_balance_reflects_open_orders() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -3611,8 +3633,13 @@ fun locked_balance_reflects_open_orders() {
     assert!(locked_deep == 0);
 
     // Place an ask order (sell USDC for USDT) — locks base (USDC)
-    let order_info = pool_proxy::place_limit_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let order_info = test_helpers::place_limit_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
         1,
@@ -3624,8 +3651,9 @@ fun locked_balance_reflects_open_orders() {
         false,
         2000000,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
     destroy(order_info);
 
     let (locked_base, _locked_quote, _locked_deep) = mm.locked_balance(&pool);

--- a/packages/deepbook_margin/tests/pool_proxy_tests.move
+++ b/packages/deepbook_margin/tests/pool_proxy_tests.move
@@ -12,6 +12,7 @@ use deepbook_margin::{
     pool_proxy,
     test_constants::{Self, USDC, USDT},
     test_helpers::{
+        Self,
         setup_pool_proxy_test_env,
         setup_margin_registry,
         create_margin_pool,
@@ -43,8 +44,8 @@ fun test_place_limit_order_ok() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -80,21 +81,33 @@ fun test_place_limit_order_ok() {
 
     // Place a limit order successfully
     // Price must be within 5% of oracle price (1_000_000_000 for USDC/USDT at $1 each)
-    let order_info = pool_proxy::place_limit_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let order_info = test_helpers::place_limit_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
-        1, // client_order_id
+        1,
+        // client_order_id
         constants::no_restriction(),
         constants::self_matching_allowed(),
-        1_000_000_000, // price (1.0 in 9 decimals, within 5% of oracle price)
-        100 * test_constants::usdc_multiplier(), // quantity
-        false, // is_bid (sell USDC for USDT)
-        false, // pay_with_deep
-        2000000, // expire_timestamp
+        1_000_000_000,
+        // price (1.0 in 9 decimals, within 5% of oracle price)
+        100 * test_constants::usdc_multiplier(),
+        // quantity
+        false,
+        // is_bid (sell USDC for USDT)
+        false,
+        // pay_with_deep
+        2000000,
+        // expire_timestamp
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
 
     // Verify the order was placed (basic sanity check)
     destroy(order_info);
@@ -110,8 +123,8 @@ fun test_place_limit_order_incorrect_pool() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -137,10 +150,16 @@ fun test_place_limit_order_incorrect_pool() {
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
 
     // Try to place order with wrong pool - should fail
-    pool_proxy::place_limit_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    test_helpers::place_limit_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
-        &mut wrong_pool, // Wrong pool!
+        &mut wrong_pool,
+        // Wrong pool!
         1,
         constants::no_restriction(),
         constants::self_matching_allowed(),
@@ -150,8 +169,9 @@ fun test_place_limit_order_incorrect_pool() {
         false,
         0,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
 
     abort
 }
@@ -161,8 +181,18 @@ fun test_place_limit_order_pool_not_enabled() {
     let (mut scenario, clock, admin_cap, maintainer_cap) = setup_margin_registry();
 
     // Create a margin pool
-    create_margin_pool<USDC>(&mut scenario, &maintainer_cap, default_protocol_config(), &clock);
-    create_margin_pool<USDT>(&mut scenario, &maintainer_cap, default_protocol_config(), &clock);
+    let base_pool_id = create_margin_pool<USDC>(
+        &mut scenario,
+        &maintainer_cap,
+        default_protocol_config(),
+        &clock,
+    );
+    let quote_pool_id = create_margin_pool<USDT>(
+        &mut scenario,
+        &maintainer_cap,
+        default_protocol_config(),
+        &clock,
+    );
 
     // Create a pool that is NOT enabled for margin trading
     let (non_margin_pool_id, _non_margin_registry_id) = create_pool_for_testing<USDC, USDT>(
@@ -214,8 +244,13 @@ fun test_place_limit_order_pool_not_enabled() {
     destroy_2!(usdc_price, usdt_price);
 
     // Try to place order with non-enabled pool - should fail
-    pool_proxy::place_limit_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    test_helpers::place_limit_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut non_margin_pool,
         1,
@@ -227,8 +262,9 @@ fun test_place_limit_order_pool_not_enabled() {
         false,
         2000000,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
 
     abort
 }
@@ -241,8 +277,8 @@ fun test_place_market_order_ok() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -279,18 +315,28 @@ fun test_place_market_order_ok() {
     destroy_2!(usdc_price, usdt_price);
 
     // Sell USDC (is_bid=false) since we deposited USDC
-    let order_info = pool_proxy::place_market_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let order_info = test_helpers::place_market_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
-        2, // client_order_id
+        2,
+        // client_order_id
         constants::self_matching_allowed(),
-        100 * test_constants::usdc_multiplier(), // quantity
-        false, // is_bid = false (sell USDC)
-        false, // pay_with_deep
+        100 * test_constants::usdc_multiplier(),
+        // quantity
+        false,
+        // is_bid = false (sell USDC)
+        false,
+        // pay_with_deep
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
 
     destroy(order_info);
     return_shared_2!(mm, pool);
@@ -304,8 +350,8 @@ fun test_place_market_order_incorrect_pool() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -329,18 +375,25 @@ fun test_place_market_order_incorrect_pool() {
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
 
-    pool_proxy::place_market_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    test_helpers::place_market_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
-        &mut wrong_pool, // Wrong pool!
+        &mut wrong_pool,
+        // Wrong pool!
         2,
         constants::self_matching_allowed(),
         100,
         true,
         false,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
 
     abort
 }
@@ -349,8 +402,18 @@ fun test_place_market_order_incorrect_pool() {
 fun test_place_market_order_pool_not_enabled() {
     let (mut scenario, clock, admin_cap, maintainer_cap) = setup_margin_registry();
 
-    create_margin_pool<USDC>(&mut scenario, &maintainer_cap, default_protocol_config(), &clock);
-    create_margin_pool<USDT>(&mut scenario, &maintainer_cap, default_protocol_config(), &clock);
+    let base_pool_id = create_margin_pool<USDC>(
+        &mut scenario,
+        &maintainer_cap,
+        default_protocol_config(),
+        &clock,
+    );
+    let quote_pool_id = create_margin_pool<USDT>(
+        &mut scenario,
+        &maintainer_cap,
+        default_protocol_config(),
+        &clock,
+    );
 
     let (non_margin_pool_id, _non_margin_registry_id) = create_pool_for_testing<USDC, USDT>(
         &mut scenario,
@@ -397,8 +460,13 @@ fun test_place_market_order_pool_not_enabled() {
     );
     destroy_2!(usdc_price, usdt_price);
 
-    pool_proxy::place_market_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    test_helpers::place_market_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut non_margin_pool,
         2,
@@ -407,8 +475,9 @@ fun test_place_market_order_pool_not_enabled() {
         false,
         false,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
 
     abort
 }
@@ -488,21 +557,28 @@ fun test_place_reduce_only_limit_order_ok() {
 
     // Now place a reduce-only limit order to buy USDC (reducing the debt)
     // Price must be within 5% of oracle price (1_000_000_000 for USDC/USDT at $1 each)
-    let order_info = pool_proxy::place_reduce_only_limit_order<USDC, USDT, USDC>(
+    let order_info = test_helpers::place_reduce_only_limit_order_v2_for_test<USDC, USDT, USDC>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
-        &base_pool, // Pass base_pool since we have USDC debt
+        // Pass base_pool since we have USDC debt
         1,
         constants::no_restriction(),
         constants::self_matching_allowed(),
-        1_000_000_000, // price (1.0 in 9 decimals, within 5% of oracle price)
-        100 * test_constants::usdc_multiplier(), // quantity (less than debt)
-        true, // is_bid = true (buying USDC to reduce debt)
+        1_000_000_000,
+        // price (1.0 in 9 decimals, within 5% of oracle price)
+        100 * test_constants::usdc_multiplier(),
+        // quantity (less than debt)
+        true,
+        // is_bid = true (buying USDC to reduce debt)
         false,
-        2000000, // expire_timestamp
+        2000000,
+        // expire_timestamp
         &clock,
-        scenario.ctx(),
     );
 
     // Verify the order was placed successfully
@@ -585,21 +661,26 @@ fun test_place_reduce_only_limit_order_ok_ask() {
     destroy(withdrawn_coin);
 
     // Now place a reduce-only limit order to sell USDC for USDT (reducing the quote debt)
-    let order_info = pool_proxy::place_reduce_only_limit_order<USDC, USDT, USDT>(
+    let order_info = test_helpers::place_reduce_only_limit_order_v2_for_test<USDC, USDT, USDT>(
+        &mut scenario,
         &registry,
+        &quote_pool,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
-        &quote_pool,
         1,
         constants::no_restriction(),
         constants::self_matching_allowed(),
-        1_000_000_000, // price (1.0 in 9 decimals)
-        100 * test_constants::usdc_multiplier(), // quantity (selling 100 USDC to get ~100 USDT, less than 300 debt)
-        false, // is_bid = false (selling USDC to get USDT)
+        1_000_000_000,
+        // price (1.0 in 9 decimals)
+        100 * test_constants::usdc_multiplier(),
+        // quantity (selling 100 USDC to get ~100 USDT, less than 300 debt)
+        false,
+        // is_bid = false (selling USDC to get USDT)
         false,
         2000000,
         &clock,
-        scenario.ctx(),
     );
 
     destroy(order_info);
@@ -617,7 +698,7 @@ fun test_place_reduce_only_limit_order_incorrect_pool() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
+        base_pool_id,
         quote_pool_id,
         pool_id,
         registry_id,
@@ -643,12 +724,16 @@ fun test_place_reduce_only_limit_order_incorrect_pool() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
 
-    pool_proxy::place_reduce_only_limit_order<USDC, USDT, USDT>(
+    test_helpers::place_reduce_only_limit_order_v2_for_test<USDC, USDT, USDT>(
+        &mut scenario,
         &registry,
-        &mut mm,
-        &mut wrong_pool, // Wrong pool!
         &quote_pool,
+        &base_pool,
+        &quote_pool,
+        &mut mm,
+        &mut wrong_pool,
         3,
         constants::no_restriction(),
         constants::self_matching_allowed(),
@@ -658,7 +743,6 @@ fun test_place_reduce_only_limit_order_incorrect_pool() {
         false,
         0,
         &clock,
-        scenario.ctx(),
     );
 
     abort
@@ -671,7 +755,7 @@ fun test_place_reduce_only_limit_order_not_reduce_only() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
+        base_pool_id,
         quote_pool_id,
         pool_id,
         registry_id,
@@ -724,24 +808,33 @@ fun test_place_reduce_only_limit_order_not_reduce_only() {
     // User has no USDC debt but has USDT debt, tries to buy USDC (is_bid = true)
     // This should fail because it's not reducing any USDC position - user is increasing exposure
     // Price must be within 5% of oracle price (1_000_000_000 for USDC/USDT at $1 each)
-    pool_proxy::place_reduce_only_limit_order<USDC, USDT, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    test_helpers::place_reduce_only_limit_order_v2_for_test<USDC, USDT, USDT>(
+        &mut scenario,
         &registry,
+        &quote_pool,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
-        &quote_pool, // Pass quote_pool since we have USDT debt
+        // Pass quote_pool since we have USDT debt
         1,
         constants::no_restriction(),
         constants::self_matching_allowed(),
-        1_000_000_000, // price (1.0 in 9 decimals, within 5% of oracle price)
-        100 * test_constants::usdc_multiplier(), // quantity
-        true, // is_bid = true (buying USDC)
+        1_000_000_000,
+        // price (1.0 in 9 decimals, within 5% of oracle price)
+        100 * test_constants::usdc_multiplier(),
+        // quantity
+        true,
+        // is_bid = true (buying USDC)
         false,
-        2000000, // expire_timestamp
+        2000000,
+        // expire_timestamp
         &clock,
-        scenario.ctx(),
     );
 
     return_shared_3!(mm, pool, quote_pool);
+    return_shared(base_pool);
     destroy(usdc_price);
     destroy(usdt_price);
     cleanup_margin_test(registry, _admin_cap, _maintainer_cap, clock, scenario);
@@ -820,21 +913,28 @@ fun test_place_reduce_only_limit_order_not_reduce_only_quantity_bid() {
 
     // User has USDC debt, tries to buy more USDC than debt
     // This should fail because user is trying to buy more USDC than debt
-    pool_proxy::place_reduce_only_limit_order<USDC, USDT, USDC>(
+    test_helpers::place_reduce_only_limit_order_v2_for_test<USDC, USDT, USDC>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
-        &base_pool, // Pass quote_pool since we have USDT debt
+        // Pass quote_pool since we have USDT debt
         1,
         constants::no_restriction(),
         constants::self_matching_allowed(),
-        constants::float_scaling(), // price
-        101 * test_constants::usdc_multiplier(), // quantity
-        true, // is_bid = true (buying USDC)
+        constants::float_scaling(),
+        // price
+        101 * test_constants::usdc_multiplier(),
+        // quantity
+        true,
+        // is_bid = true (buying USDC)
         false,
-        2000000, // expire_timestamp
+        2000000,
+        // expire_timestamp
         &clock,
-        scenario.ctx(),
     );
 
     return_shared_2!(mm, pool);
@@ -913,21 +1013,28 @@ fun test_place_reduce_only_limit_order_not_reduce_only_quantity_ask() {
 
     // User has USDC debt, tries to buy more USDC than debt
     // This should fail because user is trying to buy more USDC than debt
-    pool_proxy::place_reduce_only_limit_order<USDC, USDT, USDT>(
+    test_helpers::place_reduce_only_limit_order_v2_for_test<USDC, USDT, USDT>(
+        &mut scenario,
         &registry,
+        &quote_pool,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
-        &quote_pool, // Pass quote_pool since we have USDT debt
+        // Pass quote_pool since we have USDT debt
         1,
         constants::no_restriction(),
         constants::self_matching_allowed(),
-        constants::float_scaling(), // price
-        101 * test_constants::usdc_multiplier(), // quantity
-        false, // is_bid = false (buying USDT)
+        constants::float_scaling(),
+        // price
+        101 * test_constants::usdc_multiplier(),
+        // quantity
         false,
-        2000000, // expire_timestamp
+        // is_bid = false (buying USDT)
+        false,
+        2000000,
+        // expire_timestamp
         &clock,
-        scenario.ctx(),
     );
 
     return_shared_2!(mm, pool);
@@ -939,7 +1046,14 @@ fun test_place_reduce_only_limit_order_not_reduce_only_quantity_ask() {
 
 // === Place Reduce Only Market Order Tests ===
 
-#[test]
+// Reduce-only market BID against the standard orderbook (asks at $1.01) fills 1%
+// above oracle, which leaves the manager's `risk_ratio` slightly worse than
+// before the trade. The v2 monotonic-improvement invariant catches that and
+// aborts with `EReduceOnlyMustImproveRiskRatio`. This is the intended behavior
+// — a reduce-only fill at adverse band-edge prices is exactly the residual
+// value-leak path the v2 fix is designed to close. The matching limit-order
+// path (placed at exact oracle price) still passes its `_ok` test above.
+#[test, expected_failure(abort_code = pool_proxy::EReduceOnlyMustImproveRiskRatio)]
 fun test_place_reduce_only_market_order_ok() {
     let (
         mut scenario,
@@ -1013,18 +1127,23 @@ fun test_place_reduce_only_market_order_ok() {
     destroy(withdrawn_coin);
 
     // Now place a reduce-only market order to buy USDC (reducing the debt)
-    let order_info = pool_proxy::place_reduce_only_market_order<USDC, USDT, USDC>(
+    let order_info = test_helpers::place_reduce_only_market_order_v2_for_test<USDC, USDT, USDC>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
-        &base_pool, // Pass base_pool since we have USDC debt
+        // Pass base_pool since we have USDC debt
         2,
         constants::self_matching_allowed(),
-        100 * test_constants::usdc_multiplier(), // quantity (less than debt)
-        true, // is_bid = true (buying USDC to reduce debt)
+        100 * test_constants::usdc_multiplier(),
+        // quantity (less than debt)
+        true,
+        // is_bid = true (buying USDC to reduce debt)
         false,
         &clock,
-        scenario.ctx(),
     );
 
     // Verify the order was placed successfully
@@ -1036,7 +1155,10 @@ fun test_place_reduce_only_market_order_ok() {
     cleanup_margin_test(registry, _admin_cap, _maintainer_cap, clock, scenario);
 }
 
-#[test]
+// Symmetric to `test_place_reduce_only_market_order_ok` — sell-side reduce-only
+// market hits bids at $0.99 (1% below oracle), degrading risk_ratio. v2 aborts
+// with `EReduceOnlyMustImproveRiskRatio`.
+#[test, expected_failure(abort_code = pool_proxy::EReduceOnlyMustImproveRiskRatio)]
 fun test_place_reduce_only_market_order_ok_ask() {
     let (
         mut scenario,
@@ -1109,18 +1231,22 @@ fun test_place_reduce_only_market_order_ok_ask() {
     destroy(withdrawn_coin);
 
     // Now place a reduce-only market order to sell USDC for USDT (reducing the quote debt)
-    let order_info = pool_proxy::place_reduce_only_market_order<USDC, USDT, USDT>(
+    let order_info = test_helpers::place_reduce_only_market_order_v2_for_test<USDC, USDT, USDT>(
+        &mut scenario,
         &registry,
+        &quote_pool,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
-        &quote_pool,
         2,
         constants::self_matching_allowed(),
-        100 * test_constants::usdc_multiplier(), // quantity (selling 100 USDC to get ~100 USDT, less than 300 debt)
-        false, // is_bid = false (selling USDC to get USDT)
+        100 * test_constants::usdc_multiplier(),
+        // quantity (selling 100 USDC to get ~100 USDT, less than 300 debt)
+        false,
+        // is_bid = false (selling USDC to get USDT)
         false,
         &clock,
-        scenario.ctx(),
     );
 
     destroy(order_info);
@@ -1138,7 +1264,7 @@ fun test_place_reduce_only_market_order_incorrect_pool() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
+        base_pool_id,
         quote_pool_id,
         pool_id,
         registry_id,
@@ -1164,19 +1290,22 @@ fun test_place_reduce_only_market_order_incorrect_pool() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
 
-    pool_proxy::place_reduce_only_market_order<USDC, USDT, USDT>(
+    test_helpers::place_reduce_only_market_order_v2_for_test<USDC, USDT, USDT>(
+        &mut scenario,
         &registry,
-        &mut mm,
-        &mut wrong_pool, // Wrong pool!
         &quote_pool,
+        &base_pool,
+        &quote_pool,
+        &mut mm,
+        &mut wrong_pool,
         4,
         constants::self_matching_allowed(),
         500,
         false,
         false,
         &clock,
-        scenario.ctx(),
     );
 
     abort
@@ -1189,7 +1318,7 @@ fun test_place_reduce_only_market_order_not_reduce_only() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
+        base_pool_id,
         quote_pool_id,
         pool_id,
         registry_id,
@@ -1244,21 +1373,28 @@ fun test_place_reduce_only_market_order_not_reduce_only() {
 
     // User has no USDC debt but has USDT debt, tries to buy USDC (is_bid = true)
     // This should fail because it's not reducing any USDC position - user is increasing exposure
-    pool_proxy::place_reduce_only_market_order<USDC, USDT, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    test_helpers::place_reduce_only_market_order_v2_for_test<USDC, USDT, USDT>(
+        &mut scenario,
         &registry,
+        &quote_pool,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
-        &quote_pool, // Pass quote_pool since we have USDT debt
+        // Pass quote_pool since we have USDT debt
         3,
         constants::self_matching_allowed(),
-        100 * test_constants::usdc_multiplier(), // quantity
-        true, // is_bid = true (buying USDC)
+        100 * test_constants::usdc_multiplier(),
+        // quantity
+        true,
+        // is_bid = true (buying USDC)
         false,
         &clock,
-        scenario.ctx(),
     );
 
     return_shared_3!(mm, pool, quote_pool);
+    return_shared(base_pool);
     destroy(usdc_price);
     destroy(usdt_price);
     cleanup_margin_test(registry, _admin_cap, _maintainer_cap, clock, scenario);
@@ -1333,18 +1469,21 @@ fun test_place_reduce_only_market_order_not_reduce_only_quantity_bid() {
     destroy(coin);
 
     // User has USDC debt of 100, tries to buy 101 USDC (more than debt)
-    pool_proxy::place_reduce_only_market_order<USDC, USDT, USDC>(
+    test_helpers::place_reduce_only_market_order_v2_for_test<USDC, USDT, USDC>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
-        &base_pool,
         4,
         constants::self_matching_allowed(),
         101 * test_constants::usdc_multiplier(),
-        true, // is_bid
+        true,
+        // is_bid
         false,
         &clock,
-        scenario.ctx(),
     );
 
     abort
@@ -1420,18 +1559,21 @@ fun test_place_reduce_only_market_order_not_reduce_only_quantity_ask() {
 
     // User has USDT debt of 100, tries to sell enough to get more than 100 USDT (quote_quantity > debt)
     // Selling 150 USDC at ~1:1 should yield ~150 USDT, exceeding the 100 USDT debt
-    pool_proxy::place_reduce_only_market_order<USDC, USDT, USDT>(
+    test_helpers::place_reduce_only_market_order_v2_for_test<USDC, USDT, USDT>(
+        &mut scenario,
         &registry,
+        &quote_pool,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
-        &quote_pool,
         5,
         constants::self_matching_allowed(),
         150 * test_constants::usdc_multiplier(),
-        false, // is_bid = false (selling USDC to get USDT)
+        false,
+        // is_bid = false (selling USDC to get USDT)
         false,
         &clock,
-        scenario.ctx(),
     );
 
     abort
@@ -1445,8 +1587,8 @@ fun test_stake_ok() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -1500,8 +1642,8 @@ fun test_stake_with_deep_margin_manager() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<DEEP, USDT>();
@@ -1542,8 +1684,8 @@ fun test_modify_order_ok() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -1577,21 +1719,30 @@ fun test_modify_order_ok() {
     destroy_2!(usdc_price, usdt_price);
 
     // First place an order
-    let order_info = pool_proxy::place_limit_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let order_info = test_helpers::place_limit_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
         1,
         constants::no_restriction(),
         constants::self_matching_allowed(),
-        1_000_000_000, // price (1.0 in 9 decimals)
+        1_000_000_000,
+        // price (1.0 in 9 decimals)
         100 * test_constants::usdc_multiplier(),
-        false, // is_bid (sell USDC for USDT)
         false,
-        2000000, // expire_timestamp
+        // is_bid (sell USDC for USDT)
+        false,
+        2000000,
+        // expire_timestamp
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
 
     let order_id = order_info.order_id();
 
@@ -1618,8 +1769,8 @@ fun test_cancel_order_ok() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -1652,21 +1803,30 @@ fun test_cancel_order_ok() {
     );
     destroy_2!(usdc_price, usdt_price);
 
-    let order_info = pool_proxy::place_limit_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let order_info = test_helpers::place_limit_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
         1,
         constants::no_restriction(),
         constants::self_matching_allowed(),
-        1_000_000_000, // price (1.0 in 9 decimals)
+        1_000_000_000,
+        // price (1.0 in 9 decimals)
         100 * test_constants::usdc_multiplier(),
-        false, // is_bid (sell USDC for USDT)
         false,
-        2000000, // expire_timestamp
+        // is_bid (sell USDC for USDT)
+        false,
+        2000000,
+        // expire_timestamp
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
 
     let order_id = order_info.order_id();
 
@@ -1692,8 +1852,8 @@ fun test_cancel_orders_ok() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -1726,36 +1886,52 @@ fun test_cancel_orders_ok() {
     );
     destroy_2!(usdc_price, usdt_price);
 
-    let order_info1 = pool_proxy::place_limit_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let order_info1 = test_helpers::place_limit_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
         1,
         constants::no_restriction(),
         constants::self_matching_allowed(),
-        1_000_000_000, // price (1.0 in 9 decimals)
-        1000 * test_constants::usdc_multiplier(), // Increased quantity to meet minimum size
-        false, // is_bid (sell USDC for USDT)
+        1_000_000_000,
+        // price (1.0 in 9 decimals)
+        1000 * test_constants::usdc_multiplier(),
+        // Increased quantity to meet minimum size
         false,
-        2000000, // expire_timestamp
+        // is_bid (sell USDC for USDT)
+        false,
+        2000000,
+        // expire_timestamp
         &clock,
-        scenario.ctx(),
     );
-    let order_info2 = pool_proxy::place_limit_order<USDC, USDT>(
+    let order_info2 = test_helpers::place_limit_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
         2,
         constants::no_restriction(),
         constants::self_matching_allowed(),
-        1_020_000_000, // price (1.02 in 9 decimals, slightly higher)
-        1000 * test_constants::usdc_multiplier(), // Increased quantity to meet minimum size
-        false, // is_bid (sell USDC for USDT)
+        1_020_000_000,
+        // price (1.02 in 9 decimals, slightly higher)
+        1000 * test_constants::usdc_multiplier(),
+        // Increased quantity to meet minimum size
         false,
-        2000000, // expire_timestamp
+        // is_bid (sell USDC for USDT)
+        false,
+        2000000,
+        // expire_timestamp
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
 
     let order_ids = vector[order_info1.order_id(), order_info2.order_id()];
 
@@ -1780,8 +1956,8 @@ fun test_cancel_all_orders_ok() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -1833,8 +2009,8 @@ fun test_withdraw_settled_amounts_ok() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -1873,8 +2049,8 @@ fun test_unstake_ok() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -1913,8 +2089,8 @@ fun test_submit_proposal_ok() {
         clock,
         admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -1988,8 +2164,8 @@ fun test_vote_ok() {
         clock,
         admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -2076,8 +2252,8 @@ fun test_claim_rebates_ok() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -2117,8 +2293,8 @@ fun test_withdraw_settled_amounts_permissionless_ok() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -2155,21 +2331,33 @@ fun test_withdraw_settled_amounts_permissionless_ok() {
 
     // Place a sell order
     // Price must be within 5% of oracle price (1_000_000_000 for USDC/USDT at $1 each)
-    let order_info = pool_proxy::place_limit_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let order_info = test_helpers::place_limit_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
-        1, // client_order_id
+        1,
+        // client_order_id
         constants::no_restriction(),
         constants::self_matching_allowed(),
-        1_000_000_000, // price (1.0 in 9 decimals, within 5% of oracle price)
-        100 * test_constants::usdc_multiplier(), // quantity
-        false, // is_bid (sell USDC for USDT)
-        false, // pay_with_deep
-        2000000, // expire_timestamp
+        1_000_000_000,
+        // price (1.0 in 9 decimals, within 5% of oracle price)
+        100 * test_constants::usdc_multiplier(),
+        // quantity
+        false,
+        // is_bid (sell USDC for USDT)
+        false,
+        // pay_with_deep
+        2000000,
+        // expire_timestamp
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
 
     destroy(order_info);
 
@@ -2202,21 +2390,33 @@ fun test_withdraw_settled_amounts_permissionless_ok() {
     destroy_2!(usdc_price, usdt_price);
 
     // Place a buy order that matches user1's sell order
-    let order_info2 = pool_proxy::place_limit_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let order_info2 = test_helpers::place_limit_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm2,
         &mut pool,
-        2, // client_order_id
+        2,
+        // client_order_id
         constants::no_restriction(),
         constants::self_matching_allowed(),
-        1_000_000_000, // same price (1.0 in 9 decimals)
-        100 * test_constants::usdc_multiplier(), // same quantity
-        true, // is_bid (buy USDC with USDT)
-        false, // pay_with_deep
-        2000000, // expire_timestamp
+        1_000_000_000,
+        // same price (1.0 in 9 decimals)
+        100 * test_constants::usdc_multiplier(),
+        // same quantity
+        true,
+        // is_bid (buy USDC with USDT)
+        false,
+        // pay_with_deep
+        2000000,
+        // expire_timestamp
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
     destroy(order_info2);
 
     // Now user1 has settled balances (received USDT from the trade)
@@ -2240,8 +2440,8 @@ fun test_withdraw_settled_amounts_permissionless_no_balance_e() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -2281,8 +2481,8 @@ fun test_withdraw_settled_amounts_permissionless_incorrect_pool_e() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -2328,8 +2528,8 @@ fun test_limit_order_price_too_high() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -2367,21 +2567,28 @@ fun test_limit_order_price_too_high() {
     // Try to place order at price 10% above oracle (1_100_000_000)
     // Oracle price is 1_000_000_000 (1.0), tolerance is 5%
     // 10% above = 1_100_000_000, which exceeds upper bound of 1_050_000_000
-    pool_proxy::place_limit_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    test_helpers::place_limit_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
         1,
         constants::no_restriction(),
         constants::self_matching_allowed(),
-        1_100_000_000, // 10% above oracle - should fail
+        1_100_000_000,
+        // 10% above oracle - should fail
         100 * test_constants::usdc_multiplier(),
         true,
         false,
         18446744073709551615,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
 
     abort 0
 }
@@ -2395,8 +2602,8 @@ fun test_limit_order_price_too_low() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -2435,21 +2642,29 @@ fun test_limit_order_price_too_low() {
     // Oracle price is 1_000_000_000 (1.0), tolerance is 5%
     // 10% below = 900_000_000, which is below lower bound of 950_000_000
     // For asks, lower bound is checked - should fail
-    pool_proxy::place_limit_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    test_helpers::place_limit_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
         1,
         constants::no_restriction(),
         constants::self_matching_allowed(),
-        900_000_000, // 10% below oracle - should fail for asks
+        900_000_000,
+        // 10% below oracle - should fail for asks
         100 * test_constants::usdc_multiplier(),
-        false, // is_bid = false (ask/sell order)
+        false,
+        // is_bid = false (ask/sell order)
         false,
         18446744073709551615,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
 
     abort 0
 }
@@ -2462,8 +2677,8 @@ fun test_limit_order_price_at_upper_bound_ok() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -2501,21 +2716,29 @@ fun test_limit_order_price_at_upper_bound_ok() {
     // Place order at price exactly at 5% above oracle (1_050_000_000)
     // Oracle price is 1_000_000_000 (1.0), upper bound = 1_050_000_000
     // Using is_bid=false (sell USDC) since we deposited USDC
-    let order_info = pool_proxy::place_limit_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let order_info = test_helpers::place_limit_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
         1,
         constants::no_restriction(),
         constants::self_matching_allowed(),
-        1_050_000_000, // Exactly at upper bound - should succeed
+        1_050_000_000,
+        // Exactly at upper bound - should succeed
         100 * test_constants::usdc_multiplier(),
-        false, // sell USDC for USDT
+        false,
+        // sell USDC for USDT
         false,
         18446744073709551615,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
 
     assert!(order_info.client_order_id() == 1);
     destroy(order_info);
@@ -2531,8 +2754,8 @@ fun test_limit_order_price_at_lower_bound_ok() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -2570,21 +2793,29 @@ fun test_limit_order_price_at_lower_bound_ok() {
     // Place order at price exactly at 5% below oracle (950_000_000)
     // Oracle price is 1_000_000_000 (1.0), lower bound = 950_000_000
     // Using is_bid=false (sell USDC) since we deposited USDC
-    let order_info = pool_proxy::place_limit_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let order_info = test_helpers::place_limit_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
         1,
         constants::no_restriction(),
         constants::self_matching_allowed(),
-        950_000_000, // Exactly at lower bound - should succeed
+        950_000_000,
+        // Exactly at lower bound - should succeed
         100 * test_constants::usdc_multiplier(),
-        false, // sell USDC for USDT
+        false,
+        // sell USDC for USDT
         false,
         18446744073709551615,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
 
     assert!(order_info.client_order_id() == 1);
     destroy(order_info);
@@ -2598,8 +2829,18 @@ fun test_set_tolerance_too_low() {
     let (mut scenario, clock, admin_cap, maintainer_cap) = setup_margin_registry();
 
     // Create margin pools first (required for enabling DeepBook pool)
-    create_margin_pool<USDC>(&mut scenario, &maintainer_cap, default_protocol_config(), &clock);
-    create_margin_pool<USDT>(&mut scenario, &maintainer_cap, default_protocol_config(), &clock);
+    let base_pool_id = create_margin_pool<USDC>(
+        &mut scenario,
+        &maintainer_cap,
+        default_protocol_config(),
+        &clock,
+    );
+    let quote_pool_id = create_margin_pool<USDT>(
+        &mut scenario,
+        &maintainer_cap,
+        default_protocol_config(),
+        &clock,
+    );
 
     // Create and enable a pool
     let (pool_id, _registry_id) = create_pool_for_testing<USDC, USDT>(&mut scenario);
@@ -2636,8 +2877,18 @@ fun test_set_tolerance_too_high() {
     let (mut scenario, clock, admin_cap, maintainer_cap) = setup_margin_registry();
 
     // Create margin pools first (required for enabling DeepBook pool)
-    create_margin_pool<USDC>(&mut scenario, &maintainer_cap, default_protocol_config(), &clock);
-    create_margin_pool<USDT>(&mut scenario, &maintainer_cap, default_protocol_config(), &clock);
+    let base_pool_id = create_margin_pool<USDC>(
+        &mut scenario,
+        &maintainer_cap,
+        default_protocol_config(),
+        &clock,
+    );
+    let quote_pool_id = create_margin_pool<USDT>(
+        &mut scenario,
+        &maintainer_cap,
+        default_protocol_config(),
+        &clock,
+    );
 
     // Create and enable a pool
     let (pool_id, _registry_id) = create_pool_for_testing<USDC, USDT>(&mut scenario);
@@ -2674,8 +2925,18 @@ fun test_set_tolerance_within_bounds_ok() {
     let (mut scenario, clock, admin_cap, maintainer_cap) = setup_margin_registry();
 
     // Create margin pools first (required for enabling DeepBook pool)
-    create_margin_pool<USDC>(&mut scenario, &maintainer_cap, default_protocol_config(), &clock);
-    create_margin_pool<USDT>(&mut scenario, &maintainer_cap, default_protocol_config(), &clock);
+    let base_pool_id = create_margin_pool<USDC>(
+        &mut scenario,
+        &maintainer_cap,
+        default_protocol_config(),
+        &clock,
+    );
+    let quote_pool_id = create_margin_pool<USDT>(
+        &mut scenario,
+        &maintainer_cap,
+        default_protocol_config(),
+        &clock,
+    );
 
     // Create and enable a pool
     let (pool_id, _registry_id) = create_pool_for_testing<USDC, USDT>(&mut scenario);
@@ -2718,8 +2979,18 @@ fun test_set_tolerance_within_bounds_ok() {
 fun test_set_max_price_age_too_low() {
     let (mut scenario, clock, admin_cap, maintainer_cap) = setup_margin_registry();
 
-    create_margin_pool<USDC>(&mut scenario, &maintainer_cap, default_protocol_config(), &clock);
-    create_margin_pool<USDT>(&mut scenario, &maintainer_cap, default_protocol_config(), &clock);
+    let base_pool_id = create_margin_pool<USDC>(
+        &mut scenario,
+        &maintainer_cap,
+        default_protocol_config(),
+        &clock,
+    );
+    let quote_pool_id = create_margin_pool<USDT>(
+        &mut scenario,
+        &maintainer_cap,
+        default_protocol_config(),
+        &clock,
+    );
 
     let (pool_id, _registry_id) = create_pool_for_testing<USDC, USDT>(&mut scenario);
 
@@ -2753,8 +3024,18 @@ fun test_set_max_price_age_too_low() {
 fun test_set_max_price_age_too_high() {
     let (mut scenario, clock, admin_cap, maintainer_cap) = setup_margin_registry();
 
-    create_margin_pool<USDC>(&mut scenario, &maintainer_cap, default_protocol_config(), &clock);
-    create_margin_pool<USDT>(&mut scenario, &maintainer_cap, default_protocol_config(), &clock);
+    let base_pool_id = create_margin_pool<USDC>(
+        &mut scenario,
+        &maintainer_cap,
+        default_protocol_config(),
+        &clock,
+    );
+    let quote_pool_id = create_margin_pool<USDT>(
+        &mut scenario,
+        &maintainer_cap,
+        default_protocol_config(),
+        &clock,
+    );
 
     let (pool_id, _registry_id) = create_pool_for_testing<USDC, USDT>(&mut scenario);
 
@@ -2791,8 +3072,18 @@ fun test_tolerance_decrease_changes_bounds() {
     // Verify that decreasing tolerance from 5% to 1% correctly changes price bounds
     let (mut scenario, clock, admin_cap, maintainer_cap) = setup_margin_registry();
 
-    create_margin_pool<USDC>(&mut scenario, &maintainer_cap, default_protocol_config(), &clock);
-    create_margin_pool<USDT>(&mut scenario, &maintainer_cap, default_protocol_config(), &clock);
+    let base_pool_id = create_margin_pool<USDC>(
+        &mut scenario,
+        &maintainer_cap,
+        default_protocol_config(),
+        &clock,
+    );
+    let quote_pool_id = create_margin_pool<USDT>(
+        &mut scenario,
+        &maintainer_cap,
+        default_protocol_config(),
+        &clock,
+    );
 
     let (pool_id, _registry_id) = create_pool_for_testing<USDC, USDT>(&mut scenario);
 
@@ -2851,8 +3142,18 @@ fun test_tolerance_increase_changes_bounds() {
     // Verify that increasing tolerance from 5% to 10% correctly changes price bounds
     let (mut scenario, clock, admin_cap, maintainer_cap) = setup_margin_registry();
 
-    create_margin_pool<USDC>(&mut scenario, &maintainer_cap, default_protocol_config(), &clock);
-    create_margin_pool<USDT>(&mut scenario, &maintainer_cap, default_protocol_config(), &clock);
+    let base_pool_id = create_margin_pool<USDC>(
+        &mut scenario,
+        &maintainer_cap,
+        default_protocol_config(),
+        &clock,
+    );
+    let quote_pool_id = create_margin_pool<USDT>(
+        &mut scenario,
+        &maintainer_cap,
+        default_protocol_config(),
+        &clock,
+    );
 
     let (pool_id, _registry_id) = create_pool_for_testing<USDC, USDT>(&mut scenario);
 
@@ -2917,8 +3218,18 @@ fun test_max_price_age_decrease_makes_price_stale() {
 
     clock.set_for_testing(1_000_000); // Start at 1 second
 
-    create_margin_pool<USDC>(&mut scenario, &maintainer_cap, default_protocol_config(), &clock);
-    create_margin_pool<USDT>(&mut scenario, &maintainer_cap, default_protocol_config(), &clock);
+    let base_pool_id = create_margin_pool<USDC>(
+        &mut scenario,
+        &maintainer_cap,
+        default_protocol_config(),
+        &clock,
+    );
+    let quote_pool_id = create_margin_pool<USDT>(
+        &mut scenario,
+        &maintainer_cap,
+        default_protocol_config(),
+        &clock,
+    );
 
     let (pool_id, registry_id) = create_pool_for_testing<USDC, USDT>(&mut scenario);
 
@@ -2976,8 +3287,18 @@ fun test_max_price_age_increase_makes_price_fresh() {
 
     clock.set_for_testing(1_000_000); // Start at 1 second
 
-    create_margin_pool<USDC>(&mut scenario, &maintainer_cap, default_protocol_config(), &clock);
-    create_margin_pool<USDT>(&mut scenario, &maintainer_cap, default_protocol_config(), &clock);
+    let base_pool_id = create_margin_pool<USDC>(
+        &mut scenario,
+        &maintainer_cap,
+        default_protocol_config(),
+        &clock,
+    );
+    let quote_pool_id = create_margin_pool<USDT>(
+        &mut scenario,
+        &maintainer_cap,
+        default_protocol_config(),
+        &clock,
+    );
 
     let (pool_id, _registry_id) = create_pool_for_testing<USDC, USDT>(&mut scenario);
 
@@ -3030,8 +3351,18 @@ fun test_tolerance_decrease_rejects_order_e2e() {
     // End-to-end test: place order fails after tolerance is decreased
     let (mut scenario, clock, admin_cap, maintainer_cap) = setup_margin_registry();
 
-    create_margin_pool<USDC>(&mut scenario, &maintainer_cap, default_protocol_config(), &clock);
-    create_margin_pool<USDT>(&mut scenario, &maintainer_cap, default_protocol_config(), &clock);
+    let base_pool_id = create_margin_pool<USDC>(
+        &mut scenario,
+        &maintainer_cap,
+        default_protocol_config(),
+        &clock,
+    );
+    let quote_pool_id = create_margin_pool<USDT>(
+        &mut scenario,
+        &maintainer_cap,
+        default_protocol_config(),
+        &clock,
+    );
 
     let (pool_id, registry_id) = create_pool_for_testing<USDC, USDT>(&mut scenario);
 
@@ -3093,21 +3424,29 @@ fun test_tolerance_decrease_rejects_order_e2e() {
     destroy_2!(usdc_price, usdt_price);
 
     // Try to place bid at 4% above oracle - should FAIL with 1% tolerance
-    pool_proxy::place_limit_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    test_helpers::place_limit_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
         1,
         constants::no_restriction(),
         constants::self_matching_allowed(),
-        1_040_000_000, // 4% above oracle
+        1_040_000_000,
+        // 4% above oracle
         100 * test_constants::usdc_multiplier(),
-        true, // is_bid
+        true,
+        // is_bid
         false,
         2000000,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
 
     abort 0
 }
@@ -3119,8 +3458,18 @@ fun test_max_price_age_decrease_rejects_order_e2e() {
 
     clock.set_for_testing(1_000_000);
 
-    create_margin_pool<USDC>(&mut scenario, &maintainer_cap, default_protocol_config(), &clock);
-    create_margin_pool<USDT>(&mut scenario, &maintainer_cap, default_protocol_config(), &clock);
+    let base_pool_id = create_margin_pool<USDC>(
+        &mut scenario,
+        &maintainer_cap,
+        default_protocol_config(),
+        &clock,
+    );
+    let quote_pool_id = create_margin_pool<USDT>(
+        &mut scenario,
+        &maintainer_cap,
+        default_protocol_config(),
+        &clock,
+    );
 
     let (pool_id, registry_id) = create_pool_for_testing<USDC, USDT>(&mut scenario);
 
@@ -3185,8 +3534,13 @@ fun test_max_price_age_decrease_rejects_order_e2e() {
     destroy_2!(usdc_price, usdt_price);
 
     // Try to place order - should FAIL because price is stale
-    pool_proxy::place_limit_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    test_helpers::place_limit_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
         1,
@@ -3198,8 +3552,9 @@ fun test_max_price_age_decrease_rejects_order_e2e() {
         false,
         2000000,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
 
     abort 0
 }
@@ -3221,8 +3576,8 @@ fun test_limit_order_price_just_above_upper_bound_fails() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -3258,21 +3613,29 @@ fun test_limit_order_price_just_above_upper_bound_fails() {
 
     // Oracle price is 1_000_000_000, upper bound = 1_050_000_000
     // Price 1_050_000_001 is just above upper bound - should fail for bids
-    pool_proxy::place_limit_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    test_helpers::place_limit_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
         1,
         constants::no_restriction(),
         constants::self_matching_allowed(),
-        1_050_000_001, // Just above upper bound
+        1_050_000_001,
+        // Just above upper bound
         100 * test_constants::usdc_multiplier(),
-        true, // is_bid = true (buy order)
+        true,
+        // is_bid = true (buy order)
         false,
         18446744073709551615,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
 
     abort 0
 }
@@ -3285,8 +3648,8 @@ fun test_limit_order_price_just_below_lower_bound_fails() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -3322,21 +3685,28 @@ fun test_limit_order_price_just_below_lower_bound_fails() {
 
     // Oracle price is 1_000_000_000, lower bound = 950_000_000
     // Price 949_999_999 is just below lower bound - should fail
-    pool_proxy::place_limit_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    test_helpers::place_limit_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
         1,
         constants::no_restriction(),
         constants::self_matching_allowed(),
-        949_999_999, // Just below lower bound
+        949_999_999,
+        // Just below lower bound
         100 * test_constants::usdc_multiplier(),
         false,
         false,
         18446744073709551615,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
 
     abort 0
 }
@@ -3350,8 +3720,8 @@ fun test_bid_order_allowed_at_any_price_below_oracle() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -3389,21 +3759,29 @@ fun test_bid_order_allowed_at_any_price_below_oracle() {
     // Place bid at 50% below oracle (500_000_000)
     // Oracle price is 1_000_000_000 (1.0), this is way below lower bound of 950_000_000
     // But bids don't check lower bound - should succeed
-    let order_info = pool_proxy::place_limit_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let order_info = test_helpers::place_limit_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
         1,
         constants::no_restriction(),
         constants::self_matching_allowed(),
-        500_000_000, // 50% below oracle - should succeed for bids
+        500_000_000,
+        // 50% below oracle - should succeed for bids
         100 * test_constants::usdc_multiplier(),
-        true, // is_bid = true (buy order)
+        true,
+        // is_bid = true (buy order)
         false,
         18446744073709551615,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
 
     assert!(order_info.client_order_id() == 1);
     destroy(order_info);
@@ -3420,8 +3798,8 @@ fun test_ask_order_allowed_at_any_price_above_oracle() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -3459,21 +3837,29 @@ fun test_ask_order_allowed_at_any_price_above_oracle() {
     // Place ask at 50% above oracle (1_500_000_000)
     // Oracle price is 1_000_000_000 (1.0), this is way above upper bound of 1_050_000_000
     // But asks don't check upper bound - should succeed
-    let order_info = pool_proxy::place_limit_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let order_info = test_helpers::place_limit_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
         1,
         constants::no_restriction(),
         constants::self_matching_allowed(),
-        1_500_000_000, // 50% above oracle - should succeed for asks
+        1_500_000_000,
+        // 50% above oracle - should succeed for asks
         100 * test_constants::usdc_multiplier(),
-        false, // is_bid = false (sell order)
+        false,
+        // is_bid = false (sell order)
         false,
         18446744073709551615,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
 
     assert!(order_info.client_order_id() == 1);
     destroy(order_info);
@@ -3491,8 +3877,8 @@ fun test_market_buy_order_above_oracle_within_bounds() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -3531,18 +3917,25 @@ fun test_market_buy_order_above_oracle_within_bounds() {
 
     // Market buy USDC - will execute at $1.01 (above oracle of $1.00)
     // Bids only check upper bound ($1.05), so $1.01 should pass
-    let order_info = pool_proxy::place_market_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let order_info = test_helpers::place_market_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
         1,
         constants::self_matching_allowed(),
         100 * test_constants::usdc_multiplier(),
-        true, // is_bid = true (buy)
+        true,
+        // is_bid = true (buy)
         false,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
 
     assert!(order_info.client_order_id() == 1);
     destroy(order_info);
@@ -3560,8 +3953,8 @@ fun test_market_sell_order_below_oracle_within_bounds() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -3600,18 +3993,25 @@ fun test_market_sell_order_below_oracle_within_bounds() {
 
     // Market sell USDC - will execute at $0.99 (below oracle of $1.00)
     // Asks only check lower bound ($0.95), so $0.99 should pass
-    let order_info = pool_proxy::place_market_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let order_info = test_helpers::place_market_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
         1,
         constants::self_matching_allowed(),
         100 * test_constants::usdc_multiplier(),
-        false, // is_bid = false (sell)
+        false,
+        // is_bid = false (sell)
         false,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
 
     assert!(order_info.client_order_id() == 1);
     destroy(order_info);
@@ -3628,8 +4028,8 @@ fun test_market_buy_order_exceeds_upper_bound() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -3668,18 +4068,25 @@ fun test_market_buy_order_exceeds_upper_bound() {
 
     // Market buy USDC - will try to execute at $1.10 (exceeds upper bound of $1.05)
     // Should fail with EPriceDeviationTooHigh
-    pool_proxy::place_market_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    test_helpers::place_market_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
         1,
         constants::self_matching_allowed(),
         100 * test_constants::usdc_multiplier(),
-        true, // is_bid = true (buy)
+        true,
+        // is_bid = true (buy)
         false,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
 
     abort
 }
@@ -3693,8 +4100,8 @@ fun test_market_sell_order_below_lower_bound() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -3733,18 +4140,25 @@ fun test_market_sell_order_below_lower_bound() {
 
     // Market sell USDC - will try to execute at $0.90 (below lower bound of $0.95)
     // Should fail with EPriceDeviationTooHigh
-    pool_proxy::place_market_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    test_helpers::place_market_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
         1,
         constants::self_matching_allowed(),
         100 * test_constants::usdc_multiplier(),
-        false, // is_bid = false (sell)
+        false,
+        // is_bid = false (sell)
         false,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
 
     abort
 }
@@ -3757,8 +4171,8 @@ fun test_market_buy_order_no_liquidity() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -3795,18 +4209,25 @@ fun test_market_buy_order_no_liquidity() {
 
     // Market buy with no liquidity - base_out will be 0
     // Should fail with ENoLiquidityInOrderbook
-    pool_proxy::place_market_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    test_helpers::place_market_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
         1,
         constants::self_matching_allowed(),
         100 * test_constants::usdc_multiplier(),
-        true, // is_bid = true (buy)
+        true,
+        // is_bid = true (buy)
         false,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
 
     abort
 }
@@ -3819,8 +4240,8 @@ fun test_market_sell_order_no_liquidity() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -3857,18 +4278,25 @@ fun test_market_sell_order_no_liquidity() {
 
     // Market sell with no liquidity - base_used will be 0
     // Should fail with EPriceDeviationTooHigh
-    pool_proxy::place_market_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    test_helpers::place_market_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
         1,
         constants::self_matching_allowed(),
         100 * test_constants::usdc_multiplier(),
-        false, // is_bid = false (sell)
+        false,
+        // is_bid = false (sell)
         false,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
 
     abort
 }
@@ -3967,21 +4395,28 @@ fun test_limit_order_price_not_initialized() {
 
     // Try to place limit order without initializing price
     // Should fail with EPriceNotInitialized
-    pool_proxy::place_limit_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    test_helpers::place_limit_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
         1,
         constants::no_restriction(),
         constants::self_matching_allowed(),
-        1_000_000_000, // $1.00
+        1_000_000_000,
+        // $1.00
         100 * test_constants::usdc_multiplier(),
         false,
         false,
         18446744073709551615,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
 
     abort
 }
@@ -3994,8 +4429,8 @@ fun test_limit_order_price_stale() {
         mut clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -4033,21 +4468,28 @@ fun test_limit_order_price_stale() {
 
     // Try to place limit order with stale price
     // Should fail with EPriceUpdateRequired
-    pool_proxy::place_limit_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    test_helpers::place_limit_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
         1,
         constants::no_restriction(),
         constants::self_matching_allowed(),
-        1_000_000_000, // $1.00
+        1_000_000_000,
+        // $1.00
         100 * test_constants::usdc_multiplier(),
         false,
         false,
         18446744073709551615,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
 
     abort
 }
@@ -4061,8 +4503,8 @@ fun test_market_sell_min_size_input_fee_ok() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -4106,18 +4548,27 @@ fun test_market_sell_min_size_input_fee_ok() {
     destroy_2!(usdc_price, usdt_price);
 
     // Market sell exactly min_size USDC with input fee (pay_with_deep = false)
-    let order_info = pool_proxy::place_market_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let order_info = test_helpers::place_market_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
         &registry,
+        &base_pool,
+        &quote_pool,
         &mut mm,
         &mut pool,
         1,
         constants::self_matching_allowed(),
-        constants::min_size(), // exactly min_size
-        false, // is_bid = false (sell)
-        false, // pay_with_deep = false (use input fee)
+        constants::min_size(),
+        // exactly min_size
+        false,
+        // is_bid = false (sell)
+        false,
+        // pay_with_deep = false (use input fee)
         &clock,
-        scenario.ctx(),
     );
+    return_shared(base_pool);
+    return_shared(quote_pool);
 
     // Verify order executed
     assert!(order_info.status() == constants::filled());
@@ -4135,8 +4586,8 @@ fun test_market_buy_min_size_input_fee_ok() {
         clock,
         _admin_cap,
         _maintainer_cap,
-        _base_pool_id,
-        _quote_pool_id,
+        base_pool_id,
+        quote_pool_id,
         pool_id,
         registry_id,
     ) = setup_pool_proxy_test_env<USDC, USDT>();
@@ -4182,21 +4633,295 @@ fun test_market_buy_min_size_input_fee_ok() {
     // Market buy exactly min_size USDC with input fee (pay_with_deep = false)
     // For bids, fee is taken from quote input, not base output
     // So this should work regardless of the fix
-    let order_info = pool_proxy::place_market_order<USDC, USDT>(
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let order_info = test_helpers::place_market_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
+        &registry,
+        &base_pool,
+        &quote_pool,
+        &mut mm,
+        &mut pool,
+        1,
+        constants::self_matching_allowed(),
+        constants::min_size(),
+        // exactly min_size base to buy
+        true,
+        // is_bid = true (buy)
+        false,
+        // pay_with_deep = false (use input fee)
+        &clock,
+    );
+    return_shared(base_pool);
+    return_shared(quote_pool);
+
+    // Verify order executed
+    assert!(order_info.status() == constants::filled());
+
+    return_shared_2!(mm, pool);
+    cleanup_margin_test(registry, _admin_cap, _maintainer_cap, clock, scenario);
+}
+
+// === V1 deprecation regression tests ===
+//
+// Each v1 trading entry preserves its on-chain ABI for upgrade compatibility
+// but aborts immediately. These tests assert the abort fires with the
+// expected named error so a future refactor cannot silently restore a v1
+// path.
+
+#[test, expected_failure(abort_code = pool_proxy::EDeprecatedUseV2)]
+fun place_limit_order_v1_aborts() {
+    let (
+        mut scenario,
+        clock,
+        _admin_cap,
+        _maintainer_cap,
+        _b,
+        _q,
+        pool_id,
+        registry_id,
+    ) = setup_pool_proxy_test_env<USDC, USDT>();
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<USDC, USDT>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+
+    let _ = pool_proxy::place_limit_order<USDC, USDT>(
+        &registry,
+        &mut mm,
+        &mut pool,
+        1,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        1_000_000_000,
+        100 * test_constants::usdc_multiplier(),
+        false,
+        false,
+        2_000_000,
+        &clock,
+        scenario.ctx(),
+    );
+
+    abort 999
+}
+
+#[test, expected_failure(abort_code = pool_proxy::EDeprecatedUseV2)]
+fun place_market_order_v1_aborts() {
+    let (
+        mut scenario,
+        clock,
+        _admin_cap,
+        _maintainer_cap,
+        _b,
+        _q,
+        pool_id,
+        registry_id,
+    ) = setup_pool_proxy_test_env<USDC, USDT>();
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<USDC, USDT>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+
+    let _ = pool_proxy::place_market_order<USDC, USDT>(
         &registry,
         &mut mm,
         &mut pool,
         1,
         constants::self_matching_allowed(),
-        constants::min_size(), // exactly min_size base to buy
-        true, // is_bid = true (buy)
-        false, // pay_with_deep = false (use input fee)
+        100 * test_constants::usdc_multiplier(),
+        false,
+        false,
         &clock,
         scenario.ctx(),
     );
 
-    // Verify order executed
-    assert!(order_info.status() == constants::filled());
+    abort 999
+}
+
+#[test, expected_failure(abort_code = pool_proxy::EDeprecatedUseV2)]
+fun place_reduce_only_limit_order_v1_aborts() {
+    let (
+        mut scenario,
+        clock,
+        _admin_cap,
+        _maintainer_cap,
+        base_pool_id,
+        _q,
+        pool_id,
+        registry_id,
+    ) = setup_pool_proxy_test_env<USDC, USDT>();
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<USDC, USDT>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+
+    let _ = pool_proxy::place_reduce_only_limit_order<USDC, USDT, USDC>(
+        &registry,
+        &mut mm,
+        &mut pool,
+        &base_pool,
+        1,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        1_000_000_000,
+        100 * test_constants::usdc_multiplier(),
+        true,
+        false,
+        2_000_000,
+        &clock,
+        scenario.ctx(),
+    );
+
+    abort 999
+}
+
+#[test, expected_failure(abort_code = pool_proxy::EDeprecatedUseV2)]
+fun place_reduce_only_market_order_v1_aborts() {
+    let (
+        mut scenario,
+        clock,
+        _admin_cap,
+        _maintainer_cap,
+        base_pool_id,
+        _q,
+        pool_id,
+        registry_id,
+    ) = setup_pool_proxy_test_env<USDC, USDT>();
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<USDC, USDT>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+
+    let _ = pool_proxy::place_reduce_only_market_order<USDC, USDT, USDC>(
+        &registry,
+        &mut mm,
+        &mut pool,
+        &base_pool,
+        1,
+        constants::self_matching_allowed(),
+        100 * test_constants::usdc_multiplier(),
+        true,
+        false,
+        &clock,
+        scenario.ctx(),
+    );
+
+    abort 999
+}
+#[test]
+fun place_limit_order_v2_no_debt_at_oracle_price_ok() {
+    // Sanity: with no debt the post-trade invariant short-circuits, so
+    // `place_limit_order_v2` succeeds normally.
+    let (
+        mut scenario,
+        clock,
+        _admin_cap,
+        _maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+        registry_id,
+    ) = setup_pool_proxy_test_env<USDC, USDT>();
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<USDC, USDT>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    mm.deposit<USDC, USDT, USDC>(
+        &registry,
+        &usdc_price,
+        &usdt_price,
+        mint_coin<USDC>(1000 * test_constants::usdc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    destroy_2!(usdc_price, usdt_price);
+
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let order_info = test_helpers::place_limit_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
+        &registry,
+        &base_pool,
+        &quote_pool,
+        &mut mm,
+        &mut pool,
+        1,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        1_000_000_000,
+        100 * test_constants::usdc_multiplier(),
+        false,
+        false,
+        2_000_000,
+        &clock,
+    );
+    return_shared(base_pool);
+    return_shared(quote_pool);
+    destroy(order_info);
 
     return_shared_2!(mm, pool);
     cleanup_margin_test(registry, _admin_cap, _maintainer_cap, clock, scenario);

--- a/packages/deepbook_margin/tests/pool_proxy_tests.move
+++ b/packages/deepbook_margin/tests/pool_proxy_tests.move
@@ -1046,13 +1046,12 @@ fun test_place_reduce_only_limit_order_not_reduce_only_quantity_ask() {
 
 // === Place Reduce Only Market Order Tests ===
 
-// Reduce-only market BID against the standard orderbook (asks at $1.01) fills 1%
-// above oracle, which leaves the manager's `risk_ratio` slightly worse than
-// before the trade. The v2 monotonic-improvement invariant catches that and
-// aborts with `EReduceOnlyMustImproveRiskRatio`. This is the intended behavior
-// — a reduce-only fill at adverse band-edge prices is exactly the residual
-// value-leak path the v2 fix is designed to close. The matching limit-order
-// path (placed at exact oracle price) still passes its `_ok` test above.
+// Reduce-only market BID against the standard orderbook (asks at $1.01) fills
+// 1% above oracle, leaving the manager's `risk_ratio` slightly worse than
+// before. The v2 monotonic-improvement invariant catches that and aborts —
+// reduce-only fills must monotonically improve (or hold) solvency. The
+// matching limit-order path (placed at exact oracle price) still passes its
+// `_ok` test above.
 #[test, expected_failure(abort_code = pool_proxy::EReduceOnlyMustImproveRiskRatio)]
 fun test_place_reduce_only_market_order_ok() {
     let (
@@ -1156,8 +1155,8 @@ fun test_place_reduce_only_market_order_ok() {
 }
 
 // Symmetric to `test_place_reduce_only_market_order_ok` — sell-side reduce-only
-// market hits bids at $0.99 (1% below oracle), degrading risk_ratio. v2 aborts
-// with `EReduceOnlyMustImproveRiskRatio`.
+// market hits bids at $0.99 (1% below oracle), degrading risk_ratio. Aborts on
+// the monotonic invariant.
 #[test, expected_failure(abort_code = pool_proxy::EReduceOnlyMustImproveRiskRatio)]
 fun test_place_reduce_only_market_order_ok_ask() {
     let (

--- a/packages/deepbook_margin/tests/pool_proxy_tests.move
+++ b/packages/deepbook_margin/tests/pool_proxy_tests.move
@@ -4857,6 +4857,105 @@ fun place_reduce_only_market_order_v1_aborts() {
 
     abort 999
 }
+
+// === Post-trade solvency regression test ===
+//
+// Borrow USDC against USDT collateral right at `min_borrow_risk_ratio` (1.25,
+// the borrow floor in test config), then sell the borrowed USDC against the
+// standard orderbook bid (0.99). The 1% adverse fill drops `risk_ratio` from
+// 1.25 to ~1.24, breaching the floor; the v2 invariant aborts.
+#[test, expected_failure(abort_code = pool_proxy::EInsufficientRiskRatioAfterTrade)]
+fun place_limit_order_v2_borrow_at_floor_then_adverse_fill_aborts() {
+    let (
+        mut scenario,
+        clock,
+        _admin_cap,
+        _maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+        registry_id,
+    ) = setup_pool_proxy_test_env<USDC, USDT>();
+    setup_orderbook_liquidity_stablecoin<USDC, USDT>(&mut scenario, pool_id, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let mut base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<USDC, USDT>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+
+    // Deposit 100 USDT collateral + DEEP for fees, borrow 400 USDC.
+    // Post-borrow: 100 USDT + 400 USDC = 500 USDC-equiv, debt 400 USDC,
+    // risk_ratio = 500/400 = 1.25 (exactly at borrow floor). DEEP isn't summed
+    // by `calculate_assets`, so it doesn't affect risk_ratio.
+    mm.deposit<USDC, USDT, USDT>(
+        &registry,
+        &usdc_price,
+        &usdt_price,
+        mint_coin<USDT>(100 * test_constants::usdt_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    mm.deposit<USDC, USDT, DEEP>(
+        &registry,
+        &usdc_price,
+        &usdt_price,
+        mint_coin<DEEP>(100 * test_constants::deep_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    mm.borrow_base<USDC, USDT>(
+        &registry,
+        &mut base_pool,
+        &usdc_price,
+        &usdt_price,
+        &pool,
+        400 * test_constants::usdc_multiplier(),
+        &clock,
+        scenario.ctx(),
+    );
+    destroy_2!(usdc_price, usdt_price);
+
+    // Sell 100 USDC at 0.99 — fills against resting bid at 0.99 (pay_with_deep
+    // covers fees from the DEEP balance, not the trade output).
+    // Pre-trade asset: 400 USDC + 100 USDT = 500 USDC-equiv, debt 400.
+    // Post-trade: 300 USDC + 199 USDT = 499 USDC-equiv, debt 400,
+    // risk_ratio = 499/400 = 1.2475 < 1.25. Aborts.
+    let _ = test_helpers::place_limit_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
+        &registry,
+        &base_pool,
+        &quote_pool,
+        &mut mm,
+        &mut pool,
+        1,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        990_000_000,
+        100 * test_constants::usdc_multiplier(),
+        false, // is_bid = false (sell)
+        true, // pay_with_deep
+        2_000_000,
+        &clock,
+    );
+
+    abort 999
+}
+
 #[test]
 fun place_limit_order_v2_no_debt_at_oracle_price_ok() {
     // Sanity: with no debt the post-trade invariant short-circuits, so

--- a/packages/deepbook_margin/tests/tpsl_tests.move
+++ b/packages/deepbook_margin/tests/tpsl_tests.move
@@ -7,11 +7,12 @@ module deepbook_margin::tpsl_tests;
 use deepbook::{constants, pool::Pool, registry::Registry};
 use deepbook_margin::{
     margin_manager::{Self, MarginManager},
-    margin_pool,
+    margin_pool::{Self, MarginPool},
     margin_registry::{MarginRegistry, MarginAdminCap, MaintainerCap},
     pool_proxy,
     test_constants::{Self, SUI, USDC},
     test_helpers::{
+        Self,
         setup_margin_registry,
         create_margin_pool,
         default_protocol_config,
@@ -370,8 +371,8 @@ fun test_tpsl_trigger_below_executed() {
         clock,
         admin_cap,
         maintainer_cap,
-        _usdc_pool_id,
-        _sui_pool_id,
+        usdc_pool_id,
+        sui_pool_id,
         _pool_id,
         registry_id,
     ) = setup_sui_usdc_deepbook_margin();
@@ -462,15 +463,23 @@ fun test_tpsl_trigger_below_executed() {
     let margin_registry = scenario.take_shared<MarginRegistry>();
 
     // Execute conditional orders - should trigger and place order
-    let order_infos = mm.execute_conditional_orders<SUI, USDC>(
+    let sui_pool = scenario.take_shared_by_id<MarginPool<SUI>>(sui_pool_id);
+    let usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+    let order_infos = test_helpers::execute_conditional_orders_v2_for_test<SUI, USDC>(
+        &mut scenario,
+        &sui_pool,
+        &usdc_pool,
+        &mut mm,
         &mut pool,
         &sui_price_low,
         &usdc_price,
         &margin_registry,
-        10, // max_orders_to_execute
+        10,
+        // max_orders_to_execute
         &clock,
-        scenario.ctx(),
     );
+    return_shared(sui_pool);
+    return_shared(usdc_pool);
 
     // Verify order was executed with accurate data
     assert!(order_infos.length() == 1);
@@ -517,8 +526,8 @@ fun test_tpsl_trigger_above_executed() {
         clock,
         admin_cap,
         maintainer_cap,
-        _usdc_pool_id,
-        _sui_pool_id,
+        usdc_pool_id,
+        sui_pool_id,
         _pool_id,
         registry_id,
     ) = setup_sui_usdc_deepbook_margin();
@@ -618,15 +627,23 @@ fun test_tpsl_trigger_above_executed() {
     );
 
     // Execute conditional orders - should trigger and place order
-    let order_infos = mm.execute_conditional_orders<SUI, USDC>(
+    let sui_pool = scenario.take_shared_by_id<MarginPool<SUI>>(sui_pool_id);
+    let usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+    let order_infos = test_helpers::execute_conditional_orders_v2_for_test<SUI, USDC>(
+        &mut scenario,
+        &sui_pool,
+        &usdc_pool,
+        &mut mm,
         &mut pool,
         &sui_price_high,
         &usdc_price,
         &margin_registry,
-        10, // max_orders_to_execute
+        10,
+        // max_orders_to_execute
         &clock,
-        scenario.ctx(),
     );
+    return_shared(sui_pool);
+    return_shared(usdc_pool);
 
     // Verify order was executed with accurate data
     assert!(order_infos.length() == 1);
@@ -665,8 +682,8 @@ fun test_tpsl_orders_sorted_correctly() {
         clock,
         admin_cap,
         maintainer_cap,
-        _usdc_pool_id,
-        _sui_pool_id,
+        usdc_pool_id,
+        sui_pool_id,
         _pool_id,
         registry_id,
     ) = setup_sui_usdc_deepbook_margin();
@@ -852,8 +869,8 @@ fun test_tpsl_orders_with_same_trigger_price_maintain_fifo_order() {
         clock,
         admin_cap,
         maintainer_cap,
-        _usdc_pool_id,
-        _sui_pool_id,
+        usdc_pool_id,
+        sui_pool_id,
         _pool_id,
         registry_id,
     ) = setup_sui_usdc_deepbook_margin();
@@ -1036,8 +1053,8 @@ fun test_tpsl_trigger_price_getters() {
         clock,
         admin_cap,
         maintainer_cap,
-        _usdc_pool_id,
-        _sui_pool_id,
+        usdc_pool_id,
+        sui_pool_id,
         _pool_id,
         registry_id,
     ) = setup_sui_usdc_deepbook_margin();
@@ -1203,8 +1220,8 @@ fun test_tpsl_trigger_below_market_order_executed() {
         clock,
         admin_cap,
         maintainer_cap,
-        _usdc_pool_id,
-        _sui_pool_id,
+        usdc_pool_id,
+        sui_pool_id,
         pool_id,
         registry_id,
     ) = setup_sui_usdc_deepbook_margin();
@@ -1296,15 +1313,23 @@ fun test_tpsl_trigger_below_market_order_executed() {
     );
 
     // Execute conditional orders - should trigger and place market order
-    let order_infos = mm.execute_conditional_orders<SUI, USDC>(
+    let sui_pool = scenario.take_shared_by_id<MarginPool<SUI>>(sui_pool_id);
+    let usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+    let order_infos = test_helpers::execute_conditional_orders_v2_for_test<SUI, USDC>(
+        &mut scenario,
+        &sui_pool,
+        &usdc_pool,
+        &mut mm,
         &mut pool,
         &sui_price_low,
         &usdc_price,
         &margin_registry,
-        10, // max_orders_to_execute
+        10,
+        // max_orders_to_execute
         &clock,
-        scenario.ctx(),
     );
+    return_shared(sui_pool);
+    return_shared(usdc_pool);
 
     // Verify order was executed with accurate data
     assert!(order_infos.length() == 1);
@@ -1369,8 +1394,8 @@ fun test_tpsl_trigger_above_market_order_executed() {
         clock,
         admin_cap,
         maintainer_cap,
-        _usdc_pool_id,
-        _sui_pool_id,
+        usdc_pool_id,
+        sui_pool_id,
         pool_id,
         registry_id,
     ) = setup_sui_usdc_deepbook_margin();
@@ -1462,15 +1487,23 @@ fun test_tpsl_trigger_above_market_order_executed() {
     );
 
     // Execute conditional orders - should trigger and place market order
-    let order_infos = mm.execute_conditional_orders<SUI, USDC>(
+    let sui_pool = scenario.take_shared_by_id<MarginPool<SUI>>(sui_pool_id);
+    let usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+    let order_infos = test_helpers::execute_conditional_orders_v2_for_test<SUI, USDC>(
+        &mut scenario,
+        &sui_pool,
+        &usdc_pool,
+        &mut mm,
         &mut pool,
         &sui_price_high,
         &usdc_price,
         &margin_registry,
-        10, // max_orders_to_execute
+        10,
+        // max_orders_to_execute
         &clock,
-        scenario.ctx(),
     );
+    return_shared(sui_pool);
+    return_shared(usdc_pool);
 
     // Verify order was executed with accurate data
     assert!(order_infos.length() == 1);
@@ -1525,8 +1558,8 @@ fun test_tpsl_cancel_conditional_order() {
         clock,
         admin_cap,
         maintainer_cap,
-        _usdc_pool_id,
-        _sui_pool_id,
+        usdc_pool_id,
+        sui_pool_id,
         _pool_id,
         registry_id,
     ) = setup_sui_usdc_deepbook_margin();
@@ -1689,8 +1722,8 @@ fun test_tpsl_cancel_all_conditional_orders() {
         clock,
         admin_cap,
         maintainer_cap,
-        _usdc_pool_id,
-        _sui_pool_id,
+        usdc_pool_id,
+        sui_pool_id,
         _pool_id,
         registry_id,
     ) = setup_sui_usdc_deepbook_margin();
@@ -1824,8 +1857,8 @@ fun test_error_invalid_condition() {
         clock,
         admin_cap,
         maintainer_cap,
-        _usdc_pool_id,
-        _sui_pool_id,
+        usdc_pool_id,
+        sui_pool_id,
         _pool_id,
         registry_id,
     ) = setup_sui_usdc_deepbook_margin();
@@ -1902,8 +1935,8 @@ fun test_error_invalid_condition_trigger_above() {
         clock,
         admin_cap,
         maintainer_cap,
-        _usdc_pool_id,
-        _sui_pool_id,
+        usdc_pool_id,
+        sui_pool_id,
         _pool_id,
         registry_id,
     ) = setup_sui_usdc_deepbook_margin();
@@ -1979,8 +2012,8 @@ fun test_error_conditional_order_not_found() {
         clock,
         admin_cap,
         maintainer_cap,
-        _usdc_pool_id,
-        _sui_pool_id,
+        usdc_pool_id,
+        sui_pool_id,
         _pool_id,
         registry_id,
     ) = setup_sui_usdc_deepbook_margin();
@@ -2019,8 +2052,8 @@ fun test_error_max_conditional_orders_reached() {
         clock,
         admin_cap,
         maintainer_cap,
-        _usdc_pool_id,
-        _sui_pool_id,
+        usdc_pool_id,
+        sui_pool_id,
         _pool_id,
         registry_id,
     ) = setup_sui_usdc_deepbook_margin();
@@ -2119,8 +2152,8 @@ fun test_error_duplicate_conditional_order_identifier() {
         clock,
         admin_cap,
         maintainer_cap,
-        _usdc_pool_id,
-        _sui_pool_id,
+        usdc_pool_id,
+        sui_pool_id,
         _pool_id,
         registry_id,
     ) = setup_sui_usdc_deepbook_margin();
@@ -2221,8 +2254,8 @@ fun test_error_invalid_order_params_quantity_too_small() {
         clock,
         admin_cap,
         maintainer_cap,
-        _usdc_pool_id,
-        _sui_pool_id,
+        usdc_pool_id,
+        sui_pool_id,
         _pool_id,
         registry_id,
     ) = setup_sui_usdc_deepbook_margin();
@@ -2298,8 +2331,8 @@ fun test_error_invalid_order_params_quantity_not_lot_size_multiple() {
         clock,
         admin_cap,
         maintainer_cap,
-        _usdc_pool_id,
-        _sui_pool_id,
+        usdc_pool_id,
+        sui_pool_id,
         _pool_id,
         registry_id,
     ) = setup_sui_usdc_deepbook_margin();
@@ -2376,8 +2409,8 @@ fun test_error_invalid_order_params_price_not_tick_size_multiple() {
         clock,
         admin_cap,
         maintainer_cap,
-        _usdc_pool_id,
-        _sui_pool_id,
+        usdc_pool_id,
+        sui_pool_id,
         _pool_id,
         registry_id,
     ) = setup_sui_usdc_deepbook_margin();
@@ -2453,8 +2486,8 @@ fun test_error_invalid_order_params_price_below_min() {
         clock,
         admin_cap,
         maintainer_cap,
-        _usdc_pool_id,
-        _sui_pool_id,
+        usdc_pool_id,
+        sui_pool_id,
         _pool_id,
         registry_id,
     ) = setup_sui_usdc_deepbook_margin();
@@ -2530,8 +2563,8 @@ fun test_error_invalid_order_params_expired_timestamp() {
         clock,
         admin_cap,
         maintainer_cap,
-        _usdc_pool_id,
-        _sui_pool_id,
+        usdc_pool_id,
+        sui_pool_id,
         _pool_id,
         registry_id,
     ) = setup_sui_usdc_deepbook_margin();
@@ -2607,8 +2640,8 @@ fun test_error_invalid_order_params_market_order_quantity_too_small() {
         clock,
         admin_cap,
         maintainer_cap,
-        _usdc_pool_id,
-        _sui_pool_id,
+        usdc_pool_id,
+        sui_pool_id,
         _pool_id,
         registry_id,
     ) = setup_sui_usdc_deepbook_margin();
@@ -2684,8 +2717,8 @@ fun test_tpsl_insufficient_funds_second_order() {
         clock,
         admin_cap,
         maintainer_cap,
-        _usdc_pool_id,
-        _sui_pool_id,
+        usdc_pool_id,
+        sui_pool_id,
         _pool_id,
         registry_id,
     ) = setup_sui_usdc_deepbook_margin();
@@ -2806,15 +2839,23 @@ fun test_tpsl_insufficient_funds_second_order() {
     );
 
     // Execute conditional orders - both are triggered, but only first succeeds
-    let order_infos = mm.execute_conditional_orders<SUI, USDC>(
+    let sui_pool = scenario.take_shared_by_id<MarginPool<SUI>>(sui_pool_id);
+    let usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+    let order_infos = test_helpers::execute_conditional_orders_v2_for_test<SUI, USDC>(
+        &mut scenario,
+        &sui_pool,
+        &usdc_pool,
+        &mut mm,
         &mut pool,
         &sui_price_low,
         &usdc_price,
         &margin_registry,
-        10, // max_orders_to_execute
+        10,
+        // max_orders_to_execute
         &clock,
-        scenario.ctx(),
     );
+    return_shared(sui_pool);
+    return_shared(usdc_pool);
 
     // Only the first order should have been executed successfully
     assert!(order_infos.length() == 1);
@@ -2849,8 +2890,8 @@ fun test_tpsl_expired_order_during_execution() {
         mut clock,
         admin_cap,
         maintainer_cap,
-        _usdc_pool_id,
-        _sui_pool_id,
+        usdc_pool_id,
+        sui_pool_id,
         _pool_id,
         registry_id,
     ) = setup_sui_usdc_deepbook_margin();
@@ -2936,15 +2977,22 @@ fun test_tpsl_expired_order_during_execution() {
     let margin_registry = scenario.take_shared<MarginRegistry>();
 
     // Execute conditional orders - order is triggered but expired
-    let order_infos = mm.execute_conditional_orders<SUI, USDC>(
+    let sui_pool = scenario.take_shared_by_id<MarginPool<SUI>>(sui_pool_id);
+    let usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+    let order_infos = test_helpers::execute_conditional_orders_v2_for_test<SUI, USDC>(
+        &mut scenario,
+        &sui_pool,
+        &usdc_pool,
+        &mut mm,
         &mut pool,
         &sui_price_low,
         &usdc_price,
         &margin_registry,
         10,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(sui_pool);
+    return_shared(usdc_pool);
 
     // No orders should have been executed (order was expired)
     assert!(order_infos.length() == 0);
@@ -2973,8 +3021,8 @@ fun test_tpsl_early_exit_optimization() {
         clock,
         admin_cap,
         maintainer_cap,
-        _usdc_pool_id,
-        _sui_pool_id,
+        usdc_pool_id,
+        sui_pool_id,
         _pool_id,
         registry_id,
     ) = setup_sui_usdc_deepbook_margin();
@@ -3075,15 +3123,22 @@ fun test_tpsl_early_exit_optimization() {
     );
 
     // Execute conditional orders
-    let order_infos = mm.execute_conditional_orders<SUI, USDC>(
+    let sui_pool = scenario.take_shared_by_id<MarginPool<SUI>>(sui_pool_id);
+    let usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+    let order_infos = test_helpers::execute_conditional_orders_v2_for_test<SUI, USDC>(
+        &mut scenario,
+        &sui_pool,
+        &usdc_pool,
+        &mut mm,
         &mut pool,
         &sui_price_mid,
         &usdc_price,
         &margin_registry,
         10,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(sui_pool);
+    return_shared(usdc_pool);
 
     // Only 2 orders should have been executed (ID 1 and ID 2)
     assert!(order_infos.length() == 2);
@@ -3128,8 +3183,8 @@ fun test_tpsl_max_orders_to_execute_limit() {
         clock,
         admin_cap,
         maintainer_cap,
-        _usdc_pool_id,
-        _sui_pool_id,
+        usdc_pool_id,
+        sui_pool_id,
         _pool_id,
         registry_id,
     ) = setup_sui_usdc_deepbook_margin();
@@ -3231,15 +3286,23 @@ fun test_tpsl_max_orders_to_execute_limit() {
     );
 
     // First execution: max_orders_to_execute = 2
-    let order_infos_1 = mm.execute_conditional_orders<SUI, USDC>(
+    let sui_pool = scenario.take_shared_by_id<MarginPool<SUI>>(sui_pool_id);
+    let usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+    let order_infos_1 = test_helpers::execute_conditional_orders_v2_for_test<SUI, USDC>(
+        &mut scenario,
+        &sui_pool,
+        &usdc_pool,
+        &mut mm,
         &mut pool,
         &sui_price_low,
         &usdc_price,
         &margin_registry,
-        2, // Execute only 2 orders
+        2,
+        // Execute only 2 orders
         &clock,
-        scenario.ctx(),
     );
+    return_shared(sui_pool);
+    return_shared(usdc_pool);
 
     // First batch: 2 orders executed (ID 1, 2)
     assert!(order_infos_1.length() == 2);
@@ -3265,15 +3328,23 @@ fun test_tpsl_max_orders_to_execute_limit() {
     let margin_registry = scenario.take_shared<MarginRegistry>();
 
     // Second execution: max_orders_to_execute = 2
-    let order_infos_2 = mm.execute_conditional_orders<SUI, USDC>(
+    let sui_pool = scenario.take_shared_by_id<MarginPool<SUI>>(sui_pool_id);
+    let usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+    let order_infos_2 = test_helpers::execute_conditional_orders_v2_for_test<SUI, USDC>(
+        &mut scenario,
+        &sui_pool,
+        &usdc_pool,
+        &mut mm,
         &mut pool,
         &sui_price_low2,
         &usdc_price2,
         &margin_registry,
-        2, // Execute 2 more orders
+        2,
+        // Execute 2 more orders
         &clock,
-        scenario.ctx(),
     );
+    return_shared(sui_pool);
+    return_shared(usdc_pool);
 
     // Second batch: 2 more orders executed (ID 3, 4)
     assert!(order_infos_2.length() == 2);
@@ -3380,8 +3451,8 @@ fun test_tpsl_limit_order_price_below_lower_bound_cancelled() {
         clock,
         admin_cap,
         maintainer_cap,
-        _usdc_pool_id,
-        _sui_pool_id,
+        usdc_pool_id,
+        sui_pool_id,
         _pool_id,
         registry_id,
     ) = setup_sui_usdc_deepbook_margin();
@@ -3471,15 +3542,22 @@ fun test_tpsl_limit_order_price_below_lower_bound_cancelled() {
     );
 
     // Execute - should cancel due to price out of bounds
-    let order_infos = mm.execute_conditional_orders<SUI, USDC>(
+    let sui_pool = scenario.take_shared_by_id<MarginPool<SUI>>(sui_pool_id);
+    let usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+    let order_infos = test_helpers::execute_conditional_orders_v2_for_test<SUI, USDC>(
+        &mut scenario,
+        &sui_pool,
+        &usdc_pool,
+        &mut mm,
         &mut pool,
         &sui_price_trigger,
         &usdc_price,
         &margin_registry,
         10,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(sui_pool);
+    return_shared(usdc_pool);
 
     // Order should NOT have executed
     assert!(order_infos.length() == 0);
@@ -3506,8 +3584,8 @@ fun test_tpsl_limit_order_price_above_upper_bound_cancelled() {
         clock,
         admin_cap,
         maintainer_cap,
-        _usdc_pool_id,
-        _sui_pool_id,
+        usdc_pool_id,
+        sui_pool_id,
         _pool_id,
         registry_id,
     ) = setup_sui_usdc_deepbook_margin();
@@ -3593,15 +3671,22 @@ fun test_tpsl_limit_order_price_above_upper_bound_cancelled() {
         &clock,
     );
 
-    let order_infos = mm.execute_conditional_orders<SUI, USDC>(
+    let sui_pool = scenario.take_shared_by_id<MarginPool<SUI>>(sui_pool_id);
+    let usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+    let order_infos = test_helpers::execute_conditional_orders_v2_for_test<SUI, USDC>(
+        &mut scenario,
+        &sui_pool,
+        &usdc_pool,
+        &mut mm,
         &mut pool,
         &sui_price_trigger,
         &usdc_price,
         &margin_registry,
         10,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(sui_pool);
+    return_shared(usdc_pool);
 
     // Order should NOT have executed
     assert!(order_infos.length() == 0);
@@ -3625,8 +3710,8 @@ fun test_tpsl_market_sell_order_price_out_of_bounds_cancelled() {
         clock,
         admin_cap,
         maintainer_cap,
-        _usdc_pool_id,
-        _sui_pool_id,
+        usdc_pool_id,
+        sui_pool_id,
         pool_id,
         registry_id,
     ) = setup_sui_usdc_deepbook_margin();
@@ -3711,15 +3796,22 @@ fun test_tpsl_market_sell_order_price_out_of_bounds_cancelled() {
         &clock,
     );
 
-    let order_infos = mm.execute_conditional_orders<SUI, USDC>(
+    let sui_pool = scenario.take_shared_by_id<MarginPool<SUI>>(sui_pool_id);
+    let usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+    let order_infos = test_helpers::execute_conditional_orders_v2_for_test<SUI, USDC>(
+        &mut scenario,
+        &sui_pool,
+        &usdc_pool,
+        &mut mm,
         &mut pool,
         &sui_price_trigger,
         &usdc_price,
         &margin_registry,
         10,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(sui_pool);
+    return_shared(usdc_pool);
 
     // Market sell should be cancelled due to out-of-bounds execution price
     assert!(order_infos.length() == 0);
@@ -3743,8 +3835,8 @@ fun test_tpsl_market_buy_order_price_out_of_bounds_cancelled() {
         clock,
         admin_cap,
         maintainer_cap,
-        _usdc_pool_id,
-        _sui_pool_id,
+        usdc_pool_id,
+        sui_pool_id,
         pool_id,
         registry_id,
     ) = setup_sui_usdc_deepbook_margin();
@@ -3830,15 +3922,22 @@ fun test_tpsl_market_buy_order_price_out_of_bounds_cancelled() {
         &clock,
     );
 
-    let order_infos = mm.execute_conditional_orders<SUI, USDC>(
+    let sui_pool = scenario.take_shared_by_id<MarginPool<SUI>>(sui_pool_id);
+    let usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+    let order_infos = test_helpers::execute_conditional_orders_v2_for_test<SUI, USDC>(
+        &mut scenario,
+        &sui_pool,
+        &usdc_pool,
+        &mut mm,
         &mut pool,
         &sui_price_trigger,
         &usdc_price,
         &margin_registry,
         10,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(sui_pool);
+    return_shared(usdc_pool);
 
     // Market buy should be cancelled due to out-of-bounds execution price
     assert!(order_infos.length() == 0);
@@ -3862,8 +3961,8 @@ fun test_tpsl_market_buy_order_no_liquidity_cancelled() {
         clock,
         admin_cap,
         maintainer_cap,
-        _usdc_pool_id,
-        _sui_pool_id,
+        usdc_pool_id,
+        sui_pool_id,
         _pool_id,
         registry_id,
     ) = setup_sui_usdc_deepbook_margin();
@@ -3947,15 +4046,22 @@ fun test_tpsl_market_buy_order_no_liquidity_cancelled() {
         &clock,
     );
 
-    let order_infos = mm.execute_conditional_orders<SUI, USDC>(
+    let sui_pool = scenario.take_shared_by_id<MarginPool<SUI>>(sui_pool_id);
+    let usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+    let order_infos = test_helpers::execute_conditional_orders_v2_for_test<SUI, USDC>(
+        &mut scenario,
+        &sui_pool,
+        &usdc_pool,
+        &mut mm,
         &mut pool,
         &sui_price_trigger,
         &usdc_price,
         &margin_registry,
         10,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(sui_pool);
+    return_shared(usdc_pool);
 
     // Market buy should be cancelled due to no liquidity (base_out == 0)
     assert!(order_infos.length() == 0);
@@ -3979,8 +4085,8 @@ fun test_tpsl_mixed_orders_some_cancelled_some_executed() {
         clock,
         admin_cap,
         maintainer_cap,
-        _usdc_pool_id,
-        _sui_pool_id,
+        usdc_pool_id,
+        sui_pool_id,
         pool_id,
         registry_id,
     ) = setup_sui_usdc_deepbook_margin();
@@ -4089,15 +4195,22 @@ fun test_tpsl_mixed_orders_some_cancelled_some_executed() {
         &clock,
     );
 
-    let order_infos = mm.execute_conditional_orders<SUI, USDC>(
+    let sui_pool = scenario.take_shared_by_id<MarginPool<SUI>>(sui_pool_id);
+    let usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+    let order_infos = test_helpers::execute_conditional_orders_v2_for_test<SUI, USDC>(
+        &mut scenario,
+        &sui_pool,
+        &usdc_pool,
+        &mut mm,
         &mut pool,
         &sui_price_trigger,
         &usdc_price,
         &margin_registry,
         10,
         &clock,
-        scenario.ctx(),
     );
+    return_shared(sui_pool);
+    return_shared(usdc_pool);
 
     // Only 1 order should have executed (the one within bounds)
     assert!(order_infos.length() == 1);


### PR DESCRIPTION
## Summary
- Adds `_v2` variants of every margin-routed order placement entry. Each v2 entry recomputes the manager's `risk_ratio` against Pyth after the trade settles and aborts if the post-trade ratio breaches the borrow floor.
- v1 entries (`pool_proxy::place_{limit,market,reduce_only_limit,reduce_only_market}_order` and `margin_manager::execute_conditional_orders`) preserve their on-chain signatures (required for upgrade compatibility) but bodies are replaced with `abort EDeprecatedUseV2`. Existing managers must migrate to the `_v2` variants.
- `margin_manager::add_conditional_order` is intentionally left as v1 — registration-only, no fund movement, no risk surface to gate.
- Bumps `MARGIN_VERSION` from 4 to 5 and bumps `Published.toml` mainnet `published-at` to the v4 address (the upgrade target for v5).

## V2 entry surface

- **`pool_proxy::place_limit_order_v2` / `place_market_order_v2`** — assert post-trade `risk_ratio >= min_borrow_risk_ratio` (skipped when manager has no debt).
- **`pool_proxy::place_reduce_only_limit_order_v2` / `place_reduce_only_market_order_v2`** — assert monotonic improvement: `risk_ratio_after >= risk_ratio_before`. The borrow-floor check would trap users in the 1.1–1.25 band — exactly the people who most need to wind down via reduce-only. Monotonic doesn't trap and additionally catches within-band value leak that the borrow-floor check would allow.
- **`margin_manager::execute_conditional_orders_v2`** — same borrow-floor invariant after the batched fills. Move PTBs are atomic so the check is hoisted out of the inner loop, saving up to N-1 Pyth reads on the happy path. Skipped when no fills landed or manager has no debt.

## Key decisions

- Reduce-only uses `risk_ratio_after >= risk_ratio_before` (non-decreasing), not strict `>`. Equal-RR fills are value-neutral; strict `>` would block at-oracle wind-downs. Error constant `EReduceOnlyMustImproveRiskRatio` — name reads strict but the check is non-strict; rename if reviewers prefer.
- Reduce-only safety: the quantity predicate (`base_debt > base_asset` or `quote_debt > quote_asset`) already aborts for no-debt managers — both arms evaluate `0 > x` which is false. So `risk_ratio` is safe to compute directly without a divide-by-zero guard.
- Test wrappers in `test_helpers` (`place_*_v2_for_test`, `execute_conditional_orders_v2_for_test`) take the original v1 args plus margin pool refs and build oracle objects internally so callers don't pay the take_shared/build/destroy cost per call.

## Test plan
- [x] `sui move build` in `packages/deepbook_margin` clean
- [x] `sui move test --gas-limit 100000000000` in `packages/deepbook_margin` — 314/314 pass
- [x] New regression coverage:
  - `place_limit_order_v2_borrow_at_floor_then_adverse_fill_aborts` — borrow exactly to 1.25, sell against the orderbook bid at 0.99; 1% adverse fill drops `risk_ratio` to ~1.2475 → `EInsufficientRiskRatioAfterTrade`.
  - `execute_conditional_orders_v1_aborts` — v1 deprecation fires `EDeprecatedUseV2`.
  - `execute_conditional_orders_v2_post_loop_check_aborts` — trigger-above conditional fills at the orderbook bid while USDC is bumped to $1.01; post-loop solvency check fires.
  - 4 v1 deprecation asserts for the `pool_proxy::place_*` entries.
- [ ] Order: depends on #1003 (MARGIN_VERSION 3→4). Rebase onto `main` once #1003 merges; this branch was built on top of `port/margin-pool-capital-injection` locally so the v3→4→5 history is consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)