### PR TITLE
Predict: add builder codes

### DIFF
--- a/packages/predict/sources/builder_code.move
+++ b/packages/predict/sources/builder_code.move
@@ -1,0 +1,91 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Builder code identity and reward claiming for Predict.
+///
+/// Builder codes are deterministic shared objects derived from the Predict
+/// registry. Trade flows send add-on builder fees to the code object's address
+/// balance, and the code owner can later claim those accumulated DUSDC funds.
+module deepbook_predict::builder_code;
+
+use dusdc::dusdc::DUSDC;
+use sui::{accumulator::AccumulatorRoot, balance, coin::Coin, derived_object, event};
+
+const ENotOwner: u64 = 0;
+
+/// Key used to derive one builder code per `(owner, index)` pair.
+public struct BuilderCodeKey(address, u64) has copy, drop, store;
+
+/// Shared builder-code identity.
+public struct BuilderCode has key {
+    id: UID,
+    owner: address,
+    index: u64,
+}
+
+/// Emitted when a builder code owner claims accumulated builder fees.
+public struct BuilderFeesClaimed has copy, drop, store {
+    builder_code_id: ID,
+    owner: address,
+    amount: u64,
+}
+
+// === Public Functions ===
+
+/// Return the builder code object ID.
+public fun id(code: &BuilderCode): ID {
+    code.id.to_inner()
+}
+
+/// Return the permanent owner that can claim this code's builder fees.
+public fun owner(code: &BuilderCode): address {
+    code.owner
+}
+
+/// Return this owner's builder-code index.
+public fun index(code: &BuilderCode): u64 {
+    code.index
+}
+
+/// Return the DUSDC builder fees currently visible for this code.
+public fun claimable_builder_fees(root: &AccumulatorRoot, code: &BuilderCode): u64 {
+    balance::settled_funds_value<DUSDC>(root, code.id.to_address())
+}
+
+/// Claim all settled DUSDC builder fees accumulated for this code.
+public fun claim_all_builder_fees(
+    code: &mut BuilderCode,
+    root: &AccumulatorRoot,
+    ctx: &mut TxContext,
+): Coin<DUSDC> {
+    code.assert_owner(ctx);
+    let amount = claimable_builder_fees(root, code);
+    let withdrawal = balance::withdraw_funds_from_object<DUSDC>(&mut code.id, amount);
+    let coin = balance::redeem_funds(withdrawal).into_coin(ctx);
+    event::emit(BuilderFeesClaimed {
+        builder_code_id: code.id(),
+        owner: code.owner,
+        amount,
+    });
+    coin
+}
+
+// === Public-Package Functions ===
+
+/// Create and share a derived builder code for the transaction sender.
+public(package) fun create_and_share(registry_uid: &mut UID, index: u64, ctx: &TxContext): ID {
+    let code = BuilderCode {
+        id: derived_object::claim(registry_uid, BuilderCodeKey(ctx.sender(), index)),
+        owner: ctx.sender(),
+        index,
+    };
+    let id = code.id();
+    transfer::share_object(code);
+    id
+}
+
+// === Private Functions ===
+
+fun assert_owner(code: &BuilderCode, ctx: &TxContext) {
+    assert!(ctx.sender() == code.owner, ENotOwner);
+}

