### PR TITLE
ci: approve esbuild build script via pnpm 11 allowBuilds

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,5 @@
 	"license": "Apache-2.0",
 	"dependencies": {
 		"@mysten/prettier-plugin-move": "^0.3.5"
-	},
-	"pnpm": {
-		"onlyBuiltDependencies": ["esbuild"]
 	}
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -16,8 +16,5 @@
     "@mysten/sui": "^2.5.0",
     "esbuild": "^0.27.2",
     "tsx": "^4.21.0"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": ["esbuild"]
   }
 }

--- a/scripts/pnpm-workspace.yaml
+++ b/scripts/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
## Summary
- PR #1019 added `pnpm.onlyBuiltDependencies` to `package.json` to silence `ERR_PNPM_IGNORED_BUILDS` for esbuild. **It didn't take effect** — pnpm 11 (the version CI installs via `npm install -g pnpm`) stopped reading the `pnpm` field in `package.json`:

  > [WARN] The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored: "pnpm.onlyBuiltDependencies".

- An earlier attempt at this PR moved the setting to `pnpm-workspace.yaml` but kept the old `onlyBuiltDependencies` key. That **also doesn't work in pnpm 11** — per [the 11.0 release notes](https://pnpm.io/blog/releases/11.0), `onlyBuiltDependencies` (and its siblings) were **removed entirely** and replaced by `allowBuilds`, a name → bool map. `strictDepBuilds` now defaults to `true`, so packages not in `allowBuilds` are blocked from running scripts and the install errors out.

- This PR sets `allowBuilds: { esbuild: true }` in `pnpm-workspace.yaml` at both the repo root and under `scripts/` (each is its own pnpm project with its own `pnpm install` invocation in CI).

## Key decisions
- The `pnpm-workspace.yaml` files contain only `allowBuilds` and **no `packages:` key**, so neither repo becomes a pnpm workspace — they're just config files in the new home pnpm 11 expects.

## Test plan
- [x] Wiped `node_modules`, ran `pnpm install` at repo root with **pnpm 11.1.3** — clean install, no `ERR_PNPM_IGNORED_BUILDS`.
- [x] Wiped `scripts/node_modules`, ran `pnpm install` in `scripts/` with **pnpm 11.1.3** — clean install, and esbuild's `postinstall` script visibly executes (`.../esbuild@0.27.2/node_modules/esbuild postinstall$ node install.js / Done`), confirming `allowBuilds` is being honored.
- [ ] Re-run the failing `Build Deepbook TX` → `Upgrade Vault Protocol` dispatch on this branch and confirm `Set up working directory and install dependencies` passes.