### PR TITLE
Add Predict leverage config scaffolding

### DIFF
--- a/packages/predict/sources/config/config_constants.move
+++ b/packages/predict/sources/config/config_constants.move
@@ -31,6 +31,7 @@ const EInvalidShrinkUtilizationThreshold: u64 = 19;
 const EInvalidGrowFactor: u64 = 20;
 const EInvalidShrinkFactor: u64 = 21;
 const EInvalidSettlementLossRebateRate: u64 = 22;
+const EInvalidMaxExpiryBorrowFee: u64 = 23;
 
 // === Pool Risk ===
 
@@ -100,6 +101,21 @@ public(package) macro fun max_shrink_factor(): u64 {
 
 public(package) fun assert_shrink_factor(value: u64) {
     assert!(value >= min_shrink_factor!() && value <= max_shrink_factor!(), EInvalidShrinkFactor);
+}
+
+// === Leverage ===
+
+public(package) macro fun default_max_expiry_borrow_fee(): u64 { 200_000_000 }
+public(package) macro fun min_max_expiry_borrow_fee(): u64 { 0 }
+public(package) macro fun max_max_expiry_borrow_fee(): u64 {
+    deepbook_predict::constants::float_scaling!()
+}
+
+public(package) fun assert_max_expiry_borrow_fee(value: u64) {
+    assert!(
+        value >= min_max_expiry_borrow_fee!() && value <= max_max_expiry_borrow_fee!(),
+        EInvalidMaxExpiryBorrowFee,
+    );
 }
 
 // === Pricing ===

--- a/packages/predict/sources/config/fee_config.move
+++ b/packages/predict/sources/config/fee_config.move
@@ -70,15 +70,3 @@ public(package) fun set_settlement_loss_rebate_rate(config: &mut FeeConfig, valu
     config_constants::assert_settlement_loss_rebate_rate(value);
     config.settlement_loss_rebate_rate = value;
 }
-
-// === Test-Only Functions ===
-
-#[test_only]
-public fun destroy_for_testing(config: FeeConfig) {
-    let FeeConfig {
-        lp_fee_share: _,
-        protocol_fee_share: _,
-        insurance_fee_share: _,
-        settlement_loss_rebate_rate: _,
-    } = config;
-}

--- a/packages/predict/sources/config/leverage_config.move
+++ b/packages/predict/sources/config/leverage_config.move
@@ -1,0 +1,35 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Stored leverage template for future expiry markets.
+///
+/// Protocol config stores the admin-tunable terminal borrow fee used by future
+/// expiry markets. Each market snapshots that value at creation so later admin
+/// updates do not reprice active markets.
+module deepbook_predict::leverage_config;
+
+use deepbook_predict::config_constants;
+
+/// Leverage parameters expressed in Predict's 1e9 fixed-point price scaling.
+public struct LeverageConfig has store {
+    /// Maximum total time-only borrow premium over one expiry.
+    /// `200_000_000` means the borrow index rises from 1.00 to 1.20.
+    max_expiry_borrow_fee: u64,
+}
+
+// === Public-Package Functions ===
+
+public(package) fun max_expiry_borrow_fee(config: &LeverageConfig): u64 {
+    config.max_expiry_borrow_fee
+}
+
+public(package) fun new(): LeverageConfig {
+    LeverageConfig {
+        max_expiry_borrow_fee: config_constants::default_max_expiry_borrow_fee!(),
+    }
+}
+
+public(package) fun set_template_max_expiry_borrow_fee(config: &mut LeverageConfig, value: u64) {
+    config_constants::assert_max_expiry_borrow_fee(value);
+    config.max_expiry_borrow_fee = value;
+}

--- a/packages/predict/sources/config/market_oracle_config.move
+++ b/packages/predict/sources/config/market_oracle_config.move
@@ -92,16 +92,3 @@ fun assert_basis_bounds_inputs(
     config_constants::assert_max_basis(max_basis);
     assert!(min_basis < max_basis, EInvalidBasisBounds);
 }
-
-// === Test-Only Functions ===
-
-#[test_only]
-public fun destroy_for_testing(config: MarketOracleConfig) {
-    let MarketOracleConfig {
-        settlement_freshness_ms: _,
-        max_spot_deviation: _,
-        max_basis_deviation: _,
-        min_basis: _,
-        max_basis: _,
-    } = config;
-}

--- a/packages/predict/sources/config/pricing_config.move
+++ b/packages/predict/sources/config/pricing_config.move
@@ -122,19 +122,3 @@ public(package) fun set_block_scholes_svi_freshness_ms(config: &mut PricingConfi
     config_constants::assert_block_scholes_svi_freshness_ms(value);
     config.block_scholes_svi_freshness_ms = value;
 }
-
-// === Test-Only Functions ===
-
-#[test_only]
-public fun destroy_for_testing(config: PricingConfig) {
-    let PricingConfig {
-        base_fee: _,
-        min_fee: _,
-        utilization_multiplier: _,
-        min_ask_price: _,
-        max_ask_price: _,
-        pyth_spot_freshness_ms: _,
-        block_scholes_prices_freshness_ms: _,
-        block_scholes_svi_freshness_ms: _,
-    } = config;
-}

--- a/packages/predict/sources/config/risk_config.move
+++ b/packages/predict/sources/config/risk_config.move
@@ -95,17 +95,3 @@ public(package) fun set_shrink_factor(config: &mut RiskConfig, factor: u64) {
     config_constants::assert_shrink_factor(factor);
     config.shrink_factor = factor;
 }
-
-// === Test-Only Functions ===
-
-#[test_only]
-public fun destroy_for_testing(config: RiskConfig) {
-    let RiskConfig {
-        max_total_exposure_pct: _,
-        expiry_allocation: _,
-        grow_utilization_threshold: _,
-        shrink_utilization_threshold: _,
-        grow_factor: _,
-        shrink_factor: _,
-    } = config;
-}

--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -50,6 +50,8 @@ public struct ExpiryMarket has key {
     expiry: u64,
     /// Settlement loss rebate rate snapshotted from fee config at creation.
     settlement_loss_rebate_rate: u64,
+    /// Terminal borrow premium snapshotted from leverage config at creation.
+    max_expiry_borrow_fee: u64,
     /// Active risk budget assigned by the pool.
     allocated_capital: u64,
     /// LP-owned DUSDC backing this expiry's liability.
@@ -129,6 +131,11 @@ public fun fee_balance(market: &ExpiryMarket): u64 {
 /// Return the settlement loss rebate rate snapshotted for this expiry.
 public fun settlement_loss_rebate_rate(market: &ExpiryMarket): u64 {
     market.settlement_loss_rebate_rate
+}
+
+/// Return the terminal borrow premium snapshotted for this expiry.
+public fun max_expiry_borrow_fee(market: &ExpiryMarket): u64 {
+    market.max_expiry_borrow_fee
 }
 
 /// Return the expiry-local worst-case payout.
@@ -312,6 +319,7 @@ public(package) fun create_and_share(
         pyth_lazer_feed_id,
         expiry,
         settlement_loss_rebate_rate: config.fee_config().settlement_loss_rebate_rate(),
+        max_expiry_borrow_fee: config.leverage_config().max_expiry_borrow_fee(),
         allocated_capital,
         lp_cash_balance: allocation,
         fee_balance: balance::zero(),

--- a/packages/predict/sources/helper/constants.move
+++ b/packages/predict/sources/helper/constants.move
@@ -27,6 +27,11 @@ public macro fun float_scaling(): u64 { 1_000_000_000 }
 /// form into the package's 1e9-scaled `u64`.
 public macro fun float_scaling_decimals(): u64 { 9 }
 
+// === Leverage ===
+
+/// Window before expiry over which leverage borrow fees accrue.
+public macro fun leverage_borrow_window_ms(): u64 { 31_536_000_000 }
+
 // === Builder Fees ===
 
 /// Add-on builder fee as a fraction of the normal trade fee.

--- a/packages/predict/sources/oracle/market_oracle.move
+++ b/packages/predict/sources/oracle/market_oracle.move
@@ -782,31 +782,3 @@ public(package) fun create_test_market_oracle(
         settlement_update_timestamp_ms: 0,
     }
 }
-
-#[test_only]
-public(package) fun destroy_for_testing(market: MarketOracle) {
-    let MarketOracle {
-        id,
-        authorized_cap_ids: _,
-        allowed_versions: _,
-        pyth_source_id: _,
-        expiry: _,
-        block_scholes_spot: _,
-        block_scholes_forward: _,
-        block_scholes_price_source_timestamp_ms: _,
-        block_scholes_price_update_timestamp_ms: _,
-        block_scholes_svi: _,
-        block_scholes_svi_source_timestamp_ms: _,
-        block_scholes_svi_update_timestamp_ms: _,
-        settlement_freshness_ms: _,
-        max_spot_deviation: _,
-        max_basis_deviation: _,
-        min_basis: _,
-        max_basis: _,
-        settlement_price: _,
-        settlement_source: _,
-        settlement_source_timestamp_ms: _,
-        settlement_update_timestamp_ms: _,
-    } = market;
-    id.delete();
-}

--- a/packages/predict/sources/protocol_config.move
+++ b/packages/predict/sources/protocol_config.move
@@ -10,6 +10,7 @@ module deepbook_predict::protocol_config;
 
 use deepbook_predict::{
     fee_config::{Self, FeeConfig},
+    leverage_config::{Self, LeverageConfig},
     market_oracle_config::{Self, MarketOracleConfig},
     pricing_config::{Self, PricingConfig},
     risk_config::{Self, RiskConfig}
@@ -26,6 +27,7 @@ public struct ProtocolConfig has key {
     fee_config: FeeConfig,
     risk_config: RiskConfig,
     market_oracle_config: MarketOracleConfig,
+    leverage_config: LeverageConfig,
     /// Blocks new risk creation while true.
     trading_paused: bool,
     /// Transaction-local lock held while a full-pool valuation is assembled.
@@ -62,6 +64,10 @@ public(package) fun market_oracle_config(config: &ProtocolConfig): &MarketOracle
     &config.market_oracle_config
 }
 
+public(package) fun leverage_config(config: &ProtocolConfig): &LeverageConfig {
+    &config.leverage_config
+}
+
 /// Abort unless trading mutations are currently allowed.
 ///
 /// Intentionally omits the package-version gate: per-pool mutating flows that
@@ -95,6 +101,7 @@ public(package) fun create_and_share(ctx: &mut TxContext): ID {
         fee_config: fee_config::new(),
         risk_config: risk_config::new(),
         market_oracle_config: market_oracle_config::new(),
+        leverage_config: leverage_config::new(),
         trading_paused: false,
         valuation_in_progress: false,
     };
@@ -111,6 +118,11 @@ public(package) fun set_base_fee(config: &mut ProtocolConfig, fee: u64) {
 public(package) fun set_min_fee(config: &mut ProtocolConfig, fee: u64) {
     config.assert_not_valuation_in_progress();
     config.pricing_config.set_min_fee(fee);
+}
+
+public(package) fun set_template_max_expiry_borrow_fee(config: &mut ProtocolConfig, value: u64) {
+    config.assert_not_valuation_in_progress();
+    config.leverage_config.set_template_max_expiry_borrow_fee(value);
 }
 
 public(package) fun set_utilization_multiplier(config: &mut ProtocolConfig, multiplier: u64) {
@@ -253,25 +265,8 @@ public fun new_for_testing(ctx: &mut TxContext): ProtocolConfig {
         fee_config: fee_config::new(),
         risk_config: risk_config::new(),
         market_oracle_config: market_oracle_config::new(),
+        leverage_config: leverage_config::new(),
         trading_paused: false,
         valuation_in_progress: false,
     }
-}
-
-#[test_only]
-public fun destroy_for_testing(config: ProtocolConfig) {
-    let ProtocolConfig {
-        id,
-        pricing_config,
-        fee_config,
-        risk_config,
-        market_oracle_config,
-        trading_paused: _,
-        valuation_in_progress: _,
-    } = config;
-    id.delete();
-    pricing_config.destroy_for_testing();
-    fee_config.destroy_for_testing();
-    risk_config.destroy_for_testing();
-    market_oracle_config.destroy_for_testing();
 }

--- a/packages/predict/sources/registry.move
+++ b/packages/predict/sources/registry.move
@@ -94,6 +94,15 @@ public fun set_min_fee(config: &mut ProtocolConfig, _admin_cap: &AdminCap, fee: 
     config.set_min_fee(fee);
 }
 
+/// Set the maximum borrow-index increase snapshotted by future expiry markets.
+public fun set_template_max_expiry_borrow_fee(
+    config: &mut ProtocolConfig,
+    _admin_cap: &AdminCap,
+    value: u64,
+) {
+    config.set_template_max_expiry_borrow_fee(value);
+}
+
 /// Set the utilization multiplier.
 public fun set_utilization_multiplier(
     config: &mut ProtocolConfig,

--- a/packages/predict/tests/config/pricing_config_tests.move
+++ b/packages/predict/tests/config/pricing_config_tests.move
@@ -5,7 +5,7 @@
 module deepbook_predict::pricing_config_tests;
 
 use deepbook_predict::{config_constants, pricing_config};
-use std::unit_test::assert_eq;
+use std::unit_test::{assert_eq, destroy};
 
 #[test]
 fun defaults_expose_fee_terms() {
@@ -19,7 +19,7 @@ fun defaults_expose_fee_terms() {
     );
     assert_eq!(config.min_ask_price(), config_constants::default_min_ask_price!());
     assert_eq!(config.max_ask_price(), config_constants::default_max_ask_price!());
-    config.destroy_for_testing();
+    destroy(config);
 }
 
 #[test]
@@ -33,5 +33,5 @@ fun setters_update_fee_terms() {
     assert_eq!(config.base_fee(), 30_000_000);
     assert_eq!(config.min_fee(), 2_000_000);
     assert_eq!(config.utilization_multiplier(), 3_000_000_000);
-    config.destroy_for_testing();
+    destroy(config);
 }

--- a/packages/predict/tests/helper/oracle_cap_tests.move
+++ b/packages/predict/tests/helper/oracle_cap_tests.move
@@ -117,8 +117,8 @@ fun cleanup(
         registry::destroy_market_oracle_cap(caps.pop_back());
     };
     caps.destroy_empty();
-    market.destroy_for_testing();
-    config.destroy_for_testing();
+    destroy(market);
+    destroy(config);
     clock.destroy_for_testing();
     destroy(admin_cap);
 }


### PR DESCRIPTION
## Summary
- Add a Predict leverage config object with a template max expiry borrow fee and validation bounds.
- Snapshot the configured max expiry borrow fee into new expiry markets and expose a getter.
- Remove source-side test-only destroy helpers in favor of direct std::unit_test::destroy calls in tests.

## Key decisions
- This PR only adds config/state scaffolding for leverage; it does not add leveraged order behavior, liquidation, order-id migration, or borrow accounting.
- The admin setter is template-named because updates affect future expiry markets, not existing snapshotted markets.

## Test plan
- [x] npx -y prettier-move -c packages/predict/sources/config/config_constants.move packages/predict/sources/config/leverage_config.move packages/predict/sources/config/fee_config.move packages/predict/sources/config/pricing_config.move packages/predict/sources/config/risk_config.move packages/predict/sources/config/market_oracle_config.move packages/predict/sources/helper/constants.move packages/predict/sources/protocol_config.move packages/predict/sources/expiry_market.move packages/predict/sources/registry.move packages/predict/sources/oracle/market_oracle.move packages/predict/tests/config/pricing_config_tests.move packages/predict/tests/helper/oracle_cap_tests.move
- [x] sui move test --path packages/predict --gas-limit 100000000000
- [x] git diff --check