### PR TITLE
margin_liquidation: bump Published.toml mainnet to v3

### DIFF
--- a/packages/margin_liquidation/Published.toml
+++ b/packages/margin_liquidation/Published.toml
@@ -4,9 +4,9 @@
 
 [published.mainnet]
 chain-id = "35834a8a"
-published-at = "0x55718c06706bee34c9f3c39f662f10be354a4dcc719699ad72091dc343b641b8"
+published-at = "0x91cee4bdfaf353e9f36e0292e0065407379d741b75c1ee5e0e3674ca0169bb99"
 original-id = "0x73c593882cdb557703e903603f20bd373261fe6ba6e1a40515f4b62f10553e6a"
-version = 2
+version = 3
 toolchain-version = "1.63.1"
 build-config = { flavor = "sui", edition = "2024" }
 upgrade-capability = "0xd1b0608d02814ad1e15ddf6d8bf50bc4b8f375cd99d36f523dadc50c93fff565"


### PR DESCRIPTION
## Summary
- Bump `packages/margin_liquidation/Published.toml` mainnet to `published-at = 0x91cee4bdfaf353e9f36e0292e0065407379d741b75c1ee5e0e3674ca0169bb99` and `version = 3`, matching the on-chain upgrade.

## Key decisions
- Only `Published.toml` needs to change. There is no `LIQUIDATION_VERSION` constant in `margin_liquidation/sources/`, no hardcoded liquidation package address in `crates/indexer/src/lib.rs` (it only tracks `MAINNET_MARGIN_PACKAGES`), and no liquidation address in `scripts/config/constants.ts`. The liquidation event handler keys off `LiquidationEvent` emitted by `deepbook_margin::margin_manager`, not the vault package.
- `original-id` and `upgrade-capability` are unchanged — the upgrade cap is an owned object, not regenerated per upgrade.

## Test plan
- [x] `sui move build` in `packages/margin_liquidation` — clean (only pre-existing deprecation warning on `dynamic_field::exists_`).
- [ ] After merge: confirm next `Upgrade Vault Protocol` workflow builds against the new v3 source.