--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -79,6 +79,8 @@ public struct ExpiryValuation {
 public struct FeeAccrued has copy, drop, store {
     expiry_market_id: ID,
     total_fee: u64,
+    builder_fee: u64,
+    builder_code_id: Option<ID>,
 }
 
 // === Public Functions ===
@@ -455,7 +457,9 @@ fun mint_internal(
         quantity,
         clock,
     );
-    let payment_amount = principal_amount + fee_amount;
+    let builder_code_id = manager.builder_code_id();
+    let builder_fee_amount = builder_fee_amount(&builder_code_id, fee_amount, quantity);
+    let payment_amount = principal_amount + fee_amount + builder_fee_amount;
 
     market
         .strike_exposure
@@ -470,9 +474,11 @@ fun mint_internal(
 
     manager.increase_position(key, quantity, fee_amount);
     let mut payment = manager.withdraw(payment_amount, ctx).into_balance();
+    let builder_fee_payment = payment.split(builder_fee_amount);
     let fee_payment = payment.split(fee_amount);
     market.fee_balance.join(fee_payment);
-    market.emit_fee_accrued(fee_amount);
+    send_builder_fee(builder_code_id, builder_fee_payment);
+    market.emit_fee_accrued(fee_amount, builder_fee_amount, builder_code_id);
     market.lp_cash_balance.join(payment);
     market.assert_cash_backing();
 }
@@ -517,11 +523,17 @@ fun redeem_live_internal(
         quantity,
         clock,
     );
+    let builder_code_id = manager.builder_code_id();
+    let builder_fee_amount = builder_fee_amount(&builder_code_id, fee_amount, quantity).min(
+        principal_amount - fee_amount,
+    );
 
     let mut payout = market.dispense_lp_cash(principal_amount);
     let fee = payout.split(fee_amount);
+    let builder_fee = payout.split(builder_fee_amount);
     market.fee_balance.join(fee);
-    market.emit_fee_accrued(fee_amount);
+    send_builder_fee(builder_code_id, builder_fee);
+    market.emit_fee_accrued(fee_amount, builder_fee_amount, builder_code_id);
     market.assert_cash_backing();
     manager.deposit(payout.into_coin(ctx), ctx);
 }
@@ -672,12 +684,19 @@ fun assert_nonzero_quantity(quantity: u64) {
     assert!(quantity > 0, EZeroQuantity);
 }
 
