### PR TITLE
predict: versioned pause, PauseCap, per-pool mint pause

### DIFF
--- a/packages/predict/Move.lock
+++ b/packages/predict/Move.lock
@@ -5,13 +5,13 @@
 version = 4
 
 [pinned.mainnet.MoveStdlib]
-source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "85400e2bd37b490fcd057776e700d3fdca643396" }
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "73dd2c2ba6f9fdb21d7ffde2b50a3f2f0ac39bc1" }
 use_environment = "mainnet"
 manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
 deps = {}
 
 [pinned.mainnet.Sui]
-source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "85400e2bd37b490fcd057776e700d3fdca643396" }
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "73dd2c2ba6f9fdb21d7ffde2b50a3f2f0ac39bc1" }
 use_environment = "mainnet"
 manifest_digest = "CD547CB1ACCE0880C835DAED2D8FFCB91D56C833AE5240D3AA5B918398263195"
 deps = { MoveStdlib = "MoveStdlib" }
@@ -25,8 +25,14 @@ deps = { std = "MoveStdlib", sui = "Sui", token = "token" }
 [pinned.mainnet.deepbook_predict]
 source = { root = true }
 use_environment = "mainnet"
-manifest_digest = "99B2580DEBFC58B73A6BF596E2B61373438472CB44C424D2B6899B4D97E6AD12"
-deps = { deepbook = "deepbook", pyth_lazer = "pyth_lazer", std = "MoveStdlib", sui = "Sui" }
+manifest_digest = "DA838F8095021ACE1EE2A132C2E5FF17D794265A046AA9C85198B367298BBB4F"
+deps = { deepbook = "deepbook", dusdc = "dusdc", pyth_lazer = "pyth_lazer", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.mainnet.dusdc]
+source = { local = "../dusdc" }
+use_environment = "mainnet"
+manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
+deps = { std = "MoveStdlib", sui = "Sui" }
 
 [pinned.mainnet.pyth_lazer]
 source = { git = "https://github.com/pyth-network/pyth-crosschain.git", subdir = "lazer/contracts/sui", rev = "f80ff8b1aa2aa9ca17530a9b6294d254f938a5bf" }
@@ -35,7 +41,7 @@ manifest_digest = "6DC4B589535C23A9330A984EA7BC41000D18E222DF48EC556493CD219989C
 deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
 
 [pinned.mainnet.token]
-source = { git = "https://github.com/MystenLabs/deepbookv3.git", subdir = "packages/token", rev = "19f86ebad9c6371c4f5c07229faabb2020dc691c" }
+source = { git = "https://github.com/MystenLabs/deepbookv3.git", subdir = "packages/token", rev = "aacc105fab902376d86283158656debfdc60b387" }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }

--- a/packages/predict/simulations/src/runtime.ts
+++ b/packages/predict/simulations/src/runtime.ts
@@ -125,12 +125,7 @@ export function createPythSourceTx(feedId: number): Transaction {
   const tx = new Transaction();
   tx.moveCall({
     target: target("registry", "create_pyth_source"),
-    arguments: [
-      tx.object(REGISTRY_ID),
-      tx.object(PROTOCOL_CONFIG_ID),
-      tx.object(ADMIN_CAP_ID),
-      tx.pure.u32(feedId),
-    ],
+    arguments: [tx.object(REGISTRY_ID), tx.object(ADMIN_CAP_ID), tx.pure.u32(feedId)],
   });
   return tx;
 }

--- a/packages/predict/simulations/src/runtime.ts
+++ b/packages/predict/simulations/src/runtime.ts
@@ -125,7 +125,12 @@ export function createPythSourceTx(feedId: number): Transaction {
   const tx = new Transaction();
   tx.moveCall({
     target: target("registry", "create_pyth_source"),
-    arguments: [tx.object(REGISTRY_ID), tx.object(ADMIN_CAP_ID), tx.pure.u32(feedId)],
+    arguments: [
+      tx.object(REGISTRY_ID),
+      tx.object(PROTOCOL_CONFIG_ID),
+      tx.object(ADMIN_CAP_ID),
+      tx.pure.u32(feedId),
+    ],
   });
   return tx;
 }

--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -21,7 +21,7 @@ use deepbook_predict::{
     strike_exposure::{Self, StrikeExposure}
 };
 use dusdc::dusdc::DUSDC;
-use sui::{balance::{Self, Balance}, clock::Clock, event, vec_set::{Self, VecSet}};
+use sui::{balance::{Self, Balance}, clock::Clock, event, vec_set::VecSet};
 
 const EWrongMarketOracle: u64 = 0;
 const EWrongPythSource: u64 = 1;
@@ -186,14 +186,10 @@ public fun allowed_versions(market: &ExpiryMarket): VecSet<u64> {
     market.allowed_versions
 }
 
