### PR TITLE
predict: move exposure lifecycle into strike exposure

### DIFF
--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -397,7 +397,7 @@ public(package) fun compact_settled(
     assert!(market.fee_balance.value() >= rebate_liability, EInsufficientFeeBalance);
     assert!(market.allocated_capital >= settled_liability, EAllocationBelowMaxPayout);
 
-    market.strike_exposure.compact(settlement);
+    market.strike_exposure.compact(settlement, settled_liability);
     let returned_cash_amount = market.lp_cash_balance.value() - settled_liability;
     let returned_cash = market.lp_cash_balance.split(returned_cash_amount);
     let returned_fee_amount = market.fee_balance.value() - rebate_liability;

--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -468,17 +468,14 @@ fun mint_internal(
 
     // Quote before recording exposure so the fee basis stored with the position
     // matches the exact fee charged for this mint.
-    let (principal_amount, fee_amount) = market
-        .strike_exposure
-        .quote_mint_amounts(
-            config.pricing_config(),
-            market_oracle,
-            pyth,
-            clock,
-            &key,
-            quantity,
-            market.allocated_capital,
-        );
+    let (principal_amount, fee_amount) = market.quote_mint_amounts(
+        config,
+        market_oracle,
+        pyth,
+        key,
+        quantity,
+        clock,
+    );
     let builder_code_id = manager.builder_code_id();
     let builder_fee_amount = builder_fee_amount(&builder_code_id, fee_amount, quantity);
     let payment_amount = principal_amount + fee_amount + builder_fee_amount;
@@ -525,17 +522,14 @@ fun redeem_live_internal(
         .strike_exposure
         .remove_range(key.lower_strike(), key.higher_strike(), quantity, removed_fee_basis);
 
-    let (principal_amount, fee_amount) = market
-        .strike_exposure
-        .quote_live_redeem_amounts(
-            config.pricing_config(),
-            market_oracle,
-            pyth,
-            clock,
-            &key,
-            quantity,
-            market.allocated_capital,
-        );
+    let (principal_amount, fee_amount) = market.quote_live_redeem_amounts(
+        config,
+        market_oracle,
+        pyth,
+        key,
+        quantity,
+        clock,
+    );
     let builder_code_id = manager.builder_code_id();
     let builder_fee_amount = builder_fee_amount(&builder_code_id, fee_amount, quantity).min(
         principal_amount - fee_amount,
@@ -616,6 +610,50 @@ fun redeem_compacted_internal(
     let mut payout = market.dispense_lp_cash(payout_amount);
     payout.join(market.dispense_fee_cash(rebate));
     manager.deposit_permissionless(payout.into_coin(ctx), ctx);
+}
+
+fun quote_mint_amounts(
+    market: &ExpiryMarket,
+    config: &ProtocolConfig,
+    market_oracle: &MarketOracle,
+    pyth: &PythSource,
+    key: RangeKey,
+    quantity: u64,
+    clock: &Clock,
+): (u64, u64) {
+    let (fair_price, fee_rate) = pricing::quote_mint_live_range(
+        config.pricing_config(),
+        market_oracle,
+        pyth,
+        clock,
+        &key,
+        market.max_payout(),
+        market.allocated_capital,
+    );
+    (math::mul(fair_price, quantity), math::mul(fee_rate, quantity))
+}
+
+fun quote_live_redeem_amounts(
+    market: &ExpiryMarket,
+    config: &ProtocolConfig,
+    market_oracle: &MarketOracle,
+    pyth: &PythSource,
+    key: RangeKey,
+    quantity: u64,
+    clock: &Clock,
+): (u64, u64) {
+    let (fair_price, fee_rate) = pricing::quote_live_range(
+        config.pricing_config(),
+        market_oracle,
+        pyth,
+        clock,
+        &key,
+        market.max_payout(),
+        market.allocated_capital,
+    );
+    let principal_amount = math::mul(fair_price, quantity);
+    let fee_amount = math::mul(fee_rate, quantity).min(principal_amount);
+    (principal_amount, fee_amount)
 }
 
 fun dispense_lp_cash(market: &mut ExpiryMarket, amount: u64): Balance<DUSDC> {

--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -36,7 +36,6 @@ const EZeroAllocatedCapital: u64 = 10;
 const EInvalidTickSize: u64 = 11;
 const EInvalidStrikeGrid: u64 = 12;
 const ESettledLiabilityUnderflow: u64 = 16;
-const ECompactedLiabilityMismatch: u64 = 17;
 const EInsufficientFeeBalance: u64 = 18;
 const ECompactedRebateLiabilityUnderflow: u64 = 19;
 const EPackageVersionDisabled: u64 = 20;
@@ -56,21 +55,14 @@ public struct ExpiryMarket has key {
     lp_cash_balance: Balance<DUSDC>,
     /// Unified fee cash used for settlement loss rebates until compaction.
     fee_balance: Balance<DUSDC>,
-    /// Exposure state before compaction; none after compaction.
-    strike_exposure: Option<StrikeExposure>,
-    /// Post-compaction settlement facts and remaining escrow liabilities.
-    compacted_state: Option<CompactedState>,
+    /// Exposure lifecycle state for this expiry's oracle grid.
+    strike_exposure: StrikeExposure,
+    /// Remaining settlement loss rebate escrow after compaction.
+    compacted_rebate_liability: u64,
     /// Mirror of `ProtocolConfig.allowed_versions`; synced permissionlessly.
     allowed_versions: VecSet<u64>,
     /// When true, `mint` aborts. Other flows (redeem, settle, compact) unaffected.
     mint_paused: bool,
-}
-
-/// Settlement facts retained after strike exposure state is compacted.
-public struct CompactedState has copy, drop, store {
-    settlement: u64,
-    payout_liability: u64,
-    rebate_liability: u64,
 }
 
 /// Transaction-local valuation produced by an expiry market.
@@ -133,11 +125,7 @@ public fun settlement_loss_rebate_rate(market: &ExpiryMarket): u64 {
 
 /// Return the expiry-local worst-case payout.
 public fun max_payout(market: &ExpiryMarket): u64 {
-    if (market.is_compacted()) {
-        market.compacted_state.borrow().payout_liability
-    } else {
-        market.strike_exposure.borrow().max_payout()
-    }
+    market.strike_exposure.max_payout()
 }
 
 /// Return allocated capital not needed for worst-case payout backing.
@@ -173,7 +161,7 @@ public(package) fun utilization(market: &ExpiryMarket): u64 {
 
 /// Return true once strike exposure state has been compacted after settlement.
 public fun is_compacted(market: &ExpiryMarket): bool {
-    market.compacted_state.is_some()
+    market.strike_exposure.is_compacted()
 }
 
 /// Return whether minting is currently paused on this expiry market.
@@ -315,8 +303,8 @@ public(package) fun create_and_share(
         allocated_capital,
         lp_cash_balance: allocation,
         fee_balance: balance::zero(),
-        strike_exposure: option::some(strike_exposure::new(ctx, tick_size, min_strike, max_strike)),
-        compacted_state: option::none(),
+        strike_exposure: strike_exposure::new(tick_size, min_strike, max_strike, ctx),
+        compacted_rebate_liability: 0,
         allowed_versions,
         mint_paused: false,
     };
@@ -403,30 +391,20 @@ public(package) fun compact_settled(
     market.assert_not_compacted();
 
     let settlement = pricing::settlement_price(market_oracle);
-    let (settled_liability, losing_fee_basis) = market
-        .strike_exposure
-        .borrow()
-        .settled_values(settlement);
+    let (settled_liability, losing_fee_basis) = market.strike_exposure.settled_values(settlement);
     let rebate_liability = market.rebate_liability(losing_fee_basis);
     assert!(market.lp_cash_balance.value() >= settled_liability, EInsufficientLpCash);
     assert!(market.fee_balance.value() >= rebate_liability, EInsufficientFeeBalance);
     assert!(market.allocated_capital >= settled_liability, EAllocationBelowMaxPayout);
 
-    let exposure = market.strike_exposure.extract();
-    let compacted_payout_liability = exposure.into_settled_liability(settlement);
-    assert!(compacted_payout_liability == settled_liability, ECompactedLiabilityMismatch);
+    market.strike_exposure.compact(settlement);
     let returned_cash_amount = market.lp_cash_balance.value() - settled_liability;
     let returned_cash = market.lp_cash_balance.split(returned_cash_amount);
     let returned_fee_amount = market.fee_balance.value() - rebate_liability;
     let returned_fees = market.fee_balance.split(returned_fee_amount);
 
     market.allocated_capital = 0;
-    market.compacted_state =
-        option::some(CompactedState {
-            settlement,
-            payout_liability: settled_liability,
-            rebate_liability,
-        });
+    market.compacted_rebate_liability = rebate_liability;
     market.assert_cash_backing();
 
     (returned_cash, returned_fees)
@@ -446,32 +424,23 @@ fun current_liabilities(
     market_oracle.assert_not_pending_settlement(clock);
 
     if (market.is_compacted()) {
-        let compacted_state = market.compacted_state.borrow();
-        return (compacted_state.payout_liability, compacted_state.rebate_liability)
+        let (_, payout_liability) = market.strike_exposure.compacted_values();
+        return (payout_liability, market.compacted_rebate_liability)
     };
 
-    let strike_exposure = market.strike_exposure.borrow();
     if (market_oracle.is_settled()) {
         let settlement = pricing::settlement_price(market_oracle);
-        let (settled_value, losing_fee_basis) = strike_exposure.settled_values(settlement);
+        let (settled_value, losing_fee_basis) = market.strike_exposure.settled_values(settlement);
         (settled_value, market.rebate_liability(losing_fee_basis))
     } else {
-        let (minted_min_strike, minted_max_strike) = strike_exposure.minted_strike_range();
-        if (minted_min_strike == 0 && minted_max_strike == 0) return (0, 0);
-
-        let (grid_min, grid_tick, grid_max) = strike_exposure.strike_grid();
-        let curve = pricing::build_live_curve(
-            config.pricing_config(),
-            market_oracle,
-            pyth,
-            clock,
-            grid_min,
-            grid_tick,
-            grid_max,
-            minted_min_strike,
-            minted_max_strike,
-        );
-        let (live_value, max_losing_fee_basis) = strike_exposure.live_values(&curve);
+        let (live_value, max_losing_fee_basis) = market
+            .strike_exposure
+            .live_values(
+                config.pricing_config(),
+                market_oracle,
+                pyth,
+                clock,
+            );
         (live_value, market.rebate_liability(max_losing_fee_basis))
     }
 }
@@ -499,27 +468,24 @@ fun mint_internal(
 
     // Quote before recording exposure so the fee basis stored with the position
     // matches the exact fee charged for this mint.
-    let (principal_amount, fee_amount) = market.quote_mint_amounts(
-        config,
-        market_oracle,
-        pyth,
-        key,
-        quantity,
-        clock,
-    );
+    let (principal_amount, fee_amount) = market
+        .strike_exposure
+        .quote_mint_amounts(
+            config.pricing_config(),
+            market_oracle,
+            pyth,
+            clock,
+            &key,
+            quantity,
+            market.allocated_capital,
+        );
     let builder_code_id = manager.builder_code_id();
     let builder_fee_amount = builder_fee_amount(&builder_code_id, fee_amount, quantity);
     let payment_amount = principal_amount + fee_amount + builder_fee_amount;
 
     market
         .strike_exposure
-        .borrow_mut()
-        .insert_range(
-            key.lower_strike(),
-            key.higher_strike(),
-            quantity,
-            fee_amount,
-        );
+        .insert_range(key.lower_strike(), key.higher_strike(), quantity, fee_amount);
     assert!(market.allocated_capital >= market.max_payout(), EAllocationBelowMaxPayout);
 
     manager.increase_position(key, quantity, fee_amount);
@@ -557,22 +523,19 @@ fun redeem_live_internal(
     // Live redeem quotes intentionally use post-removal liability for utilization fees.
     market
         .strike_exposure
-        .borrow_mut()
-        .remove_range(
-            key.lower_strike(),
-            key.higher_strike(),
-            quantity,
-            removed_fee_basis,
-        );
+        .remove_range(key.lower_strike(), key.higher_strike(), quantity, removed_fee_basis);
 
-    let (principal_amount, fee_amount) = market.quote_live_redeem_amounts(
-        config,
-        market_oracle,
-        pyth,
-        key,
-        quantity,
-        clock,
-    );
+    let (principal_amount, fee_amount) = market
+        .strike_exposure
+        .quote_live_redeem_amounts(
+            config.pricing_config(),
+            market_oracle,
+            pyth,
+            clock,
+            &key,
+            quantity,
+            market.allocated_capital,
+        );
     let builder_code_id = manager.builder_code_id();
     let builder_fee_amount = builder_fee_amount(&builder_code_id, fee_amount, quantity).min(
         principal_amount - fee_amount,
@@ -602,7 +565,7 @@ fun redeem_settled_internal(
 
     let settlement = pricing::settlement_price(market_oracle);
     let payout_amount = pricing::settled_range_payout(settlement, &key, quantity);
-    let (current_liability, _) = market.strike_exposure.borrow().settled_values(settlement);
+    let (current_liability, _) = market.strike_exposure.settled_values(settlement);
     assert!(current_liability >= payout_amount, ESettledLiabilityUnderflow);
     assert!(market.lp_cash_balance.value() >= current_liability, EInsufficientLpCash);
 
@@ -616,13 +579,7 @@ fun redeem_settled_internal(
 
     market
         .strike_exposure
-        .borrow_mut()
-        .remove_range(
-            key.lower_strike(),
-            key.higher_strike(),
-            quantity,
-            removed_fee_basis,
-        );
+        .remove_range(key.lower_strike(), key.higher_strike(), quantity, removed_fee_basis);
     let mut payout = market.dispense_lp_cash(payout_amount);
     payout.join(market.dispense_fee_cash(rebate));
     manager.deposit_permissionless(payout.into_coin(ctx), ctx);
@@ -639,14 +596,8 @@ fun redeem_compacted_internal(
     assert!(market.is_compacted(), EMarketNotCompacted);
     assert_nonzero_quantity(quantity);
 
-    let (settlement, current_payout_liability, current_rebate_liability) = {
-        let compacted_state = market.compacted_state.borrow();
-        (
-            compacted_state.settlement,
-            compacted_state.payout_liability,
-            compacted_state.rebate_liability,
-        )
-    };
+    let (settlement, current_payout_liability) = market.strike_exposure.compacted_values();
+    let current_rebate_liability = market.compacted_rebate_liability;
     let payout_amount = pricing::settled_range_payout(settlement, &key, quantity);
     assert!(current_payout_liability >= payout_amount, ECompactedLiabilityUnderflow);
     assert!(market.lp_cash_balance.value() >= current_payout_liability, EInsufficientLpCash);
@@ -660,56 +611,11 @@ fun redeem_compacted_internal(
     assert!(current_rebate_liability >= rebate, ECompactedRebateLiabilityUnderflow);
     assert!(market.fee_balance.value() >= current_rebate_liability, EInsufficientFeeBalance);
 
-    let compacted_state = market.compacted_state.borrow_mut();
-    compacted_state.payout_liability = current_payout_liability - payout_amount;
-    compacted_state.rebate_liability = current_rebate_liability - rebate;
+    market.strike_exposure.decrease_compacted_liability(payout_amount);
+    market.compacted_rebate_liability = current_rebate_liability - rebate;
     let mut payout = market.dispense_lp_cash(payout_amount);
     payout.join(market.dispense_fee_cash(rebate));
     manager.deposit_permissionless(payout.into_coin(ctx), ctx);
-}
-
-fun quote_mint_amounts(
-    market: &ExpiryMarket,
-    config: &ProtocolConfig,
-    market_oracle: &MarketOracle,
-    pyth: &PythSource,
-    key: RangeKey,
-    quantity: u64,
-    clock: &Clock,
-): (u64, u64) {
-    let (fair_price, fee_rate) = pricing::quote_mint_live_range(
-        config.pricing_config(),
-        market_oracle,
-        pyth,
-        clock,
-        &key,
-        market.max_payout(),
-        market.allocated_capital,
-    );
-    (math::mul(fair_price, quantity), math::mul(fee_rate, quantity))
-}
-
-fun quote_live_redeem_amounts(
-    market: &ExpiryMarket,
-    config: &ProtocolConfig,
-    market_oracle: &MarketOracle,
-    pyth: &PythSource,
-    key: RangeKey,
-    quantity: u64,
-    clock: &Clock,
-): (u64, u64) {
-    let (fair_price, fee_rate) = pricing::quote_live_range(
-        config.pricing_config(),
-        market_oracle,
-        pyth,
-        clock,
-        &key,
-        market.max_payout(),
-        market.allocated_capital,
-    );
-    let principal_amount = math::mul(fair_price, quantity);
-    let fee_amount = math::mul(fee_rate, quantity).min(principal_amount);
-    (principal_amount, fee_amount)
 }
 
 fun dispense_lp_cash(market: &mut ExpiryMarket, amount: u64): Balance<DUSDC> {

--- a/packages/predict/sources/helper/strike_exposure.move
+++ b/packages/predict/sources/helper/strike_exposure.move
@@ -3,39 +3,181 @@
 
 /// Strike exposure store for one oracle.
 ///
-/// This module is the package boundary for expiry exposure accounting. It keeps
-/// a dense NAV matrix and sparse payout tree in sync while leaving each index's
-/// storage and query logic in its owning module.
+/// This module is the package boundary for expiry exposure accounting across
+/// the live, settled, and compacted phases. It keeps live NAV and payout
+/// indexes in sync while they exist, owns grid-aware quote helpers, and retains
+/// compacted payout facts after dense strike state is destroyed.
 module deepbook_predict::strike_exposure;
 
-use deepbook::constants::max_u64;
+use deepbook::{constants::max_u64, math};
 use deepbook_predict::{
     constants,
-    pricing::CurvePoint,
+    market_oracle::MarketOracle,
+    pricing,
+    pricing_config::PricingConfig,
+    pyth_source::PythSource,
+    range_key::RangeKey,
     strike_nav_matrix::{Self, StrikeNavMatrix},
     strike_payout_tree::{Self, StrikePayoutTree}
 };
+use sui::clock::Clock;
 
-/// Exposure book composed from a dense NAV matrix and sparse payout tree.
+const EMarketCompacted: u64 = 0;
+const EMarketNotCompacted: u64 = 1;
+const ECompactedLiabilityUnderflow: u64 = 2;
+const EInvalidStrikeGrid: u64 = 3;
+
+/// Exposure lifecycle state for one oracle grid.
 public struct StrikeExposure has store {
+    grid_min: u64,
+    grid_tick: u64,
+    grid_max: u64,
+    live: Option<LiveExposure>,
+    compacted: Option<CompactedExposure>,
+}
+
+/// Live exposure indexes composed from dense NAV and sparse payout storage.
+public struct LiveExposure has store {
     nav: StrikeNavMatrix,
     payout: StrikePayoutTree,
     minted_min_strike: u64,
     minted_max_strike: u64,
 }
 
+/// Settlement facts retained after live exposure indexes are compacted.
+public struct CompactedExposure has copy, drop, store {
+    settlement: u64,
+    payout_liability: u64,
+}
+
+/// Return the exact worst-case settled payout across all settlement prices.
+public(package) fun max_payout(exposure: &StrikeExposure): u64 {
+    if (exposure.is_compacted()) {
+        exposure.compacted.borrow().payout_liability
+    } else {
+        exposure.live.borrow().payout.max_payout()
+    }
+}
+
+/// Return true once live indexes have been compacted into settled liabilities.
+public(package) fun is_compacted(exposure: &StrikeExposure): bool {
+    exposure.compacted.is_some()
+}
+
+/// Evaluate live option value and conservative maximum losing fee basis.
+public(package) fun live_values(
+    exposure: &StrikeExposure,
+    config: &PricingConfig,
+    market: &MarketOracle,
+    pyth: &PythSource,
+    clock: &Clock,
+): (u64, u64) {
+    assert!(!exposure.is_compacted(), EMarketCompacted);
+
+    let live = exposure.live.borrow();
+    let (minted_min_strike, minted_max_strike) = live.minted_strike_range();
+    let option_value = if (minted_min_strike == 0 && minted_max_strike == 0) {
+        0
+    } else {
+        let curve = pricing::build_live_curve(
+            config,
+            market,
+            pyth,
+            clock,
+            exposure.grid_min,
+            exposure.grid_tick,
+            exposure.grid_max,
+            minted_min_strike,
+            minted_max_strike,
+        );
+        live.nav.live_value(&curve, minted_min_strike, minted_max_strike)
+    };
+    (option_value, live.payout.conservative_losing_fee_basis())
+}
+
+/// Evaluate settled liability and exact losing fee basis.
+public(package) fun settled_values(exposure: &StrikeExposure, settlement: u64): (u64, u64) {
+    assert!(!exposure.is_compacted(), EMarketCompacted);
+    exposure.live.borrow().payout.settled_values(settlement)
+}
+
+/// Return compacted settlement facts.
+public(package) fun compacted_values(exposure: &StrikeExposure): (u64, u64) {
+    assert!(exposure.is_compacted(), EMarketNotCompacted);
+    let compacted = exposure.compacted.borrow();
+    (compacted.settlement, compacted.payout_liability)
+}
+
+/// Quote live mint amounts for a grid-aligned range.
+public(package) fun quote_mint_amounts(
+    exposure: &StrikeExposure,
+    config: &PricingConfig,
+    market: &MarketOracle,
+    pyth: &PythSource,
+    clock: &Clock,
+    key: &RangeKey,
+    quantity: u64,
+    allocated_capital: u64,
+): (u64, u64) {
+    assert!(!exposure.is_compacted(), EMarketCompacted);
+    exposure.assert_range_on_grid(key);
+    let (fair_price, fee_rate) = pricing::quote_mint_live_range(
+        config,
+        market,
+        pyth,
+        clock,
+        key,
+        exposure.max_payout(),
+        allocated_capital,
+    );
+    (math::mul(fair_price, quantity), math::mul(fee_rate, quantity))
+}
+
+/// Quote live redeem amounts for a grid-aligned range.
+public(package) fun quote_live_redeem_amounts(
+    exposure: &StrikeExposure,
+    config: &PricingConfig,
+    market: &MarketOracle,
+    pyth: &PythSource,
+    clock: &Clock,
+    key: &RangeKey,
+    quantity: u64,
+    allocated_capital: u64,
+): (u64, u64) {
+    assert!(!exposure.is_compacted(), EMarketCompacted);
+    exposure.assert_range_on_grid(key);
+    let (fair_price, fee_rate) = pricing::quote_live_range(
+        config,
+        market,
+        pyth,
+        clock,
+        key,
+        exposure.max_payout(),
+        allocated_capital,
+    );
+    let principal_amount = math::mul(fair_price, quantity);
+    let fee_amount = math::mul(fee_rate, quantity).min(principal_amount);
+    (principal_amount, fee_amount)
+}
+
 /// Create a strike exposure book for the oracle grid.
 public(package) fun new(
-    ctx: &mut TxContext,
     tick_size: u64,
     min_strike: u64,
     max_strike: u64,
+    ctx: &mut TxContext,
 ): StrikeExposure {
     StrikeExposure {
-        nav: strike_nav_matrix::new(ctx, tick_size, min_strike, max_strike),
-        payout: strike_payout_tree::new(ctx, tick_size, min_strike, max_strike),
-        minted_min_strike: max_u64(),
-        minted_max_strike: 0,
+        grid_min: min_strike,
+        grid_tick: tick_size,
+        grid_max: max_strike,
+        live: option::some(LiveExposure {
+            nav: strike_nav_matrix::new(tick_size, min_strike, max_strike, ctx),
+            payout: strike_payout_tree::new(tick_size, min_strike, max_strike, ctx),
+            minted_min_strike: max_u64(),
+            minted_max_strike: 0,
+        }),
+        compacted: option::none(),
     }
 }
 
@@ -47,9 +189,12 @@ public(package) fun insert_range(
     qty: u64,
     fee_basis: u64,
 ) {
-    exposure.payout.insert_range(lower, higher, qty, fee_basis);
-    exposure.nav.insert_range(lower, higher, qty);
-    exposure.track_minted_boundaries(lower, higher);
+    assert!(!exposure.is_compacted(), EMarketCompacted);
+    exposure.assert_strikes_on_grid(lower, higher);
+    let live = exposure.live.borrow_mut();
+    live.payout.insert_range(lower, higher, qty, fee_basis);
+    live.nav.insert_range(lower, higher, qty);
+    live.track_minted_boundaries(lower, higher);
 }
 
 /// Remove interval quantity for `(lower, higher]`.
@@ -60,64 +205,74 @@ public(package) fun remove_range(
     qty: u64,
     fee_basis: u64,
 ) {
-    exposure.payout.remove_range(lower, higher, qty, fee_basis);
-    exposure.nav.remove_range(lower, higher, qty);
+    assert!(!exposure.is_compacted(), EMarketCompacted);
+    exposure.assert_strikes_on_grid(lower, higher);
+    let live = exposure.live.borrow_mut();
+    live.payout.remove_range(lower, higher, qty, fee_basis);
+    live.nav.remove_range(lower, higher, qty);
 }
 
-/// Return the exact worst-case settled payout across all settlement prices.
-public(package) fun max_payout(exposure: &StrikeExposure): u64 {
-    exposure.payout.max_payout()
+/// Reduce compacted payout liability after a post-compaction redeem.
+public(package) fun decrease_compacted_liability(
+    exposure: &mut StrikeExposure,
+    payout_amount: u64,
+) {
+    assert!(exposure.is_compacted(), EMarketNotCompacted);
+    let compacted = exposure.compacted.borrow_mut();
+    assert!(compacted.payout_liability >= payout_amount, ECompactedLiabilityUnderflow);
+    compacted.payout_liability = compacted.payout_liability - payout_amount;
 }
 
-/// Evaluate live option value and conservative maximum losing fee basis.
-public(package) fun live_values(exposure: &StrikeExposure, curve: &vector<CurvePoint>): (u64, u64) {
-    let (minted_min_strike, minted_max_strike) = exposure.minted_strike_range();
-    let option_value = if (minted_min_strike == 0 && minted_max_strike == 0) {
-        0
-    } else {
-        exposure.nav.live_value(curve, minted_min_strike, minted_max_strike)
-    };
-    (option_value, exposure.payout.conservative_losing_fee_basis())
-}
-
-/// Evaluate settled liability and exact losing fee basis.
-public(package) fun settled_values(exposure: &StrikeExposure, settlement: u64): (u64, u64) {
-    exposure.payout.settled_values(settlement)
-}
-
-/// Return the strike grid this book was created with.
-public(package) fun strike_grid(exposure: &StrikeExposure): (u64, u64, u64) {
-    exposure.nav.strike_grid()
-}
-
-/// Return historical minted strike bounds, or `(0, 0)` for an untouched book.
-public(package) fun minted_strike_range(exposure: &StrikeExposure): (u64, u64) {
-    if (exposure.minted_min_strike > exposure.minted_max_strike) (0, 0) else (
-        exposure.minted_min_strike,
-        exposure.minted_max_strike,
-    )
-}
-
-/// Consume the exposure book after settlement and return exact settled liability.
-public(package) fun into_settled_liability(exposure: StrikeExposure, settlement: u64): u64 {
-    let StrikeExposure {
+/// Compact live indexes into settled liability state.
+public(package) fun compact(exposure: &mut StrikeExposure, settlement: u64): u64 {
+    assert!(!exposure.is_compacted(), EMarketCompacted);
+    let live = exposure.live.extract();
+    let LiveExposure {
         nav,
         payout,
         minted_min_strike: _,
         minted_max_strike: _,
-    } = exposure;
+    } = live;
     nav.destroy();
-    payout.into_settled_liability(settlement)
+    let payout_liability = payout.into_settled_liability(settlement);
+    exposure.compacted =
+        option::some(CompactedExposure {
+            settlement,
+            payout_liability,
+        });
+    payout_liability
 }
 
-fun track_minted_boundaries(exposure: &mut StrikeExposure, lower: u64, higher: u64) {
+fun minted_strike_range(live: &LiveExposure): (u64, u64) {
+    if (live.minted_min_strike > live.minted_max_strike) (0, 0) else (
+        live.minted_min_strike,
+        live.minted_max_strike,
+    )
+}
+
+fun assert_range_on_grid(exposure: &StrikeExposure, key: &RangeKey) {
+    exposure.assert_strikes_on_grid(key.lower_strike(), key.higher_strike())
+}
+
+fun assert_strikes_on_grid(exposure: &StrikeExposure, lower: u64, higher: u64) {
+    assert!(lower < higher, EInvalidStrikeGrid);
+    if (lower != constants::neg_inf!()) exposure.assert_finite_strike_on_grid(lower);
+    if (higher != constants::pos_inf!()) exposure.assert_finite_strike_on_grid(higher);
+}
+
+fun assert_finite_strike_on_grid(exposure: &StrikeExposure, strike: u64) {
+    assert!(strike >= exposure.grid_min && strike <= exposure.grid_max, EInvalidStrikeGrid);
+    assert!((strike - exposure.grid_min) % exposure.grid_tick == 0, EInvalidStrikeGrid);
+}
+
+fun track_minted_boundaries(live: &mut LiveExposure, lower: u64, higher: u64) {
     if (lower != constants::neg_inf!()) {
-        exposure.minted_min_strike = exposure.minted_min_strike.min(lower);
-        exposure.minted_max_strike = exposure.minted_max_strike.max(lower);
+        live.minted_min_strike = live.minted_min_strike.min(lower);
+        live.minted_max_strike = live.minted_max_strike.max(lower);
     };
 
     if (higher != constants::pos_inf!()) {
-        exposure.minted_min_strike = exposure.minted_min_strike.min(higher);
-        exposure.minted_max_strike = exposure.minted_max_strike.max(higher);
+        live.minted_min_strike = live.minted_min_strike.min(higher);
+        live.minted_max_strike = live.minted_max_strike.max(higher);
     };
 }

--- a/packages/predict/sources/helper/strike_exposure.move
+++ b/packages/predict/sources/helper/strike_exposure.move
@@ -9,14 +9,13 @@
 /// compacted payout facts after dense strike state is destroyed.
 module deepbook_predict::strike_exposure;
 
-use deepbook::{constants::max_u64, math};
+use deepbook::constants::max_u64;
 use deepbook_predict::{
     constants,
     market_oracle::MarketOracle,
     pricing,
     pricing_config::PricingConfig,
     pyth_source::PythSource,
-    range_key::RangeKey,
     strike_nav_matrix::{Self, StrikeNavMatrix},
     strike_payout_tree::{Self, StrikePayoutTree}
 };
@@ -107,58 +106,6 @@ public(package) fun compacted_values(exposure: &StrikeExposure): (u64, u64) {
     assert!(exposure.is_compacted(), EMarketNotCompacted);
     let compacted = exposure.compacted.borrow();
     (compacted.settlement, compacted.payout_liability)
-}
-
-/// Quote live mint amounts for a grid-aligned range.
-public(package) fun quote_mint_amounts(
-    exposure: &StrikeExposure,
-    config: &PricingConfig,
-    market: &MarketOracle,
-    pyth: &PythSource,
-    clock: &Clock,
-    key: &RangeKey,
-    quantity: u64,
-    allocated_capital: u64,
-): (u64, u64) {
-    assert!(!exposure.is_compacted(), EMarketCompacted);
-    exposure.assert_range_on_grid(key);
-    let (fair_price, fee_rate) = pricing::quote_mint_live_range(
-        config,
-        market,
-        pyth,
-        clock,
-        key,
-        exposure.max_payout(),
-        allocated_capital,
-    );
-    (math::mul(fair_price, quantity), math::mul(fee_rate, quantity))
-}
-
-/// Quote live redeem amounts for a grid-aligned range.
-public(package) fun quote_live_redeem_amounts(
-    exposure: &StrikeExposure,
-    config: &PricingConfig,
-    market: &MarketOracle,
-    pyth: &PythSource,
-    clock: &Clock,
-    key: &RangeKey,
-    quantity: u64,
-    allocated_capital: u64,
-): (u64, u64) {
-    assert!(!exposure.is_compacted(), EMarketCompacted);
-    exposure.assert_range_on_grid(key);
-    let (fair_price, fee_rate) = pricing::quote_live_range(
-        config,
-        market,
-        pyth,
-        clock,
-        key,
-        exposure.max_payout(),
-        allocated_capital,
-    );
-    let principal_amount = math::mul(fair_price, quantity);
-    let fee_amount = math::mul(fee_rate, quantity).min(principal_amount);
-    (principal_amount, fee_amount)
 }
 
 /// Create a strike exposure book for the oracle grid.
@@ -253,10 +200,6 @@ fun minted_strike_range(live: &LiveExposure): (u64, u64) {
         live.minted_min_strike,
         live.minted_max_strike,
     )
-}
-
-fun assert_range_on_grid(exposure: &StrikeExposure, key: &RangeKey) {
-    exposure.assert_strikes_on_grid(key.lower_strike(), key.higher_strike())
 }
 
 fun assert_strikes_on_grid(exposure: &StrikeExposure, lower: u64, higher: u64) {

--- a/packages/predict/sources/helper/strike_exposure.move
+++ b/packages/predict/sources/helper/strike_exposure.move
@@ -26,6 +26,7 @@ const EMarketCompacted: u64 = 0;
 const EMarketNotCompacted: u64 = 1;
 const ECompactedLiabilityUnderflow: u64 = 2;
 const EInvalidStrikeGrid: u64 = 3;
+const ECompactedLiabilityMismatch: u64 = 4;
 
 /// Exposure lifecycle state for one oracle grid.
 public struct StrikeExposure has store {
@@ -224,7 +225,11 @@ public(package) fun decrease_compacted_liability(
 }
 
 /// Compact live indexes into settled liability state.
-public(package) fun compact(exposure: &mut StrikeExposure, settlement: u64): u64 {
+public(package) fun compact(
+    exposure: &mut StrikeExposure,
+    settlement: u64,
+    expected_payout_liability: u64,
+) {
     assert!(!exposure.is_compacted(), EMarketCompacted);
     let live = exposure.live.extract();
     let LiveExposure {
@@ -235,12 +240,12 @@ public(package) fun compact(exposure: &mut StrikeExposure, settlement: u64): u64
     } = live;
     nav.destroy();
     let payout_liability = payout.into_settled_liability(settlement);
+    assert!(payout_liability == expected_payout_liability, ECompactedLiabilityMismatch);
     exposure.compacted =
         option::some(CompactedExposure {
             settlement,
             payout_liability,
         });
-    payout_liability
 }
 
 fun minted_strike_range(live: &LiveExposure): (u64, u64) {

--- a/packages/predict/sources/helper/strike_nav_matrix.move
+++ b/packages/predict/sources/helper/strike_nav_matrix.move
@@ -43,10 +43,10 @@ public struct NavSlot has copy, drop, store {
 
 /// Create a fully preallocated NAV matrix for the oracle strike grid.
 public(package) fun new(
-    ctx: &mut TxContext,
     tick_size: u64,
     min_strike: u64,
     max_strike: u64,
+    ctx: &mut TxContext,
 ): StrikeNavMatrix {
     assert_valid_grid(tick_size, min_strike, max_strike);
 
@@ -143,11 +143,6 @@ public(package) fun live_value(
     };
 
     value
-}
-
-/// Return the strike grid this matrix was created with.
-public(package) fun strike_grid(nav: &StrikeNavMatrix): (u64, u64, u64) {
-    (nav.min_strike, nav.tick_size, nav.max_strike)
 }
 
 /// Destroy all preallocated page storage.

--- a/packages/predict/sources/helper/strike_payout_tree.move
+++ b/packages/predict/sources/helper/strike_payout_tree.move
@@ -57,10 +57,10 @@ public struct PayoutSummary has copy, drop, store {
 
 /// Create an empty sparse payout tree for the oracle strike grid.
 public(package) fun new(
-    ctx: &mut TxContext,
     tick_size: u64,
     min_strike: u64,
     max_strike: u64,
+    ctx: &mut TxContext,
 ): StrikePayoutTree {
     assert_valid_grid(tick_size, min_strike, max_strike);
 


### PR DESCRIPTION
## Summary
- Move Predict strike exposure live/compacted lifecycle state into `StrikeExposure`.
- Keep ExpiryMarket focused on cash and rebate accounting while delegating grid-aware valuation and quote helpers to `StrikeExposure`.
- Remove redundant compacted payout state and unused NAV grid accessor.

## Key decisions
- `StrikeExposure` now owns compacted payout facts; `ExpiryMarket` keeps only compacted rebate liability as a plain number.
- This PR intentionally keeps `RangeKey` APIs unchanged and does not introduce order IDs or leverage behavior.

## Test plan
- [x] `npx -y prettier-move -c packages/predict/sources/expiry_market.move packages/predict/sources/helper/strike_exposure.move packages/predict/sources/helper/strike_nav_matrix.move packages/predict/sources/helper/strike_payout_tree.move --write`
- [x] `git diff --check`
- [x] `sui move build --path packages/predict`
- [x] `sui move test --path packages/predict --gas-limit 100000000000`
