### PR TITLE
scripts: set minimumReleaseAge=0 in pnpm-workspace.yaml

### DIFF
--- a/scripts/pnpm-workspace.yaml
+++ b/scripts/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
 allowBuilds:
   esbuild: true
+
+minimumReleaseAge: 0


### PR DESCRIPTION
## Summary
- pnpm v11 defaults `minimumReleaseAge` to 1440 minutes (1 day), which blocks lockfile entries for packages published in the last 24h. The `Build Deepbook TX` GitHub Action failed verifying the lockfile after we bumped `@mysten/deepbook-v3` to `1.4.0` shortly after its publish.
- Set `minimumReleaseAge: 0` in `scripts/pnpm-workspace.yaml` so freshly published SDK versions can be installed by the scripts workspace without waiting out the supply-chain delay.

## Key decisions
- Scoped to `scripts/pnpm-workspace.yaml` (not the repo-root workspace) so the relaxed policy only affects the transaction-building scripts, not any other workspaces that might be added later.
- Per pnpm v11, this setting must live in `pnpm-workspace.yaml` — `.npmrc` is now auth/registry-only.

## Test plan
- [ ] Re-run the `Build Deepbook TX` workflow with `Setup Upgrades` against `tlee/setup-upgrades` (or a branch that pulls in this fix) and confirm the lockfile policy check no longer rejects `@mysten/deepbook-v3@1.4.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)