### PR TITLE
predict: gate version sync through Registry; drop manager mirror

### DIFF
--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -209,12 +209,6 @@ public fun produce_valuation(
     }
 }
 
-/// Refresh this market's mirrored `allowed_versions`. Permissionless: callers
-/// pass `registry.allowed_versions()` as the source of truth.
-public fun update_allowed_versions(market: &mut ExpiryMarket, allowed_versions: VecSet<u64>) {
-    market.allowed_versions = allowed_versions;
-}
-
 /// Mint a live position interval against this expiry market.
 ///
 /// Requires the package version to be allowed for this market, per-market mint
@@ -356,6 +350,13 @@ public fun compact_storage(
 }
 
 // === Public-Package Functions ===
+
+/// Overwrite this market's mirrored `allowed_versions`. The only authorized
+/// caller is `registry::sync_expiry_market_allowed_versions`, which reads the
+/// source of truth from `Registry`.
+public(package) fun set_allowed_versions(market: &mut ExpiryMarket, allowed_versions: VecSet<u64>) {
+    market.allowed_versions = allowed_versions;
+}
 
 /// Consume an expiry valuation and return its market ID and value.
 public(package) fun unpack(valuation: ExpiryValuation): (ID, u64) {

--- a/packages/predict/sources/oracle/market_oracle.move
+++ b/packages/predict/sources/oracle/market_oracle.move
@@ -151,12 +151,6 @@ public fun allowed_versions(market: &MarketOracle): VecSet<u64> {
     market.allowed_versions
 }
 
-/// Refresh this oracle's mirrored `allowed_versions`. Permissionless: callers
-/// pass `registry.allowed_versions()` as the source of truth.
-public fun update_allowed_versions(market: &mut MarketOracle, allowed_versions: VecSet<u64>) {
-    market.allowed_versions = allowed_versions;
-}
-
 /// Return the MarketOracleCap object ID.
 public fun cap_id(cap: &MarketOracleCap): ID {
     cap.id.to_inner()
@@ -420,6 +414,13 @@ public fun set_basis_bounds(
 }
 
 // === Public-Package Functions ===
+
+/// Overwrite this oracle's mirrored `allowed_versions`. The only authorized
+/// caller is `registry::sync_market_oracle_allowed_versions`, which reads the
+/// source of truth from `Registry`.
+public(package) fun set_allowed_versions(market: &mut MarketOracle, allowed_versions: VecSet<u64>) {
+    market.allowed_versions = allowed_versions;
+}
 
 /// Return forward / spot basis, aborting until both values are initialized.
 public(package) fun block_scholes_basis(market: &MarketOracle): u64 {

--- a/packages/predict/sources/oracle/pyth_source.move
+++ b/packages/predict/sources/oracle/pyth_source.move
@@ -118,13 +118,14 @@ public fun expiry_fee_max_multiplier(source: &PythSource): u64 {
     source.expiry_fee_max_multiplier
 }
 
-/// Refresh this source's mirrored `allowed_versions`. Permissionless: callers
-/// pass `registry.allowed_versions()` as the source of truth.
-public fun update_allowed_versions(source: &mut PythSource, allowed_versions: VecSet<u64>) {
+// === Public-Package Functions ===
+
+/// Overwrite this source's mirrored `allowed_versions`. The only authorized
+/// caller is `registry::sync_pyth_source_allowed_versions`, which reads the
+/// source of truth from `Registry`.
+public(package) fun set_allowed_versions(source: &mut PythSource, allowed_versions: VecSet<u64>) {
     source.allowed_versions = allowed_versions;
 }
-
-// === Public-Package Functions ===
 
 /// Return the timestamp that pricing can use for freshness checks.
 public(package) fun freshness_timestamp_ms(source: &PythSource): u64 {

--- a/packages/predict/sources/plp.move
+++ b/packages/predict/sources/plp.move
@@ -111,12 +111,6 @@ public fun allowed_versions(vault: &PoolVault): VecSet<u64> {
     vault.allowed_versions
 }
 
-/// Refresh this vault's mirrored `allowed_versions`. Permissionless: callers
-/// pass `registry.allowed_versions()` as the source of truth.
-public fun update_allowed_versions(vault: &mut PoolVault, allowed_versions: VecSet<u64>) {
-    vault.allowed_versions = allowed_versions;
-}
-
 /// Return idle DUSDC held by the pool.
 public fun idle_balance(vault: &PoolVault): u64 {
     vault.idle_balance.value()
@@ -328,6 +322,13 @@ public fun withdraw(
 }
 
 // === Public-Package Functions ===
+
+/// Overwrite this vault's mirrored `allowed_versions`. The only authorized
+/// caller is `registry::sync_pool_vault_allowed_versions`, which reads the
+/// source of truth from `Registry`.
+public(package) fun set_allowed_versions(vault: &mut PoolVault, allowed_versions: VecSet<u64>) {
+    vault.allowed_versions = allowed_versions;
+}
 
 /// Create an empty pool vault from the PLP treasury cap.
 public(package) fun new(treasury_cap: TreasuryCap<PLP>, ctx: &mut TxContext): PoolVault {

--- a/packages/predict/sources/predict_manager.move
+++ b/packages/predict/sources/predict_manager.move
@@ -11,11 +11,10 @@ module deepbook_predict::predict_manager;
 use deepbook::balance_manager::{Self, BalanceManager, DepositCap};
 use deepbook_predict::builder_code::{Self, BuilderCode};
 use dusdc::dusdc::DUSDC;
-use sui::{coin::Coin, derived_object, event, table::{Self, Table}, vec_set::VecSet};
+use sui::{coin::Coin, derived_object, event, table::{Self, Table}};
 
 const EInsufficientPosition: u64 = 0;
 const ENotOwner: u64 = 1;
-const EPackageVersionDisabled: u64 = 3;
 const EExpirySummaryHasOpenPositions: u64 = 4;
 const EPositionAlreadyExists: u64 = 5;
 
@@ -41,9 +40,6 @@ public struct PredictManager has key {
     positions: Table<PositionKey, bool>,
     /// Per-expiry aggregate trading cash flows and open position count.
     expiry_summaries: Table<ID, ExpiryTradingSummary>,
-    /// Mirror of `ProtocolConfig.allowed_versions`. Owners run the permissionless
-    /// sync to track admin changes; package mutations gate on this set.
-    allowed_versions: VecSet<u64>,
 }
 
 /// Aggregate trading cash flow for one manager in one expiry market.
@@ -79,25 +75,12 @@ public fun id(self: &PredictManager): ID {
 
 /// Deposit coins into the PredictManager.
 public fun deposit(self: &mut PredictManager, coin: Coin<DUSDC>, ctx: &mut TxContext) {
-    self.assert_version_allowed();
     self.balance_manager.deposit(coin, ctx);
 }
 
 /// Withdraw coins from the PredictManager.
 public fun withdraw(self: &mut PredictManager, amount: u64, ctx: &mut TxContext): Coin<DUSDC> {
-    self.assert_version_allowed();
     self.balance_manager.withdraw(amount, ctx)
-}
-
-/// Return this manager's mirrored set of allowed package versions.
-public fun allowed_versions(self: &PredictManager): VecSet<u64> {
-    self.allowed_versions
-}
-
-/// Refresh this manager's mirrored `allowed_versions`. Permissionless: callers
-/// pass `registry.allowed_versions()` as the source of truth.
-public fun update_allowed_versions(self: &mut PredictManager, allowed_versions: VecSet<u64>) {
-    self.allowed_versions = allowed_versions;
 }
 
 /// Return the BalanceManager owner for this PredictManager.
@@ -162,7 +145,6 @@ public fun set_builder_code(
     builder_code: &BuilderCode,
     ctx: &TxContext,
 ) {
-    self.assert_version_allowed();
     self.assert_owner(ctx);
     let builder_code_id = builder_code::id(builder_code);
     self.builder_code_id = option::some(builder_code_id);
@@ -175,7 +157,6 @@ public fun set_builder_code(
 
 /// Clear sticky builder-code attribution for future trades.
 public fun unset_builder_code(self: &mut PredictManager, ctx: &TxContext) {
-    self.assert_version_allowed();
     self.assert_owner(ctx);
     self.builder_code_id = option::none();
     event::emit(BuilderCodeSet {
@@ -188,11 +169,7 @@ public fun unset_builder_code(self: &mut PredictManager, ctx: &TxContext) {
 // === Public-Package Functions ===
 
 /// Create a derived PredictManager for the sender.
-public(package) fun new(
-    registry_uid: &mut UID,
-    allowed_versions: VecSet<u64>,
-    ctx: &mut TxContext,
-): PredictManager {
+public(package) fun new(registry_uid: &mut UID, ctx: &mut TxContext): PredictManager {
     let id = derived_object::claim(registry_uid, PredictManagerKey(ctx.sender(), 0));
     let mut balance_manager = balance_manager::new(ctx);
     let deposit_cap = balance_manager.mint_deposit_cap(ctx);
@@ -204,16 +181,7 @@ public(package) fun new(
         builder_code_id: option::none(),
         positions: table::new(ctx),
         expiry_summaries: table::new(ctx),
-        allowed_versions,
     }
-}
-
-/// Abort if the running package version is not allowed for this manager.
-public(package) fun assert_version_allowed(self: &PredictManager) {
-    assert!(
-        self.allowed_versions.contains(&deepbook_predict::constants::current_version!()),
-        EPackageVersionDisabled,
-    );
 }
 
 /// Deposit protocol payouts without requiring the manager owner as sender.

--- a/packages/predict/sources/registry.move
+++ b/packages/predict/sources/registry.move
@@ -265,6 +265,35 @@ public fun disable_version(registry: &mut Registry, _admin_cap: &AdminCap, versi
     registry.disable_version_internal(version);
 }
 
+// === Version Sync (permissionless) ===
+//
+// Each shared object that gates flows on a mirrored `allowed_versions` set
+// exposes one `sync_*` entry below. The registry is the source of truth: the
+// caller supplies `&Registry`, and the entry copies its current set into the
+// target. The package-internal `set_allowed_versions` setters on the target
+// modules are not callable from outside the package, so user-supplied
+// `VecSet<u64>` cannot reach a mirror through any other path.
+
+/// Sync an expiry market's `allowed_versions` mirror from the registry.
+public fun sync_expiry_market_allowed_versions(registry: &Registry, market: &mut ExpiryMarket) {
+    market.set_allowed_versions(registry.allowed_versions);
+}
+
+/// Sync a pool vault's `allowed_versions` mirror from the registry.
+public fun sync_pool_vault_allowed_versions(registry: &Registry, vault: &mut PoolVault) {
+    vault.set_allowed_versions(registry.allowed_versions);
+}
+
+/// Sync a market oracle's `allowed_versions` mirror from the registry.
+public fun sync_market_oracle_allowed_versions(registry: &Registry, market: &mut MarketOracle) {
+    market.set_allowed_versions(registry.allowed_versions);
+}
+
+/// Sync a Pyth source's `allowed_versions` mirror from the registry.
+public fun sync_pyth_source_allowed_versions(registry: &Registry, source: &mut PythSource) {
+    source.set_allowed_versions(registry.allowed_versions);
+}
+
 // === PauseCap Lifecycle (admin) ===
 
 /// Mint a new `PauseCap`. Admin-only and bypasses the version gate so the
@@ -447,8 +476,7 @@ public fun create_builder_code(registry: &mut Registry, index: u64, ctx: &mut Tx
 
 /// Create a derived PredictManager for the caller.
 public fun create_manager(registry: &mut Registry, ctx: &mut TxContext): PredictManager {
-    let allowed_versions = registry.allowed_versions;
-    predict_manager::new(&mut registry.id, allowed_versions, ctx)
+    predict_manager::new(&mut registry.id, ctx)
 }
 
 /// Create and share a derived PredictManager for the caller.

--- a/packages/predict/tests/pause_tests.move
+++ b/packages/predict/tests/pause_tests.move
@@ -115,6 +115,35 @@ fun revoked_pause_cap_cannot_act() {
     abort 999
 }
 
+#[test]
+fun sync_market_oracle_copies_registry_allowed_versions() {
+    let ctx = &mut tx_context::dummy();
+    let (mut registry, admin_cap) = registry::new_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+    let current = constants::current_version!();
+    let next = NEXT_VERSION;
+
+    // Market mirrors only {current_version!()} at creation.
+    assert_eq!(market.allowed_versions().length(), 1);
+    assert!(market.allowed_versions().contains(&current));
+
+    // Admin adds NEXT_VERSION; the market's mirror is still stale.
+    registry::enable_version(&mut registry, &admin_cap, next);
+    assert!(!market.allowed_versions().contains(&next));
+
+    // Sync copies the registry's set verbatim into the market.
+    registry::sync_market_oracle_allowed_versions(&registry, &mut market);
+    assert_eq!(market.allowed_versions().length(), 2);
+    assert!(market.allowed_versions().contains(&current));
+    assert!(market.allowed_versions().contains(&next));
+
+    registry::destroy_registry_for_testing(registry);
+    destroy(market);
+    destroy(cap);
+    destroy(admin_cap);
+}
+
 #[test, expected_failure(abort_code = market_oracle::EPackageVersionDisabled)]
 fun synced_market_oracle_blocks_disabled_version() {
     let ctx = &mut tx_context::dummy();
@@ -129,7 +158,7 @@ fun synced_market_oracle_blocks_disabled_version() {
     let current = constants::current_version!();
     registry::enable_version(&mut registry, &admin_cap, NEXT_VERSION);
     registry::disable_version(&mut registry, &admin_cap, current);
-    market.update_allowed_versions(registry.allowed_versions());
+    registry::sync_market_oracle_allowed_versions(&registry, &mut market);
 
     market.update_svi(
         &config,


### PR DESCRIPTION
## Summary
- Replace five permissionless `update_allowed_versions(&mut Target, VecSet<u64>)` entries with `sync_*_allowed_versions(&Registry, &mut Target)` entries on `registry.move`. The new entries read the canonical set from the Registry and copy it into the target. Each target module exposes a `public(package) set_allowed_versions` setter that is not reachable from outside the package.
- Drop `allowed_versions` from `PredictManager` entirely (field, getter, setter, internal `assert_version_allowed` calls, and the parameter on `predict_manager::new`).

## Key decisions
- **Why move the sync entries to `registry.move` instead of changing each `update_allowed_versions` to take `&Registry`.** `registry.move` already imports every target module. Adding `use Registry` in any target module would create a cycle. Moving the entries to where the Registry import already lives avoids that.
- **Why drop `PredictManager.allowed_versions`.** The manager wraps a `BalanceManager` and tracks per-user position pointers. The only operations the mirror gated — `deposit`, `withdraw`, `set_builder_code`, `unset_builder_code` — move user-owned cash and metadata, not protocol state. Mint / redeem / claim flows all go through `ExpiryMarket`, which has its own (still-mirrored) version gate. Per-user mirrors don't scale: after any version change, N users would each need to be permissionlessly synced before their cash operations work again. Removing it eliminates a liveness foot-gun without weakening any safety property the protocol depends on.
- **Why keep mirrors on `ExpiryMarket`, `PoolVault`, `MarketOracle`, and `PythSource`.** Those four own protocol-critical state (trading exposure, pool capital, oracle settlement inputs, oracle source freshness) and there are a small bounded number of them, so permissionless syncs are feasible.
- The new sync entries are themselves un-gated (no `assert_version_allowed` on them) so admin can always re-sync after a version change, matching the existing version-management bypass pattern.

## Test plan
- [x] `sui move test --gas-limit 100000000000` → 18 pass (added one positive test, `sync_market_oracle_copies_registry_allowed_versions`, that exercises the new sync entry end-to-end; existing `synced_market_oracle_blocks_disabled_version` updated to call the new sync API).
- [x] `bunx prettier-move -c sources/**/*.move tests/**/*.move --write` clean.
- [x] No callers of removed APIs remain in `crates/` or `scripts/` (grep clean).
- [ ] Manual: confirm a griefing call of the old form (`market.update_allowed_versions(vec_set::empty())`) no longer compiles externally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)