### PR TITLE
predict: enforce position lot size

### DIFF
--- a/packages/predict/simulations/src/shared.ts
+++ b/packages/predict/simulations/src/shared.ts
@@ -92,6 +92,7 @@ const SCENARIO_COLUMNS = [
 
 const DEFAULT_SCENARIO_QUANTITY_SCALE = 10_000n;
 const SCENARIO_QUANTITY_SCALE_ENV = "SIM_QUANTITY_SCALE";
+const POSITION_LOT_SIZE = 10_000n;
 
 function resolveScenarioQuantityScale(): bigint {
   const value = process.env[SCENARIO_QUANTITY_SCALE_ENV];
@@ -148,7 +149,12 @@ function normalizeMintQuantity(rawQuantity: bigint, lineNumber: number): bigint 
   if (normalized <= 0n) {
     throw new Error(`Scenario line ${lineNumber}: normalized mint quantity must be positive`);
   }
-  return normalized;
+
+  const lots = normalized / POSITION_LOT_SIZE;
+  if (lots <= 0n) {
+    throw new Error(`Scenario line ${lineNumber}: normalized mint quantity must be at least one position lot`);
+  }
+  return lots * POSITION_LOT_SIZE;
 }
 
 function parseRow(row: RawScenarioRow, lineNumber: number): ScenarioRow {

--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -41,6 +41,7 @@ const EInsufficientFeeBalance: u64 = 18;
 const ECompactedRebateLiabilityUnderflow: u64 = 19;
 const EPackageVersionDisabled: u64 = 20;
 const EMintPaused: u64 = 21;
+const EInvalidQuantity: u64 = 22;
 
 /// Per-expiry market state.
 public struct ExpiryMarket has key {
@@ -495,7 +496,7 @@ fun mint_internal(
     pricing::assert_live_oracle_fresh(config.pricing_config(), market_oracle, clock);
     market.assert_range_key_matches(&key);
     market.assert_not_compacted();
-    assert_nonzero_quantity(quantity);
+    assert_valid_quantity(quantity);
 
     // Quote before recording exposure so the fee basis stored with the position
     // matches the exact fee charged for this mint.
@@ -551,7 +552,7 @@ fun redeem_live_internal(
     pricing::assert_live_oracle_fresh(config.pricing_config(), market_oracle, clock);
     market.assert_range_key_matches(&key);
     market.assert_not_compacted();
-    assert_nonzero_quantity(quantity);
+    assert_valid_quantity(quantity);
     let removed_fee_basis = manager.decrease_position(key, quantity);
 
     // Live redeem quotes intentionally use post-removal liability for utilization fees.
@@ -598,7 +599,7 @@ fun redeem_settled_internal(
 ) {
     market.assert_range_key_matches(&key);
     market.assert_not_compacted();
-    assert_nonzero_quantity(quantity);
+    assert_valid_quantity(quantity);
 
     let settlement = pricing::settlement_price(market_oracle);
     let payout_amount = pricing::settled_range_payout(settlement, &key, quantity);
@@ -637,7 +638,7 @@ fun redeem_compacted_internal(
 ) {
     market.assert_range_key_matches(&key);
     assert!(market.is_compacted(), EMarketNotCompacted);
-    assert_nonzero_quantity(quantity);
+    assert_valid_quantity(quantity);
 
     let (settlement, current_payout_liability, current_rebate_liability) = {
         let compacted_state = market.compacted_state.borrow();
@@ -730,8 +731,9 @@ fun assert_range_key_matches(market: &ExpiryMarket, key: &RangeKey) {
     assert!(key.oracle_id() == market.market_oracle_id, EWrongMarketOracle);
 }
 
-fun assert_nonzero_quantity(quantity: u64) {
+fun assert_valid_quantity(quantity: u64) {
     assert!(quantity > 0, EZeroQuantity);
+    assert!(quantity % constants::position_lot_size!() == 0, EInvalidQuantity);
 }
 
 fun emit_fee_accrued(

--- a/packages/predict/sources/helper/constants.move
+++ b/packages/predict/sources/helper/constants.move
@@ -27,6 +27,11 @@ public macro fun float_scaling(): u64 { 1_000_000_000 }
 /// form into the package's 1e9-scaled `u64`.
 public macro fun float_scaling_decimals(): u64 { 9 }
 
+// === Position Sizing ===
+
+/// Minimum position quantity increment.
+public macro fun position_lot_size(): u64 { 10_000 }
+
 // === Builder Fees ===
 
 /// Add-on builder fee as a fraction of the normal trade fee.


### PR DESCRIPTION
## Summary
- Add a Predict position lot size constant set to 10,000.
- Enforce lot-aligned quantities across mint and redeem paths.
- Normalize simulation mint quantities to full position lots.

## Test Plan
- `npx -y prettier-move -c packages/predict/sources/helper/constants.move packages/predict/sources/expiry_market.move --write`
- `git diff --check`
- `sui move test --path packages/predict --gas-limit 100000000000`
