### PR TITLE
margin v5: register mainnet package 0x124bb3d8

### DIFF
--- a/crates/indexer/src/lib.rs
+++ b/crates/indexer/src/lib.rs
@@ -44,7 +44,9 @@ const TESTNET_PACKAGES: &[&str] = &[
 const MAINNET_MARGIN_PACKAGES: &[&str] = &[
     "0x97d9473771b01f77b0940c589484184b49f6444627ec121314fae6a6d36fb86b",
     "0xcb4fc91921494ebe6979e201fdb2d67388ffdf6a1b1eb4952526259074de8d0b",
-    "0xfbd322126f1452fd4c89aedbaeb9fd0c44df9b5cedbe70d76bf80dc086031377", // Latest
+    "0xfbd322126f1452fd4c89aedbaeb9fd0c44df9b5cedbe70d76bf80dc086031377",
+    "0x7767428727629a08dfd196bd4fc00d8a060e30da33aa63f4087fb3271e615a98",
+    "0x124bb3d8105d6d301c0d40feaa54d65df6b301e4d8ddd5eb8475b0f8a18cff2e", // Latest
 ];
 const TESTNET_MARGIN_PACKAGES: &[&str] = &[
     "0xb8620c24c9ea1a4a41e79613d2b3d1d93648d1bb6f6b789a7c8f261c94110e4b",

--- a/packages/deepbook_margin/Published.toml
+++ b/packages/deepbook_margin/Published.toml
@@ -4,9 +4,9 @@
 
 [published.mainnet]
 chain-id = "35834a8a"
-published-at = "0x7767428727629a08dfd196bd4fc00d8a060e30da33aa63f4087fb3271e615a98"
+published-at = "0x124bb3d8105d6d301c0d40feaa54d65df6b301e4d8ddd5eb8475b0f8a18cff2e"
 original-id = "0x97d9473771b01f77b0940c589484184b49f6444627ec121314fae6a6d36fb86b"
-version = 4
+version = 5
 toolchain-version = "1.63.1"
 build-config = { flavor = "sui", edition = "2024" }
 upgrade-capability = "0xd57c7a41b31c0a1fab5e71d296a75daf2e9e09945df383d4745daa49f06d9c56"

--- a/scripts/transactions/adminInjectCapital.ts
+++ b/scripts/transactions/adminInjectCapital.ts
@@ -19,10 +19,9 @@ declare const process: {
 
 const MAINNET = "mainnet";
 
-// Upgraded margin package (v4). Canonical v3 lives at
-// 0xfbd322126f1452fd4c89aedbaeb9fd0c44df9b5cedbe70d76bf80dc086031377.
+// Upgraded margin package (v5).
 const MARGIN_PACKAGE =
-  "0x7767428727629a08dfd196bd4fc00d8a060e30da33aa63f4087fb3271e615a98";
+  "0x124bb3d8105d6d301c0d40feaa54d65df6b301e4d8ddd5eb8475b0f8a18cff2e";
 
 const MARGIN_REGISTRY_ID =
   "0x0e40998b359a9ccbab22a98ed21bd4346abf19158bc7980c8291908086b3a742";


### PR DESCRIPTION
## Summary
- Add v5 mainnet margin package `0x124bb3d8105d6d301c0d40feaa54d65df6b301e4d8ddd5eb8475b0f8a18cff2e` to `MAINNET_MARGIN_PACKAGES` as the new Latest.
- Backfill v4 (`0x7767428727629a08dfd196bd4fc00d8a060e30da33aa63f4087fb3271e615a98`) which was missed when it was published — without it, the indexer would not recognize v4 events.
- Bump `packages/deepbook_margin/Published.toml` mainnet to `published-at = v5`, `version = 5` so future upgrades resolve from v5.
- Point `scripts/transactions/adminInjectCapital.ts` `MARGIN_PACKAGE` at v5.

## Key decisions
- Kept the older v1–v4 entries in `MAINNET_MARGIN_PACKAGES` rather than replacing them. The indexer matches any of them, and existing manager objects on v3/v4 still need their wind-down (repay/withdraw/reduce-only) events captured per the `MARGIN_VERSION` bump in `434a5085a`.
- `original-id` and `upgrade-capability` in `Published.toml` are unchanged (upgrade cap is an owned object, not regenerated per upgrade).

## Test plan
- [x] `cargo fmt -p deepbook-indexer`
- [x] `cargo build -p deepbook-indexer`
- [x] `sui move build` in `packages/deepbook_margin`
- [ ] After merge + deploy: confirm indexer ingests an event from the v5 package address