### PR TITLE
margin v5: drop redundant DebtAsset pool from reduce-only v2 entries

### DIFF
--- a/packages/deepbook_margin/sources/pool_proxy.move
+++ b/packages/deepbook_margin/sources/pool_proxy.move
@@ -268,11 +268,10 @@ public fun place_market_order_v2<BaseAsset, QuoteAsset>(
 }
 
 /// Places a reduce-only order in the pool. Used when margin trading is disabled.
-public fun place_reduce_only_limit_order_v2<BaseAsset, QuoteAsset, DebtAsset>(
+public fun place_reduce_only_limit_order_v2<BaseAsset, QuoteAsset>(
     registry: &MarginRegistry,
     margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
     pool: &mut Pool<BaseAsset, QuoteAsset>,
-    margin_pool: &MarginPool<DebtAsset>,
     base_margin_pool: &MarginPool<BaseAsset>,
     quote_margin_pool: &MarginPool<QuoteAsset>,
     base_oracle: &PriceInfoObject,
@@ -293,10 +292,11 @@ public fun place_reduce_only_limit_order_v2<BaseAsset, QuoteAsset, DebtAsset>(
 
     registry.assert_price(pool.id(), price, is_bid, clock);
 
-    let (base_debt, quote_debt) = margin_manager.calculate_debts<BaseAsset, QuoteAsset, DebtAsset>(
-        margin_pool,
-        clock,
-    );
+    let (base_debt, quote_debt) = if (margin_manager.has_base_debt()) {
+        margin_manager.calculate_debts(base_margin_pool, clock)
+    } else {
+        margin_manager.calculate_debts(quote_margin_pool, clock)
+    };
     let (base_asset, quote_asset) = margin_manager.calculate_assets<BaseAsset, QuoteAsset>(
         pool,
     );
@@ -354,11 +354,10 @@ public fun place_reduce_only_limit_order_v2<BaseAsset, QuoteAsset, DebtAsset>(
 }
 
 /// Places a reduce-only market order in the pool. Used when margin trading is disabled.
-public fun place_reduce_only_market_order_v2<BaseAsset, QuoteAsset, DebtAsset>(
+public fun place_reduce_only_market_order_v2<BaseAsset, QuoteAsset>(
     registry: &MarginRegistry,
     margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
     pool: &mut Pool<BaseAsset, QuoteAsset>,
-    margin_pool: &MarginPool<DebtAsset>,
     base_margin_pool: &MarginPool<BaseAsset>,
     quote_margin_pool: &MarginPool<QuoteAsset>,
     base_oracle: &PriceInfoObject,
@@ -374,10 +373,11 @@ public fun place_reduce_only_market_order_v2<BaseAsset, QuoteAsset, DebtAsset>(
     registry.load_inner();
     assert!(margin_manager.deepbook_pool() == pool.id(), EIncorrectDeepBookPool);
 
-    let (base_debt, quote_debt) = margin_manager.calculate_debts<BaseAsset, QuoteAsset, DebtAsset>(
-        margin_pool,
-        clock,
-    );
+    let (base_debt, quote_debt) = if (margin_manager.has_base_debt()) {
+        margin_manager.calculate_debts(base_margin_pool, clock)
+    } else {
+        margin_manager.calculate_debts(quote_margin_pool, clock)
+    };
     let (base_asset, quote_asset) = margin_manager.calculate_assets<BaseAsset, QuoteAsset>(
         pool,
     );

--- a/packages/deepbook_margin/tests/helper/test_helpers.move
+++ b/packages/deepbook_margin/tests/helper/test_helpers.move
@@ -1299,10 +1299,9 @@ public fun place_market_order_v2_for_test<BaseAsset, QuoteAsset>(
     order_info
 }
 
-public fun place_reduce_only_limit_order_v2_for_test<BaseAsset, QuoteAsset, DebtAsset>(
+public fun place_reduce_only_limit_order_v2_for_test<BaseAsset, QuoteAsset>(
     scenario: &mut Scenario,
     registry: &MarginRegistry,
-    debt_margin_pool: &MarginPool<DebtAsset>,
     base_margin_pool: &MarginPool<BaseAsset>,
     quote_margin_pool: &MarginPool<QuoteAsset>,
     mm: &mut deepbook_margin::margin_manager::MarginManager<BaseAsset, QuoteAsset>,
@@ -1319,11 +1318,10 @@ public fun place_reduce_only_limit_order_v2_for_test<BaseAsset, QuoteAsset, Debt
 ): deepbook::order_info::OrderInfo {
     let base_oracle = build_price_info_for_type<BaseAsset>(scenario, clock);
     let quote_oracle = build_price_info_for_type<QuoteAsset>(scenario, clock);
-    let order_info = pool_proxy::place_reduce_only_limit_order_v2<BaseAsset, QuoteAsset, DebtAsset>(
+    let order_info = pool_proxy::place_reduce_only_limit_order_v2<BaseAsset, QuoteAsset>(
         registry,
         mm,
         pool,
-        debt_margin_pool,
         base_margin_pool,
         quote_margin_pool,
         &base_oracle,
@@ -1344,10 +1342,9 @@ public fun place_reduce_only_limit_order_v2_for_test<BaseAsset, QuoteAsset, Debt
     order_info
 }
 
-public fun place_reduce_only_market_order_v2_for_test<BaseAsset, QuoteAsset, DebtAsset>(
+public fun place_reduce_only_market_order_v2_for_test<BaseAsset, QuoteAsset>(
     scenario: &mut Scenario,
     registry: &MarginRegistry,
-    debt_margin_pool: &MarginPool<DebtAsset>,
     base_margin_pool: &MarginPool<BaseAsset>,
     quote_margin_pool: &MarginPool<QuoteAsset>,
     mm: &mut deepbook_margin::margin_manager::MarginManager<BaseAsset, QuoteAsset>,
@@ -1361,15 +1358,10 @@ public fun place_reduce_only_market_order_v2_for_test<BaseAsset, QuoteAsset, Deb
 ): deepbook::order_info::OrderInfo {
     let base_oracle = build_price_info_for_type<BaseAsset>(scenario, clock);
     let quote_oracle = build_price_info_for_type<QuoteAsset>(scenario, clock);
-    let order_info = pool_proxy::place_reduce_only_market_order_v2<
-        BaseAsset,
-        QuoteAsset,
-        DebtAsset,
-    >(
+    let order_info = pool_proxy::place_reduce_only_market_order_v2<BaseAsset, QuoteAsset>(
         registry,
         mm,
         pool,
-        debt_margin_pool,
         base_margin_pool,
         quote_margin_pool,
         &base_oracle,

--- a/packages/deepbook_margin/tests/pool_proxy_tests.move
+++ b/packages/deepbook_margin/tests/pool_proxy_tests.move
@@ -557,10 +557,9 @@ fun test_place_reduce_only_limit_order_ok() {
 
     // Now place a reduce-only limit order to buy USDC (reducing the debt)
     // Price must be within 5% of oracle price (1_000_000_000 for USDC/USDT at $1 each)
-    let order_info = test_helpers::place_reduce_only_limit_order_v2_for_test<USDC, USDT, USDC>(
+    let order_info = test_helpers::place_reduce_only_limit_order_v2_for_test<USDC, USDT>(
         &mut scenario,
         &registry,
-        &base_pool,
         &base_pool,
         &quote_pool,
         &mut mm,
@@ -661,10 +660,9 @@ fun test_place_reduce_only_limit_order_ok_ask() {
     destroy(withdrawn_coin);
 
     // Now place a reduce-only limit order to sell USDC for USDT (reducing the quote debt)
-    let order_info = test_helpers::place_reduce_only_limit_order_v2_for_test<USDC, USDT, USDT>(
+    let order_info = test_helpers::place_reduce_only_limit_order_v2_for_test<USDC, USDT>(
         &mut scenario,
         &registry,
-        &quote_pool,
         &base_pool,
         &quote_pool,
         &mut mm,
@@ -726,10 +724,9 @@ fun test_place_reduce_only_limit_order_incorrect_pool() {
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
     let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
 
-    test_helpers::place_reduce_only_limit_order_v2_for_test<USDC, USDT, USDT>(
+    test_helpers::place_reduce_only_limit_order_v2_for_test<USDC, USDT>(
         &mut scenario,
         &registry,
-        &quote_pool,
         &base_pool,
         &quote_pool,
         &mut mm,
@@ -742,6 +739,65 @@ fun test_place_reduce_only_limit_order_incorrect_pool() {
         false,
         false,
         0,
+        &clock,
+    );
+
+    abort
+}
+
+// Defense-in-depth: passing a margin pool whose id is not registered against
+// the manager must abort in `calculate_debts` with EIncorrectMarginPool. The
+// only constructable "wrong pool" scenario in tests is a manager with no debt
+// at all (the registry enforces one MarginPool<Asset> per asset type, so a
+// debt-side mismatch cannot be wired up). The v2 entry dispatches to
+// `calculate_debts(quote_margin_pool, ...)` when `has_base_debt` is false,
+// and the registered margin_pool_id is None, so the contains-check fails.
+#[test, expected_failure(abort_code = margin_manager::EIncorrectMarginPool)]
+fun test_place_reduce_only_limit_order_v2_unregistered_pool() {
+    let (
+        mut scenario,
+        clock,
+        _admin_cap,
+        _maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+        registry_id,
+    ) = setup_pool_proxy_test_env<USDC, USDT>();
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<USDC, USDT>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+
+    test_helpers::place_reduce_only_limit_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
+        &registry,
+        &base_pool,
+        &quote_pool,
+        &mut mm,
+        &mut pool,
+        1,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        1_000_000_000,
+        100 * test_constants::usdc_multiplier(),
+        true,
+        false,
+        2000000,
         &clock,
     );
 
@@ -809,10 +865,9 @@ fun test_place_reduce_only_limit_order_not_reduce_only() {
     // This should fail because it's not reducing any USDC position - user is increasing exposure
     // Price must be within 5% of oracle price (1_000_000_000 for USDC/USDT at $1 each)
     let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
-    test_helpers::place_reduce_only_limit_order_v2_for_test<USDC, USDT, USDT>(
+    test_helpers::place_reduce_only_limit_order_v2_for_test<USDC, USDT>(
         &mut scenario,
         &registry,
-        &quote_pool,
         &base_pool,
         &quote_pool,
         &mut mm,
@@ -913,10 +968,9 @@ fun test_place_reduce_only_limit_order_not_reduce_only_quantity_bid() {
 
     // User has USDC debt, tries to buy more USDC than debt
     // This should fail because user is trying to buy more USDC than debt
-    test_helpers::place_reduce_only_limit_order_v2_for_test<USDC, USDT, USDC>(
+    test_helpers::place_reduce_only_limit_order_v2_for_test<USDC, USDT>(
         &mut scenario,
         &registry,
-        &base_pool,
         &base_pool,
         &quote_pool,
         &mut mm,
@@ -1013,10 +1067,9 @@ fun test_place_reduce_only_limit_order_not_reduce_only_quantity_ask() {
 
     // User has USDC debt, tries to buy more USDC than debt
     // This should fail because user is trying to buy more USDC than debt
-    test_helpers::place_reduce_only_limit_order_v2_for_test<USDC, USDT, USDT>(
+    test_helpers::place_reduce_only_limit_order_v2_for_test<USDC, USDT>(
         &mut scenario,
         &registry,
-        &quote_pool,
         &base_pool,
         &quote_pool,
         &mut mm,
@@ -1126,10 +1179,9 @@ fun test_place_reduce_only_market_order_ok() {
     destroy(withdrawn_coin);
 
     // Now place a reduce-only market order to buy USDC (reducing the debt)
-    let order_info = test_helpers::place_reduce_only_market_order_v2_for_test<USDC, USDT, USDC>(
+    let order_info = test_helpers::place_reduce_only_market_order_v2_for_test<USDC, USDT>(
         &mut scenario,
         &registry,
-        &base_pool,
         &base_pool,
         &quote_pool,
         &mut mm,
@@ -1230,10 +1282,9 @@ fun test_place_reduce_only_market_order_ok_ask() {
     destroy(withdrawn_coin);
 
     // Now place a reduce-only market order to sell USDC for USDT (reducing the quote debt)
-    let order_info = test_helpers::place_reduce_only_market_order_v2_for_test<USDC, USDT, USDT>(
+    let order_info = test_helpers::place_reduce_only_market_order_v2_for_test<USDC, USDT>(
         &mut scenario,
         &registry,
-        &quote_pool,
         &base_pool,
         &quote_pool,
         &mut mm,
@@ -1291,10 +1342,9 @@ fun test_place_reduce_only_market_order_incorrect_pool() {
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
     let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
 
-    test_helpers::place_reduce_only_market_order_v2_for_test<USDC, USDT, USDT>(
+    test_helpers::place_reduce_only_market_order_v2_for_test<USDC, USDT>(
         &mut scenario,
         &registry,
-        &quote_pool,
         &base_pool,
         &quote_pool,
         &mut mm,
@@ -1303,6 +1353,58 @@ fun test_place_reduce_only_market_order_incorrect_pool() {
         constants::self_matching_allowed(),
         500,
         false,
+        false,
+        &clock,
+    );
+
+    abort
+}
+
+// Market-order counterpart of `test_place_reduce_only_limit_order_v2_unregistered_pool`.
+// See that test for the rationale (registry uniqueness blocks a debt-side
+// mismatch; only the no-debt path is constructable).
+#[test, expected_failure(abort_code = margin_manager::EIncorrectMarginPool)]
+fun test_place_reduce_only_market_order_v2_unregistered_pool() {
+    let (
+        mut scenario,
+        clock,
+        _admin_cap,
+        _maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+        registry_id,
+    ) = setup_pool_proxy_test_env<USDC, USDT>();
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<USDC, USDT>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+
+    test_helpers::place_reduce_only_market_order_v2_for_test<USDC, USDT>(
+        &mut scenario,
+        &registry,
+        &base_pool,
+        &quote_pool,
+        &mut mm,
+        &mut pool,
+        2,
+        constants::self_matching_allowed(),
+        100 * test_constants::usdc_multiplier(),
+        true,
         false,
         &clock,
     );
@@ -1373,10 +1475,9 @@ fun test_place_reduce_only_market_order_not_reduce_only() {
     // User has no USDC debt but has USDT debt, tries to buy USDC (is_bid = true)
     // This should fail because it's not reducing any USDC position - user is increasing exposure
     let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
-    test_helpers::place_reduce_only_market_order_v2_for_test<USDC, USDT, USDT>(
+    test_helpers::place_reduce_only_market_order_v2_for_test<USDC, USDT>(
         &mut scenario,
         &registry,
-        &quote_pool,
         &base_pool,
         &quote_pool,
         &mut mm,
@@ -1468,10 +1569,9 @@ fun test_place_reduce_only_market_order_not_reduce_only_quantity_bid() {
     destroy(coin);
 
     // User has USDC debt of 100, tries to buy 101 USDC (more than debt)
-    test_helpers::place_reduce_only_market_order_v2_for_test<USDC, USDT, USDC>(
+    test_helpers::place_reduce_only_market_order_v2_for_test<USDC, USDT>(
         &mut scenario,
         &registry,
-        &base_pool,
         &base_pool,
         &quote_pool,
         &mut mm,
@@ -1558,10 +1658,9 @@ fun test_place_reduce_only_market_order_not_reduce_only_quantity_ask() {
 
     // User has USDT debt of 100, tries to sell enough to get more than 100 USDT (quote_quantity > debt)
     // Selling 150 USDC at ~1:1 should yield ~150 USDT, exceeding the 100 USDT debt
-    test_helpers::place_reduce_only_market_order_v2_for_test<USDC, USDT, USDT>(
+    test_helpers::place_reduce_only_market_order_v2_for_test<USDC, USDT>(
         &mut scenario,
         &registry,
-        &quote_pool,
         &base_pool,
         &quote_pool,
         &mut mm,


### PR DESCRIPTION
## Summary
- `place_reduce_only_{limit,market}_order_v2` previously took three margin pools — an explicit `&MarginPool<DebtAsset>` plus the `(base, quote)` pair. Since `DebtAsset` must equal `BaseAsset` or `QuoteAsset`, the debt pool always duplicated one of the other two, and the redundancy was a PTB-input footgun (caller could pass three unrelated pools, only runtime-detected).
- Drop the `<DebtAsset>` generic and `margin_pool` parameter from both `_v2` entries; dispatch internally on `margin_manager.has_base_debt()` to pick the correct typed pool from `(base_margin_pool, quote_margin_pool)`. Same dispatch shape already used by `manager_state` and `risk_ratio`.
- Update `test_helpers` and all call sites in `pool_proxy_tests`. Added two `unregistered_pool` `expected_failure` tests asserting `EIncorrectMarginPool` still fires.

## Key decisions
- **Modified `_v2` in place rather than introducing `_v3`** — `_v2` is from #1006 (yesterday) and not yet published on-chain, so editing the signature is safe. If `_v2` had shipped we would have had to add `_v3` and deprecate.
- **Inlined the dispatch in `pool_proxy` rather than adding a new `margin_manager` helper** — only two call sites, and `manager_state` already uses the same `has_base_debt`-based shape, so a public helper would have added API surface for two callers' worth of DRY.
- **No safety regression.** Every prior check still fires:
  - `EIncorrectMarginPool` — still raised by `calculate_debts`, now on the dispatched pool.
  - `EInvalidDebtAsset` — still asserted in `calculate_debts`, now tautologically true because the type system picks the correct asset side (strictly *stronger* than the old runtime check).
  - `EIncorrectDeepBookPool`, `ENotReduceOnlyOrder`, `registry.assert_price`, post-trade `EReduceOnlyMustImproveRiskRatio` — unchanged.
- **Wrong-pool test coverage.** The `MarginRegistry` enforces one `MarginPool<Asset>` per asset (`EMarginPoolAlreadyExists`), so under the new signature a *debt-side* mismatch is structurally unconstructable in tests. Only the no-debt path is reachable, which is what the two new tests exercise. Existing happy-path tests (`*_ok` for base debt, `*_ok_ask` for quote debt) already cover both dispatch branches.

## Test plan
- [x] `sui move build` in `packages/deepbook_margin`
- [x] `sui move test --gas-limit 100000000000` — 324 passed, 0 failed (322 prior + 2 new)
- [x] `bunx prettier-move -c <changed files> --write` — no formatting changes needed
- [ ] Reviewer sanity-check: confirm `_v2` is not yet published on the v5 package upgrade so the signature edit is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)