-fun emit_fee_accrued(market: &ExpiryMarket, total_fee: u64) {
-    if (total_fee == 0) return;
+fun emit_fee_accrued(
+    market: &ExpiryMarket,
+    total_fee: u64,
+    builder_fee: u64,
+    builder_code_id: Option<ID>,
+) {
+    if (total_fee == 0 && builder_fee == 0) return;
 
     event::emit(FeeAccrued {
         expiry_market_id: market.id(),
         total_fee,
+        builder_fee,
+        builder_code_id,
     });
 }
 
@@ -691,6 +710,25 @@ fun assert_not_compacted(market: &ExpiryMarket) {
 
 fun rebate_liability(market: &ExpiryMarket, losing_fee_basis: u64): u64 {
     math::mul(losing_fee_basis, market.settlement_loss_rebate_rate)
+}
+
+fun builder_fee_amount(builder_code_id: &Option<ID>, fee_amount: u64, quantity: u64): u64 {
+    if (builder_code_id.is_some()) {
+        math::mul(fee_amount, constants::builder_fee_multiplier!()).min(
+            math::mul(quantity, constants::max_builder_fee_rate!()),
+        )
+    } else {
+        0
+    }
+}
+
+fun send_builder_fee(builder_code_id: Option<ID>, fee: Balance<DUSDC>) {
+    if (fee.value() == 0) {
+        fee.destroy_zero();
+        return
+    };
+    let builder_code_id = builder_code_id.destroy_some();
+    balance::send_funds(fee, builder_code_id.to_address());
 }
 
 fun lp_fee_surplus_value(config: &ProtocolConfig, fee_surplus: u64): u64 {

--- a/packages/predict/sources/helper/constants.move
+++ b/packages/predict/sources/helper/constants.move
@@ -21,6 +21,14 @@ public macro fun float_scaling(): u64 { 1_000_000_000 }
 /// form into the package's 1e9-scaled `u64`.
 public macro fun float_scaling_decimals(): u64 { 9 }
 
+// === Builder Fees ===
+
+/// Add-on builder fee as a fraction of the normal trade fee.
+public macro fun builder_fee_multiplier(): u64 { 100_000_000 }
+
+/// Maximum all-in builder fee rate per traded quantity.
+public macro fun max_builder_fee_rate(): u64 { 5_000_000 }
+
 // === Time Constants ===
 
 /// Milliseconds in a 365-day year.

--- a/packages/predict/sources/predict_manager.move
+++ b/packages/predict/sources/predict_manager.move
@@ -9,9 +9,9 @@
 module deepbook_predict::predict_manager;
 
 use deepbook::balance_manager::{Self, BalanceManager, DepositCap};
-use deepbook_predict::{math, range_key::RangeKey};
+use deepbook_predict::{builder_code::{Self, BuilderCode}, math, range_key::RangeKey};
 use dusdc::dusdc::DUSDC;
-use sui::{coin::Coin, derived_object, table::{Self, Table}};
+use sui::{coin::Coin, derived_object, event, table::{Self, Table}};
 
 const EInsufficientPosition: u64 = 0;
 const ENotOwner: u64 = 1;
@@ -26,6 +26,7 @@ public struct PredictManager has key {
     id: UID,
     balance_manager: BalanceManager,
     deposit_cap: DepositCap,
+    builder_code_id: Option<ID>,
     /// RangeKey -> position quantity and raw rebate fee basis.
     positions: Table<RangeKey, Position>,
 }
@@ -36,11 +37,23 @@ public struct Position has store {
     rebate_fee_basis: u64,
 }
 
+/// Emitted when a manager owner changes sticky builder-code attribution.
+public struct BuilderCodeSet has copy, drop, store {
+    predict_manager_id: ID,
+    owner: address,
+    builder_code_id: Option<ID>,
+}
+
 // === Public Functions ===
 
 /// Share a newly created PredictManager object.
 public fun share(self: PredictManager) {
     transfer::share_object(self);
+}
+
+/// Return the PredictManager object ID.
+public fun id(self: &PredictManager): ID {
+    self.id.to_inner()
 }
 
 /// Deposit coins into the PredictManager.
@@ -81,6 +94,38 @@ public fun balance(self: &PredictManager): u64 {
     self.balance_manager.balance<DUSDC>()
 }
 
+/// Return the sticky builder-code ID used for future trades, if one is set.
+public fun builder_code_id(self: &PredictManager): Option<ID> {
+    self.builder_code_id
+}
+
+/// Set sticky builder-code attribution for future trades.
+public fun set_builder_code(
+    self: &mut PredictManager,
+    builder_code: &BuilderCode,
+    ctx: &TxContext,
+) {
+    self.assert_owner(ctx);
+    let builder_code_id = builder_code::id(builder_code);
+    self.builder_code_id = option::some(builder_code_id);
+    event::emit(BuilderCodeSet {
+        predict_manager_id: self.id(),
+        owner: self.owner(),
+        builder_code_id: option::some(builder_code_id),
+    });
+}
+
+/// Clear sticky builder-code attribution for future trades.
+public fun unset_builder_code(self: &mut PredictManager, ctx: &TxContext) {
+    self.assert_owner(ctx);
+    self.builder_code_id = option::none();
+    event::emit(BuilderCodeSet {
+        predict_manager_id: self.id(),
+        owner: self.owner(),
+        builder_code_id: option::none(),
+    });
+}
+
 // === Public-Package Functions ===
 
 /// Create a derived PredictManager for the sender.
@@ -93,6 +138,7 @@ public(package) fun new(registry_uid: &mut UID, ctx: &mut TxContext): PredictMan
         id,
         balance_manager,
         deposit_cap,
+        builder_code_id: option::none(),
         positions: table::new(ctx),
     }
 }

--- a/packages/predict/sources/registry.move
+++ b/packages/predict/sources/registry.move
@@ -10,6 +10,7 @@
 module deepbook_predict::registry;
 
 use deepbook_predict::{
+    builder_code,
     expiry_market,
     market_oracle::{Self, MarketOracle, MarketOracleCap},
     plp::PoolVault,
@@ -292,6 +293,11 @@ public fun create_expiry_market(
     registry.expiry_market_ids.add(expiry, expiry_market_id);
 
     (expiry_market_id, market_oracle_id)
+}
+
+/// Create a derived shared BuilderCode for the caller and index.
+public fun create_builder_code(registry: &mut Registry, index: u64, ctx: &mut TxContext): ID {
+    builder_code::create_and_share(&mut registry.id, index, ctx)
 }
 
 /// Create a derived PredictManager for the caller.


### PR DESCRIPTION
## Summary
- Add first-class Predict builder code objects with deterministic IDs derived from the registry.
- Store sticky builder-code attribution on PredictManager and apply add-on builder fees to mint and live redeem flows.
- Route builder fees to builder-code address balances and add claim support plus event attribution.

## Key decisions
- Builder fees are an add-on to existing Predict fees, not split from rebate/surplus fee accounting.
- Builder fee is 10% of the normal fee, capped at 50 bps of traded quantity.
- Builder code ownership is permanent; managers can set or unset sticky attribution.

## Test plan
- [x] sui move build --path packages/predict
- [ ] No Move tests added per request