### PR TITLE
Optimize net deposit raw balance query

### DIFF
--- a/crates/server/src/reader.rs
+++ b/crates/server/src/reader.rs
@@ -1341,13 +1341,16 @@ impl Reader {
             ),
             raw_totals AS (
                 SELECT
-                    b.asset,
-                    SUM(CASE WHEN b.deposit THEN b.amount ELSE -b.amount END) AS net_amount
-                FROM balances b
-                JOIN asset_cutoffs ac ON ac.asset = b.asset
-                WHERE b.checkpoint_timestamp_ms >= ac.cutoff_ms
-                  AND b.checkpoint_timestamp_ms < $3
-                GROUP BY b.asset
+                    ac.asset,
+                    raw.net_amount
+                FROM asset_cutoffs ac
+                LEFT JOIN LATERAL (
+                    SELECT SUM(CASE WHEN b.deposit THEN b.amount ELSE -b.amount END) AS net_amount
+                    FROM balances b
+                    WHERE b.asset = ac.asset
+                      AND b.checkpoint_timestamp_ms >= ac.cutoff_ms
+                      AND b.checkpoint_timestamp_ms < $3
+                ) raw ON TRUE
             )
             SELECT
                 COALESCE(h.asset, p.asset) AS asset,


### PR DESCRIPTION
## Summary
- Make the /get_net_deposits raw balance query start from requested asset cutoffs and use a lateral lookup into balances.
- Avoid the planner shape that sequentially scans the entire balances table before filtering to the requested assets.

## Key decisions
- Keep the endpoint semantics unchanged: materialized view totals are combined with raw balance rows from each asset cutoff to the requested timestamp.
- Use LEFT JOIN LATERAL so assets with no raw rows still remain in the result and contribute zero via COALESCE.

## Test plan
- [x] cargo fmt -p deepbook-server
- [x] cargo build -p deepbook-server
- [x] git diff --check origin/main..HEAD