### PR TITLE
scripts: disable margin v3/v4, mint core pause caps, enable margin pairs

### DIFF
--- a/.claude/rules/scripts.md
+++ b/.claude/rules/scripts.md
@@ -80,6 +80,19 @@ Mainnet multisig transactions require a gas object:
 GAS_OBJECT=0x... pnpm tsx transactions/script.ts
 ```
 
+### Margin Registry State Persists Across `disable_version`
+`MarginRegistry.disable_version(v)` only removes `v` from `allowed_versions`. It does **not**
+clear `pool_registry` (the `Table<ID, PoolConfig>` of registered deepbook pools) or reset each
+pool's `enabled` flag. Practical consequences for migration scripts:
+- Re-calling `registerDeepbookPool` on a pool that's already in the table aborts with
+  `EPoolAlreadyRegistered` (margin_registry code 2). After a version disable, use only
+  `enableDeepbookPool` to re-enable previously-registered pools.
+- A pool's `enabled` state survives the disable. If a pool is already enabled,
+  `enableDeepbookPool` aborts with `EPoolAlreadyEnabled` (code 5); if already disabled,
+  `disableDeepbookPool` aborts with `EPoolAlreadyDisabled` (code 6).
+- `enableDeepbookPoolForLoan` only requires the deepbook pool to be registered, not enabled,
+  so you can stage loan flows for pools that will stay disabled in trading.
+
 ### Move Abort Errors
 Format: `MoveAbort(MoveLocation { module: ModuleId { address: ..., name: "module_name" }, function: N, instruction: M }, ERROR_CODE)`
 

--- a/.github/workflows/deepbookv3-build-tx.yml
+++ b/.github/workflows/deepbookv3-build-tx.yml
@@ -30,6 +30,7 @@ on:
           - Fund Liquidation Vault
           - Update Interest Rates
           - Margin Prep
+          - Enable Margin Trading
           - Prep Balance Manager
           - Revoke Pausecap
           - Admin Inject Capital
@@ -450,6 +451,17 @@ jobs:
           ORIGIN: gh_action
         run: |
           cd scripts && pnpm install && pnpm tsx transactions/marginPrep.ts
+
+      - name: Enable Margin Trading
+        if: ${{ inputs.transaction_type == 'Enable Margin Trading' }}
+        env:
+          NODE_ENV: production
+          GAS_OBJECT: ${{ inputs.gas_object_id }}
+          NETWORK: mainnet
+          ORIGIN: gh_action
+          RPC_URL: ${{ inputs.rpc }}
+        run: |
+          cd scripts && pnpm install && pnpm tsx transactions/enableMarginTrading.ts
 
       - name: Prep Balance Manager
         if: ${{ inputs.transaction_type == 'Prep Balance Manager' }}

--- a/scripts/transactions/enableMarginTrading.ts
+++ b/scripts/transactions/enableMarginTrading.ts
@@ -12,7 +12,6 @@ import {
   deepMarginPoolCapID,
   walMarginPoolCapID,
   suiUsdeMarginPoolCapID,
-  usdSuiMarginPoolCapID,
   xbtcMarginPoolCapID,
 } from "../config/constants.js";
 import { deepbook } from "@mysten/deepbook-v3";
@@ -35,16 +34,18 @@ import { SuiGrpcClient } from "@mysten/sui/grpc";
 
   const tx = new Transaction();
 
-  // Step 1: Disable old margin package versions 3 and 4 (v5 is the live version)
+  // Step 1: Disable margin package versions 3 and 4
   client.deepbook.marginAdmin.disableVersion(3)(tx);
   client.deepbook.marginAdmin.disableVersion(4)(tx);
 
-  // Step 2: Mint 3 DeepbookCorePauseCaps and distribute to ops addresses
-  //   - 2 caps to 0x517f822cd3c45a3ac3dbfab73c060d9a0d96bec7fffa204c341e7e0877c9787c
-  //   - 1 cap  to 0x1b71380623813c8aee2ab9a68d96c19d0e45fc872e8c22dd70dfedfb76cbb192
+  // Step 2: Mint 4 DeepbookCorePauseCaps and distribute
+  //   - 2 to 0x517f822cd3c45a3ac3dbfab73c060d9a0d96bec7fffa204c341e7e0877c9787c
+  //   - 1 to 0x1b71380623813c8aee2ab9a68d96c19d0e45fc872e8c22dd70dfedfb76cbb192
+  //   - 1 to 0xe9584eb3262c8cee0d0e8ff4fe4f20c5053e4748a23a4c46954d0c21fbbf0aff
   const corePauseCap1 = client.deepbook.deepBookAdmin.mintCorePauseCap()(tx);
   const corePauseCap2 = client.deepbook.deepBookAdmin.mintCorePauseCap()(tx);
   const corePauseCap3 = client.deepbook.deepBookAdmin.mintCorePauseCap()(tx);
+  const corePauseCap4 = client.deepbook.deepBookAdmin.mintCorePauseCap()(tx);
   tx.transferObjects(
     [corePauseCap1, corePauseCap2],
     "0x517f822cd3c45a3ac3dbfab73c060d9a0d96bec7fffa204c341e7e0877c9787c",
@@ -53,12 +54,26 @@ import { SuiGrpcClient } from "@mysten/sui/grpc";
     [corePauseCap3],
     "0x1b71380623813c8aee2ab9a68d96c19d0e45fc872e8c22dd70dfedfb76cbb192",
   );
+  tx.transferObjects(
+    [corePauseCap4],
+    "0xe9584eb3262c8cee0d0e8ff4fe4f20c5053e4748a23a4c46954d0c21fbbf0aff",
+  );
 
-  // Step 3: Re-enable margin trading on the 6 pairs.
-  // All 6 pools (SUI_USDC, DEEP_USDC, WAL_USDC, SUI_SUIUSDE, SUIUSDE_USDC, XBTC_USDC)
-  // were previously registered and are currently disabled. pool_registry persists
-  // across disable_version, so re-registering would abort with EPoolAlreadyRegistered.
-  // USDSUI pairs intentionally remain disabled in margin.
+  // Step 3: Mint 2 margin pause caps and distribute
+  //   - 1 to 0x517f822cd3c45a3ac3dbfab73c060d9a0d96bec7fffa204c341e7e0877c9787c
+  //   - 1 to 0xe9584eb3262c8cee0d0e8ff4fe4f20c5053e4748a23a4c46954d0c21fbbf0aff
+  const marginPauseCap1 = client.deepbook.marginAdmin.mintPauseCap()(tx);
+  const marginPauseCap2 = client.deepbook.marginAdmin.mintPauseCap()(tx);
+  tx.transferObjects(
+    [marginPauseCap1],
+    "0x517f822cd3c45a3ac3dbfab73c060d9a0d96bec7fffa204c341e7e0877c9787c",
+  );
+  tx.transferObjects(
+    [marginPauseCap2],
+    "0xe9584eb3262c8cee0d0e8ff4fe4f20c5053e4748a23a4c46954d0c21fbbf0aff",
+  );
+
+  // Step 4: Enable margin trading on the 6 pairs
   client.deepbook.marginAdmin.enableDeepbookPool("SUI_USDC")(tx);
   client.deepbook.marginAdmin.enableDeepbookPool("DEEP_USDC")(tx);
   client.deepbook.marginAdmin.enableDeepbookPool("WAL_USDC")(tx);
@@ -66,7 +81,7 @@ import { SuiGrpcClient } from "@mysten/sui/grpc";
   client.deepbook.marginAdmin.enableDeepbookPool("SUIUSDE_USDC")(tx);
   client.deepbook.marginAdmin.enableDeepbookPool("XBTC_USDC")(tx);
 
-  // Step 4: Enable each (pair, asset) loan flow for the 6 enabled pairs
+  // Step 5: Enable each (pair, asset) loan flow for the 6 pairs
   client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
     "SUI_USDC",
     "SUI",
@@ -124,28 +139,6 @@ import { SuiGrpcClient } from "@mysten/sui/grpc";
   )(tx);
   client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
     "XBTC_USDC",
-    "USDC",
-    tx.object(usdcMarginPoolCapID[env]),
-  )(tx);
-
-  // Step 5: Stage loan flow for USDSUI pairs (pairs stay disabled in margin)
-  client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
-    "SUI_USDSUI",
-    "SUI",
-    tx.object(suiMarginPoolCapID[env]),
-  )(tx);
-  client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
-    "SUI_USDSUI",
-    "USDSUI",
-    tx.object(usdSuiMarginPoolCapID[env]),
-  )(tx);
-  client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
-    "USDSUI_USDC",
-    "USDSUI",
-    tx.object(usdSuiMarginPoolCapID[env]),
-  )(tx);
-  client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
-    "USDSUI_USDC",
     "USDC",
     tx.object(usdcMarginPoolCapID[env]),
   )(tx);

--- a/scripts/transactions/enableMarginTrading.ts
+++ b/scripts/transactions/enableMarginTrading.ts
@@ -38,14 +38,16 @@ import { SuiGrpcClient } from "@mysten/sui/grpc";
   client.deepbook.marginAdmin.disableVersion(3)(tx);
   client.deepbook.marginAdmin.disableVersion(4)(tx);
 
-  // Step 2: Mint 4 DeepbookCorePauseCaps and distribute
+  // Step 2: Mint 5 DeepbookCorePauseCaps and distribute
   //   - 2 to 0x517f822cd3c45a3ac3dbfab73c060d9a0d96bec7fffa204c341e7e0877c9787c
   //   - 1 to 0x1b71380623813c8aee2ab9a68d96c19d0e45fc872e8c22dd70dfedfb76cbb192
   //   - 1 to 0xe9584eb3262c8cee0d0e8ff4fe4f20c5053e4748a23a4c46954d0c21fbbf0aff
+  //   - 1 to 0x361b079475aa70e00ee71022168a7eb0ea4ace066c4c0d7bec4a66d721deec0a
   const corePauseCap1 = client.deepbook.deepBookAdmin.mintCorePauseCap()(tx);
   const corePauseCap2 = client.deepbook.deepBookAdmin.mintCorePauseCap()(tx);
   const corePauseCap3 = client.deepbook.deepBookAdmin.mintCorePauseCap()(tx);
   const corePauseCap4 = client.deepbook.deepBookAdmin.mintCorePauseCap()(tx);
+  const corePauseCap5 = client.deepbook.deepBookAdmin.mintCorePauseCap()(tx);
   tx.transferObjects(
     [corePauseCap1, corePauseCap2],
     "0x517f822cd3c45a3ac3dbfab73c060d9a0d96bec7fffa204c341e7e0877c9787c",
@@ -58,12 +60,18 @@ import { SuiGrpcClient } from "@mysten/sui/grpc";
     [corePauseCap4],
     "0xe9584eb3262c8cee0d0e8ff4fe4f20c5053e4748a23a4c46954d0c21fbbf0aff",
   );
+  tx.transferObjects(
+    [corePauseCap5],
+    "0x361b079475aa70e00ee71022168a7eb0ea4ace066c4c0d7bec4a66d721deec0a",
+  );
 
-  // Step 3: Mint 2 margin pause caps and distribute
+  // Step 3: Mint 3 margin pause caps and distribute
   //   - 1 to 0x517f822cd3c45a3ac3dbfab73c060d9a0d96bec7fffa204c341e7e0877c9787c
   //   - 1 to 0xe9584eb3262c8cee0d0e8ff4fe4f20c5053e4748a23a4c46954d0c21fbbf0aff
+  //   - 1 to 0x361b079475aa70e00ee71022168a7eb0ea4ace066c4c0d7bec4a66d721deec0a
   const marginPauseCap1 = client.deepbook.marginAdmin.mintPauseCap()(tx);
   const marginPauseCap2 = client.deepbook.marginAdmin.mintPauseCap()(tx);
+  const marginPauseCap3 = client.deepbook.marginAdmin.mintPauseCap()(tx);
   tx.transferObjects(
     [marginPauseCap1],
     "0x517f822cd3c45a3ac3dbfab73c060d9a0d96bec7fffa204c341e7e0877c9787c",
@@ -71,6 +79,10 @@ import { SuiGrpcClient } from "@mysten/sui/grpc";
   tx.transferObjects(
     [marginPauseCap2],
     "0xe9584eb3262c8cee0d0e8ff4fe4f20c5053e4748a23a4c46954d0c21fbbf0aff",
+  );
+  tx.transferObjects(
+    [marginPauseCap3],
+    "0x361b079475aa70e00ee71022168a7eb0ea4ace066c4c0d7bec4a66d721deec0a",
   );
 
   // Step 4: Enable margin trading on the 6 pairs

--- a/scripts/transactions/enableMarginTrading.ts
+++ b/scripts/transactions/enableMarginTrading.ts
@@ -1,0 +1,156 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+import { Transaction } from "@mysten/sui/transactions";
+import { prepareMultisigTx } from "../utils/utils.js";
+import {
+  adminCapOwner,
+  adminCapID,
+  marginAdminCapID,
+  marginMaintainerCapID,
+  suiMarginPoolCapID,
+  usdcMarginPoolCapID,
+  deepMarginPoolCapID,
+  walMarginPoolCapID,
+  suiUsdeMarginPoolCapID,
+  usdSuiMarginPoolCapID,
+  xbtcMarginPoolCapID,
+} from "../config/constants.js";
+import { deepbook } from "@mysten/deepbook-v3";
+import { SuiGrpcClient } from "@mysten/sui/grpc";
+
+(async () => {
+  const env = "mainnet";
+
+  const client = new SuiGrpcClient({
+    baseUrl: "https://sui-mainnet.mystenlabs.com",
+    network: "mainnet",
+  }).$extend(
+    deepbook({
+      address: adminCapOwner[env],
+      adminCap: adminCapID[env],
+      marginAdminCap: marginAdminCapID[env],
+      marginMaintainerCap: marginMaintainerCapID[env],
+    }),
+  );
+
+  const tx = new Transaction();
+
+  // Step 1: Disable old margin package versions 3 and 4 (v5 is the live version)
+  client.deepbook.marginAdmin.disableVersion(3)(tx);
+  client.deepbook.marginAdmin.disableVersion(4)(tx);
+
+  // Step 2: Mint 3 DeepbookCorePauseCaps and distribute to ops addresses
+  //   - 2 caps to 0x517f822cd3c45a3ac3dbfab73c060d9a0d96bec7fffa204c341e7e0877c9787c
+  //   - 1 cap  to 0x1b71380623813c8aee2ab9a68d96c19d0e45fc872e8c22dd70dfedfb76cbb192
+  const corePauseCap1 = client.deepbook.deepBookAdmin.mintCorePauseCap()(tx);
+  const corePauseCap2 = client.deepbook.deepBookAdmin.mintCorePauseCap()(tx);
+  const corePauseCap3 = client.deepbook.deepBookAdmin.mintCorePauseCap()(tx);
+  tx.transferObjects(
+    [corePauseCap1, corePauseCap2],
+    "0x517f822cd3c45a3ac3dbfab73c060d9a0d96bec7fffa204c341e7e0877c9787c",
+  );
+  tx.transferObjects(
+    [corePauseCap3],
+    "0x1b71380623813c8aee2ab9a68d96c19d0e45fc872e8c22dd70dfedfb76cbb192",
+  );
+
+  // Step 3: Re-enable margin trading on the 6 pairs.
+  // All 6 pools (SUI_USDC, DEEP_USDC, WAL_USDC, SUI_SUIUSDE, SUIUSDE_USDC, XBTC_USDC)
+  // were previously registered and are currently disabled. pool_registry persists
+  // across disable_version, so re-registering would abort with EPoolAlreadyRegistered.
+  // USDSUI pairs intentionally remain disabled in margin.
+  client.deepbook.marginAdmin.enableDeepbookPool("SUI_USDC")(tx);
+  client.deepbook.marginAdmin.enableDeepbookPool("DEEP_USDC")(tx);
+  client.deepbook.marginAdmin.enableDeepbookPool("WAL_USDC")(tx);
+  client.deepbook.marginAdmin.enableDeepbookPool("SUI_SUIUSDE")(tx);
+  client.deepbook.marginAdmin.enableDeepbookPool("SUIUSDE_USDC")(tx);
+  client.deepbook.marginAdmin.enableDeepbookPool("XBTC_USDC")(tx);
+
+  // Step 4: Enable each (pair, asset) loan flow for the 6 enabled pairs
+  client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
+    "SUI_USDC",
+    "SUI",
+    tx.object(suiMarginPoolCapID[env]),
+  )(tx);
+  client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
+    "SUI_USDC",
+    "USDC",
+    tx.object(usdcMarginPoolCapID[env]),
+  )(tx);
+  client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
+    "DEEP_USDC",
+    "DEEP",
+    tx.object(deepMarginPoolCapID[env]),
+  )(tx);
+  client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
+    "DEEP_USDC",
+    "USDC",
+    tx.object(usdcMarginPoolCapID[env]),
+  )(tx);
+  client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
+    "WAL_USDC",
+    "WAL",
+    tx.object(walMarginPoolCapID[env]),
+  )(tx);
+  client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
+    "WAL_USDC",
+    "USDC",
+    tx.object(usdcMarginPoolCapID[env]),
+  )(tx);
+  client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
+    "SUI_SUIUSDE",
+    "SUI",
+    tx.object(suiMarginPoolCapID[env]),
+  )(tx);
+  client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
+    "SUI_SUIUSDE",
+    "SUIUSDE",
+    tx.object(suiUsdeMarginPoolCapID[env]),
+  )(tx);
+  client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
+    "SUIUSDE_USDC",
+    "SUIUSDE",
+    tx.object(suiUsdeMarginPoolCapID[env]),
+  )(tx);
+  client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
+    "SUIUSDE_USDC",
+    "USDC",
+    tx.object(usdcMarginPoolCapID[env]),
+  )(tx);
+  client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
+    "XBTC_USDC",
+    "XBTC",
+    tx.object(xbtcMarginPoolCapID[env]),
+  )(tx);
+  client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
+    "XBTC_USDC",
+    "USDC",
+    tx.object(usdcMarginPoolCapID[env]),
+  )(tx);
+
+  // Step 5: Stage loan flow for USDSUI pairs (pairs stay disabled in margin)
+  client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
+    "SUI_USDSUI",
+    "SUI",
+    tx.object(suiMarginPoolCapID[env]),
+  )(tx);
+  client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
+    "SUI_USDSUI",
+    "USDSUI",
+    tx.object(usdSuiMarginPoolCapID[env]),
+  )(tx);
+  client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
+    "USDSUI_USDC",
+    "USDSUI",
+    tx.object(usdSuiMarginPoolCapID[env]),
+  )(tx);
+  client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
+    "USDSUI_USDC",
+    "USDC",
+    tx.object(usdcMarginPoolCapID[env]),
+  )(tx);
+
+  const res = await prepareMultisigTx(tx, env, adminCapOwner[env]);
+
+  console.dir(res, { depth: null });
+})();

--- a/scripts/transactions/marginPrep.ts
+++ b/scripts/transactions/marginPrep.ts
@@ -40,11 +40,12 @@ import { SuiGrpcClient } from "@mysten/sui/grpc";
   client.deepbook.marginAdmin.disableVersion(3)(tx);
   client.deepbook.marginAdmin.disableVersion(4)(tx);
 
-  // 2a. Mint core pause caps (2 to 0x517..., 1 to 0x1b71..., 1 to 0xe958...)
+  // 2a. Mint core pause caps (2 to 0x517..., 1 to 0x1b71..., 1 to 0xe958..., 1 to 0x361b...)
   const corePauseCap1 = client.deepbook.deepBookAdmin.mintCorePauseCap()(tx);
   const corePauseCap2 = client.deepbook.deepBookAdmin.mintCorePauseCap()(tx);
   const corePauseCap3 = client.deepbook.deepBookAdmin.mintCorePauseCap()(tx);
   const corePauseCap4 = client.deepbook.deepBookAdmin.mintCorePauseCap()(tx);
+  const corePauseCap5 = client.deepbook.deepBookAdmin.mintCorePauseCap()(tx);
   tx.transferObjects(
     [corePauseCap1, corePauseCap2],
     "0x517f822cd3c45a3ac3dbfab73c060d9a0d96bec7fffa204c341e7e0877c9787c",
@@ -57,10 +58,15 @@ import { SuiGrpcClient } from "@mysten/sui/grpc";
     [corePauseCap4],
     "0xe9584eb3262c8cee0d0e8ff4fe4f20c5053e4748a23a4c46954d0c21fbbf0aff",
   );
+  tx.transferObjects(
+    [corePauseCap5],
+    "0x361b079475aa70e00ee71022168a7eb0ea4ace066c4c0d7bec4a66d721deec0a",
+  );
 
-  // 2b. Mint margin pause caps (1 each to 0x517... and 0xe958...)
+  // 2b. Mint margin pause caps (1 each to 0x517..., 0xe958..., 0x361b...)
   const marginPauseCap1 = client.deepbook.marginAdmin.mintPauseCap()(tx);
   const marginPauseCap2 = client.deepbook.marginAdmin.mintPauseCap()(tx);
+  const marginPauseCap3 = client.deepbook.marginAdmin.mintPauseCap()(tx);
   tx.transferObjects(
     [marginPauseCap1],
     "0x517f822cd3c45a3ac3dbfab73c060d9a0d96bec7fffa204c341e7e0877c9787c",
@@ -68,6 +74,10 @@ import { SuiGrpcClient } from "@mysten/sui/grpc";
   tx.transferObjects(
     [marginPauseCap2],
     "0xe9584eb3262c8cee0d0e8ff4fe4f20c5053e4748a23a4c46954d0c21fbbf0aff",
+  );
+  tx.transferObjects(
+    [marginPauseCap3],
+    "0x361b079475aa70e00ee71022168a7eb0ea4ace066c4c0d7bec4a66d721deec0a",
   );
 
   // // 3. Mint maintainerCap

--- a/scripts/transactions/marginPrep.ts
+++ b/scripts/transactions/marginPrep.ts
@@ -40,10 +40,11 @@ import { SuiGrpcClient } from "@mysten/sui/grpc";
   client.deepbook.marginAdmin.disableVersion(3)(tx);
   client.deepbook.marginAdmin.disableVersion(4)(tx);
 
-  // 2. Mint core pause caps (2 to 0x517..., 1 to 0x1b71...)
+  // 2a. Mint core pause caps (2 to 0x517..., 1 to 0x1b71..., 1 to 0xe958...)
   const corePauseCap1 = client.deepbook.deepBookAdmin.mintCorePauseCap()(tx);
   const corePauseCap2 = client.deepbook.deepBookAdmin.mintCorePauseCap()(tx);
   const corePauseCap3 = client.deepbook.deepBookAdmin.mintCorePauseCap()(tx);
+  const corePauseCap4 = client.deepbook.deepBookAdmin.mintCorePauseCap()(tx);
   tx.transferObjects(
     [corePauseCap1, corePauseCap2],
     "0x517f822cd3c45a3ac3dbfab73c060d9a0d96bec7fffa204c341e7e0877c9787c",
@@ -52,23 +53,22 @@ import { SuiGrpcClient } from "@mysten/sui/grpc";
     [corePauseCap3],
     "0x1b71380623813c8aee2ab9a68d96c19d0e45fc872e8c22dd70dfedfb76cbb192",
   );
+  tx.transferObjects(
+    [corePauseCap4],
+    "0xe9584eb3262c8cee0d0e8ff4fe4f20c5053e4748a23a4c46954d0c21fbbf0aff",
+  );
 
-  // // (Previously step 2) Margin PauseCap distribution
-  // const pauseCap1 = client.deepbook.marginAdmin.mintPauseCap()(tx);
-  // const pauseCap2 = client.deepbook.marginAdmin.mintPauseCap()(tx);
-  // const pauseCap3 = client.deepbook.marginAdmin.mintPauseCap()(tx);
-  // tx.transferObjects(
-  //   [pauseCap1],
-  //   "0x517f822cd3c45a3ac3dbfab73c060d9a0d96bec7fffa204c341e7e0877c9787c"
-  // );
-  // tx.transferObjects(
-  //   [pauseCap2],
-  //   "0x1b71380623813c8aee2ab9a68d96c19d0e45fc872e8c22dd70dfedfb76cbb192"
-  // );
-  // tx.transferObjects(
-  //   [pauseCap3],
-  //   "0x7da4267928e568da4f64f5a80f5b63680f3c2e008f4f96f475b60ff1c48c0dcf"
-  // );
+  // 2b. Mint margin pause caps (1 each to 0x517... and 0xe958...)
+  const marginPauseCap1 = client.deepbook.marginAdmin.mintPauseCap()(tx);
+  const marginPauseCap2 = client.deepbook.marginAdmin.mintPauseCap()(tx);
+  tx.transferObjects(
+    [marginPauseCap1],
+    "0x517f822cd3c45a3ac3dbfab73c060d9a0d96bec7fffa204c341e7e0877c9787c",
+  );
+  tx.transferObjects(
+    [marginPauseCap2],
+    "0xe9584eb3262c8cee0d0e8ff4fe4f20c5053e4748a23a4c46954d0c21fbbf0aff",
+  );
 
   // // 3. Mint maintainerCap
   // const maintainerCap = client.deepbook.marginAdmin.mintMaintainerCap()(tx);

--- a/scripts/transactions/marginPrep.ts
+++ b/scripts/transactions/marginPrep.ts
@@ -36,10 +36,24 @@ import { SuiGrpcClient } from "@mysten/sui/grpc";
 
   const tx = new Transaction();
 
-  // // 1. Enable Margin package in core deepbook
-  // client.deepbook.deepBookAdmin.authorizeMarginApp()(tx);
+  // 1. Disable margin versions 3 and 4
+  client.deepbook.marginAdmin.disableVersion(3)(tx);
+  client.deepbook.marginAdmin.disableVersion(4)(tx);
 
-  // // 2. PauseCap distribution
+  // 2. Mint core pause caps (2 to 0x517..., 1 to 0x1b71...)
+  const corePauseCap1 = client.deepbook.deepBookAdmin.mintCorePauseCap()(tx);
+  const corePauseCap2 = client.deepbook.deepBookAdmin.mintCorePauseCap()(tx);
+  const corePauseCap3 = client.deepbook.deepBookAdmin.mintCorePauseCap()(tx);
+  tx.transferObjects(
+    [corePauseCap1, corePauseCap2],
+    "0x517f822cd3c45a3ac3dbfab73c060d9a0d96bec7fffa204c341e7e0877c9787c",
+  );
+  tx.transferObjects(
+    [corePauseCap3],
+    "0x1b71380623813c8aee2ab9a68d96c19d0e45fc872e8c22dd70dfedfb76cbb192",
+  );
+
+  // // (Previously step 2) Margin PauseCap distribution
   // const pauseCap1 = client.deepbook.marginAdmin.mintPauseCap()(tx);
   // const pauseCap2 = client.deepbook.marginAdmin.mintPauseCap()(tx);
   // const pauseCap3 = client.deepbook.marginAdmin.mintPauseCap()(tx);
@@ -61,21 +75,21 @@ import { SuiGrpcClient } from "@mysten/sui/grpc";
   // tx.transferObjects([maintainerCap], adminCapOwner[env]);
 
   // // 4. Pyth Config
-  const maxAgeSeconds = 70;
-  const pythConfig = client.deepbook.marginAdmin.newPythConfig(
-    [
-      { coinKey: "SUI", maxConfBps: 300, maxEwmaDifferenceBps: 1500 }, // maxConfBps: 3%, maxEwmaDifferenceBps: 15%
-      { coinKey: "USDC", maxConfBps: 100, maxEwmaDifferenceBps: 500 }, // maxConfBps: 1%, maxEwmaDifferenceBps: 5%
-      { coinKey: "DEEP", maxConfBps: 500, maxEwmaDifferenceBps: 3000 }, // maxConfBps: 5%, maxEwmaDifferenceBps: 30%
-      { coinKey: "WAL", maxConfBps: 500, maxEwmaDifferenceBps: 3000 }, // maxConfBps: 5%, maxEwmaDifferenceBps: 30%
-      { coinKey: "SUIUSDE", maxConfBps: 100, maxEwmaDifferenceBps: 500 }, // maxConfBps: 1%, maxEwmaDifferenceBps: 5%
-      { coinKey: "XBTC", maxConfBps: 200, maxEwmaDifferenceBps: 1000 }, // maxConfBps: 2%, maxEwmaDifferenceBps: 10%
-      { coinKey: "USDSUI", maxConfBps: 100, maxEwmaDifferenceBps: 500 }, // maxConfBps: 1%, maxEwmaDifferenceBps: 5%
-    ],
-    maxAgeSeconds, // maxAgeSeconds: 70 seconds
-  )(tx);
-  client.deepbook.marginAdmin.removeConfig()(tx);
-  client.deepbook.marginAdmin.addConfig(pythConfig)(tx);
+  // const maxAgeSeconds = 70;
+  // const pythConfig = client.deepbook.marginAdmin.newPythConfig(
+  //   [
+  //     { coinKey: "SUI", maxConfBps: 300, maxEwmaDifferenceBps: 1500 }, // maxConfBps: 3%, maxEwmaDifferenceBps: 15%
+  //     { coinKey: "USDC", maxConfBps: 100, maxEwmaDifferenceBps: 500 }, // maxConfBps: 1%, maxEwmaDifferenceBps: 5%
+  //     { coinKey: "DEEP", maxConfBps: 500, maxEwmaDifferenceBps: 3000 }, // maxConfBps: 5%, maxEwmaDifferenceBps: 30%
+  //     { coinKey: "WAL", maxConfBps: 500, maxEwmaDifferenceBps: 3000 }, // maxConfBps: 5%, maxEwmaDifferenceBps: 30%
+  //     { coinKey: "SUIUSDE", maxConfBps: 100, maxEwmaDifferenceBps: 500 }, // maxConfBps: 1%, maxEwmaDifferenceBps: 5%
+  //     { coinKey: "XBTC", maxConfBps: 200, maxEwmaDifferenceBps: 1000 }, // maxConfBps: 2%, maxEwmaDifferenceBps: 10%
+  //     { coinKey: "USDSUI", maxConfBps: 100, maxEwmaDifferenceBps: 500 }, // maxConfBps: 1%, maxEwmaDifferenceBps: 5%
+  //   ],
+  //   maxAgeSeconds, // maxAgeSeconds: 70 seconds
+  // )(tx);
+  // client.deepbook.marginAdmin.removeConfig()(tx);
+  // client.deepbook.marginAdmin.addConfig(pythConfig)(tx);
 
   // // 5. Create margin pools
   // const USDCprotocolConfig = client.deepbook.marginMaintainer.newProtocolConfig(
@@ -229,7 +243,7 @@ import { SuiGrpcClient } from "@mysten/sui/grpc";
   //   XBTCprotocolConfig,
   // )(tx);
 
-  // // 3. Registering and enabling pools
+  // 3. Enabling pools (already registered in prior version, just re-enable)
   // const PoolConfigSUIUSDC = client.deepbook.marginAdmin.newPoolConfig("SUI_USDC", {
   //   minWithdrawRiskRatio: 2,
   //   minBorrowRiskRatio: 1.2499,
@@ -238,9 +252,8 @@ import { SuiGrpcClient } from "@mysten/sui/grpc";
   //   userLiquidationReward: 0.02,
   //   poolLiquidationReward: 0.03,
   // })(tx);
-
   // client.deepbook.marginAdmin.registerDeepbookPool("SUI_USDC", PoolConfigSUIUSDC)(tx);
-  // client.deepbook.marginAdmin.enableDeepbookPool("SUI_USDC")(tx);
+  client.deepbook.marginAdmin.enableDeepbookPool("SUI_USDC")(tx);
 
   // const PoolConfigDEEPUSDC = client.deepbook.marginAdmin.newPoolConfig(
   //   "DEEP_USDC",
@@ -257,7 +270,7 @@ import { SuiGrpcClient } from "@mysten/sui/grpc";
   //   "DEEP_USDC",
   //   PoolConfigDEEPUSDC,
   // )(tx);
-  // client.deepbook.marginAdmin.enableDeepbookPool("DEEP_USDC")(tx);
+  client.deepbook.marginAdmin.enableDeepbookPool("DEEP_USDC")(tx);
 
   // const poolConfigWalUsdc = client.deepbook.marginAdmin.newPoolConfig(
   //   "WAL_USDC",
@@ -274,7 +287,7 @@ import { SuiGrpcClient } from "@mysten/sui/grpc";
   //   "WAL_USDC",
   //   poolConfigWalUsdc,
   // )(tx);
-  // client.deepbook.marginAdmin.enableDeepbookPool("WAL_USDC")(tx);
+  client.deepbook.marginAdmin.enableDeepbookPool("WAL_USDC")(tx);
 
   // const poolConfigSuiSuiusde = client.deepbook.marginAdmin.newPoolConfig(
   //   "SUI_SUIUSDE",
@@ -291,7 +304,7 @@ import { SuiGrpcClient } from "@mysten/sui/grpc";
   //   "SUI_SUIUSDE",
   //   poolConfigSuiSuiusde,
   // )(tx);
-  // client.deepbook.marginAdmin.enableDeepbookPool("SUI_SUIUSDE")(tx);
+  client.deepbook.marginAdmin.enableDeepbookPool("SUI_SUIUSDE")(tx);
 
   // const poolConfigSuiusdeUsdc = client.deepbook.marginAdmin.newPoolConfig(
   //   "SUIUSDE_USDC",
@@ -308,101 +321,101 @@ import { SuiGrpcClient } from "@mysten/sui/grpc";
   //   "SUIUSDE_USDC",
   //   poolConfigSuiusdeUsdc,
   // )(tx);
-  // client.deepbook.marginAdmin.enableDeepbookPool("SUIUSDE_USDC")(tx);
+  client.deepbook.marginAdmin.enableDeepbookPool("SUIUSDE_USDC")(tx);
 
   // Register and enable SUI_USDSUI pool
-  const poolConfigSuiUsdsui = client.deepbook.marginAdmin.newPoolConfig(
-    "SUI_USDSUI",
-    {
-      minWithdrawRiskRatio: 2,
-      minBorrowRiskRatio: 1.2499,
-      liquidationRiskRatio: 1.1,
-      targetLiquidationRiskRatio: 1.25,
-      userLiquidationReward: 0.02,
-      poolLiquidationReward: 0.03,
-    },
+  // const poolConfigSuiUsdsui = client.deepbook.marginAdmin.newPoolConfig(
+  //   "SUI_USDSUI",
+  //   {
+  //     minWithdrawRiskRatio: 2,
+  //     minBorrowRiskRatio: 1.2499,
+  //     liquidationRiskRatio: 1.1,
+  //     targetLiquidationRiskRatio: 1.25,
+  //     userLiquidationReward: 0.02,
+  //     poolLiquidationReward: 0.03,
+  //   },
+  // )(tx);
+  // client.deepbook.marginAdmin.registerDeepbookPool(
+  //   "SUI_USDSUI",
+  //   poolConfigSuiUsdsui,
+  // )(tx);
+  // client.deepbook.marginAdmin.enableDeepbookPool("SUI_USDSUI")(tx);
+
+  // // Register and enable USDSUI_USDC pool
+  // const poolConfigUsdsuiUsdc = client.deepbook.marginAdmin.newPoolConfig(
+  //   "USDSUI_USDC",
+  //   {
+  //     minWithdrawRiskRatio: 2,
+  //     minBorrowRiskRatio: 1.2499,
+  //     liquidationRiskRatio: 1.1,
+  //     targetLiquidationRiskRatio: 1.25,
+  //     userLiquidationReward: 0.02,
+  //     poolLiquidationReward: 0.03,
+  //   },
+  // )(tx);
+  // client.deepbook.marginAdmin.registerDeepbookPool(
+  //   "USDSUI_USDC",
+  //   poolConfigUsdsuiUsdc,
+  // )(tx);
+  // client.deepbook.marginAdmin.enableDeepbookPool("USDSUI_USDC")(tx);
+
+  // 4. Enable deepbook pool for loan
+  client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
+    "SUI_USDC",
+    "USDC",
+    tx.object(usdcMarginPoolCapID[env]),
   )(tx);
-  client.deepbook.marginAdmin.registerDeepbookPool(
-    "SUI_USDSUI",
-    poolConfigSuiUsdsui,
+  client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
+    "DEEP_USDC",
+    "USDC",
+    tx.object(usdcMarginPoolCapID[env]),
   )(tx);
-  client.deepbook.marginAdmin.enableDeepbookPool("SUI_USDSUI")(tx);
-
-  // Register and enable USDSUI_USDC pool
-  const poolConfigUsdsuiUsdc = client.deepbook.marginAdmin.newPoolConfig(
-    "USDSUI_USDC",
-    {
-      minWithdrawRiskRatio: 2,
-      minBorrowRiskRatio: 1.2499,
-      liquidationRiskRatio: 1.1,
-      targetLiquidationRiskRatio: 1.25,
-      userLiquidationReward: 0.02,
-      poolLiquidationReward: 0.03,
-    },
+  client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
+    "WAL_USDC",
+    "USDC",
+    tx.object(usdcMarginPoolCapID[env]),
   )(tx);
-  client.deepbook.marginAdmin.registerDeepbookPool(
-    "USDSUI_USDC",
-    poolConfigUsdsuiUsdc,
+  client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
+    "DEEP_USDC",
+    "DEEP",
+    tx.object(deepMarginPoolCapID[env]),
   )(tx);
-  client.deepbook.marginAdmin.enableDeepbookPool("USDSUI_USDC")(tx);
+  client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
+    "SUI_USDC",
+    "SUI",
+    tx.object(suiMarginPoolCapID[env]),
+  )(tx);
+  client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
+    "WAL_USDC",
+    "WAL",
+    tx.object(walMarginPoolCapID[env]),
+  )(tx);
 
-  // // 4. Enable deepbook pool for loan
-  // client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
-  //   "SUI_USDC",
-  //   "USDC",
-  //   tx.object(usdcMarginPoolCapID[env])
-  // )(tx);
-  // client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
-  //   "DEEP_USDC",
-  //   "USDC",
-  //   tx.object(usdcMarginPoolCapID[env])
-  // )(tx);
-  // client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
-  //   "WAL_USDC",
-  //   "USDC",
-  //   tx.object(usdcMarginPoolCapID[env])
-  // )(tx);
-  // client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
-  //   "DEEP_USDC",
-  //   "DEEP",
-  //   tx.object(deepMarginPoolCapID[env])
-  // )(tx);
-  // client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
-  //   "SUI_USDC",
-  //   "SUI",
-  //   tx.object(suiMarginPoolCapID[env])
-  // )(tx);
-  // client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
-  //   "WAL_USDC",
-  //   "WAL",
-  //   tx.object(walMarginPoolCapID[env])
-  // )(tx);
+  // Enable SUIUSDE_USDC for loan from SUIUSDE and USDC pools
+  client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
+    "SUIUSDE_USDC",
+    "SUIUSDE",
+    tx.object(suiUsdeMarginPoolCapID[env]),
+  )(tx);
+  client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
+    "SUIUSDE_USDC",
+    "USDC",
+    tx.object(usdcMarginPoolCapID[env]),
+  )(tx);
 
-  // // Enable SUIUSDE_USDC for loan from SUIUSDE and USDC pools
-  // client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
-  //   "SUIUSDE_USDC",
-  //   "SUIUSDE",
-  //   tx.object(suiUsdeMarginPoolCapID[env]),
-  // )(tx);
-  // client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
-  //   "SUIUSDE_USDC",
-  //   "USDC",
-  //   tx.object(usdcMarginPoolCapID[env]),
-  // )(tx);
+  // Enable SUI_SUIUSDE for loan from SUI and SUIUSDE pools
+  client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
+    "SUI_SUIUSDE",
+    "SUI",
+    tx.object(suiMarginPoolCapID[env]),
+  )(tx);
+  client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
+    "SUI_SUIUSDE",
+    "SUIUSDE",
+    tx.object(suiUsdeMarginPoolCapID[env]),
+  )(tx);
 
-  // // Enable SUI_SUIUSDE for loan from SUI and SUIUSDE pools
-  // client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
-  //   "SUI_SUIUSDE",
-  //   "SUI",
-  //   tx.object(suiMarginPoolCapID[env]),
-  // )(tx);
-  // client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
-  //   "SUI_SUIUSDE",
-  //   "SUIUSDE",
-  //   tx.object(suiUsdeMarginPoolCapID[env]),
-  // )(tx);
-
-  // Register and enable XBTC_USDC pool
+  // Enable XBTC_USDC pool (already registered in prior version)
   // const poolConfigXbtcUsdc = client.deepbook.marginAdmin.newPoolConfig(
   //   "XBTC_USDC",
   //   {
@@ -418,19 +431,19 @@ import { SuiGrpcClient } from "@mysten/sui/grpc";
   //   "XBTC_USDC",
   //   poolConfigXbtcUsdc,
   // )(tx);
-  // client.deepbook.marginAdmin.enableDeepbookPool("XBTC_USDC")(tx);
+  client.deepbook.marginAdmin.enableDeepbookPool("XBTC_USDC")(tx);
 
   // Enable XBTC_USDC for loan from USDC and XBTC pools
-  // client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
-  //   "XBTC_USDC",
-  //   "USDC",
-  //   tx.object(usdcMarginPoolCapID[env]),
-  // )(tx);
-  // client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
-  //   "XBTC_USDC",
-  //   "XBTC",
-  //   tx.object(xbtcMarginPoolCapID[env]),
-  // )(tx);
+  client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
+    "XBTC_USDC",
+    "USDC",
+    tx.object(usdcMarginPoolCapID[env]),
+  )(tx);
+  client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(
+    "XBTC_USDC",
+    "XBTC",
+    tx.object(xbtcMarginPoolCapID[env]),
+  )(tx);
 
   // Enable SUI_USDSUI for loan from SUI and USDSUI pools
   client.deepbook.marginMaintainer.enableDeepbookPoolForLoan(


### PR DESCRIPTION
## Summary
- Replace step 1 of `marginPrep.ts` with `marginAdmin.disableVersion(3)` + `disableVersion(4)` to retire old margin packages now that v5 is live (commit 5be65282).
- Mint 3 `DeepbookCorePauseCap`s via `deepBookAdmin.mintCorePauseCap`: 2 transferred to `0x517f...9787c`, 1 to `0x1b71...bb192`.
- Re-enable 6 previously-registered margin pools (SUI_USDC, DEEP_USDC, WAL_USDC, SUI_SUIUSDE, SUIUSDE_USDC, XBTC_USDC) and enable their loan flows on the relevant margin pools.
- Stage `enableDeepbookPoolForLoan` for `SUI_USDSUI` and `USDSUI_USDC` while keeping USDSUI pairs themselves disabled in margin trading.
- Add `scripts/transactions/enableMarginTrading.ts` — a clean, no-dead-code companion script that captures the same transaction in 5 numbered steps.

## Key decisions
- `pool_registry` in `MarginRegistry` is a `Table<ID, PoolConfig>` that persists across `disable_version` (see `packages/deepbook_margin/sources/margin_registry.move:62,392`). All 6 pools above are already registered and disabled, so the script intentionally does NOT call `registerDeepbookPool` — doing so would abort with `EPoolAlreadyRegistered` (code 2).
- USDSUI pool register/enable stays commented in `marginPrep.ts`; only the loan-enable calls are staged so the maintainer cap surface is ready when those pairs flip on later.
- `enableMarginTrading.ts` mirrors the same call set as the cleaned-up `marginPrep.ts` but strips all commented-out historical blocks for readability/review.

## Test plan
- [ ] Dry-run multisig build: `cd scripts && GAS_OBJECT=0x... pnpm tsx transactions/enableMarginTrading.ts`. Confirm `console.dir` shows:
  - 2 `disableVersion` calls
  - 3 `mintCorePauseCap` + 2 `transferObjects`
  - 6 `enableDeepbookPool` (no `registerDeepbookPool`)
  - 16 `enableDeepbookPoolForLoan` (12 for the 6 active pairs, 4 for USDSUI)
- [ ] Same dry-run for `marginPrep.ts` produces an identical effects summary
- [ ] After multisig execution, on-chain check: `MarginRegistry.allowed_versions` no longer contains 3, 4
- [ ] After execution: 3 new `DeepbookCorePauseCap` objects owned by the two ops addresses
- [ ] After execution: `enableDeepbookPool` succeeds for all 6 pairs (none aborts `EPoolAlreadyEnabled`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)