-/// Permissionlessly refresh this market's mirrored `allowed_versions` from
-/// the live protocol config. Anyone can call to propagate an admin/PauseCap
-/// version change to a lagging market.
-public fun update_allowed_versions_permissionless(
-    market: &mut ExpiryMarket,
-    config: &ProtocolConfig,
-) {
-    market.allowed_versions = config.allowed_versions();
+/// Refresh this market's mirrored `allowed_versions`. Permissionless: callers
+/// pass `registry.allowed_versions()` as the source of truth.
+public fun update_allowed_versions(market: &mut ExpiryMarket, allowed_versions: VecSet<u64>) {
+    market.allowed_versions = allowed_versions;
 }
 
 /// Construct a range key for this expiry market.
@@ -304,6 +300,7 @@ public(package) fun create_and_share(
     expiry: u64,
     min_strike: u64,
     tick_size: u64,
+    allowed_versions: VecSet<u64>,
     ctx: &mut TxContext,
 ): ID {
     assert_valid_strike_grid(min_strike, tick_size);
@@ -320,7 +317,7 @@ public(package) fun create_and_share(
         fee_balance: balance::zero(),
         strike_exposure: option::some(strike_exposure::new(ctx, tick_size, min_strike, max_strike)),
         compacted_state: option::none(),
-        allowed_versions: vec_set::singleton(constants::current_version!()),
+        allowed_versions,
         mint_paused: false,
     };
     let id = market.id();
@@ -390,12 +387,6 @@ public(package) fun set_mint_paused(market: &mut ExpiryMarket, paused: bool) {
 /// Force `mint_paused = true` (used by PauseCap path on registry; one-way).
 public(package) fun pause_mint(market: &mut ExpiryMarket) {
     market.mint_paused = true;
-}
-
-/// Authoritative sync of mirrored `allowed_versions` from protocol config.
-/// Used by both the admin and pause cap paths through registry.
-public(package) fun update_allowed_versions(market: &mut ExpiryMarket, config: &ProtocolConfig) {
-    market.allowed_versions = config.allowed_versions();
 }
 
 /// Compact settled expiry state and return surplus cash to the pool.

--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -21,7 +21,7 @@ use deepbook_predict::{
     strike_exposure::{Self, StrikeExposure}
 };
 use dusdc::dusdc::DUSDC;
-use sui::{balance::{Self, Balance}, clock::Clock, event};
+use sui::{balance::{Self, Balance}, clock::Clock, event, vec_set::{Self, VecSet}};
 
 const EWrongMarketOracle: u64 = 0;
 const EWrongPythSource: u64 = 1;
@@ -39,6 +39,8 @@ const ESettledLiabilityUnderflow: u64 = 16;
 const ECompactedLiabilityMismatch: u64 = 17;
 const EInsufficientFeeBalance: u64 = 18;
 const ECompactedRebateLiabilityUnderflow: u64 = 19;
+const EPackageVersionDisabled: u64 = 20;
+const EMintPaused: u64 = 21;
 
 /// Per-expiry market state.
 public struct ExpiryMarket has key {
@@ -58,6 +60,10 @@ public struct ExpiryMarket has key {
     strike_exposure: Option<StrikeExposure>,
     /// Post-compaction settlement facts and remaining escrow liabilities.
     compacted_state: Option<CompactedState>,
+    /// Mirror of `ProtocolConfig.allowed_versions`; synced permissionlessly.
+    allowed_versions: VecSet<u64>,
+    /// When true, `mint` aborts. Other flows (redeem, settle, compact) unaffected.
+    mint_paused: bool,
 }
 
 /// Settlement facts retained after strike exposure state is compacted.
@@ -170,6 +176,26 @@ public fun is_compacted(market: &ExpiryMarket): bool {
     market.compacted_state.is_some()
 }
 
+/// Return whether minting is currently paused on this expiry market.
+public fun mint_paused(market: &ExpiryMarket): bool {
+    market.mint_paused
+}
+
+/// Return this market's mirrored set of allowed package versions.
+public fun allowed_versions(market: &ExpiryMarket): VecSet<u64> {
+    market.allowed_versions
+}
+
+/// Permissionlessly refresh this market's mirrored `allowed_versions` from
+/// the live protocol config. Anyone can call to propagate an admin/PauseCap
+/// version change to a lagging market.
+public fun update_allowed_versions_permissionless(
+    market: &mut ExpiryMarket,
+    config: &ProtocolConfig,
+) {
+    market.allowed_versions = config.allowed_versions();
+}
+
 /// Construct a range key for this expiry market.
 public fun range_key(market: &ExpiryMarket, lower_strike: u64, higher_strike: u64): RangeKey {
     range_key::new(market.market_oracle_id, lower_strike, higher_strike)
@@ -206,8 +232,9 @@ public fun read_valuation(
 
 /// Mint a live position interval against this expiry market.
 ///
-/// Requires trading to be allowed, manager ownership, a live fresh oracle, and
-/// enough expiry allocation to back the post-mint max payout.
+/// Requires the package version to be allowed for this market, per-market mint
+/// pause to be off, trading globally enabled, manager ownership, a live fresh
+/// oracle, and enough expiry allocation to back the post-mint max payout.
 public fun mint(
     market: &mut ExpiryMarket,
     config: &ProtocolConfig,
@@ -219,6 +246,8 @@ public fun mint(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
+    market.assert_version_allowed();
+    market.assert_mint_not_paused();
     config.assert_trading_allowed();
     market.mint_internal(config, manager, market_oracle, pyth, key, quantity, clock, ctx);
 }
@@ -238,6 +267,7 @@ public fun redeem(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
+    market.assert_version_allowed();
     config.assert_not_valuation_in_progress();
     if (market.is_compacted()) {
         market.redeem_compacted_internal(manager, key, quantity, ctx);
@@ -290,6 +320,8 @@ public(package) fun create_and_share(
         fee_balance: balance::zero(),
         strike_exposure: option::some(strike_exposure::new(ctx, tick_size, min_strike, max_strike)),
         compacted_state: option::none(),
+        allowed_versions: vec_set::singleton(constants::current_version!()),
+        mint_paused: false,
     };
     let id = market.id();
     transfer::share_object(market);
@@ -298,6 +330,7 @@ public(package) fun create_and_share(
 
 /// Add pool-provided DUSDC to this live expiry's allocation and LP cash.
 public(package) fun receive_allocation(market: &mut ExpiryMarket, allocation: Balance<DUSDC>) {
+    market.assert_version_allowed();
     market.assert_not_compacted();
     let amount = allocation.value();
     market.allocated_capital = market.allocated_capital + amount;
@@ -309,6 +342,7 @@ public(package) fun receive_allocation(market: &mut ExpiryMarket, allocation: Ba
 /// Aborts if the requested amount would reduce allocation or cash below the
 /// expiry's current worst-case payout backing.
 public(package) fun return_allocation(market: &mut ExpiryMarket, amount: u64): Balance<DUSDC> {
+    market.assert_version_allowed();
     assert!(amount <= market.returnable_capital(), EAllocationBelowMaxPayout);
 
     market.allocated_capital = market.allocated_capital - amount;
@@ -340,6 +374,30 @@ public(package) fun assert_market_oracle(market: &ExpiryMarket, market_oracle: &
     assert!(market.market_oracle_id == market_oracle.id(), EWrongMarketOracle);
 }
 
+/// Abort if the running package version is not allowed for this market.
+public(package) fun assert_version_allowed(market: &ExpiryMarket) {
+    assert!(
+        market.allowed_versions.contains(&constants::current_version!()),
+        EPackageVersionDisabled,
+    );
+}
+
+/// Set per-market mint pause (used by AdminCap admin path on registry).
+public(package) fun set_mint_paused(market: &mut ExpiryMarket, paused: bool) {
+    market.mint_paused = paused;
+}
+
+/// Force `mint_paused = true` (used by PauseCap path on registry; one-way).
+public(package) fun pause_mint(market: &mut ExpiryMarket) {
+    market.mint_paused = true;
+}
+
+/// Authoritative sync of mirrored `allowed_versions` from protocol config.
+/// Used by both the admin and pause cap paths through registry.
+public(package) fun update_allowed_versions(market: &mut ExpiryMarket, config: &ProtocolConfig) {
+    market.allowed_versions = config.allowed_versions();
+}
+
 /// Compact settled expiry state and return surplus cash to the pool.
 ///
 /// Consumes strike exposure state, leaves only settled liability backing in the
@@ -349,6 +407,7 @@ public(package) fun compact_settled(
     market: &mut ExpiryMarket,
     market_oracle: &MarketOracle,
 ): (Balance<DUSDC>, Balance<DUSDC>) {
+    market.assert_version_allowed();
     market.assert_market_oracle(market_oracle);
     market.assert_not_compacted();
 
@@ -706,6 +765,10 @@ fun assert_cash_backing(market: &ExpiryMarket) {
 
 fun assert_not_compacted(market: &ExpiryMarket) {
     assert!(!market.is_compacted(), EMarketCompacted);
+}
+
+fun assert_mint_not_paused(market: &ExpiryMarket) {
+    assert!(!market.mint_paused, EMintPaused);
 }
 
 fun rebate_liability(market: &ExpiryMarket, losing_fee_basis: u64): u64 {

--- a/packages/predict/sources/helper/constants.move
+++ b/packages/predict/sources/helper/constants.move
@@ -10,6 +10,12 @@
 /// - Use deepbook::math for all mul/div operations
 module deepbook_predict::constants;
 
+// === Package Versioning ===
+
+/// Current package version. Bumped on each upgrade and added to the protocol
+/// `allowed_versions` set by admin so version-gated entry points keep working.
+public macro fun current_version(): u64 { 1 }
+
 // === Scaling ===
 
 /// Fixed-point scaling factor (1e9) for math operations and prices.

--- a/packages/predict/sources/oracle/market_oracle.move
+++ b/packages/predict/sources/oracle/market_oracle.move
@@ -151,13 +151,10 @@ public fun allowed_versions(market: &MarketOracle): VecSet<u64> {
     market.allowed_versions
 }
 
-/// Permissionlessly refresh this oracle's mirrored `allowed_versions` from
-/// the live protocol config.
-public fun update_allowed_versions_permissionless(
-    market: &mut MarketOracle,
-    config: &ProtocolConfig,
-) {
-    market.allowed_versions = config.allowed_versions();
+/// Refresh this oracle's mirrored `allowed_versions`. Permissionless: callers
+/// pass `registry.allowed_versions()` as the source of truth.
+public fun update_allowed_versions(market: &mut MarketOracle, allowed_versions: VecSet<u64>) {
+    market.allowed_versions = allowed_versions;
 }
 
 /// Return the MarketOracleCap object ID.
@@ -465,6 +462,7 @@ public(package) fun create_and_share(
     config: &MarketOracleConfig,
     cap: &MarketOracleCap,
     expiry: u64,
+    allowed_versions: VecSet<u64>,
     ctx: &mut TxContext,
 ): ID {
     let cap_id = cap.cap_id();
@@ -473,7 +471,7 @@ public(package) fun create_and_share(
     let market = MarketOracle {
         id: object::new(ctx),
         authorized_cap_ids,
-        allowed_versions: vec_set::singleton(constants::current_version!()),
+        allowed_versions,
         pyth_source_id: pyth.id(),
         expiry,
         block_scholes_spot: 0,
@@ -531,11 +529,6 @@ public(package) fun assert_version_allowed(market: &MarketOracle) {
         market.allowed_versions.contains(&constants::current_version!()),
         EPackageVersionDisabled,
     );
-}
-
-/// Authoritative sync of mirrored `allowed_versions` from protocol config.
-public(package) fun update_allowed_versions(market: &mut MarketOracle, config: &ProtocolConfig) {
-    market.allowed_versions = config.allowed_versions();
 }
 
 /// Abort unless this oracle is bound to the supplied Pyth source.

--- a/packages/predict/sources/oracle/market_oracle.move
+++ b/packages/predict/sources/oracle/market_oracle.move
@@ -12,6 +12,7 @@ module deepbook_predict::market_oracle;
 use deepbook::math;
 use deepbook_predict::{
     config_constants,
+    constants,
     i64,
     market_oracle_config::MarketOracleConfig,
     protocol_config::ProtocolConfig,
@@ -36,6 +37,7 @@ const EFutureSVISourceUpdate: u64 = 13;
 const EPendingSettlement: u64 = 14;
 const EMarketNotSettled: u64 = 15;
 const EInvalidSettlementTimestamp: u64 = 16;
+const EPackageVersionDisabled: u64 = 17;
 
 const STATUS_ACTIVE: u8 = 1;
 const STATUS_PENDING_SETTLEMENT: u8 = 2;
@@ -58,6 +60,8 @@ public struct MarketOracle has key {
     id: UID,
     /// MarketOracleCap IDs authorized to write Block Scholes data.
     authorized_cap_ids: VecSet<ID>,
+    /// Mirror of `ProtocolConfig.allowed_versions`; synced permissionlessly.
+    allowed_versions: VecSet<u64>,
     pyth_source_id: ID,
     expiry: u64,
     block_scholes_spot: u64,
@@ -140,6 +144,20 @@ public fun new_svi_params(a: u64, b: u64, rho: i64::I64, m: i64::I64, sigma: u64
 /// Return the market oracle object ID.
 public fun id(market: &MarketOracle): ID {
     market.id.to_inner()
+}
+
+/// Return this oracle's mirrored set of allowed package versions.
+public fun allowed_versions(market: &MarketOracle): VecSet<u64> {
+    market.allowed_versions
+}
+
+/// Permissionlessly refresh this oracle's mirrored `allowed_versions` from
+/// the live protocol config.
+public fun update_allowed_versions_permissionless(
+    market: &mut MarketOracle,
+    config: &ProtocolConfig,
+) {
+    market.allowed_versions = config.allowed_versions();
 }
 
 /// Return the MarketOracleCap object ID.
@@ -282,6 +300,7 @@ public fun update_block_scholes_prices(
     block_scholes_source_timestamp_ms: u64,
     clock: &Clock,
 ) {
+    market.assert_version_allowed();
     market.assert_authorized_cap(cap);
     config.assert_not_valuation_in_progress();
     market.assert_pyth_source(pyth);
@@ -318,6 +337,7 @@ public fun settle_if_possible(
     cap: &MarketOracleCap,
     clock: &Clock,
 ): bool {
+    market.assert_version_allowed();
     market.assert_authorized_cap(cap);
     config.assert_not_valuation_in_progress();
     if (market.status(clock) != STATUS_PENDING_SETTLEMENT) return false;
@@ -336,6 +356,7 @@ public fun update_svi(
     source_timestamp_ms: u64,
     clock: &Clock,
 ) {
+    market.assert_version_allowed();
     market.assert_authorized_cap(cap);
     config.assert_not_valuation_in_progress();
     market.assert_active(clock);
@@ -370,6 +391,7 @@ public fun set_settlement_freshness_ms(
     cap: &MarketOracleCap,
     value: u64,
 ) {
+    market.assert_version_allowed();
     market.assert_authorized_cap(cap);
     config.assert_not_valuation_in_progress();
     config_constants::assert_settlement_freshness_ms(value);
@@ -389,6 +411,7 @@ public fun set_basis_bounds(
     min_basis: u64,
     max_basis: u64,
 ) {
+    market.assert_version_allowed();
     market.assert_authorized_cap(cap);
     config.assert_not_valuation_in_progress();
     validate_basis_bounds_inputs(max_spot_deviation, max_basis_deviation, min_basis, max_basis);
@@ -450,6 +473,7 @@ public(package) fun create_and_share(
     let market = MarketOracle {
         id: object::new(ctx),
         authorized_cap_ids,
+        allowed_versions: vec_set::singleton(constants::current_version!()),
         pyth_source_id: pyth.id(),
         expiry,
         block_scholes_spot: 0,
@@ -483,6 +507,7 @@ public(package) fun create_and_share(
 
 /// Authorize an additional cap to write this market oracle.
 public(package) fun register_cap(market: &mut MarketOracle, cap: &MarketOracleCap) {
+    market.assert_version_allowed();
     let cap_id = cap.cap_id();
     assert!(!market.authorized_cap_ids.contains(&cap_id), EInvalidMarketOracleCap);
     market.authorized_cap_ids.insert(cap_id);
@@ -490,6 +515,7 @@ public(package) fun register_cap(market: &mut MarketOracle, cap: &MarketOracleCa
 
 /// Remove a cap from this market oracle's writer set.
 public(package) fun unregister_cap(market: &mut MarketOracle, cap_id: ID) {
+    market.assert_version_allowed();
     assert!(market.authorized_cap_ids.contains(&cap_id), EInvalidMarketOracleCap);
     market.authorized_cap_ids.remove(&cap_id);
 }
@@ -497,6 +523,19 @@ public(package) fun unregister_cap(market: &mut MarketOracle, cap_id: ID) {
 /// Let a cap holder remove its own cap from this market oracle.
 public(package) fun self_unregister_cap(market: &mut MarketOracle, cap: &MarketOracleCap) {
     market.unregister_cap(cap.cap_id());
+}
+
+/// Abort if the running package version is not allowed for this oracle.
+public(package) fun assert_version_allowed(market: &MarketOracle) {
+    assert!(
+        market.allowed_versions.contains(&constants::current_version!()),
+        EPackageVersionDisabled,
+    );
+}
+
+/// Authoritative sync of mirrored `allowed_versions` from protocol config.
+public(package) fun update_allowed_versions(market: &mut MarketOracle, config: &ProtocolConfig) {
+    market.allowed_versions = config.allowed_versions();
 }
 
 /// Abort unless this oracle is bound to the supplied Pyth source.
@@ -723,6 +762,7 @@ public(package) fun create_test_market_oracle(
     MarketOracle {
         id: object::new(ctx),
         authorized_cap_ids,
+        allowed_versions: vec_set::singleton(constants::current_version!()),
         pyth_source_id,
         expiry,
         block_scholes_spot: 0,
@@ -755,6 +795,7 @@ public(package) fun destroy_for_testing(market: MarketOracle) {
     let MarketOracle {
         id,
         authorized_cap_ids: _,
+        allowed_versions: _,
         pyth_source_id: _,
         expiry: _,
         block_scholes_spot: _,

--- a/packages/predict/sources/oracle/pyth_source.move
+++ b/packages/predict/sources/oracle/pyth_source.move
@@ -10,7 +10,7 @@ module deepbook_predict::pyth_source;
 
 use deepbook_predict::{constants, lazer_helper, protocol_config::ProtocolConfig};
 use pyth_lazer::update::Update as LazerUpdate;
-use sui::{clock::Clock, event, vec_set::{Self, VecSet}};
+use sui::{clock::Clock, event, vec_set::VecSet};
 
 const EStaleSourceUpdate: u64 = 0;
 const EZeroSpot: u64 = 1;
@@ -101,12 +101,10 @@ public fun allowed_versions(source: &PythSource): VecSet<u64> {
     source.allowed_versions
 }
 
-/// Permissionlessly refresh this source's mirrored `allowed_versions`.
-public fun update_allowed_versions_permissionless(
-    source: &mut PythSource,
-    config: &ProtocolConfig,
-) {
-    source.allowed_versions = config.allowed_versions();
+/// Refresh this source's mirrored `allowed_versions`. Permissionless: callers
+/// pass `registry.allowed_versions()` as the source of truth.
+public fun update_allowed_versions(source: &mut PythSource, allowed_versions: VecSet<u64>) {
+    source.allowed_versions = allowed_versions;
 }
 
 // === Public-Package Functions ===
@@ -117,14 +115,18 @@ public(package) fun freshness_timestamp_ms(source: &PythSource): u64 {
 }
 
 /// Create and share a Pyth source bound to a Lazer feed id.
-public(package) fun create_and_share(feed_id: u32, ctx: &mut TxContext): ID {
+public(package) fun create_and_share(
+    feed_id: u32,
+    allowed_versions: VecSet<u64>,
+    ctx: &mut TxContext,
+): ID {
     let source = PythSource {
         id: object::new(ctx),
         feed_id,
         spot: 0,
         source_timestamp_ms: 0,
         update_timestamp_ms: 0,
-        allowed_versions: vec_set::singleton(constants::current_version!()),
+        allowed_versions,
     };
     let id = source.id();
     transfer::share_object(source);
@@ -137,11 +139,6 @@ public(package) fun assert_version_allowed(source: &PythSource) {
         source.allowed_versions.contains(&constants::current_version!()),
         EPackageVersionDisabled,
     );
-}
-
-/// Authoritative sync of mirrored `allowed_versions` from protocol config.
-public(package) fun update_allowed_versions(source: &mut PythSource, config: &ProtocolConfig) {
-    source.allowed_versions = config.allowed_versions();
 }
 
 fun us_to_ms_ceil(timestamp_us: u64): u64 {

--- a/packages/predict/sources/oracle/pyth_source.move
+++ b/packages/predict/sources/oracle/pyth_source.move
@@ -8,13 +8,14 @@
 /// forward, apply circuit breakers, or settle a market.
 module deepbook_predict::pyth_source;
 
-use deepbook_predict::{lazer_helper, protocol_config::ProtocolConfig};
+use deepbook_predict::{constants, lazer_helper, protocol_config::ProtocolConfig};
 use pyth_lazer::update::Update as LazerUpdate;
-use sui::{clock::Clock, event};
+use sui::{clock::Clock, event, vec_set::{Self, VecSet}};
 
 const EStaleSourceUpdate: u64 = 0;
 const EZeroSpot: u64 = 1;
 const EFutureSourceUpdate: u64 = 2;
+const EPackageVersionDisabled: u64 = 3;
 
 /// Emitted when a verified Pyth Lazer spot update is accepted.
 public struct PythSourceUpdated has copy, drop, store {
@@ -34,6 +35,8 @@ public struct PythSource has key {
     source_timestamp_ms: u64,
     /// On-chain timestamp when the latest accepted update landed.
     update_timestamp_ms: u64,
+    /// Mirror of `ProtocolConfig.allowed_versions`; synced permissionlessly.
+    allowed_versions: VecSet<u64>,
 }
 
 /// Decode and store a verified Pyth Lazer spot update.
@@ -46,6 +49,7 @@ public fun update_from_lazer(
     update: LazerUpdate,
     clock: &Clock,
 ) {
+    source.assert_version_allowed();
     config.assert_not_valuation_in_progress();
     let (spot, source_timestamp_us) = lazer_helper::extract_spot(&update, source.feed_id);
     let source_timestamp_ms = us_to_ms_ceil(source_timestamp_us);
@@ -92,6 +96,19 @@ public fun update_timestamp_ms(source: &PythSource): u64 {
     source.update_timestamp_ms
 }
 
+/// Return this source's mirrored set of allowed package versions.
+public fun allowed_versions(source: &PythSource): VecSet<u64> {
+    source.allowed_versions
+}
+
+/// Permissionlessly refresh this source's mirrored `allowed_versions`.
+public fun update_allowed_versions_permissionless(
+    source: &mut PythSource,
+    config: &ProtocolConfig,
+) {
+    source.allowed_versions = config.allowed_versions();
+}
+
 // === Public-Package Functions ===
 
 /// Return the timestamp that pricing can use for freshness checks.
@@ -107,10 +124,24 @@ public(package) fun create_and_share(feed_id: u32, ctx: &mut TxContext): ID {
         spot: 0,
         source_timestamp_ms: 0,
         update_timestamp_ms: 0,
+        allowed_versions: vec_set::singleton(constants::current_version!()),
     };
     let id = source.id();
     transfer::share_object(source);
     id
+}
+
+/// Abort if the running package version is not allowed for this source.
+public(package) fun assert_version_allowed(source: &PythSource) {
+    assert!(
+        source.allowed_versions.contains(&constants::current_version!()),
+        EPackageVersionDisabled,
+    );
+}
+
+/// Authoritative sync of mirrored `allowed_versions` from protocol config.
+public(package) fun update_allowed_versions(source: &mut PythSource, config: &ProtocolConfig) {
+    source.allowed_versions = config.allowed_versions();
 }
 
 fun us_to_ms_ceil(timestamp_us: u64): u64 {

--- a/packages/predict/sources/plp.move
+++ b/packages/predict/sources/plp.move
@@ -110,9 +110,10 @@ public fun allowed_versions(vault: &PoolVault): VecSet<u64> {
     vault.allowed_versions
 }
 
-/// Permissionlessly refresh this vault's mirrored `allowed_versions`.
-public fun update_allowed_versions_permissionless(vault: &mut PoolVault, config: &ProtocolConfig) {
-    vault.allowed_versions = config.allowed_versions();
+/// Refresh this vault's mirrored `allowed_versions`. Permissionless: callers
+/// pass `registry.allowed_versions()` as the source of truth.
+public fun update_allowed_versions(vault: &mut PoolVault, allowed_versions: VecSet<u64>) {
+    vault.allowed_versions = allowed_versions;
 }
 
 /// Return idle DUSDC held by the pool.
@@ -337,11 +338,6 @@ public(package) fun assert_version_allowed(vault: &PoolVault) {
         vault.allowed_versions.contains(&constants::current_version!()),
         EPackageVersionDisabled,
     );
-}
-
-/// Authoritative sync of mirrored `allowed_versions` from protocol config.
-public(package) fun update_allowed_versions(vault: &mut PoolVault, config: &ProtocolConfig) {
-    vault.allowed_versions = config.allowed_versions();
 }
 
 /// Create and share an empty pool vault from the PLP treasury cap.

--- a/packages/predict/sources/plp.move
+++ b/packages/predict/sources/plp.move
@@ -12,6 +12,7 @@ module deepbook_predict::plp;
 use deepbook::math;
 use deepbook_predict::{
     config_constants,
+    constants,
     expiry_market::{ExpiryMarket, ExpiryValuation},
     market_oracle::MarketOracle,
     math as predict_math,
@@ -19,7 +20,13 @@ use deepbook_predict::{
     risk_config::RiskConfig
 };
 use dusdc::dusdc::DUSDC;
-use sui::{balance::{Self, Balance}, clock::Clock, coin::{Self, Coin, TreasuryCap}, coin_registry};
+use sui::{
+    balance::{Self, Balance},
+    clock::Clock,
+    coin::{Self, Coin, TreasuryCap},
+    coin_registry,
+    vec_set::{Self, VecSet}
+};
 
 const EExpiryMarketAlreadyActive: u64 = 0;
 const EExpiryMarketNotActive: u64 = 1;
@@ -38,6 +45,7 @@ const EZeroWithdraw: u64 = 17;
 const EInvalidInitialSupply: u64 = 18;
 const EZeroShares: u64 = 19;
 const EZeroPoolValue: u64 = 20;
+const EPackageVersionDisabled: u64 = 21;
 
 /// One-time witness type for Predict LP token registration.
 public struct PLP has drop {}
@@ -56,6 +64,8 @@ public struct PoolVault has key {
     active_expiry_markets: vector<ID>,
     /// Sum of active expiry risk budgets allocated out of the pool.
     total_allocated_capital: u64,
+    /// Mirror of `ProtocolConfig.allowed_versions`; synced permissionlessly.
+    allowed_versions: VecSet<u64>,
 }
 
 /// Transaction-local pool valuation accumulator.
@@ -95,6 +105,16 @@ public fun id(vault: &PoolVault): ID {
     vault.id.to_inner()
 }
 
+/// Return this vault's mirrored set of allowed package versions.
+public fun allowed_versions(vault: &PoolVault): VecSet<u64> {
+    vault.allowed_versions
+}
+
+/// Permissionlessly refresh this vault's mirrored `allowed_versions`.
+public fun update_allowed_versions_permissionless(vault: &mut PoolVault, config: &ProtocolConfig) {
+    vault.allowed_versions = config.allowed_versions();
+}
+
 /// Return idle DUSDC held by the pool.
 public fun idle_balance(vault: &PoolVault): u64 {
     vault.idle_balance.value()
@@ -131,6 +151,7 @@ public fun total_allocated_capital(vault: &PoolVault): u64 {
 /// Callers must add one valuation witness for each active expiry before
 /// supplying or withdrawing.
 public fun start_valuation(vault: &PoolVault, config: &mut ProtocolConfig): PoolValuation {
+    vault.assert_version_allowed();
     config.begin_valuation();
     PoolValuation {
         pool_vault_id: vault.id(),
@@ -166,6 +187,7 @@ public fun grow_expiry_allocation(
     market_oracle: &MarketOracle,
     clock: &Clock,
 ) {
+    vault.assert_version_allowed();
     config.assert_trading_allowed();
     assert!(vault.active_expiry_markets.contains(&market.id()), EExpiryMarketNotActive);
     market.assert_market_oracle(market_oracle);
@@ -189,6 +211,7 @@ public fun shrink_expiry_allocation(
     market_oracle: &MarketOracle,
     clock: &Clock,
 ) {
+    vault.assert_version_allowed();
     config.assert_not_valuation_in_progress();
     assert!(vault.active_expiry_markets.contains(&market.id()), EExpiryMarketNotActive);
     market.assert_market_oracle(market_oracle);
@@ -211,6 +234,7 @@ public fun compact_expiry_market(
     market: &mut ExpiryMarket,
     market_oracle: &MarketOracle,
 ) {
+    vault.assert_version_allowed();
     config.assert_not_valuation_in_progress();
     assert!(vault.active_expiry_markets.contains(&market.id()), EExpiryMarketNotActive);
     let allocated_reduction = market.allocated_capital();
@@ -236,6 +260,7 @@ public fun supply(
     payment: Coin<DUSDC>,
     ctx: &mut TxContext,
 ): Coin<PLP> {
+    vault.assert_version_allowed();
     let pool_value = vault.validated_pool_value(config, &valuation);
     let payment_amount = payment.value();
     assert!(payment_amount > 0, EZeroSupply);
@@ -267,6 +292,7 @@ public fun withdraw(
     lp_coin: Coin<PLP>,
     ctx: &mut TxContext,
 ): Coin<DUSDC> {
+    vault.assert_version_allowed();
     let pool_value = vault.validated_pool_value(config, &valuation);
     let lp_amount = lp_coin.value();
     assert!(lp_amount > 0, EZeroWithdraw);
@@ -301,7 +327,21 @@ public(package) fun new(treasury_cap: TreasuryCap<PLP>, ctx: &mut TxContext): Po
         treasury_cap,
         active_expiry_markets: vector[],
         total_allocated_capital: 0,
+        allowed_versions: vec_set::singleton(constants::current_version!()),
     }
+}
+
+/// Abort if the running package version is not allowed for this vault.
+public(package) fun assert_version_allowed(vault: &PoolVault) {
+    assert!(
+        vault.allowed_versions.contains(&constants::current_version!()),
+        EPackageVersionDisabled,
+    );
+}
+
+/// Authoritative sync of mirrored `allowed_versions` from protocol config.
+public(package) fun update_allowed_versions(vault: &mut PoolVault, config: &ProtocolConfig) {
+    vault.allowed_versions = config.allowed_versions();
 }
 
 /// Create and share an empty pool vault from the PLP treasury cap.

--- a/packages/predict/sources/predict_manager.move
+++ b/packages/predict/sources/predict_manager.move
@@ -9,13 +9,20 @@
 module deepbook_predict::predict_manager;
 
 use deepbook::balance_manager::{Self, BalanceManager, DepositCap};
-use deepbook_predict::{builder_code::{Self, BuilderCode}, math, range_key::RangeKey};
+use deepbook_predict::{
+    builder_code::{Self, BuilderCode},
+    constants,
+    math,
+    protocol_config::ProtocolConfig,
+    range_key::RangeKey
+};
 use dusdc::dusdc::DUSDC;
-use sui::{coin::Coin, derived_object, event, table::{Self, Table}};
+use sui::{coin::Coin, derived_object, event, table::{Self, Table}, vec_set::{Self, VecSet}};
 
 const EInsufficientPosition: u64 = 0;
 const ENotOwner: u64 = 1;
 const EZeroQuantity: u64 = 2;
+const EPackageVersionDisabled: u64 = 3;
 
 /// The key for deriving predict manager. u64 is optional for
 /// supporting multiple managers per address. Defaults to 0 in v1.
@@ -29,6 +36,9 @@ public struct PredictManager has key {
     builder_code_id: Option<ID>,
     /// RangeKey -> position quantity and raw rebate fee basis.
     positions: Table<RangeKey, Position>,
+    /// Mirror of `ProtocolConfig.allowed_versions`. Owners run the permissionless
+    /// sync to track admin changes; package mutations gate on this set.
+    allowed_versions: VecSet<u64>,
 }
 
 /// Quantity plus raw fee basis attached to one active range position.
@@ -58,12 +68,27 @@ public fun id(self: &PredictManager): ID {
 
 /// Deposit coins into the PredictManager.
 public fun deposit(self: &mut PredictManager, coin: Coin<DUSDC>, ctx: &mut TxContext) {
+    self.assert_version_allowed();
     self.balance_manager.deposit(coin, ctx);
 }
 
 /// Withdraw coins from the PredictManager.
 public fun withdraw(self: &mut PredictManager, amount: u64, ctx: &mut TxContext): Coin<DUSDC> {
+    self.assert_version_allowed();
     self.balance_manager.withdraw(amount, ctx)
+}
+
+/// Return this manager's mirrored set of allowed package versions.
+public fun allowed_versions(self: &PredictManager): VecSet<u64> {
+    self.allowed_versions
+}
+
+/// Permissionlessly refresh this manager's mirrored `allowed_versions`.
+public fun update_allowed_versions_permissionless(
+    self: &mut PredictManager,
+    config: &ProtocolConfig,
+) {
+    self.allowed_versions = config.allowed_versions();
 }
 
 /// Return the BalanceManager owner for this PredictManager.
@@ -105,6 +130,7 @@ public fun set_builder_code(
     builder_code: &BuilderCode,
     ctx: &TxContext,
 ) {
+    self.assert_version_allowed();
     self.assert_owner(ctx);
     let builder_code_id = builder_code::id(builder_code);
     self.builder_code_id = option::some(builder_code_id);
@@ -117,6 +143,7 @@ public fun set_builder_code(
 
 /// Clear sticky builder-code attribution for future trades.
 public fun unset_builder_code(self: &mut PredictManager, ctx: &TxContext) {
+    self.assert_version_allowed();
     self.assert_owner(ctx);
     self.builder_code_id = option::none();
     event::emit(BuilderCodeSet {
@@ -140,7 +167,16 @@ public(package) fun new(registry_uid: &mut UID, ctx: &mut TxContext): PredictMan
         deposit_cap,
         builder_code_id: option::none(),
         positions: table::new(ctx),
+        allowed_versions: vec_set::singleton(constants::current_version!()),
     }
+}
+
+/// Abort if the running package version is not allowed for this manager.
+public(package) fun assert_version_allowed(self: &PredictManager) {
+    assert!(
+        self.allowed_versions.contains(&constants::current_version!()),
+        EPackageVersionDisabled,
+    );
 }
 
 /// Deposit protocol payouts without requiring the manager owner as sender.

--- a/packages/predict/sources/predict_manager.move
+++ b/packages/predict/sources/predict_manager.move
@@ -9,15 +9,9 @@
 module deepbook_predict::predict_manager;
 
 use deepbook::balance_manager::{Self, BalanceManager, DepositCap};
-use deepbook_predict::{
-    builder_code::{Self, BuilderCode},
-    constants,
-    math,
-    protocol_config::ProtocolConfig,
-    range_key::RangeKey
-};
+use deepbook_predict::{builder_code::{Self, BuilderCode}, math, range_key::RangeKey};
 use dusdc::dusdc::DUSDC;
-use sui::{coin::Coin, derived_object, event, table::{Self, Table}, vec_set::{Self, VecSet}};
+use sui::{coin::Coin, derived_object, event, table::{Self, Table}, vec_set::VecSet};
 
 const EInsufficientPosition: u64 = 0;
 const ENotOwner: u64 = 1;
@@ -83,12 +77,10 @@ public fun allowed_versions(self: &PredictManager): VecSet<u64> {
     self.allowed_versions
 }
 
-/// Permissionlessly refresh this manager's mirrored `allowed_versions`.
-public fun update_allowed_versions_permissionless(
-    self: &mut PredictManager,
-    config: &ProtocolConfig,
-) {
-    self.allowed_versions = config.allowed_versions();
+/// Refresh this manager's mirrored `allowed_versions`. Permissionless: callers
+/// pass `registry.allowed_versions()` as the source of truth.
+public fun update_allowed_versions(self: &mut PredictManager, allowed_versions: VecSet<u64>) {
+    self.allowed_versions = allowed_versions;
 }
 
 /// Return the BalanceManager owner for this PredictManager.
@@ -156,7 +148,11 @@ public fun unset_builder_code(self: &mut PredictManager, ctx: &TxContext) {
 // === Public-Package Functions ===
 
 /// Create a derived PredictManager for the sender.
-public(package) fun new(registry_uid: &mut UID, ctx: &mut TxContext): PredictManager {
+public(package) fun new(
+    registry_uid: &mut UID,
+    allowed_versions: VecSet<u64>,
+    ctx: &mut TxContext,
+): PredictManager {
     let id = derived_object::claim(registry_uid, PredictManagerKey(ctx.sender(), 0));
     let mut balance_manager = balance_manager::new(ctx);
     let deposit_cap = balance_manager.mint_deposit_cap(ctx);
@@ -167,14 +163,14 @@ public(package) fun new(registry_uid: &mut UID, ctx: &mut TxContext): PredictMan
         deposit_cap,
         builder_code_id: option::none(),
         positions: table::new(ctx),
-        allowed_versions: vec_set::singleton(constants::current_version!()),
+        allowed_versions,
     }
 }
 
 /// Abort if the running package version is not allowed for this manager.
 public(package) fun assert_version_allowed(self: &PredictManager) {
     assert!(
-        self.allowed_versions.contains(&constants::current_version!()),
+        self.allowed_versions.contains(&deepbook_predict::constants::current_version!()),
         EPackageVersionDisabled,
     );
 }

--- a/packages/predict/sources/protocol_config.move
+++ b/packages/predict/sources/protocol_config.move
@@ -9,21 +9,15 @@
 module deepbook_predict::protocol_config;
 
 use deepbook_predict::{
-    constants,
     fee_config::{Self, FeeConfig},
     market_oracle_config::{Self, MarketOracleConfig},
     pricing_config::{Self, PricingConfig},
     risk_config::{Self, RiskConfig}
 };
-use sui::vec_set::{Self, VecSet};
 
 const ETradingPaused: u64 = 0;
 const EValuationInProgress: u64 = 1;
 const EValuationNotInProgress: u64 = 2;
-const EPackageVersionDisabled: u64 = 3;
-const EVersionAlreadyEnabled: u64 = 4;
-const EVersionNotEnabled: u64 = 5;
-const ECannotDisableLastVersion: u64 = 6;
 
 /// Shared protocol policy and config state.
 public struct ProtocolConfig has key {
@@ -36,10 +30,6 @@ public struct ProtocolConfig has key {
     trading_paused: bool,
     /// Transaction-local lock held while a full-pool valuation is assembled.
     valuation_in_progress: bool,
-    /// Package versions currently permitted to mutate protocol state. Per-pool
-    /// objects mirror this set; admin and pause cap holders update via the
-    /// registry, while permissionless syncers refresh the mirror from here.
-    allowed_versions: VecSet<u64>,
 }
 
 // === Public Functions ===
@@ -52,15 +42,6 @@ public fun id(config: &ProtocolConfig): ID {
 /// Return whether trading is currently paused.
 public fun trading_paused(config: &ProtocolConfig): bool {
     config.trading_paused
-}
-
-/// Return the set of package versions currently permitted to mutate state.
-///
-/// Read accessor used by per-pool sync helpers (`update_*_allowed_versions`)
-/// and external monitoring. Bypasses the version gate so it stays callable
-/// while the package is paused.
-public fun allowed_versions(config: &ProtocolConfig): VecSet<u64> {
-    config.allowed_versions
 }
 
 // === Public-Package Functions ===
@@ -83,24 +64,12 @@ public(package) fun market_oracle_config(config: &ProtocolConfig): &MarketOracle
 
 /// Abort unless trading mutations are currently allowed.
 ///
-/// Intentionally omits the global version gate: per-pool mutating flows that
-/// call this assert their own mirrored `allowed_versions` set, which lets each
-/// pool lag behind a global version change until a permissionless sync.
+/// Intentionally omits the package-version gate: per-pool mutating flows that
+/// call this assert their own mirrored `allowed_versions`, sourced from the
+/// registry.
 public(package) fun assert_trading_allowed(config: &ProtocolConfig) {
     config.assert_not_trading_paused();
     config.assert_not_valuation_in_progress();
-}
-
-/// Abort if the running package version is not in `allowed_versions`.
-///
-/// Used as the global kill switch on top-level admin entry points that mutate
-/// `ProtocolConfig`. Per-pool mutating functions check their own mirrored set
-/// instead, so each pool can advance independently after a permissionless sync.
-public(package) fun assert_version_allowed(config: &ProtocolConfig) {
-    assert!(
-        config.allowed_versions.contains(&constants::current_version!()),
-        EPackageVersionDisabled,
-    );
 }
 
 /// Abort unless a valuation lock is currently active.
@@ -118,12 +87,6 @@ fun assert_not_trading_paused(config: &ProtocolConfig) {
     assert!(!config.trading_paused, ETradingPaused);
 }
 
-/// Bundled gate used by every admin setter on `ProtocolConfig`.
-fun assert_admin_setter_allowed(config: &ProtocolConfig) {
-    config.assert_version_allowed();
-    config.assert_not_valuation_in_progress();
-}
-
 /// Create and share the protocol-wide configuration object.
 public(package) fun create_and_share(ctx: &mut TxContext): ID {
     let config = ProtocolConfig {
@@ -134,69 +97,49 @@ public(package) fun create_and_share(ctx: &mut TxContext): ID {
         market_oracle_config: market_oracle_config::new(),
         trading_paused: false,
         valuation_in_progress: false,
-        allowed_versions: vec_set::singleton(constants::current_version!()),
     };
     let id = config.id();
     transfer::share_object(config);
     id
 }
 
-/// Add a package version to the allowed set.
-///
-/// Bypasses the version gate so admin can re-enable a paused version even when
-/// the active version is disabled.
-public(package) fun enable_version(config: &mut ProtocolConfig, version: u64) {
-    assert!(!config.allowed_versions.contains(&version), EVersionAlreadyEnabled);
-    config.allowed_versions.insert(version);
-}
-
-/// Remove a package version from the allowed set.
-///
-/// Bypasses the version gate so admin can revoke a version even when the
-/// active version is already disabled. Refuses to leave the set empty.
-public(package) fun disable_version(config: &mut ProtocolConfig, version: u64) {
-    assert!(config.allowed_versions.contains(&version), EVersionNotEnabled);
-    assert!(config.allowed_versions.length() > 1, ECannotDisableLastVersion);
-    config.allowed_versions.remove(&version);
-}
-
 public(package) fun set_base_fee(config: &mut ProtocolConfig, fee: u64) {
-    config.assert_admin_setter_allowed();
+    config.assert_not_valuation_in_progress();
     config.pricing_config.set_base_fee(fee);
 }
 
 public(package) fun set_min_fee(config: &mut ProtocolConfig, fee: u64) {
-    config.assert_admin_setter_allowed();
+    config.assert_not_valuation_in_progress();
     config.pricing_config.set_min_fee(fee);
 }
 
 public(package) fun set_utilization_multiplier(config: &mut ProtocolConfig, multiplier: u64) {
-    config.assert_admin_setter_allowed();
+    config.assert_not_valuation_in_progress();
     config.pricing_config.set_utilization_multiplier(multiplier);
 }
 
 public(package) fun set_min_ask_price(config: &mut ProtocolConfig, value: u64) {
-    config.assert_admin_setter_allowed();
+    config.assert_not_valuation_in_progress();
     config.pricing_config.set_min_ask_price(value);
 }
 
 public(package) fun set_max_ask_price(config: &mut ProtocolConfig, value: u64) {
-    config.assert_admin_setter_allowed();
+    config.assert_not_valuation_in_progress();
     config.pricing_config.set_max_ask_price(value);
 }
 
 public(package) fun set_pyth_spot_freshness_ms(config: &mut ProtocolConfig, value: u64) {
-    config.assert_admin_setter_allowed();
+    config.assert_not_valuation_in_progress();
     config.pricing_config.set_pyth_spot_freshness_ms(value);
 }
 
 public(package) fun set_block_scholes_prices_freshness_ms(config: &mut ProtocolConfig, value: u64) {
-    config.assert_admin_setter_allowed();
+    config.assert_not_valuation_in_progress();
     config.pricing_config.set_block_scholes_prices_freshness_ms(value);
 }
 
 public(package) fun set_block_scholes_svi_freshness_ms(config: &mut ProtocolConfig, value: u64) {
-    config.assert_admin_setter_allowed();
+    config.assert_not_valuation_in_progress();
     config.pricing_config.set_block_scholes_svi_freshness_ms(value);
 }
 
@@ -206,7 +149,7 @@ public(package) fun set_fee_shares(
     protocol_fee_share: u64,
     insurance_fee_share: u64,
 ) {
-    config.assert_admin_setter_allowed();
+    config.assert_not_valuation_in_progress();
     config.fee_config.set_fee_shares(lp_fee_share, protocol_fee_share, insurance_fee_share);
 }
 
@@ -214,37 +157,37 @@ public(package) fun set_template_settlement_loss_rebate_rate(
     config: &mut ProtocolConfig,
     value: u64,
 ) {
-    config.assert_admin_setter_allowed();
+    config.assert_not_valuation_in_progress();
     config.fee_config.set_settlement_loss_rebate_rate(value);
 }
 
 public(package) fun set_max_total_exposure_pct(config: &mut ProtocolConfig, pct: u64) {
-    config.assert_admin_setter_allowed();
+    config.assert_not_valuation_in_progress();
     config.risk_config.set_max_total_exposure_pct(pct);
 }
 
 public(package) fun set_expiry_allocation(config: &mut ProtocolConfig, allocation: u64) {
-    config.assert_admin_setter_allowed();
+    config.assert_not_valuation_in_progress();
     config.risk_config.set_expiry_allocation(allocation);
 }
 
 public(package) fun set_grow_utilization_threshold(config: &mut ProtocolConfig, threshold: u64) {
-    config.assert_admin_setter_allowed();
+    config.assert_not_valuation_in_progress();
     config.risk_config.set_grow_utilization_threshold(threshold);
 }
 
 public(package) fun set_shrink_utilization_threshold(config: &mut ProtocolConfig, threshold: u64) {
-    config.assert_admin_setter_allowed();
+    config.assert_not_valuation_in_progress();
     config.risk_config.set_shrink_utilization_threshold(threshold);
 }
 
 public(package) fun set_grow_factor(config: &mut ProtocolConfig, factor: u64) {
-    config.assert_admin_setter_allowed();
+    config.assert_not_valuation_in_progress();
     config.risk_config.set_grow_factor(factor);
 }
 
 public(package) fun set_shrink_factor(config: &mut ProtocolConfig, factor: u64) {
-    config.assert_admin_setter_allowed();
+    config.assert_not_valuation_in_progress();
     config.risk_config.set_shrink_factor(factor);
 }
 
@@ -253,7 +196,7 @@ public(package) fun set_market_oracle_template_settlement_freshness_ms(
     config: &mut ProtocolConfig,
     value: u64,
 ) {
-    config.assert_admin_setter_allowed();
+    config.assert_not_valuation_in_progress();
     config.market_oracle_config.set_settlement_freshness_ms(value);
 }
 
@@ -265,7 +208,7 @@ public(package) fun set_market_oracle_template_basis_bounds(
     min_basis: u64,
     max_basis: u64,
 ) {
-    config.assert_admin_setter_allowed();
+    config.assert_not_valuation_in_progress();
     config
         .market_oracle_config
         .set_basis_bounds(
@@ -277,7 +220,7 @@ public(package) fun set_market_oracle_template_basis_bounds(
 }
 
 public(package) fun set_trading_paused(config: &mut ProtocolConfig, paused: bool) {
-    config.assert_admin_setter_allowed();
+    config.assert_not_valuation_in_progress();
     config.trading_paused = paused;
 }
 
@@ -312,7 +255,6 @@ public fun new_for_testing(ctx: &mut TxContext): ProtocolConfig {
         market_oracle_config: market_oracle_config::new(),
         trading_paused: false,
         valuation_in_progress: false,
-        allowed_versions: vec_set::singleton(constants::current_version!()),
     }
 }
 
@@ -326,7 +268,6 @@ public fun destroy_for_testing(config: ProtocolConfig) {
         market_oracle_config,
         trading_paused: _,
         valuation_in_progress: _,
-        allowed_versions: _,
     } = config;
     id.delete();
     pricing_config.destroy_for_testing();

--- a/packages/predict/sources/protocol_config.move
+++ b/packages/predict/sources/protocol_config.move
@@ -9,15 +9,21 @@
 module deepbook_predict::protocol_config;
 
 use deepbook_predict::{
+    constants,
     fee_config::{Self, FeeConfig},
     market_oracle_config::{Self, MarketOracleConfig},
     pricing_config::{Self, PricingConfig},
     risk_config::{Self, RiskConfig}
 };
+use sui::vec_set::{Self, VecSet};
 
 const ETradingPaused: u64 = 0;
 const EValuationInProgress: u64 = 1;
 const EValuationNotInProgress: u64 = 2;
+const EPackageVersionDisabled: u64 = 3;
+const EVersionAlreadyEnabled: u64 = 4;
+const EVersionNotEnabled: u64 = 5;
+const ECannotDisableLastVersion: u64 = 6;
 
 /// Shared protocol policy and config state.
 public struct ProtocolConfig has key {
@@ -30,6 +36,10 @@ public struct ProtocolConfig has key {
     trading_paused: bool,
     /// Transaction-local lock held while a full-pool valuation is assembled.
     valuation_in_progress: bool,
+    /// Package versions currently permitted to mutate protocol state. Per-pool
+    /// objects mirror this set; admin and pause cap holders update via the
+    /// registry, while permissionless syncers refresh the mirror from here.
+    allowed_versions: VecSet<u64>,
 }
 
 // === Public Functions ===
@@ -42,6 +52,15 @@ public fun id(config: &ProtocolConfig): ID {
 /// Return whether trading is currently paused.
 public fun trading_paused(config: &ProtocolConfig): bool {
     config.trading_paused
+}
+
+/// Return the set of package versions currently permitted to mutate state.
+///
+/// Read accessor used by per-pool sync helpers (`update_*_allowed_versions`)
+/// and external monitoring. Bypasses the version gate so it stays callable
+/// while the package is paused.
+public fun allowed_versions(config: &ProtocolConfig): VecSet<u64> {
+    config.allowed_versions
 }
 
 // === Public-Package Functions ===
@@ -63,9 +82,25 @@ public(package) fun market_oracle_config(config: &ProtocolConfig): &MarketOracle
 }
 
 /// Abort unless trading mutations are currently allowed.
+///
+/// Intentionally omits the global version gate: per-pool mutating flows that
+/// call this assert their own mirrored `allowed_versions` set, which lets each
+/// pool lag behind a global version change until a permissionless sync.
 public(package) fun assert_trading_allowed(config: &ProtocolConfig) {
     config.assert_not_trading_paused();
     config.assert_not_valuation_in_progress();
+}
+
+/// Abort if the running package version is not in `allowed_versions`.
+///
+/// Used as the global kill switch on top-level admin entry points that mutate
+/// `ProtocolConfig`. Per-pool mutating functions check their own mirrored set
+/// instead, so each pool can advance independently after a permissionless sync.
+public(package) fun assert_version_allowed(config: &ProtocolConfig) {
+    assert!(
+        config.allowed_versions.contains(&constants::current_version!()),
+        EPackageVersionDisabled,
+    );
 }
 
 /// Abort unless a valuation lock is currently active.
@@ -83,6 +118,12 @@ fun assert_not_trading_paused(config: &ProtocolConfig) {
     assert!(!config.trading_paused, ETradingPaused);
 }
 
+/// Bundled gate used by every admin setter on `ProtocolConfig`.
+fun assert_admin_setter_allowed(config: &ProtocolConfig) {
+    config.assert_version_allowed();
+    config.assert_not_valuation_in_progress();
+}
+
 /// Create and share the protocol-wide configuration object.
 public(package) fun create_and_share(ctx: &mut TxContext): ID {
     let config = ProtocolConfig {
@@ -93,49 +134,69 @@ public(package) fun create_and_share(ctx: &mut TxContext): ID {
         market_oracle_config: market_oracle_config::new(),
         trading_paused: false,
         valuation_in_progress: false,
+        allowed_versions: vec_set::singleton(constants::current_version!()),
     };
     let id = config.id();
     transfer::share_object(config);
     id
 }
 
+/// Add a package version to the allowed set.
+///
+/// Bypasses the version gate so admin can re-enable a paused version even when
+/// the active version is disabled.
+public(package) fun enable_version(config: &mut ProtocolConfig, version: u64) {
+    assert!(!config.allowed_versions.contains(&version), EVersionAlreadyEnabled);
+    config.allowed_versions.insert(version);
+}
+
+/// Remove a package version from the allowed set.
+///
+/// Bypasses the version gate so admin can revoke a version even when the
+/// active version is already disabled. Refuses to leave the set empty.
+public(package) fun disable_version(config: &mut ProtocolConfig, version: u64) {
+    assert!(config.allowed_versions.contains(&version), EVersionNotEnabled);
+    assert!(config.allowed_versions.length() > 1, ECannotDisableLastVersion);
+    config.allowed_versions.remove(&version);
+}
+
 public(package) fun set_base_fee(config: &mut ProtocolConfig, fee: u64) {
-    config.assert_not_valuation_in_progress();
+    config.assert_admin_setter_allowed();
     config.pricing_config.set_base_fee(fee);
 }
 
 public(package) fun set_min_fee(config: &mut ProtocolConfig, fee: u64) {
-    config.assert_not_valuation_in_progress();
+    config.assert_admin_setter_allowed();
     config.pricing_config.set_min_fee(fee);
 }
 
 public(package) fun set_utilization_multiplier(config: &mut ProtocolConfig, multiplier: u64) {
-    config.assert_not_valuation_in_progress();
+    config.assert_admin_setter_allowed();
     config.pricing_config.set_utilization_multiplier(multiplier);
 }
 
 public(package) fun set_min_ask_price(config: &mut ProtocolConfig, value: u64) {
-    config.assert_not_valuation_in_progress();
+    config.assert_admin_setter_allowed();
     config.pricing_config.set_min_ask_price(value);
 }
 
 public(package) fun set_max_ask_price(config: &mut ProtocolConfig, value: u64) {
-    config.assert_not_valuation_in_progress();
+    config.assert_admin_setter_allowed();
     config.pricing_config.set_max_ask_price(value);
 }
 
 public(package) fun set_pyth_spot_freshness_ms(config: &mut ProtocolConfig, value: u64) {
-    config.assert_not_valuation_in_progress();
+    config.assert_admin_setter_allowed();
     config.pricing_config.set_pyth_spot_freshness_ms(value);
 }
 
 public(package) fun set_block_scholes_prices_freshness_ms(config: &mut ProtocolConfig, value: u64) {
-    config.assert_not_valuation_in_progress();
+    config.assert_admin_setter_allowed();
     config.pricing_config.set_block_scholes_prices_freshness_ms(value);
 }
 
 public(package) fun set_block_scholes_svi_freshness_ms(config: &mut ProtocolConfig, value: u64) {
-    config.assert_not_valuation_in_progress();
+    config.assert_admin_setter_allowed();
     config.pricing_config.set_block_scholes_svi_freshness_ms(value);
 }
 
@@ -145,7 +206,7 @@ public(package) fun set_fee_shares(
     protocol_fee_share: u64,
     insurance_fee_share: u64,
 ) {
-    config.assert_not_valuation_in_progress();
+    config.assert_admin_setter_allowed();
     config.fee_config.set_fee_shares(lp_fee_share, protocol_fee_share, insurance_fee_share);
 }
 
@@ -153,37 +214,37 @@ public(package) fun set_template_settlement_loss_rebate_rate(
     config: &mut ProtocolConfig,
     value: u64,
 ) {
-    config.assert_not_valuation_in_progress();
+    config.assert_admin_setter_allowed();
     config.fee_config.set_settlement_loss_rebate_rate(value);
 }
 
 public(package) fun set_max_total_exposure_pct(config: &mut ProtocolConfig, pct: u64) {
-    config.assert_not_valuation_in_progress();
+    config.assert_admin_setter_allowed();
     config.risk_config.set_max_total_exposure_pct(pct);
 }
 
 public(package) fun set_expiry_allocation(config: &mut ProtocolConfig, allocation: u64) {
-    config.assert_not_valuation_in_progress();
+    config.assert_admin_setter_allowed();
     config.risk_config.set_expiry_allocation(allocation);
 }
 
 public(package) fun set_grow_utilization_threshold(config: &mut ProtocolConfig, threshold: u64) {
-    config.assert_not_valuation_in_progress();
+    config.assert_admin_setter_allowed();
     config.risk_config.set_grow_utilization_threshold(threshold);
 }
 
 public(package) fun set_shrink_utilization_threshold(config: &mut ProtocolConfig, threshold: u64) {
-    config.assert_not_valuation_in_progress();
+    config.assert_admin_setter_allowed();
     config.risk_config.set_shrink_utilization_threshold(threshold);
 }
 
 public(package) fun set_grow_factor(config: &mut ProtocolConfig, factor: u64) {
-    config.assert_not_valuation_in_progress();
+    config.assert_admin_setter_allowed();
     config.risk_config.set_grow_factor(factor);
 }
 
 public(package) fun set_shrink_factor(config: &mut ProtocolConfig, factor: u64) {
-    config.assert_not_valuation_in_progress();
+    config.assert_admin_setter_allowed();
     config.risk_config.set_shrink_factor(factor);
 }
 
@@ -192,7 +253,7 @@ public(package) fun set_market_oracle_template_settlement_freshness_ms(
     config: &mut ProtocolConfig,
     value: u64,
 ) {
-    config.assert_not_valuation_in_progress();
+    config.assert_admin_setter_allowed();
     config.market_oracle_config.set_settlement_freshness_ms(value);
 }
 
@@ -204,7 +265,7 @@ public(package) fun set_market_oracle_template_basis_bounds(
     min_basis: u64,
     max_basis: u64,
 ) {
-    config.assert_not_valuation_in_progress();
+    config.assert_admin_setter_allowed();
     config
         .market_oracle_config
         .set_basis_bounds(
@@ -216,8 +277,15 @@ public(package) fun set_market_oracle_template_basis_bounds(
 }
 
 public(package) fun set_trading_paused(config: &mut ProtocolConfig, paused: bool) {
-    config.assert_not_valuation_in_progress();
+    config.assert_admin_setter_allowed();
     config.trading_paused = paused;
+}
+
+/// Force `trading_paused = true` without admin authority. Reserved for
+/// `PauseCap` holders going through the registry; cannot be used to unpause.
+public(package) fun pause_trading(config: &mut ProtocolConfig) {
+    config.assert_not_valuation_in_progress();
+    config.trading_paused = true;
 }
 
 /// Begin a transaction-local full-pool valuation lock.
@@ -244,6 +312,7 @@ public fun new_for_testing(ctx: &mut TxContext): ProtocolConfig {
         market_oracle_config: market_oracle_config::new(),
         trading_paused: false,
         valuation_in_progress: false,
+        allowed_versions: vec_set::singleton(constants::current_version!()),
     }
 }
 
@@ -257,6 +326,7 @@ public fun destroy_for_testing(config: ProtocolConfig) {
         market_oracle_config,
         trading_paused: _,
         valuation_in_progress: _,
+        allowed_versions: _,
     } = config;
     id.delete();
     pricing_config.destroy_for_testing();

--- a/packages/predict/sources/registry.move
+++ b/packages/predict/sources/registry.move
@@ -11,23 +11,31 @@ module deepbook_predict::registry;
 
 use deepbook_predict::{
     builder_code,
-    expiry_market,
+    expiry_market::{Self, ExpiryMarket},
     market_oracle::{Self, MarketOracle, MarketOracleCap},
     plp::PoolVault,
     predict_manager::{Self, PredictManager},
     protocol_config::{Self, ProtocolConfig},
     pyth_source::{Self, PythSource}
 };
-use sui::{clock::Clock, table::{Self, Table}};
+use sui::{clock::Clock, table::{Self, Table}, vec_set::{Self, VecSet}};
 
 const EFeedIdMismatch: u64 = 2;
 const EPythSourceAlreadyCreated: u64 = 3;
 const EInvalidExpiry: u64 = 4;
 const EExpiryMarketAlreadyCreated: u64 = 5;
+const EPauseCapNotValid: u64 = 6;
 
 /// Capability for admin operations.
 /// Created during package init, transferred to deployer (multisig).
 public struct AdminCap has key, store {
+    id: UID,
+}
+
+/// Capability for emergency pause operations. Admin can mint these for
+/// trusted operators; holders can disable versions, pause global trading,
+/// and pause per-market minting. Cannot unpause anything.
+public struct PauseCap has key, store {
     id: UID,
 }
 
@@ -38,6 +46,9 @@ public struct Registry has key {
     pyth_source_ids: Table<u32, ID>,
     /// Created expiry markets keyed by expiry timestamp.
     expiry_market_ids: Table<u64, ID>,
+    /// IDs of `PauseCap` objects currently authorized to use pause-only entries.
+    /// Admin mints into this set and revokes from it.
+    allowed_pause_caps: VecSet<ID>,
 }
 
 // === Public Functions ===
@@ -200,15 +211,106 @@ public fun set_trading_paused(config: &mut ProtocolConfig, _admin_cap: &AdminCap
     config.set_trading_paused(paused);
 }
 
+// === Version Management (admin) ===
+
+/// Add `version` to `ProtocolConfig.allowed_versions`.
+///
+/// Not version-gated so admin can re-enable a previously disabled version.
+public fun enable_version(config: &mut ProtocolConfig, _admin_cap: &AdminCap, version: u64) {
+    config.enable_version(version);
+}
+
+/// Remove `version` from `ProtocolConfig.allowed_versions`.
+///
+/// Not version-gated so admin can revoke a version even after the active
+/// version has been paused. The set may not be left empty.
+public fun disable_version(config: &mut ProtocolConfig, _admin_cap: &AdminCap, version: u64) {
+    config.disable_version(version);
+}
+
+// === PauseCap Lifecycle (admin) ===
+
+/// Mint a new `PauseCap`. Admin-only and bypasses the version gate so the
+/// kill switch remains available even when admin has misconfigured versions.
+public fun mint_pause_cap(
+    registry: &mut Registry,
+    _admin_cap: &AdminCap,
+    ctx: &mut TxContext,
+): PauseCap {
+    let id = object::new(ctx);
+    registry.allowed_pause_caps.insert(id.to_inner());
+    PauseCap { id }
+}
+
+/// Revoke a previously minted `PauseCap` by ID. Admin-only.
+public fun revoke_pause_cap(registry: &mut Registry, _admin_cap: &AdminCap, pause_cap_id: ID) {
+    assert!(registry.allowed_pause_caps.contains(&pause_cap_id), EPauseCapNotValid);
+    registry.allowed_pause_caps.remove(&pause_cap_id);
+}
+
+/// Destroy a `PauseCap` the holder no longer needs.
+public fun destroy_pause_cap(cap: PauseCap) {
+    let PauseCap { id } = cap;
+    id.delete();
+}
+
+// === Emergency Pause (PauseCap) ===
+
+/// Disable a package version via a valid `PauseCap`. One-way: admin must
+/// `enable_version` to restore.
+public fun disable_version_pause_cap(
+    registry: &Registry,
+    config: &mut ProtocolConfig,
+    version: u64,
+    pause_cap: &PauseCap,
+) {
+    registry.assert_valid_pause_cap(pause_cap);
+    config.disable_version(version);
+}
+
+/// Force `trading_paused = true` via a valid `PauseCap`. One-way.
+public fun pause_trading_pause_cap(
+    registry: &Registry,
+    config: &mut ProtocolConfig,
+    pause_cap: &PauseCap,
+) {
+    registry.assert_valid_pause_cap(pause_cap);
+    config.pause_trading();
+}
+
+/// Force `mint_paused = true` on a single expiry market via a valid `PauseCap`.
+/// One-way; admin's `set_expiry_market_mint_paused` is needed to unpause.
+public fun pause_expiry_market_mint_pause_cap(
+    registry: &Registry,
+    market: &mut ExpiryMarket,
+    pause_cap: &PauseCap,
+) {
+    registry.assert_valid_pause_cap(pause_cap);
+    market.pause_mint();
+}
+
+// === Per-Market Mint Pause (admin) ===
+
+/// Set `mint_paused` on a single expiry market. Admin can pause or unpause.
+public fun set_expiry_market_mint_paused(
+    market: &mut ExpiryMarket,
+    _admin_cap: &AdminCap,
+    paused: bool,
+) {
+    market.set_mint_paused(paused);
+}
+
 /// Create a shared Pyth source for one admin-approved Lazer feed.
 ///
 /// The registry enforces one source object per feed ID.
 public fun create_pyth_source(
     registry: &mut Registry,
+    config: &ProtocolConfig,
     _admin_cap: &AdminCap,
     pyth_lazer_feed_id: u32,
     ctx: &mut TxContext,
 ): ID {
+    config.assert_version_allowed();
     assert!(!registry.pyth_source_ids.contains(pyth_lazer_feed_id), EPythSourceAlreadyCreated);
     let pyth_source_id = pyth_source::create_and_share(pyth_lazer_feed_id, ctx);
     registry.pyth_source_ids.add(pyth_lazer_feed_id, pyth_source_id);
@@ -264,6 +366,7 @@ public fun create_expiry_market(
     clock: &Clock,
     ctx: &mut TxContext,
 ): (ID, ID) {
+    config.assert_version_allowed();
     config.assert_trading_allowed();
     assert!(expiry > clock.timestamp_ms(), EInvalidExpiry);
     let pyth_lazer_feed_id = pyth.feed_id();
@@ -336,11 +439,17 @@ fun new_registry_and_admin_cap(ctx: &mut TxContext): (Registry, AdminCap) {
             id: object::new(ctx),
             pyth_source_ids: table::new(ctx),
             expiry_market_ids: table::new(ctx),
+            allowed_pause_caps: vec_set::empty(),
         },
         AdminCap {
             id: object::new(ctx),
         },
     )
+}
+
+/// Abort unless the supplied `PauseCap` was minted by admin and not revoked.
+fun assert_valid_pause_cap(registry: &Registry, pause_cap: &PauseCap) {
+    assert!(registry.allowed_pause_caps.contains(&pause_cap.id.to_inner()), EPauseCapNotValid);
 }
 
 // === Test-Only Functions ===
@@ -361,4 +470,24 @@ public fun init_for_testing(ctx: &mut TxContext): ID {
 /// Create an admin cap for tests.
 public fun create_admin_cap_for_testing(ctx: &mut TxContext): AdminCap {
     AdminCap { id: object::new(ctx) }
+}
+
+#[test_only]
+/// Return a Registry + AdminCap without sharing or storing the registry.
+/// Use this when a test wants direct access without `test_scenario`.
+public fun new_for_testing(ctx: &mut TxContext): (Registry, AdminCap) {
+    new_registry_and_admin_cap(ctx)
+}
+
+#[test_only]
+public fun destroy_registry_for_testing(registry: Registry) {
+    let Registry {
+        id,
+        pyth_source_ids,
+        expiry_market_ids,
+        allowed_pause_caps: _,
+    } = registry;
+    id.delete();
+    pyth_source_ids.destroy_empty();
+    expiry_market_ids.destroy_empty();
 }

--- a/packages/predict/sources/registry.move
+++ b/packages/predict/sources/registry.move
@@ -11,6 +11,7 @@ module deepbook_predict::registry;
 
 use deepbook_predict::{
     builder_code,
+    constants,
     expiry_market::{Self, ExpiryMarket},
     market_oracle::{Self, MarketOracle, MarketOracleCap},
     plp::PoolVault,
@@ -25,6 +26,10 @@ const EPythSourceAlreadyCreated: u64 = 3;
 const EInvalidExpiry: u64 = 4;
 const EExpiryMarketAlreadyCreated: u64 = 5;
 const EPauseCapNotValid: u64 = 6;
+const EPackageVersionDisabled: u64 = 7;
+const EVersionAlreadyEnabled: u64 = 8;
+const EVersionNotEnabled: u64 = 9;
+const ECannotDisableLastVersion: u64 = 10;
 
 /// Capability for admin operations.
 /// Created during package init, transferred to deployer (multisig).
@@ -49,6 +54,9 @@ public struct Registry has key {
     /// IDs of `PauseCap` objects currently authorized to use pause-only entries.
     /// Admin mints into this set and revokes from it.
     allowed_pause_caps: VecSet<ID>,
+    /// Package versions currently permitted to mutate per-pool state. Authoritative
+    /// source; pool objects mirror this set and refresh via permissionless sync.
+    allowed_versions: VecSet<u64>,
 }
 
 // === Public Functions ===
@@ -56,6 +64,24 @@ public struct Registry has key {
 /// Return the registry object ID.
 public fun id(registry: &Registry): ID {
     registry.id.to_inner()
+}
+
+/// Return the set of package versions currently permitted to mutate per-pool
+/// state. Pool sync helpers snapshot this; newly-created pools inherit it.
+public fun allowed_versions(registry: &Registry): VecSet<u64> {
+    registry.allowed_versions
+}
+
+/// Abort if the running package version is not in the allowed set.
+///
+/// Bypasses are package-internal version-management entries
+/// (`enable_version`, `disable_version`, PauseCap-based disables) so admin
+/// can recover from any disabled state.
+public(package) fun assert_version_allowed(registry: &Registry) {
+    assert!(
+        registry.allowed_versions.contains(&constants::current_version!()),
+        EPackageVersionDisabled,
+    );
 }
 
 /// Set the base fee multiplier.
@@ -213,19 +239,20 @@ public fun set_trading_paused(config: &mut ProtocolConfig, _admin_cap: &AdminCap
 
 // === Version Management (admin) ===
 
-/// Add `version` to `ProtocolConfig.allowed_versions`.
+/// Add `version` to the registry's allowed set.
 ///
 /// Not version-gated so admin can re-enable a previously disabled version.
-public fun enable_version(config: &mut ProtocolConfig, _admin_cap: &AdminCap, version: u64) {
-    config.enable_version(version);
+public fun enable_version(registry: &mut Registry, _admin_cap: &AdminCap, version: u64) {
+    assert!(!registry.allowed_versions.contains(&version), EVersionAlreadyEnabled);
+    registry.allowed_versions.insert(version);
 }
 
-/// Remove `version` from `ProtocolConfig.allowed_versions`.
+/// Remove `version` from the registry's allowed set.
 ///
 /// Not version-gated so admin can revoke a version even after the active
 /// version has been paused. The set may not be left empty.
-public fun disable_version(config: &mut ProtocolConfig, _admin_cap: &AdminCap, version: u64) {
-    config.disable_version(version);
+public fun disable_version(registry: &mut Registry, _admin_cap: &AdminCap, version: u64) {
+    registry.disable_version_internal(version);
 }
 
 // === PauseCap Lifecycle (admin) ===
@@ -258,14 +285,9 @@ public fun destroy_pause_cap(cap: PauseCap) {
 
 /// Disable a package version via a valid `PauseCap`. One-way: admin must
 /// `enable_version` to restore.
-public fun disable_version_pause_cap(
-    registry: &Registry,
-    config: &mut ProtocolConfig,
-    version: u64,
-    pause_cap: &PauseCap,
-) {
+public fun disable_version_pause_cap(registry: &mut Registry, version: u64, pause_cap: &PauseCap) {
     registry.assert_valid_pause_cap(pause_cap);
-    config.disable_version(version);
+    registry.disable_version_internal(version);
 }
 
 /// Force `trading_paused = true` via a valid `PauseCap`. One-way.
@@ -305,14 +327,17 @@ public fun set_expiry_market_mint_paused(
 /// The registry enforces one source object per feed ID.
 public fun create_pyth_source(
     registry: &mut Registry,
-    config: &ProtocolConfig,
     _admin_cap: &AdminCap,
     pyth_lazer_feed_id: u32,
     ctx: &mut TxContext,
 ): ID {
-    config.assert_version_allowed();
+    registry.assert_version_allowed();
     assert!(!registry.pyth_source_ids.contains(pyth_lazer_feed_id), EPythSourceAlreadyCreated);
-    let pyth_source_id = pyth_source::create_and_share(pyth_lazer_feed_id, ctx);
+    let pyth_source_id = pyth_source::create_and_share(
+        pyth_lazer_feed_id,
+        registry.allowed_versions,
+        ctx,
+    );
     registry.pyth_source_ids.add(pyth_lazer_feed_id, pyth_source_id);
     pyth_source_id
 }
@@ -366,7 +391,7 @@ public fun create_expiry_market(
     clock: &Clock,
     ctx: &mut TxContext,
 ): (ID, ID) {
-    config.assert_version_allowed();
+    registry.assert_version_allowed();
     config.assert_trading_allowed();
     assert!(expiry > clock.timestamp_ms(), EInvalidExpiry);
     let pyth_lazer_feed_id = pyth.feed_id();
@@ -374,12 +399,14 @@ public fun create_expiry_market(
     assert!(registry.pyth_source_ids[pyth_lazer_feed_id] == pyth.id(), EFeedIdMismatch);
     expiry_market::assert_valid_strike_grid(min_strike, tick_size);
     assert!(!registry.expiry_market_ids.contains(expiry), EExpiryMarketAlreadyCreated);
+    let allowed_versions = registry.allowed_versions;
     let allocation = pool_vault.allocate_to_new_expiry(config.risk_config());
     let market_oracle_id = market_oracle::create_and_share(
         pyth,
         config.market_oracle_config(),
         cap,
         expiry,
+        allowed_versions,
         ctx,
     );
     let expiry_market_id = expiry_market::create_and_share(
@@ -390,6 +417,7 @@ public fun create_expiry_market(
         expiry,
         min_strike,
         tick_size,
+        allowed_versions,
         ctx,
     );
     pool_vault.register_expiry_market(expiry_market_id);
@@ -405,7 +433,8 @@ public fun create_builder_code(registry: &mut Registry, index: u64, ctx: &mut Tx
 
 /// Create a derived PredictManager for the caller.
 public fun create_manager(registry: &mut Registry, ctx: &mut TxContext): PredictManager {
-    predict_manager::new(&mut registry.id, ctx)
+    let allowed_versions = registry.allowed_versions;
+    predict_manager::new(&mut registry.id, allowed_versions, ctx)
 }
 
 /// Create and share a derived PredictManager for the caller.
@@ -440,6 +469,7 @@ fun new_registry_and_admin_cap(ctx: &mut TxContext): (Registry, AdminCap) {
             pyth_source_ids: table::new(ctx),
             expiry_market_ids: table::new(ctx),
             allowed_pause_caps: vec_set::empty(),
+            allowed_versions: vec_set::singleton(constants::current_version!()),
         },
         AdminCap {
             id: object::new(ctx),
@@ -450,6 +480,14 @@ fun new_registry_and_admin_cap(ctx: &mut TxContext): (Registry, AdminCap) {
 /// Abort unless the supplied `PauseCap` was minted by admin and not revoked.
 fun assert_valid_pause_cap(registry: &Registry, pause_cap: &PauseCap) {
     assert!(registry.allowed_pause_caps.contains(&pause_cap.id.to_inner()), EPauseCapNotValid);
+}
+
+/// Remove a version from the allowed set, enforcing the non-empty invariant.
+/// Shared by the admin `disable_version` and PauseCap `disable_version_pause_cap`.
+fun disable_version_internal(registry: &mut Registry, version: u64) {
+    assert!(registry.allowed_versions.contains(&version), EVersionNotEnabled);
+    assert!(registry.allowed_versions.length() > 1, ECannotDisableLastVersion);
+    registry.allowed_versions.remove(&version);
 }
 
 // === Test-Only Functions ===
@@ -486,6 +524,7 @@ public fun destroy_registry_for_testing(registry: Registry) {
         pyth_source_ids,
         expiry_market_ids,
         allowed_pause_caps: _,
+        allowed_versions: _,
     } = registry;
     id.delete();
     pyth_source_ids.destroy_empty();

--- a/packages/predict/tests/pause_tests.move
+++ b/packages/predict/tests/pause_tests.move
@@ -1,0 +1,167 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module deepbook_predict::pause_tests;
+
+use deepbook_predict::{constants, i64, market_oracle, protocol_config, registry};
+use std::unit_test::{assert_eq, destroy};
+use sui::clock;
+
+const NEXT_VERSION: u64 = 2;
+const EXPIRY_MS: u64 = 100_000;
+const NOW_MS: u64 = 10_000;
+const SVI_TIMESTAMP_MS: u64 = 1_000;
+
+#[test]
+fun default_allowed_versions_contains_current() {
+    let ctx = &mut tx_context::dummy();
+    let config = protocol_config::new_for_testing(ctx);
+    let allowed = config.allowed_versions();
+    let current = constants::current_version!();
+    assert_eq!(allowed.length(), 1);
+    assert!(allowed.contains(&current));
+    destroy(config);
+}
+
+#[test]
+fun admin_can_enable_then_disable_a_version() {
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+
+    let next = NEXT_VERSION;
+    registry::enable_version(&mut config, &admin_cap, next);
+    assert!(config.allowed_versions().contains(&next));
+
+    registry::disable_version(&mut config, &admin_cap, next);
+    assert!(!config.allowed_versions().contains(&next));
+
+    destroy(config);
+    destroy(admin_cap);
+}
+
+#[test, expected_failure(abort_code = protocol_config::ECannotDisableLastVersion)]
+fun cannot_disable_last_allowed_version() {
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+
+    registry::disable_version(&mut config, &admin_cap, constants::current_version!());
+    abort 999
+}
+
+#[test, expected_failure(abort_code = protocol_config::EVersionAlreadyEnabled)]
+fun enable_already_enabled_version_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+
+    registry::enable_version(&mut config, &admin_cap, constants::current_version!());
+    abort 999
+}
+
+#[test, expected_failure(abort_code = protocol_config::EVersionNotEnabled)]
+fun disable_not_enabled_version_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+
+    registry::disable_version(&mut config, &admin_cap, NEXT_VERSION);
+    abort 999
+}
+
+#[test, expected_failure(abort_code = protocol_config::EPackageVersionDisabled)]
+fun disabled_version_blocks_admin_setter() {
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+
+    // Add NEXT_VERSION so we can disable current_version!() without leaving an empty set.
+    registry::enable_version(&mut config, &admin_cap, NEXT_VERSION);
+    registry::disable_version(&mut config, &admin_cap, constants::current_version!());
+
+    registry::set_base_fee(&mut config, &admin_cap, 1);
+    abort 999
+}
+
+#[test]
+fun pause_cap_can_disable_version() {
+    let ctx = &mut tx_context::dummy();
+    let (mut registry, admin_cap) = registry::new_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+    let current = constants::current_version!();
+
+    registry::enable_version(&mut config, &admin_cap, NEXT_VERSION);
+    let pause_cap = registry::mint_pause_cap(&mut registry, &admin_cap, ctx);
+
+    registry::disable_version_pause_cap(&registry, &mut config, current, &pause_cap);
+    assert!(!config.allowed_versions().contains(&current));
+
+    registry::destroy_pause_cap(pause_cap);
+    registry::destroy_registry_for_testing(registry);
+    destroy(config);
+    destroy(admin_cap);
+}
+
+#[test]
+fun pause_cap_pause_trading_is_one_way() {
+    let ctx = &mut tx_context::dummy();
+    let (mut registry, admin_cap) = registry::new_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+    let pause_cap = registry::mint_pause_cap(&mut registry, &admin_cap, ctx);
+
+    assert!(!config.trading_paused());
+    registry::pause_trading_pause_cap(&registry, &mut config, &pause_cap);
+    assert!(config.trading_paused());
+
+    registry::destroy_pause_cap(pause_cap);
+    registry::destroy_registry_for_testing(registry);
+    destroy(config);
+    destroy(admin_cap);
+}
+
+#[test, expected_failure(abort_code = registry::EPauseCapNotValid)]
+fun revoked_pause_cap_cannot_act() {
+    let ctx = &mut tx_context::dummy();
+    let (mut registry, admin_cap) = registry::new_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+    registry::enable_version(&mut config, &admin_cap, NEXT_VERSION);
+    let pause_cap = registry::mint_pause_cap(&mut registry, &admin_cap, ctx);
+    let pause_cap_id = object::id(&pause_cap);
+
+    registry::revoke_pause_cap(&mut registry, &admin_cap, pause_cap_id);
+    registry::disable_version_pause_cap(
+        &registry,
+        &mut config,
+        NEXT_VERSION,
+        &pause_cap,
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = market_oracle::EPackageVersionDisabled)]
+fun synced_market_oracle_blocks_disabled_version() {
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+    let mut clock = clock::create_for_testing(ctx);
+    clock.set_for_testing(NOW_MS);
+
+    // Disable current_version, then sync the market to propagate the change.
+    let current = constants::current_version!();
+    registry::enable_version(&mut config, &admin_cap, NEXT_VERSION);
+    registry::disable_version(&mut config, &admin_cap, current);
+    market.update_allowed_versions_permissionless(&config);
+
+    market.update_svi(
+        &config,
+        &cap,
+        market_oracle::new_svi_params(1, 2, i64::zero(), i64::zero(), 3),
+        SVI_TIMESTAMP_MS,
+        &clock,
+    );
+    abort 999
+}

--- a/packages/predict/tests/pause_tests.move
+++ b/packages/predict/tests/pause_tests.move
@@ -16,72 +16,55 @@ const SVI_TIMESTAMP_MS: u64 = 1_000;
 #[test]
 fun default_allowed_versions_contains_current() {
     let ctx = &mut tx_context::dummy();
-    let config = protocol_config::new_for_testing(ctx);
-    let allowed = config.allowed_versions();
+    let (registry, admin_cap) = registry::new_for_testing(ctx);
+    let allowed = registry.allowed_versions();
     let current = constants::current_version!();
     assert_eq!(allowed.length(), 1);
     assert!(allowed.contains(&current));
-    destroy(config);
+    registry::destroy_registry_for_testing(registry);
+    destroy(admin_cap);
 }
 
 #[test]
 fun admin_can_enable_then_disable_a_version() {
     let ctx = &mut tx_context::dummy();
-    let mut config = protocol_config::new_for_testing(ctx);
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let (mut registry, admin_cap) = registry::new_for_testing(ctx);
 
     let next = NEXT_VERSION;
-    registry::enable_version(&mut config, &admin_cap, next);
-    assert!(config.allowed_versions().contains(&next));
+    registry::enable_version(&mut registry, &admin_cap, next);
+    assert!(registry.allowed_versions().contains(&next));
 
-    registry::disable_version(&mut config, &admin_cap, next);
-    assert!(!config.allowed_versions().contains(&next));
+    registry::disable_version(&mut registry, &admin_cap, next);
+    assert!(!registry.allowed_versions().contains(&next));
 
-    destroy(config);
+    registry::destroy_registry_for_testing(registry);
     destroy(admin_cap);
 }
 
-#[test, expected_failure(abort_code = protocol_config::ECannotDisableLastVersion)]
+#[test, expected_failure(abort_code = registry::ECannotDisableLastVersion)]
 fun cannot_disable_last_allowed_version() {
     let ctx = &mut tx_context::dummy();
-    let mut config = protocol_config::new_for_testing(ctx);
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let (mut registry, admin_cap) = registry::new_for_testing(ctx);
 
-    registry::disable_version(&mut config, &admin_cap, constants::current_version!());
+    registry::disable_version(&mut registry, &admin_cap, constants::current_version!());
     abort 999
 }
 
-#[test, expected_failure(abort_code = protocol_config::EVersionAlreadyEnabled)]
+#[test, expected_failure(abort_code = registry::EVersionAlreadyEnabled)]
 fun enable_already_enabled_version_aborts() {
     let ctx = &mut tx_context::dummy();
-    let mut config = protocol_config::new_for_testing(ctx);
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let (mut registry, admin_cap) = registry::new_for_testing(ctx);
 
-    registry::enable_version(&mut config, &admin_cap, constants::current_version!());
+    registry::enable_version(&mut registry, &admin_cap, constants::current_version!());
     abort 999
 }
 
-#[test, expected_failure(abort_code = protocol_config::EVersionNotEnabled)]
+#[test, expected_failure(abort_code = registry::EVersionNotEnabled)]
 fun disable_not_enabled_version_aborts() {
     let ctx = &mut tx_context::dummy();
-    let mut config = protocol_config::new_for_testing(ctx);
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let (mut registry, admin_cap) = registry::new_for_testing(ctx);
 
-    registry::disable_version(&mut config, &admin_cap, NEXT_VERSION);
-    abort 999
-}
-
-#[test, expected_failure(abort_code = protocol_config::EPackageVersionDisabled)]
-fun disabled_version_blocks_admin_setter() {
-    let ctx = &mut tx_context::dummy();
-    let mut config = protocol_config::new_for_testing(ctx);
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-
-    // Add NEXT_VERSION so we can disable current_version!() without leaving an empty set.
-    registry::enable_version(&mut config, &admin_cap, NEXT_VERSION);
-    registry::disable_version(&mut config, &admin_cap, constants::current_version!());
-
-    registry::set_base_fee(&mut config, &admin_cap, 1);
+    registry::disable_version(&mut registry, &admin_cap, NEXT_VERSION);
     abort 999
 }
 
@@ -89,18 +72,16 @@ fun disabled_version_blocks_admin_setter() {
 fun pause_cap_can_disable_version() {
     let ctx = &mut tx_context::dummy();
     let (mut registry, admin_cap) = registry::new_for_testing(ctx);
-    let mut config = protocol_config::new_for_testing(ctx);
     let current = constants::current_version!();
 
-    registry::enable_version(&mut config, &admin_cap, NEXT_VERSION);
+    registry::enable_version(&mut registry, &admin_cap, NEXT_VERSION);
     let pause_cap = registry::mint_pause_cap(&mut registry, &admin_cap, ctx);
 
-    registry::disable_version_pause_cap(&registry, &mut config, current, &pause_cap);
-    assert!(!config.allowed_versions().contains(&current));
+    registry::disable_version_pause_cap(&mut registry, current, &pause_cap);
+    assert!(!registry.allowed_versions().contains(&current));
 
     registry::destroy_pause_cap(pause_cap);
     registry::destroy_registry_for_testing(registry);
-    destroy(config);
     destroy(admin_cap);
 }
 
@@ -125,36 +106,30 @@ fun pause_cap_pause_trading_is_one_way() {
 fun revoked_pause_cap_cannot_act() {
     let ctx = &mut tx_context::dummy();
     let (mut registry, admin_cap) = registry::new_for_testing(ctx);
-    let mut config = protocol_config::new_for_testing(ctx);
-    registry::enable_version(&mut config, &admin_cap, NEXT_VERSION);
+    registry::enable_version(&mut registry, &admin_cap, NEXT_VERSION);
     let pause_cap = registry::mint_pause_cap(&mut registry, &admin_cap, ctx);
     let pause_cap_id = object::id(&pause_cap);
 
     registry::revoke_pause_cap(&mut registry, &admin_cap, pause_cap_id);
-    registry::disable_version_pause_cap(
-        &registry,
-        &mut config,
-        NEXT_VERSION,
-        &pause_cap,
-    );
+    registry::disable_version_pause_cap(&mut registry, NEXT_VERSION, &pause_cap);
     abort 999
 }
 
 #[test, expected_failure(abort_code = market_oracle::EPackageVersionDisabled)]
 fun synced_market_oracle_blocks_disabled_version() {
     let ctx = &mut tx_context::dummy();
-    let mut config = protocol_config::new_for_testing(ctx);
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let (mut registry, admin_cap) = registry::new_for_testing(ctx);
+    let config = protocol_config::new_for_testing(ctx);
     let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
     let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
     let mut clock = clock::create_for_testing(ctx);
     clock.set_for_testing(NOW_MS);
 
-    // Disable current_version, then sync the market to propagate the change.
+    // Disable current_version on the registry, then sync the market.
     let current = constants::current_version!();
-    registry::enable_version(&mut config, &admin_cap, NEXT_VERSION);
-    registry::disable_version(&mut config, &admin_cap, current);
-    market.update_allowed_versions_permissionless(&config);
+    registry::enable_version(&mut registry, &admin_cap, NEXT_VERSION);
+    registry::disable_version(&mut registry, &admin_cap, current);
+    market.update_allowed_versions(registry.allowed_versions());
 
     market.update_svi(
         &config,


### PR DESCRIPTION
## Summary
- Adds per-package `allowed_versions` gate on every shared mutable Predict object (`ProtocolConfig`, `ExpiryMarket`, `MarketOracle`, `PoolVault`, `PredictManager`, `PythSource`), mirroring the deepbook core pattern so each pool stays parallelizable without going through the global config.
- Introduces `PauseCap`: admin mints and revokes via `Registry`; holders can one-way `disable_version`, set `trading_paused=true`, and pause minting on a single `ExpiryMarket`. Cannot unpause anything.
- Adds per-`ExpiryMarket` `mint_paused` flag, settable bidirectionally by `AdminCap` and one-way by `PauseCap`. Only `mint` is blocked; redeem, valuation, and allocation moves keep working.
- Existing `trading_paused` flag retained; admin can flip either way, PauseCap can only set it to true.
- Permissionless `update_*_allowed_versions_permissionless` on each shared object so anyone can propagate an admin/PauseCap version change.

## Key decisions
- `allowed_versions` is mirrored per-pool rather than read off `ProtocolConfig` at gate time. Each pool can lag a global change until permissionless sync catches it up — matches deepbook core and avoids forcing every entry point to take `&ProtocolConfig` just for the gate.
- Admin setters on `ProtocolConfig` are version-gated; version-management (`enable_version`/`disable_version`/`mint_pause_cap`/`revoke_pause_cap`/`disable_version_pause_cap`) bypasses the gate so admin can recover from any disabled state.
- `assert_trading_allowed` deliberately does NOT include the version gate, because per-pool flows that call it already check their own mirrored set.
- New per-pool objects (`ExpiryMarket`/`MarketOracle`/`PythSource`) initialize `allowed_versions` to `singleton(current_version!())`. If admin had already disabled the current version, a new pool would need a permissionless sync to inherit that state — accepted as a small window in exchange for not threading `ProtocolConfig` through every create path.
- `create_pyth_source` gained a `&ProtocolConfig` parameter (was missing the gate); `simulations/src/runtime.ts` updated to match.

## Test plan
- [x] \`cd packages/predict && sui move test --gas-limit 100000000000\` → 18 pass
- [x] \`bunx prettier-move -c sources/**/*.move tests/**/*.move --write\` clean
- [ ] \`cd packages/predict/simulations && bash run.sh --setup --skip-analysis\`
- [ ] Manual: mint pause cap, disable version, confirm mint aborts; revoke pause cap, confirm subsequent use aborts with \`EPauseCapNotValid\`.