### PR TITLE
add margin share price metrics

### DIFF
--- a/crates/server/src/margin_metrics/metrics.rs
+++ b/crates/server/src/margin_metrics/metrics.rs
@@ -14,6 +14,8 @@ pub struct MarginMetrics {
     pub vault_balance: GaugeVec,
     pub supply_cap: GaugeVec,
     pub interest_rate: GaugeVec,
+    pub supply_share_price: GaugeVec,
+    pub borrow_share_price: GaugeVec,
     pub available_withdrawal: GaugeVec,
     pub utilization_rate: GaugeVec,
     pub solvency_ratio: GaugeVec,
@@ -63,6 +65,22 @@ impl MarginMetrics {
             interest_rate: register_gauge_vec_with_registry!(
                 "margin_pool_interest_rate",
                 "Current interest rate for the margin pool (normalized, 1.0 = 100%)",
+                &["pool_id", "asset_type"],
+                registry
+            )
+            .unwrap(),
+
+            supply_share_price: register_gauge_vec_with_registry!(
+                "margin_pool_supply_share_price",
+                "Current margin pool supply share price (normalized, 1.0 = one underlying unit per share)",
+                &["pool_id", "asset_type"],
+                registry
+            )
+            .unwrap(),
+
+            borrow_share_price: register_gauge_vec_with_registry!(
+                "margin_pool_borrow_share_price",
+                "Current margin pool borrow share price (normalized, 1.0 = one underlying unit per share)",
                 &["pool_id", "asset_type"],
                 registry
             )
@@ -135,6 +153,8 @@ impl MarginMetrics {
         supply_cap: u64,
         interest_rate: u64,
         available_withdrawal: u64,
+        supply_share_price: u64,
+        borrow_share_price: u64,
         decimals: i16,
     ) {
         let divisor = 10_f64.powi(decimals as i32);
@@ -155,6 +175,12 @@ impl MarginMetrics {
         self.interest_rate
             .with_label_values(&[pool_id, asset_type])
             .set(interest_rate as f64 / 1_000_000_000.0);
+        self.supply_share_price
+            .with_label_values(&[pool_id, asset_type])
+            .set(supply_share_price as f64 / 1_000_000_000.0);
+        self.borrow_share_price
+            .with_label_values(&[pool_id, asset_type])
+            .set(borrow_share_price as f64 / 1_000_000_000.0);
         self.available_withdrawal
             .with_label_values(&[pool_id, asset_type])
             .set(available_withdrawal as f64 / divisor);

--- a/crates/server/src/margin_metrics/poller.rs
+++ b/crates/server/src/margin_metrics/poller.rs
@@ -101,6 +101,8 @@ impl MarginPoller {
                         state.supply_cap,
                         state.interest_rate,
                         state.available_withdrawal,
+                        state.supply_share_price,
+                        state.borrow_share_price,
                         pool_info.decimals,
                     );
 

--- a/crates/server/src/margin_metrics/rpc_client.rs
+++ b/crates/server/src/margin_metrics/rpc_client.rs
@@ -33,6 +33,8 @@ pub struct MarginPoolState {
     pub supply_cap: u64,
     pub interest_rate: u64,
     pub available_withdrawal: u64,
+    pub supply_share_price: u64,
+    pub borrow_share_price: u64,
 }
 
 pub struct MarginRpcClient {
@@ -96,6 +98,8 @@ impl MarginRpcClient {
             supply_cap: state.3,
             interest_rate: state.4,
             available_withdrawal: state.5,
+            supply_share_price: state.6,
+            borrow_share_price: state.7,
         })
     }
 
@@ -104,7 +108,7 @@ impl MarginRpcClient {
         pool_id: ObjectID,
         initial_shared_version: SequenceNumber,
         type_tag: &TypeTag,
-    ) -> Result<(u64, u64, u64, u64, u64, u64)> {
+    ) -> Result<(u64, u64, u64, u64, u64, u64, u64, u64)> {
         let mut ptb = ProgrammableTransactionBuilder::new();
 
         // Input 0: Pool object
@@ -177,8 +181,26 @@ impl MarginRpcClient {
             package: self.margin_package_id,
             module: MARGIN_POOL_MODULE.to_string(),
             function: "get_available_withdrawal".to_string(),
-            type_arguments: type_args,
+            type_arguments: type_args.clone(),
             arguments: vec![Argument::Input(0), Argument::Input(1)],
+        })));
+
+        // Command 6: supply_ratio<Asset>(pool)
+        ptb.command(Command::MoveCall(Box::new(ProgrammableMoveCall {
+            package: self.margin_package_id,
+            module: MARGIN_POOL_MODULE.to_string(),
+            function: "supply_ratio".to_string(),
+            type_arguments: type_args.clone(),
+            arguments: vec![Argument::Input(0)],
+        })));
+
+        // Command 7: borrow_ratio<Asset>(pool)
+        ptb.command(Command::MoveCall(Box::new(ProgrammableMoveCall {
+            package: self.margin_package_id,
+            module: MARGIN_POOL_MODULE.to_string(),
+            function: "borrow_ratio".to_string(),
+            type_arguments: type_args,
+            arguments: vec![Argument::Input(0)],
         })));
 
         let builder = ptb.finish();
@@ -201,6 +223,8 @@ impl MarginRpcClient {
         let supply_cap = self.extract_u64(&results, 3, "supply_cap")?;
         let interest_rate = self.extract_u64(&results, 4, "interest_rate")?;
         let available_withdrawal = self.extract_u64(&results, 5, "get_available_withdrawal")?;
+        let supply_share_price = self.extract_u64(&results, 6, "supply_ratio")?;
+        let borrow_share_price = self.extract_u64(&results, 7, "borrow_ratio")?;
 
         Ok((
             total_supply,
@@ -209,6 +233,8 @@ impl MarginRpcClient {
             supply_cap,
             interest_rate,
             available_withdrawal,
+            supply_share_price,
+            borrow_share_price,
         ))
     }
 


### PR DESCRIPTION
## Summary
- Add explicit Prometheus gauges for margin pool supply and borrow share prices.
- Query supply_ratio and borrow_ratio in the margin metrics RPC batch and pass them through the poller.
- Normalize both share price metrics from 9-decimal fixed-point values.

## Key decisions
- Use explicit metric names, margin_pool_supply_share_price and margin_pool_borrow_share_price, instead of the ambiguous margin_pool_share_price.
- Keep the change scoped to live Prometheus metrics; no snapshot schema or test changes are included.

## Test plan
- [x] cargo fmt -p deepbook-server
- [x] cargo build -p deepbook-server
