### PR TITLE
margin v5: clear all shares when liquidation withdraws all collateral

### DIFF
--- a/packages/deepbook_margin/sources/margin_manager.move
+++ b/packages/deepbook_margin/sources/margin_manager.move
@@ -794,9 +794,9 @@ public fun liquidate<BaseAsset, QuoteAsset, DebtAsset>(
     let repay_amount = max_repay.min(input_coin_without_pool_reward); // 97.087
     let repay_amount_with_pool_reward = math::mul(repay_amount, liquidation_reward_with_pool); // 97.087 * 1.03 = 100
 
-    // If assets are insufficient to cover full debt + reward, the liquidator drains all
-    // collateral at `max_repay`; clear every borrow share so the shortfall is recorded as
-    // `pool_default` rather than left as silent residual debt on an empty manager.
+    // If assets are insufficient to cover full debt + reward, the manager's collateral is
+    // fully withdrawn at `max_repay`. Clear every borrow share so the shortfall is recorded
+    // as `pool_default` rather than left as silent residual debt on an empty manager.
     let assets_exhausted = assets_in_debt_unit <= debt_with_reward;
     let repay_shares = if (assets_exhausted && repay_amount == max_repay) {
         borrowed_shares

--- a/packages/deepbook_margin/sources/margin_manager.move
+++ b/packages/deepbook_margin/sources/margin_manager.move
@@ -794,7 +794,11 @@ public fun liquidate<BaseAsset, QuoteAsset, DebtAsset>(
     let repay_amount = max_repay.min(input_coin_without_pool_reward); // 97.087
     let repay_amount_with_pool_reward = math::mul(repay_amount, liquidation_reward_with_pool); // 97.087 * 1.03 = 100
 
-    let repay_shares = if (risk_ratio < constants::float_scaling() && repay_amount == max_repay) {
+    // If assets are insufficient to cover full debt + reward, the liquidator drains all
+    // collateral at `max_repay`; clear every borrow share so the shortfall is recorded as
+    // `pool_default` rather than left as silent residual debt on an empty manager.
+    let assets_exhausted = assets_in_debt_unit <= debt_with_reward;
+    let repay_shares = if (assets_exhausted && repay_amount == max_repay) {
         borrowed_shares
     } else {
         math::mul(

--- a/packages/deepbook_margin/tests/margin_manager_tests.move
+++ b/packages/deepbook_margin/tests/margin_manager_tests.move
@@ -4153,3 +4153,498 @@ fun test_liquidate_partial_keeps_proportional_shares() {
     return_shared(mm);
     cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
 }
+
+// Issue 2 negative case (partial liquidator in the slightly-solvent range): same risk
+// envelope as `test_liquidate_slightly_solvent_clears_all_shares` (risk_ratio ≈ 1.0375,
+// `assets_exhausted` is true), but the liquidator brings a small repay coin so
+// `repay_amount < max_repay`. The fix's IF branch must NOT fire on the second predicate
+// — proportional shares run, residual debt + residual collateral remain.
+#[test]
+fun test_liquidate_partial_in_slightly_solvent_range_keeps_residual() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        _btc_pool_id,
+        usdc_pool_id,
+        _pool_id,
+        registry_id,
+    ) = setup_btc_usd_deepbook_margin();
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<BTC, USDC>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+
+    mm.deposit<BTC, USDC, BTC>(
+        &registry,
+        &btc_price,
+        &usdc_price,
+        mint_coin<BTC>(btc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    mm.borrow_quote<BTC, USDC>(
+        &registry,
+        &mut usdc_pool,
+        &btc_price,
+        &usdc_price,
+        &pool,
+        40_000_000_000, // 40k USDC
+        &clock,
+        scenario.ctx(),
+    );
+    let (_, borrowed_quote_before) = mm.borrowed_shares();
+
+    // Same drop as the all-shares test (BTC=$1500, risk_ratio=1.0375, assets_exhausted=true).
+    destroy(btc_price);
+    destroy(usdc_price);
+    scenario.next_tx(test_constants::admin());
+    let btc_price_dropped = build_btc_price_info_object(&mut scenario, 1500, &clock);
+    let usdc_price_fresh = build_demo_usdc_price_info_object(&mut scenario, &clock);
+
+    scenario.next_tx(test_constants::liquidator());
+    // Only 10k USDC: input/1.03 ≈ 9,708.74 USDC = repay_amount, which is far below
+    // max_repay (≈ 39,523.81). The IF branch requires `repay_amount == max_repay`, so
+    // we must hit the proportional ELSE branch.
+    let debt_coin = mint_coin<USDC>(10_000_000_000, scenario.ctx());
+    let (base_coin, quote_coin, remaining_debt) = mm.liquidate<BTC, USDC, USDC>(
+        &registry,
+        &btc_price_dropped,
+        &usdc_price_fresh,
+        &mut usdc_pool,
+        &mut pool,
+        debt_coin,
+        &clock,
+        scenario.ctx(),
+    );
+
+    // Proportional: ~24.27% of borrow shares repaid, ~75.73% remain. The manager keeps
+    // 1 BTC (untouched — debt is quote, out_amount fits entirely in available USDC) plus
+    // ~29,806 USDC of residual collateral backing those residual shares.
+    let borrowed_quote_after = mm.borrowed_quote_shares();
+    assert!(borrowed_quote_after > 0);
+    assert!(borrowed_quote_after < borrowed_quote_before);
+    assert!(mm.margin_pool_id().is_some());
+    let (base_asset, quote_asset) = mm.calculate_assets(&pool);
+    assert!(base_asset == btc_multiplier()); // 1 BTC untouched
+    assert!(quote_asset > 0);
+    // out_amount (≈ 10,194.17 USDC) all comes from the quote leg.
+    assert!(base_coin.value() == 0);
+    assert!(quote_coin.value() > 0);
+
+    destroy_3!(base_coin, quote_coin, remaining_debt);
+    return_shared_2!(usdc_pool, pool);
+    destroy_2!(btc_price_dropped, usdc_price_fresh);
+    return_shared(mm);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+// Issue 2 default-recording check: deep into the slightly-solvent range
+// (risk_ratio ≈ 1.01, below the ≈1.0194 break-even where pool coin covers full debt),
+// the fix must clear all shares AND `repay_liquidation` must record an honest
+// `pool_default`. The before-fix proportional path silently absorbed this shortfall as
+// unrepayable residual shares; the after-fix path surfaces it via
+// `decrease_supply_absolute`, observable as a drop in `pool.total_supply()`.
+#[test]
+fun test_liquidate_records_pool_default_when_repay_below_debt() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        _btc_pool_id,
+        usdc_pool_id,
+        _pool_id,
+        registry_id,
+    ) = setup_btc_usd_deepbook_margin();
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<BTC, USDC>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+
+    mm.deposit<BTC, USDC, BTC>(
+        &registry,
+        &btc_price,
+        &usdc_price,
+        mint_coin<BTC>(btc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    mm.borrow_quote<BTC, USDC>(
+        &registry,
+        &mut usdc_pool,
+        &btc_price,
+        &usdc_price,
+        &pool,
+        40_000_000_000, // 40k USDC
+        &clock,
+        scenario.ctx(),
+    );
+
+    // Drop BTC hard to $400. assets_in_debt_unit = 400 + 40000 = 40400; debt = 40000;
+    // risk_ratio = 1.01. max_repay = 40400/1.05 ≈ 38,476.19; coin paid to pool ≈
+    // 38,476.19 * 1.03 ≈ 39,630.48; full-debt amount = 40,000 → default ≈ 369.52 USDC.
+    destroy(btc_price);
+    destroy(usdc_price);
+    scenario.next_tx(test_constants::admin());
+    let btc_price_dropped = build_btc_price_info_object(&mut scenario, 400, &clock);
+    let usdc_price_fresh = build_demo_usdc_price_info_object(&mut scenario, &clock);
+
+    // Snapshot pool supply right before the liquidation. The clock has not advanced
+    // between borrow and now, so `update` inside `decrease_borrow_shares` accrues no
+    // interest; the only delta on `total_supply` comes from the (reward | default)
+    // branch in `repay_liquidation`.
+    let supply_before = usdc_pool.total_supply();
+
+    scenario.next_tx(test_constants::liquidator());
+    let debt_coin = mint_coin<USDC>(100_000_000_000, scenario.ctx()); // 100k USDC
+    let (base_coin, quote_coin, remaining_debt) = mm.liquidate<BTC, USDC, USDC>(
+        &registry,
+        &btc_price_dropped,
+        &usdc_price_fresh,
+        &mut usdc_pool,
+        &mut pool,
+        debt_coin,
+        &clock,
+        scenario.ctx(),
+    );
+
+    // Full liquidation: zero shares, zero collateral, manager detached.
+    assert!(mm.borrowed_base_shares() == 0);
+    assert!(mm.borrowed_quote_shares() == 0);
+    assert!(mm.margin_pool_id().is_none());
+    let (base_asset, quote_asset) = mm.calculate_assets(&pool);
+    assert!(base_asset == 0);
+    assert!(quote_asset == 0);
+
+    // Pool supply strictly decreased — `repay_liquidation` hit the `default` branch and
+    // called `decrease_supply_absolute`. Pre-fix, this same scenario went through
+    // `increase_supply_absolute` (silent +1,154.29 phantom reward) while leaving 3.81%
+    // of borrow shares stranded on the drained manager.
+    let supply_after = usdc_pool.total_supply();
+    assert!(supply_after < supply_before);
+
+    destroy_3!(base_coin, quote_coin, remaining_debt);
+    return_shared_2!(usdc_pool, pool);
+    destroy_2!(btc_price_dropped, usdc_price_fresh);
+    return_shared(mm);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+// Issue 2 deep-default check: risk_ratio ≈ 1.001 (near the bottom of the
+// slightly-solvent range). Verifies that the fix records a large default — close to
+// the maximum default magnitude of ~1.9% of debt — and that no excess value leaks to
+// the liquidator beyond the standard 2% user reward envelope.
+#[test]
+fun test_liquidate_near_risk_ratio_one_records_large_default() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        _btc_pool_id,
+        usdc_pool_id,
+        _pool_id,
+        registry_id,
+    ) = setup_btc_usd_deepbook_margin();
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<BTC, USDC>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+
+    mm.deposit<BTC, USDC, BTC>(
+        &registry,
+        &btc_price,
+        &usdc_price,
+        mint_coin<BTC>(btc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    mm.borrow_quote<BTC, USDC>(
+        &registry,
+        &mut usdc_pool,
+        &btc_price,
+        &usdc_price,
+        &pool,
+        40_000_000_000,
+        &clock,
+        scenario.ctx(),
+    );
+
+    // BTC at $50 → assets_in_debt_unit = 50 + 40000 = 40050, debt = 40000, risk_ratio
+    // ≈ 1.00125 (near the bottom of the slightly-solvent range). max_repay ≈
+    // 38,142.857; coin to pool ≈ 39,287.143; full-debt amount = 40,000 → default ≈
+    // 712.857 USDC (close to the ~1.9% theoretical max default in this range).
+    destroy(btc_price);
+    destroy(usdc_price);
+    scenario.next_tx(test_constants::admin());
+    let btc_price_dropped = build_btc_price_info_object(&mut scenario, 50, &clock);
+    let usdc_price_fresh = build_demo_usdc_price_info_object(&mut scenario, &clock);
+
+    let supply_before = usdc_pool.total_supply();
+
+    scenario.next_tx(test_constants::liquidator());
+    let debt_coin = mint_coin<USDC>(100_000_000_000, scenario.ctx()); // 100k USDC
+    let (base_coin, quote_coin, remaining_debt) = mm.liquidate<BTC, USDC, USDC>(
+        &registry,
+        &btc_price_dropped,
+        &usdc_price_fresh,
+        &mut usdc_pool,
+        &mut pool,
+        debt_coin,
+        &clock,
+        scenario.ctx(),
+    );
+
+    // Full clear + drain (modulo dust from integer division in the oracle conversion —
+    // a few raw units of base/quote can remain at certain price points). `base_asset`
+    // <= 1000 raw means at most 10⁻⁵ BTC ≈ $0.0005 stranded — economically zero.
+    assert!(mm.borrowed_quote_shares() == 0);
+    assert!(mm.margin_pool_id().is_none());
+    let (base_asset, quote_asset) = mm.calculate_assets(&pool);
+    assert!(base_asset < 1000);
+    assert!(quote_asset < 1000);
+
+    // Default booked: total_supply strictly drops by ~712.857 USDC (raw 712_857_142).
+    // The drop must be strictly positive (default occurred) and bounded above by the
+    // theoretical max default in this range (~2% of debt = 800_000_000 raw USDC).
+    let supply_after = usdc_pool.total_supply();
+    let supply_drop = supply_before - supply_after;
+    assert!(supply_drop > 500_000_000); // > $500 USDC default — sanity lower bound
+    assert!(supply_drop < 800_000_000); // < ~$800 USDC default — sanity upper bound
+
+    destroy_3!(base_coin, quote_coin, remaining_debt);
+    return_shared_2!(usdc_pool, pool);
+    destroy_2!(btc_price_dropped, usdc_price_fresh);
+    return_shared(mm);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+// Boundary check just OUTSIDE the fix's `assets_exhausted` condition: assets is
+// strictly greater than `debt_with_reward` (scenario c by the slimmest margin). The IF
+// branch MUST NOT fire — the proportional ELSE branch must run, leaving residual shares
+// + collateral. Guards against an off-by-one that would over-clear shares in scenario c.
+#[test]
+fun test_liquidate_just_outside_assets_exhausted_runs_proportional() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        _btc_pool_id,
+        usdc_pool_id,
+        _pool_id,
+        registry_id,
+    ) = setup_btc_usd_deepbook_margin();
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<BTC, USDC>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+
+    mm.deposit<BTC, USDC, BTC>(
+        &registry,
+        &btc_price,
+        &usdc_price,
+        mint_coin<BTC>(btc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    mm.borrow_quote<BTC, USDC>(
+        &registry,
+        &mut usdc_pool,
+        &btc_price,
+        &usdc_price,
+        &pool,
+        40_000_000_000,
+        &clock,
+        scenario.ctx(),
+    );
+
+    // BTC at $2001 → assets_in_debt_unit = 2001 + 40000 = 42001, just 1 USDC above
+    // debt_with_reward (40000 * 1.05 = 42000). risk_ratio ≈ 1.05003 (liquidatable since
+    // < 1.10). debt_repay = (1.25 * 40000 - 42001) / 0.20 = 39995 (< 40000); max_repay =
+    // debt_repay = 39995. The fix's IF must NOT fire because `assets_exhausted` is false.
+    destroy(btc_price);
+    destroy(usdc_price);
+    scenario.next_tx(test_constants::admin());
+    let btc_price_dropped = build_btc_price_info_object(&mut scenario, 2001, &clock);
+    let usdc_price_fresh = build_demo_usdc_price_info_object(&mut scenario, &clock);
+
+    scenario.next_tx(test_constants::liquidator());
+    let debt_coin = mint_coin<USDC>(100_000_000_000, scenario.ctx());
+    let (base_coin, quote_coin, remaining_debt) = mm.liquidate<BTC, USDC, USDC>(
+        &registry,
+        &btc_price_dropped,
+        &usdc_price_fresh,
+        &mut usdc_pool,
+        &mut pool,
+        debt_coin,
+        &clock,
+        scenario.ctx(),
+    );
+
+    // Proportional ran (repay_shares ≈ borrowed_shares * 39995/40000): a tiny residual
+    // of borrow shares remains, position still attached to the pool.
+    assert!(mm.borrowed_quote_shares() > 0);
+    assert!(mm.margin_pool_id().is_some());
+
+    destroy_3!(base_coin, quote_coin, remaining_debt);
+    return_shared_2!(usdc_pool, pool);
+    destroy_2!(btc_price_dropped, usdc_price_fresh);
+    return_shared(mm);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+// `repay_amount == max_repay` boundary: a liquidator providing one unit less than the
+// amount needed to reach max_repay must NOT trigger the all-shares IF branch, even when
+// `assets_exhausted` is true. The proportional formula runs; residual shares remain.
+// Guards against an off-by-one in the equality check that would over-clear shares.
+#[test]
+fun test_liquidate_repay_just_below_max_does_not_clear_all() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        _btc_pool_id,
+        usdc_pool_id,
+        _pool_id,
+        registry_id,
+    ) = setup_btc_usd_deepbook_margin();
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<BTC, USDC>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+
+    mm.deposit<BTC, USDC, BTC>(
+        &registry,
+        &btc_price,
+        &usdc_price,
+        mint_coin<BTC>(btc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    mm.borrow_quote<BTC, USDC>(
+        &registry,
+        &mut usdc_pool,
+        &btc_price,
+        &usdc_price,
+        &pool,
+        40_000_000_000,
+        &clock,
+        scenario.ctx(),
+    );
+
+    // Same slightly-solvent setup (BTC=$1500, risk_ratio=1.0375, assets_exhausted=true).
+    // max_repay = 39_523_809_523 raw USDC. The smallest input that yields
+    // `input/1.03 >= max_repay` (after truncation) is 40_709_523_809 raw — providing
+    // one unit less (40_709_523_808) makes `input_coin_without_pool_reward` truncate to
+    // 39_523_809_522, strictly below max_repay, so `repay_amount < max_repay` and the IF
+    // guard's second predicate fails.
+    destroy(btc_price);
+    destroy(usdc_price);
+    scenario.next_tx(test_constants::admin());
+    let btc_price_dropped = build_btc_price_info_object(&mut scenario, 1500, &clock);
+    let usdc_price_fresh = build_demo_usdc_price_info_object(&mut scenario, &clock);
+
+    scenario.next_tx(test_constants::liquidator());
+    let debt_coin = mint_coin<USDC>(40_709_523_808, scenario.ctx());
+    let (base_coin, quote_coin, remaining_debt) = mm.liquidate<BTC, USDC, USDC>(
+        &registry,
+        &btc_price_dropped,
+        &usdc_price_fresh,
+        &mut usdc_pool,
+        &mut pool,
+        debt_coin,
+        &clock,
+        scenario.ctx(),
+    );
+
+    // Even though `assets_exhausted` is true, the IF gate requires
+    // `repay_amount == max_repay`. With input one unit short, repay_amount strictly
+    // below max_repay → proportional branch runs → residual shares remain.
+    assert!(mm.borrowed_quote_shares() > 0);
+    assert!(mm.margin_pool_id().is_some());
+
+    destroy_3!(base_coin, quote_coin, remaining_debt);
+    return_shared_2!(usdc_pool, pool);
+    destroy_2!(btc_price_dropped, usdc_price_fresh);
+    return_shared(mm);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}

--- a/packages/deepbook_margin/tests/margin_manager_tests.move
+++ b/packages/deepbook_margin/tests/margin_manager_tests.move
@@ -3844,3 +3844,312 @@ fun execute_conditional_orders_v2_post_loop_check_aborts() {
     destroy_2!(usdc_price_high, usdt_price);
     abort 999
 }
+
+// === Audit Followup Regression Tests ===
+
+// Issue 1 regression (audit report on `withdraw_with_proof` aborting when the BalanceKey
+// is missing): a fully one-sided position — user deposits base and borrows base, so the
+// quote (USDC) key is never created — must liquidate without aborting on the missing key.
+// Pre-PR #756 the inner `assert!(key_exists, EBalanceManagerBalanceTooLow)` in
+// `balance_manager::withdraw_with_proof` would abort the `liquidation_withdraw(0, USDC)`
+// call that runs for the empty side; PR #756 made the missing key auto-allocate a zero
+// balance, so the call now passes.
+#[test]
+fun test_liquidate_one_sided_base_collateral_base_debt() {
+    let (
+        mut scenario,
+        mut clock,
+        admin_cap,
+        maintainer_cap,
+        btc_pool_id,
+        _usdc_pool_id,
+        _pool_id,
+        registry_id,
+    ) = setup_btc_usd_deepbook_margin();
+
+    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<BTC, USDC>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
+
+    // Deposit 1 BTC, borrow 4 BTC. The borrowed BTC is deposited back into the manager's
+    // balance manager (base key), so the manager holds 5 BTC total against 4 BTC of debt
+    // (risk_ratio = 1.25, exactly min_borrow_risk_ratio). The USDC (quote) key is never
+    // created on this manager.
+    mm.deposit<BTC, USDC, BTC>(
+        &registry,
+        &btc_price,
+        &usdc_price,
+        mint_coin<BTC>(btc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    mm.borrow_base<BTC, USDC>(
+        &registry,
+        &mut btc_pool,
+        &btc_price,
+        &usdc_price,
+        &pool,
+        4 * btc_multiplier(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    // Advance ~3 years so interest accrues enough to push the debt above the
+    // liquidation_risk_ratio threshold (1.10). Same-asset borrow means oracle prices
+    // can't move the ratio — only interest can.
+    advance_time(&mut clock, 3 * 365 * 86_400_000);
+
+    destroy(btc_price);
+    destroy(usdc_price);
+    scenario.next_tx(test_constants::admin());
+    let btc_price_fresh = build_btc_price_info_object(&mut scenario, 50000, &clock);
+    let usdc_price_fresh = build_demo_usdc_price_info_object(&mut scenario, &clock);
+
+    scenario.next_tx(test_constants::liquidator());
+    let debt_coin = mint_coin<BTC>(10 * btc_multiplier(), scenario.ctx());
+
+    // Liquidate must not abort despite the missing USDC key — the in-function
+    // `liquidation_withdraw(0, USDC)` should pass through (zero amount, key absent).
+    let (base_coin, quote_coin, remaining_debt) = mm.liquidate<BTC, USDC, BTC>(
+        &registry,
+        &btc_price_fresh,
+        &usdc_price_fresh,
+        &mut btc_pool,
+        &mut pool,
+        debt_coin,
+        &clock,
+        scenario.ctx(),
+    );
+
+    // Liquidator receives BTC collateral; no USDC has ever existed on this manager.
+    assert!(base_coin.value() > 0);
+    assert!(quote_coin.value() == 0);
+
+    destroy_3!(base_coin, quote_coin, remaining_debt);
+    return_shared_2!(btc_pool, pool);
+    destroy_2!(btc_price_fresh, usdc_price_fresh);
+    return_shared(mm);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+// Issue 2 main fix: when the position is liquidatable AND still solvent in [1.0, 1.05]
+// (assets are insufficient to cover full debt + reward), liquidation drains all collateral
+// at `max_repay`. The old `risk_ratio < float_scaling()` gate left residual borrow shares
+// proportional to `repay_amount / debt` on an empty manager — silent bad debt. The fix
+// switches the gate to `assets_in_debt_unit <= debt_with_reward`, which fires for the
+// whole exhausted-collateral range and clears every share.
+#[test]
+fun test_liquidate_slightly_solvent_clears_all_shares() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        _btc_pool_id,
+        usdc_pool_id,
+        _pool_id,
+        registry_id,
+    ) = setup_btc_usd_deepbook_margin();
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<BTC, USDC>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+
+    // Deposit 1 BTC ($50k), borrow 40k USDC. Post-borrow: manager holds 1 BTC + 40k USDC,
+    // debt = 40k USDC, risk_ratio = 90k / 40k = 2.25 (well above min_borrow_risk_ratio).
+    mm.deposit<BTC, USDC, BTC>(
+        &registry,
+        &btc_price,
+        &usdc_price,
+        mint_coin<BTC>(btc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    mm.borrow_quote<BTC, USDC>(
+        &registry,
+        &mut usdc_pool,
+        &btc_price,
+        &usdc_price,
+        &pool,
+        40_000_000_000, // 40k USDC
+        &clock,
+        scenario.ctx(),
+    );
+
+    // Drop BTC to $1500. New assets_in_debt_unit = 1500 + 40000 = 41500 USDC; debt = 40000
+    // USDC; risk_ratio = 41500 / 40000 = 1.0375 — liquidatable (< 1.10) AND slightly solvent
+    // (>= 1.0). Critical: assets_in_debt_unit (41500) < debt_with_reward (40000 * 1.05 =
+    // 42000), so `assets_exhausted` is true and the fix's branch fires.
+    destroy(btc_price);
+    destroy(usdc_price);
+    scenario.next_tx(test_constants::admin());
+    let btc_price_dropped = build_btc_price_info_object(&mut scenario, 1500, &clock);
+    let usdc_price_fresh = build_demo_usdc_price_info_object(&mut scenario, &clock);
+
+    scenario.next_tx(test_constants::liquidator());
+    // Generous repay coin — caps at max_repay (~39.52k USDC) inside the contract.
+    let debt_coin = mint_coin<USDC>(100_000_000_000, scenario.ctx()); // 100k USDC
+    let (base_coin, quote_coin, remaining_debt) = mm.liquidate<BTC, USDC, USDC>(
+        &registry,
+        &btc_price_dropped,
+        &usdc_price_fresh,
+        &mut usdc_pool,
+        &mut pool,
+        debt_coin,
+        &clock,
+        scenario.ctx(),
+    );
+
+    // With the fix: every borrow share is cleared and the manager is fully detached from
+    // the margin pool. Without the fix, ~1.2% of shares (40000 - 39524 worth) would remain
+    // on a drained manager as silent bad debt.
+    assert!(mm.borrowed_base_shares() == 0);
+    assert!(mm.borrowed_quote_shares() == 0);
+    assert!(mm.margin_pool_id().is_none());
+    let (base_asset, quote_asset) = mm.calculate_assets(&pool);
+    // out_amount = max_repay * 1.05 = 41500 == assets_in_debt_unit, so the manager is
+    // drained of both legs.
+    assert!(base_asset == 0);
+    assert!(quote_asset == 0);
+    // Liquidator received both legs (BTC came from `max_base_out` after USDC was exhausted).
+    assert!(base_coin.value() > 0);
+    assert!(quote_coin.value() > 0);
+
+    destroy_3!(base_coin, quote_coin, remaining_debt);
+    return_shared_2!(usdc_pool, pool);
+    destroy_2!(btc_price_dropped, usdc_price_fresh);
+    return_shared(mm);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+// Issue 2 negative case: scenario (c) — partial liquidation when assets > debt * 1.05.
+// The proportional share formula must still run; the manager keeps residual shares
+// backed by remaining collateral. This guards against the fix over-clearing shares in
+// healthy partial liquidations.
+#[test]
+fun test_liquidate_partial_keeps_proportional_shares() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        _btc_pool_id,
+        usdc_pool_id,
+        _pool_id,
+        registry_id,
+    ) = setup_btc_usd_deepbook_margin();
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<BTC, USDC>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+
+    mm.deposit<BTC, USDC, BTC>(
+        &registry,
+        &btc_price,
+        &usdc_price,
+        mint_coin<BTC>(btc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    mm.borrow_quote<BTC, USDC>(
+        &registry,
+        &mut usdc_pool,
+        &btc_price,
+        &usdc_price,
+        &pool,
+        40_000_000_000, // 40k USDC
+        &clock,
+        scenario.ctx(),
+    );
+    let (_, borrowed_quote_before) = mm.borrowed_shares();
+
+    // Drop BTC to $3200. assets_in_debt_unit = 3200 + 40000 = 43200; debt = 40000;
+    // risk_ratio = 1.08 — liquidatable (< 1.10) but in scenario (c): assets_in_debt_unit
+    // (43200) > debt_with_reward (42000), so `assets_exhausted` is false and the
+    // proportional branch must run. Expected debt_repay = (1.25 * 40000 - 43200) / 0.20
+    // = 34000 USDC; ~85% of borrow shares are repaid, 15% remain backed by collateral.
+    destroy(btc_price);
+    destroy(usdc_price);
+    scenario.next_tx(test_constants::admin());
+    let btc_price_dropped = build_btc_price_info_object(&mut scenario, 3200, &clock);
+    let usdc_price_fresh = build_demo_usdc_price_info_object(&mut scenario, &clock);
+
+    scenario.next_tx(test_constants::liquidator());
+    let debt_coin = mint_coin<USDC>(100_000_000_000, scenario.ctx()); // 100k USDC
+    let (base_coin, quote_coin, remaining_debt) = mm.liquidate<BTC, USDC, USDC>(
+        &registry,
+        &btc_price_dropped,
+        &usdc_price_fresh,
+        &mut usdc_pool,
+        &mut pool,
+        debt_coin,
+        &clock,
+        scenario.ctx(),
+    );
+
+    // Partial liquidation: residual shares + residual collateral remain, manager still
+    // attached to the margin pool.
+    let borrowed_quote_after = mm.borrowed_quote_shares();
+    assert!(borrowed_quote_after > 0);
+    assert!(borrowed_quote_after < borrowed_quote_before);
+    assert!(mm.margin_pool_id().is_some());
+    let (base_asset, quote_asset) = mm.calculate_assets(&pool);
+    // out_amount = 34000 * 1.05 = 35700 USDC. quote_out = min(35700, 40000) = 35700 USDC,
+    // so 1 BTC stays untouched and ~4300 USDC remain. Liquidator gets only USDC.
+    assert!(base_asset > 0);
+    assert!(quote_asset > 0);
+    assert!(base_coin.value() == 0);
+    assert!(quote_coin.value() > 0);
+
+    destroy_3!(base_coin, quote_coin, remaining_debt);
+    return_shared_2!(usdc_pool, pool);
+    destroy_2!(btc_price_dropped, usdc_price_fresh);
+    return_shared(mm);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}


### PR DESCRIPTION
## Summary
- Fix residual borrow shares left on an empty manager when liquidation withdraws all collateral but the position is still slightly solvent (`risk_ratio` in `[1.0, 1.05]` with the default 5% total reward). The old `risk_ratio < float_scaling()` gate only fired below 1.0, so the proportional branch ran in the slightly-solvent range and left ~1–5% of shares behind as silent residual debt on an empty manager.
- Replace the gate with `assets_in_debt_unit <= debt_with_reward && repay_amount == max_repay`, which captures the whole "assets are the binding constraint at max_repay" range and clears every share in a single call.
- Add regression tests for both the new behavior and (separately) the one-sided `withdraw_with_proof` scenario, which was already fixed in #756.

## What changes (with numbers)

**Prev:** if someone had a risk ratio of 1.02 with 5% rewards, the liquidator would pay ~0.97 (~1.02 including rewards), receive all of the collateral, and the manager would be left with a residual ~0.03 of debt and zero assets. In theory a second liquidator could clean this up; in practice they have no incentive (max_repay on a zero-collateral position is 0, so they'd pay gas to receive nothing), so the phantom debt would sit on the manager forever — inflating the pool's apparent `total_borrow` and the prior liquidation's apparent `pool_reward`.

**Now:** if someone has a risk ratio of 1.02 with 5% rewards, the liquidator still pays ~0.97 (~1.02 including rewards) and receives all of the collateral — but we clear **all** of the borrow shares in this single call. The ~0.03 that would have been residual debt is now absorbed by a smaller `pool_reward` (in the [1.02, 1.05] range) or surfaced as an explicit `pool_default` (in the [1.0, 1.02] range), matching the actual collateral collected. The manager is fully detached, no follow-up liquidation needed.

The net economic effect on the pool is identical in both paths — the fix just moves the loss out of "phantom open loan on an empty manager" and into the explicit reward/default accounting.

## Key decisions
- New condition is `assets_in_debt_unit <= debt_with_reward` rather than `risk_ratio < 1`. This precisely matches "the manager's collateral was fully withdrawn at max_repay" (scenarios a and b in the existing comment block at `margin_manager.move:757-760`) and does **not** fire for scenario c (partial liquidation when assets > debt × 1.05), where residual proportional shares are correctly backed by remaining collateral.
- Liquidator's 2% user reward is unchanged. The pool gets a smaller-than-3% reward (or an explicit `pool_default`) in the slightly-solvent range because the manager's collateral can't fund both full debt and full 3% pool reward — that's the whole reason this range exists.
- `withdraw_with_proof` is left alone. The reported abort was fixed in #756 ("improve withdrawal") on Dec 30 2025: the missing-key branch now creates a zero balance instead of asserting `key_exists`. Liquidation only ever requests `withdraw_amount = 0` for the missing side, so the assert (`0 >= 0`) passes. Added a dedicated regression test as defense against future re-introduction.

## Test plan
- [x] `sui move build` (deepbook_margin) — clean
- [x] `sui move test --gas-limit 100000000000` (deepbook_margin) — 322 / 322 pass

Tests that catch the bug (verified to FAIL pre-fix by reverting the conditional locally):
- [x] `test_liquidate_slightly_solvent_clears_all_shares` — main fix at risk_ratio 1.0375 (asserts `borrowed_quote_shares == 0`)
- [x] `test_liquidate_records_pool_default_when_repay_below_debt` — default booked at risk_ratio 1.01 (asserts pool `total_supply` strictly drops)
- [x] `test_liquidate_near_risk_ratio_one_records_large_default` — default magnitude bounded `[$500, $800]` on $40k debt at risk_ratio ≈ 1.00125

Regression / boundary guards (pass before AND after the fix):
- [x] `test_liquidate_one_sided_base_collateral_base_debt` — one-sided position regression (separately fixed in #756)
- [x] `test_liquidate_partial_keeps_proportional_shares` — scenario c (assets > debt × 1.05) untouched
- [x] `test_liquidate_partial_in_slightly_solvent_range_keeps_residual` — small repay coin in the slightly-solvent range keeps residual proportionally
- [x] `test_liquidate_just_outside_assets_exhausted_runs_proportional` — off-by-one guard on the `assets_in_debt_unit <= debt_with_reward` predicate
- [x] `test_liquidate_repay_just_below_max_does_not_clear_all` — off-by-one guard on the `repay_amount == max_repay` predicate

- [x] `bunx prettier-move -c` on modified files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)