### PR TITLE
predict: PredictManager cap system + self-owned constructor (DBU-413)

### DIFF
--- a/packages/predict/simulations/src/runtime.ts
+++ b/packages/predict/simulations/src/runtime.ts
@@ -348,11 +348,16 @@ function finishPoolSyncWithExpiry(tx: Transaction, params: ExpiryPoolSyncParams)
 
 function addMint(tx: Transaction, params: MintParams): void {
     const { lower, higher } = binaryRangeBounds(params.strike, params.isUp);
+    const proof = tx.moveCall({
+        target: target("predict_manager", "generate_proof_as_owner"),
+        arguments: [tx.object(params.managerId)],
+    });
     tx.moveCall({
         target: target("expiry_market", "mint"),
         arguments: [
             tx.object(params.expiryMarketId),
             tx.object(params.managerId),
+            proof,
             tx.object(params.protocolConfigId),
             tx.object(params.oracleId),
             tx.object(params.pythSourceId),
@@ -366,11 +371,19 @@ function addMint(tx: Transaction, params: MintParams): void {
 }
 
 function addRedeem(tx: Transaction, params: RedeemParams): void {
+    // The sim always acts as the manager owner, so it uses the authorized
+    // `redeem` with a proof. Works for live redeems (proof consumed) and
+    // settled / liquidated redeems (proof dropped).
+    const proof = tx.moveCall({
+        target: target("predict_manager", "generate_proof_as_owner"),
+        arguments: [tx.object(params.managerId)],
+    });
     tx.moveCall({
         target: target("expiry_market", "redeem"),
         arguments: [
             tx.object(params.expiryMarketId),
             tx.object(params.managerId),
+            proof,
             tx.object(params.protocolConfigId),
             tx.object(params.oracleId),
             tx.object(params.pythSourceId),

--- a/packages/predict/sources/constants.move
+++ b/packages/predict/sources/constants.move
@@ -134,3 +134,13 @@ public macro fun neg_inf(): u64 { 0 }
 
 /// Sentinel upper strike for ranges open to positive infinity.
 public macro fun pos_inf(): u64 { std::u64::max_value!() }
+
+// === PredictManager Derivation ===
+
+/// `PredictManagerKey` u64 slot for sender-owned managers created via
+/// `predict_manager::new`.
+public macro fun sender_owned_manager_slot(): u64 { 0 }
+
+/// `PredictManagerKey` u64 slot for self-owned managers created via
+/// `predict_manager::new_self_owned`.
+public macro fun self_owned_manager_slot(): u64 { 1 }

--- a/packages/predict/sources/events/account_events.move
+++ b/packages/predict/sources/events/account_events.move
@@ -26,6 +26,24 @@ public struct BuilderCodeSet has copy, drop, store {
     builder_code_id: Option<ID>,
 }
 
+/// Emitted when a `PredictTradeCap` is minted.
+public struct PredictTradeCapMinted has copy, drop, store {
+    predict_manager_id: ID,
+    cap_id: ID,
+}
+
+/// Emitted when a `PredictDepositCap` is minted.
+public struct PredictDepositCapMinted has copy, drop, store {
+    predict_manager_id: ID,
+    cap_id: ID,
+}
+
+/// Emitted when a `PredictWithdrawCap` is minted.
+public struct PredictWithdrawCapMinted has copy, drop, store {
+    predict_manager_id: ID,
+    cap_id: ID,
+}
+
 // === Public-Package Functions ===
 
 public(package) fun emit_predict_manager_created(predict_manager_id: ID, owner: address) {
@@ -57,4 +75,16 @@ public(package) fun emit_builder_code_set(
         owner,
         builder_code_id,
     });
+}
+
+public(package) fun emit_predict_trade_cap_minted(predict_manager_id: ID, cap_id: ID) {
+    event::emit(PredictTradeCapMinted { predict_manager_id, cap_id });
+}
+
+public(package) fun emit_predict_deposit_cap_minted(predict_manager_id: ID, cap_id: ID) {
+    event::emit(PredictDepositCapMinted { predict_manager_id, cap_id });
+}
+
+public(package) fun emit_predict_withdraw_cap_minted(predict_manager_id: ID, cap_id: ID) {
+    event::emit(PredictWithdrawCapMinted { predict_manager_id, cap_id });
 }

--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -18,7 +18,7 @@ use deepbook_predict::{
     market_oracle::{MarketOracle, MarketOracleCap},
     order::{Self, Order},
     order_events,
-    predict_manager::PredictManager,
+    predict_manager::{PredictManager, PredictTradeProof},
     pricing,
     pricing_config::PricingConfig,
     protocol_config::ProtocolConfig,
@@ -36,6 +36,7 @@ const EPackageVersionDisabled: u64 = 4;
 const EMintPaused: u64 = 5;
 const EUnresolvedTradingFeesUnderflow: u64 = 6;
 const EFullCloseRequired: u64 = 7;
+const EProofRequiredForLiveRedeem: u64 = 8;
 
 /// Per-expiry market state.
 public struct ExpiryMarket has key {
@@ -154,15 +155,18 @@ public fun set_mint_paused(market: &mut ExpiryMarket, _admin_cap: &AdminCap, pau
 /// Mint a live position interval against this expiry market.
 ///
 /// Requires the package version to be allowed for this market, per-market mint
-/// pause to be off, trading globally enabled, manager ownership, a live fresh
-/// oracle, enough expiry cash to back the post-mint max payout and rebate reserve,
-/// and leveraged floor terms below this expiry's liquidation LTV at terminal.
-/// Leveraged mints must also satisfy leverage tier policy and be above the current
-/// liquidation threshold at entry.
-/// Returns the minted order ID for future order-scoped flows.
+/// pause to be off, trading globally enabled, a valid `PredictTradeProof` for
+/// the manager, a live fresh oracle, enough expiry cash to back the post-mint
+/// max payout and rebate reserve, and leveraged floor terms below this expiry's
+/// liquidation LTV at terminal. Leveraged mints must also satisfy leverage tier
+/// policy and be above the current liquidation threshold at entry. Mint fees are
+/// paid by routing a withdraw through the manager's trade proof, so the proof is
+/// required even for owner-initiated mints. Returns the minted order ID for
+/// future order-scoped flows.
 public fun mint(
     market: &mut ExpiryMarket,
     manager: &mut PredictManager,
+    proof: &PredictTradeProof,
     config: &ProtocolConfig,
     market_oracle: &MarketOracle,
     pyth: &PythSource,
@@ -178,6 +182,7 @@ public fun mint(
     config.assert_trading_allowed();
     market.mint_internal(
         manager,
+        proof,
         config,
         market_oracle,
         pyth,
@@ -190,12 +195,43 @@ public fun mint(
     )
 }
 
-/// Redeem live or settled order quantity.
-///
-/// Live redeems can close part or all of an order. Settled and liquidated-order
-/// redeems require a full close and return no replacement. Returns
-/// `(closed_order_id, replacement_order_id)`.
+/// Redeem an order you hold trade authority over (the manager owner or a
+/// `PredictTradeCap` holder), authorized by a `PredictTradeProof`. Works in any
+/// order state: a live order is priced and closed (partial or full); a settled
+/// or already-liquidated order is fully closed and the proof is ignored (it has
+/// `drop`). Returns `(closed_order_id, replacement_order_id)`; a replacement is
+/// present only when a live partial close leaves quantity open.
 public fun redeem(
+    market: &mut ExpiryMarket,
+    manager: &mut PredictManager,
+    proof: PredictTradeProof,
+    config: &ProtocolConfig,
+    market_oracle: &MarketOracle,
+    pyth: &PythSource,
+    order_id: u256,
+    close_quantity: u64,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): (u256, Option<u256>) {
+    market.redeem_internal(
+        manager,
+        option::some(proof),
+        config,
+        market_oracle,
+        pyth,
+        order_id,
+        close_quantity,
+        clock,
+        ctx,
+    )
+}
+
+/// Permissionlessly redeem a resolved order without trade authority: a settled
+/// market full close (payout credited to the order's manager) or clearing an
+/// already-liquidated order (no payout). Any caller may run this for keeper
+/// sweeps / cleanup. Aborts with `EProofRequiredForLiveRedeem` if the order is
+/// still live, since closing live risk requires a proof. Requires a full close.
+public fun redeem_settled(
     market: &mut ExpiryMarket,
     manager: &mut PredictManager,
     config: &ProtocolConfig,
@@ -206,43 +242,17 @@ public fun redeem(
     clock: &Clock,
     ctx: &mut TxContext,
 ): (u256, Option<u256>) {
-    market.assert_version_allowed();
-    config.assert_not_valuation_in_progress();
-    market.assert_market_oracle(market_oracle);
-    let redeemed_order = order::from_order_id(order_id);
-    if (market.strike_exposure.is_liquidated_order(&redeemed_order)) {
-        market.redeem_liquidated_order(manager, &redeemed_order, close_quantity);
-        return (redeemed_order.id(), option::none())
-    };
-
-    if (market_oracle.is_settled()) {
-        assert!(close_quantity == redeemed_order.quantity(), EFullCloseRequired);
-        market.redeem_settled_internal(manager, market_oracle, &redeemed_order, ctx);
-        (redeemed_order.id(), option::none())
-    } else {
-        market.run_liquidation_pass(
-            config.pricing_config(),
-            market_oracle,
-            pyth,
-            config.risk_config().trade_liquidation_budget(),
-            clock,
-        );
-        if (market.strike_exposure.is_liquidated_order(&redeemed_order)) {
-            market.redeem_liquidated_order(manager, &redeemed_order, close_quantity);
-            return (redeemed_order.id(), option::none())
-        };
-        let replacement_order_id = market.redeem_live_internal(
-            manager,
-            config,
-            market_oracle,
-            pyth,
-            &redeemed_order,
-            close_quantity,
-            clock,
-            ctx,
-        );
-        (redeemed_order.id(), replacement_order_id)
-    }
+    market.redeem_internal(
+        manager,
+        option::none(),
+        config,
+        market_oracle,
+        pyth,
+        order_id,
+        close_quantity,
+        clock,
+        ctx,
+    )
 }
 
 /// Run one bounded liquidation pass over active leveraged orders.
@@ -524,6 +534,64 @@ fun builder_fee_amount(builder_code_id: &Option<ID>, fee_amount: u64, quantity: 
     }
 }
 
+/// Shared redeem dispatch behind `redeem` (proof) and `redeem_settled` (none).
+/// `proof` is consumed only on the live branch; the settled and liquidated
+/// branches drop it. The live branch requires `some`, else
+/// `EProofRequiredForLiveRedeem`.
+fun redeem_internal(
+    market: &mut ExpiryMarket,
+    manager: &mut PredictManager,
+    proof: Option<PredictTradeProof>,
+    config: &ProtocolConfig,
+    market_oracle: &MarketOracle,
+    pyth: &PythSource,
+    order_id: u256,
+    close_quantity: u64,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): (u256, Option<u256>) {
+    market.assert_version_allowed();
+    config.assert_not_valuation_in_progress();
+    market.assert_market_oracle(market_oracle);
+    let redeemed_order = order::from_order_id(order_id);
+    if (market.strike_exposure.is_liquidated_order(&redeemed_order)) {
+        market.redeem_liquidated_order(manager, &redeemed_order, close_quantity);
+        return (redeemed_order.id(), option::none())
+    };
+
+    if (market_oracle.is_settled()) {
+        assert!(close_quantity == redeemed_order.quantity(), EFullCloseRequired);
+        market.redeem_settled_internal(manager, market_oracle, &redeemed_order, ctx);
+        (redeemed_order.id(), option::none())
+    } else {
+        market.run_liquidation_pass(
+            config.pricing_config(),
+            market_oracle,
+            pyth,
+            config.risk_config().trade_liquidation_budget(),
+            clock,
+        );
+        if (market.strike_exposure.is_liquidated_order(&redeemed_order)) {
+            market.redeem_liquidated_order(manager, &redeemed_order, close_quantity);
+            return (redeemed_order.id(), option::none())
+        };
+        assert!(proof.is_some(), EProofRequiredForLiveRedeem);
+        let live_proof = proof.destroy_some();
+        let replacement_order_id = market.redeem_live_internal(
+            manager,
+            &live_proof,
+            config,
+            market_oracle,
+            pyth,
+            &redeemed_order,
+            close_quantity,
+            clock,
+            ctx,
+        );
+        (redeemed_order.id(), replacement_order_id)
+    }
+}
+
 fun redeem_liquidated_order(
     market: &mut ExpiryMarket,
     manager: &mut PredictManager,
@@ -544,6 +612,7 @@ fun assert_cash_backing(market: &ExpiryMarket) {
 fun mint_internal(
     market: &mut ExpiryMarket,
     manager: &mut PredictManager,
+    proof: &PredictTradeProof,
     config: &ProtocolConfig,
     market_oracle: &MarketOracle,
     pyth: &PythSource,
@@ -554,7 +623,7 @@ fun mint_internal(
     clock: &Clock,
     ctx: &mut TxContext,
 ): u256 {
-    manager.assert_owner(ctx);
+    // Proof is validated inside withdraw_with_proof below.
     manager.update_stake(ctx);
     market.assert_market_oracle(market_oracle);
     market.assert_pyth_feed(pyth);
@@ -584,6 +653,7 @@ fun mint_internal(
 
     let builder_fee_amount = market.settle_mint_payment(
         manager,
+        proof,
         &minted_order,
         fee_amount,
         ctx,
@@ -603,6 +673,7 @@ fun mint_internal(
 fun redeem_live_internal(
     market: &mut ExpiryMarket,
     manager: &mut PredictManager,
+    proof: &PredictTradeProof,
     config: &ProtocolConfig,
     market_oracle: &MarketOracle,
     pyth: &PythSource,
@@ -611,7 +682,7 @@ fun redeem_live_internal(
     clock: &Clock,
     ctx: &mut TxContext,
 ): Option<u256> {
-    manager.assert_owner(ctx);
+    // Proof is validated inside deposit_with_proof below.
     manager.update_stake(ctx);
     market.assert_pyth_feed(pyth);
     pricing::assert_live_quote_available(config.pricing_config(), market_oracle, pyth, clock);
@@ -641,6 +712,7 @@ fun redeem_live_internal(
 
     let builder_fee_amount = market.settle_live_redeem_payment(
         manager,
+        proof,
         redeem_amount,
         fee_amount,
         close_quantity,
@@ -686,6 +758,7 @@ fun redeem_settled_internal(
 fun settle_mint_payment(
     market: &mut ExpiryMarket,
     manager: &mut PredictManager,
+    proof: &PredictTradeProof,
     order: &Order,
     fee_amount: u64,
     ctx: &mut TxContext,
@@ -697,7 +770,7 @@ fun settle_mint_payment(
     let withdraw_amount = user_contribution + fee_amount + builder_fee_amount;
 
     manager.add_position(market.id(), order.id());
-    let mut payment = manager.withdraw(withdraw_amount, ctx).into_balance();
+    let mut payment = manager.withdraw_with_proof(proof, withdraw_amount, ctx).into_balance();
     let builder_fee_payment = payment.split(builder_fee_amount);
     send_builder_fee(builder_code_id, builder_fee_payment);
     let fee_payment = payment.split(fee_amount);
@@ -713,6 +786,7 @@ fun settle_mint_payment(
 fun settle_live_redeem_payment(
     market: &mut ExpiryMarket,
     manager: &mut PredictManager,
+    proof: &PredictTradeProof,
     redeem_amount: u64,
     fee_amount: u64,
     redeemed_quantity: u64,
@@ -734,7 +808,7 @@ fun settle_live_redeem_payment(
     send_builder_fee(builder_code_id, builder_fee);
 
     market.assert_cash_backing();
-    deposit_live_payout(manager, market, payout, redeem_amount, ctx);
+    deposit_live_payout(manager, proof, market, payout, redeem_amount, ctx);
     builder_fee_amount
 }
 
@@ -764,13 +838,14 @@ fun collect_trade_fee(
 
 fun deposit_live_payout(
     manager: &mut PredictManager,
+    proof: &PredictTradeProof,
     market: &ExpiryMarket,
     payout: Balance<DUSDC>,
     gross_received_amount: u64,
     ctx: &mut TxContext,
 ) {
     manager.record_gross_received_from_expiry(market.id(), gross_received_amount);
-    manager.deposit(payout.into_coin(ctx), ctx);
+    manager.deposit_with_proof(proof, payout.into_coin(ctx), ctx);
 }
 
 fun deposit_permissionless_payout(

--- a/packages/predict/sources/predict_manager.move
+++ b/packages/predict/sources/predict_manager.move
@@ -6,21 +6,48 @@
 /// Users deposit DUSDC into the PredictManager. DUSDC custody is delegated to
 /// BalanceManager, while positions are tracked by order IDs scoped to an
 /// ExpiryMarket.
+///
+/// Authorization mirrors BalanceManager: the manager owner can act directly,
+/// or grant `PredictTradeCap`, `PredictDepositCap`, and `PredictWithdrawCap`
+/// to other addresses. `PredictTradeProof` is consumed by predict modules to
+/// authorize a mint/redeem trade and to route the fee deposit/withdraw
+/// through the manager's inner BalanceManager caps. The inner BalanceManager
+/// `DepositCap` and `WithdrawCap` are held by PredictManager itself and never
+/// exposed — all custody operations route through them so the inner
+/// BalanceManager owner check never fires from a cap holder's call.
 module deepbook_predict::predict_manager;
 
-use deepbook::balance_manager::{Self, BalanceManager, DepositCap};
-use deepbook_predict::{account_events, builder_code::{Self, BuilderCode}};
+use deepbook::{
+    balance_manager::{Self, BalanceManager, DepositCap, WithdrawCap, TradeCap},
+    registry::Registry as DeepbookRegistry
+};
+use deepbook_predict::{account_events, builder_code::{Self, BuilderCode}, constants};
 use dusdc::dusdc::DUSDC;
-use sui::{coin::Coin, derived_object, table::{Self, Table}};
+use sui::{coin::Coin, derived_object, table::{Self, Table}, vec_set::{Self, VecSet}};
 
 const EInsufficientPosition: u64 = 0;
 const ENotOwner: u64 = 1;
-const EExpirySummaryHasOpenPositions: u64 = 2;
-const EPositionAlreadyExists: u64 = 3;
+const EInvalidProof: u64 = 2;
+const EInvalidCap: u64 = 3;
+const EMaxCapsReached: u64 = 4;
+const ECapNotInList: u64 = 5;
+const EExpirySummaryHasOpenPositions: u64 = 6;
+const EPositionAlreadyExists: u64 = 7;
 
-/// The key for deriving predict manager. u64 is optional for
-/// supporting multiple managers per address. Defaults to 0 in v1.
+/// Cap-count safety ceiling per manager. Mirrors BalanceManager's MAX_TRADE_CAPS.
+const MAX_CAPS: u64 = 1000;
+
+/// The key for deriving predict manager. u64 distinguishes managers per
+/// address: index 0 is reserved for sender-owned managers (`new`), index 1
+/// for self-owned managers (`new_self_owned`). Future indices may extend the
+/// scheme if multiple managers per sender are added.
 public struct PredictManagerKey(address, u64) has copy, drop, store;
+
+/// Witness used to prove that calls into `balance_manager::new_with_custom_owner_caps_v2`
+/// originate from this package. The deepbook `Registry` admin must authorize
+/// `PredictApp` once via `authorize_app<PredictApp>` before `new_self_owned`
+/// can succeed.
+public struct PredictApp has drop {}
 
 /// Manager-local position key binding an order ID to the expiry market that minted it.
 public struct PositionKey has copy, drop, store {
@@ -34,7 +61,22 @@ public struct PositionKey has copy, drop, store {
 public struct PredictManager has key {
     id: UID,
     balance_manager: BalanceManager,
+    /// Inner BalanceManager `DepositCap` used by PredictManager to credit the
+    /// underlying balance without going through the BalanceManager owner check.
     deposit_cap: DepositCap,
+    /// Inner BalanceManager `WithdrawCap` used by PredictManager to debit the
+    /// underlying balance without going through the BalanceManager owner check.
+    withdraw_cap: WithdrawCap,
+    /// BalanceManager `TradeCap` returned by `new_with_custom_owner_caps_v2`.
+    /// PredictManager doesn't trade on deepbook pools, so the cap is never
+    /// consumed — we hold it because BalanceManager doesn't expose a public
+    /// destroy. `option::none` on sender-owned managers (their constructor
+    /// doesn't go through `_v2`).
+    bm_trade_cap: Option<TradeCap>,
+    /// IDs of PredictManager caps (PredictTradeCap / PredictDepositCap /
+    /// PredictWithdrawCap) authorized to act on this manager. Revoking removes
+    /// the ID from this set.
+    allow_listed: VecSet<ID>,
     builder_code_id: Option<ID>,
     /// Open order positions scoped by expiry market.
     positions: Table<PositionKey, bool>,
@@ -62,6 +104,36 @@ public struct ExpiryTradingSummary has store {
     gross_received_from_expiry: u64,
 }
 
+/// Owners of a `PredictTradeCap` can generate a `PredictTradeProof` to mint/redeem
+/// positions on this manager. Risk of equivocation since `PredictTradeCap` is
+/// an owned object — high-frequency callers should trade as the manager owner.
+public struct PredictTradeCap has key, store {
+    id: UID,
+    predict_manager_id: ID,
+}
+
+/// `PredictDepositCap` is used to deposit funds into a PredictManager by a
+/// non-owner.
+public struct PredictDepositCap has key, store {
+    id: UID,
+    predict_manager_id: ID,
+}
+
+/// `PredictWithdrawCap` is used to withdraw funds from a PredictManager by a
+/// non-owner.
+public struct PredictWithdrawCap has key, store {
+    id: UID,
+    predict_manager_id: ID,
+}
+
+/// Manager owner and `PredictTradeCap` holders can generate a `PredictTradeProof`.
+/// Predict modules consume the proof to authorize the trade and to route
+/// deposit / withdraw through the manager's inner BalanceManager caps.
+public struct PredictTradeProof has drop {
+    predict_manager_id: ID,
+    trader: address,
+}
+
 // === Public Functions ===
 
 /// Share a newly created PredictManager object.
@@ -72,16 +144,6 @@ public fun share(self: PredictManager) {
 /// Return the PredictManager object ID.
 public fun id(self: &PredictManager): ID {
     self.id.to_inner()
-}
-
-/// Deposit coins into the PredictManager.
-public fun deposit(self: &mut PredictManager, coin: Coin<DUSDC>, ctx: &mut TxContext) {
-    self.balance_manager.deposit(coin, ctx);
-}
-
-/// Withdraw coins from the PredictManager.
-public fun withdraw(self: &mut PredictManager, amount: u64, ctx: &mut TxContext): Coin<DUSDC> {
-    self.balance_manager.withdraw(amount, ctx)
 }
 
 /// Return the BalanceManager owner for this PredictManager.
@@ -155,18 +217,115 @@ public fun unset_builder_code(self: &mut PredictManager, ctx: &TxContext) {
     account_events::emit_builder_code_set(self.id(), self.owner(), option::none());
 }
 
+/// Mint a `PredictTradeCap`. Only the manager owner can mint. Unreachable
+/// on self-owned managers; all caps for those are minted by `new_self_owned`.
+public fun mint_trade_cap(self: &mut PredictManager, ctx: &mut TxContext): PredictTradeCap {
+    self.assert_owner(ctx);
+    let manager_id = self.id();
+    self.mint_trade_cap_internal(manager_id, ctx)
+}
+
+/// Mint a `PredictDepositCap`. Only the manager owner can mint. Unreachable
+/// on self-owned managers; all caps for those are minted by `new_self_owned`.
+public fun mint_deposit_cap(self: &mut PredictManager, ctx: &mut TxContext): PredictDepositCap {
+    self.assert_owner(ctx);
+    let manager_id = self.id();
+    self.mint_deposit_cap_internal(manager_id, ctx)
+}
+
+/// Mint a `PredictWithdrawCap`. Only the manager owner can mint. Unreachable
+/// on self-owned managers; all caps for those are minted by `new_self_owned`.
+public fun mint_withdraw_cap(self: &mut PredictManager, ctx: &mut TxContext): PredictWithdrawCap {
+    self.assert_owner(ctx);
+    let manager_id = self.id();
+    self.mint_withdraw_cap_internal(manager_id, ctx)
+}
+
+/// Revoke a previously minted cap. Only the manager owner can revoke. Works
+/// for any of `PredictTradeCap`, `PredictDepositCap`, or `PredictWithdrawCap`
+/// since they all live in the same `allow_listed` set.
+public fun revoke_cap(self: &mut PredictManager, cap_id: &ID, ctx: &TxContext) {
+    self.assert_owner(ctx);
+    assert!(self.allow_listed.contains(cap_id), ECapNotInList);
+    self.allow_listed.remove(cap_id);
+}
+
+/// Generate a `PredictTradeProof` as the manager owner. No equivocation risk.
+public fun generate_proof_as_owner(self: &PredictManager, ctx: &TxContext): PredictTradeProof {
+    self.assert_owner(ctx);
+    PredictTradeProof { predict_manager_id: self.id(), trader: ctx.sender() }
+}
+
+/// Generate a `PredictTradeProof` using a `PredictTradeCap`. Cap is an owned object
+/// so the holder risks equivocation when generating proofs in concurrent PTBs.
+public fun generate_proof_as_trader(
+    self: &PredictManager,
+    trade_cap: &PredictTradeCap,
+    ctx: &TxContext,
+): PredictTradeProof {
+    self.validate_trader(trade_cap);
+    PredictTradeProof { predict_manager_id: self.id(), trader: ctx.sender() }
+}
+
+/// Abort unless the proof was generated for this manager.
+public fun validate_proof(self: &PredictManager, proof: &PredictTradeProof) {
+    assert!(self.id() == proof.predict_manager_id, EInvalidProof);
+}
+
+/// Deposit DUSDC into the manager. Only the manager owner may call.
+public fun deposit(self: &mut PredictManager, coin: Coin<DUSDC>, ctx: &mut TxContext) {
+    self.assert_owner(ctx);
+    self.balance_manager.deposit_with_cap(&self.deposit_cap, coin, ctx);
+}
+
+/// Withdraw DUSDC from the manager. Only the manager owner may call.
+public fun withdraw(self: &mut PredictManager, amount: u64, ctx: &mut TxContext): Coin<DUSDC> {
+    self.assert_owner(ctx);
+    self.balance_manager.withdraw_with_cap(&self.withdraw_cap, amount, ctx)
+}
+
+/// Deposit DUSDC using a `PredictDepositCap`.
+public fun deposit_with_cap(
+    self: &mut PredictManager,
+    cap: &PredictDepositCap,
+    coin: Coin<DUSDC>,
+    ctx: &TxContext,
+) {
+    self.validate_depositor(cap);
+    self.balance_manager.deposit_with_cap(&self.deposit_cap, coin, ctx);
+}
+
+/// Withdraw DUSDC using a `PredictWithdrawCap`.
+public fun withdraw_with_cap(
+    self: &mut PredictManager,
+    cap: &PredictWithdrawCap,
+    amount: u64,
+    ctx: &mut TxContext,
+): Coin<DUSDC> {
+    self.validate_withdrawer(cap);
+    self.balance_manager.withdraw_with_cap(&self.withdraw_cap, amount, ctx)
+}
+
 // === Public-Package Functions ===
 
-/// Create a derived PredictManager for the sender.
+/// Create a sender-owned PredictManager. The sender is the BalanceManager
+/// owner and can act directly on the manager without holding any cap.
 public(package) fun new(registry_uid: &mut UID, ctx: &mut TxContext): PredictManager {
-    let id = derived_object::claim(registry_uid, PredictManagerKey(ctx.sender(), 0));
+    let id = derived_object::claim(
+        registry_uid,
+        PredictManagerKey(ctx.sender(), constants::sender_owned_manager_slot!()),
+    );
     let mut balance_manager = balance_manager::new(ctx);
     let deposit_cap = balance_manager.mint_deposit_cap(ctx);
+    let withdraw_cap = balance_manager.mint_withdraw_cap(ctx);
 
     let manager = PredictManager {
         id,
         balance_manager,
         deposit_cap,
+        withdraw_cap,
+        bm_trade_cap: option::none(),
+        allow_listed: vec_set::empty(),
         builder_code_id: option::none(),
         positions: table::new(ctx),
         expiry_summaries: table::new(ctx),
@@ -178,13 +337,96 @@ public(package) fun new(registry_uid: &mut UID, ctx: &mut TxContext): PredictMan
     manager
 }
 
-/// Deposit protocol payouts without requiring the manager owner as sender.
+/// Create a PredictManager that owns itself: the inner BalanceManager's owner
+/// is set to the PredictManager's own ID-as-address, which no transaction
+/// sender can ever match. The owner-direct deposit/withdraw and `mint_*_cap`
+/// paths are permanently unreachable, so the caps minted here are the only
+/// authority that will ever exist on this manager.
+///
+/// Intended for contracts (vaults, custodial products) that don't want a
+/// deployer-key trust anchor. The caller receives one cap of each kind and
+/// is expected to install them inside its own contract object.
+///
+/// Requires `PredictApp` to be authorized on the deepbook `Registry` via
+/// `deepbook::registry::authorize_app<PredictApp>` — a one-time admin tx on
+/// the deepbook side.
+public(package) fun new_self_owned(
+    registry_uid: &mut UID,
+    deepbook_registry: &DeepbookRegistry,
+    ctx: &mut TxContext,
+): (PredictManager, PredictDepositCap, PredictWithdrawCap, PredictTradeCap) {
+    let id = derived_object::claim(
+        registry_uid,
+        PredictManagerKey(ctx.sender(), constants::self_owned_manager_slot!()),
+    );
+    let owner_address = id.to_inner().to_address();
+
+    let (
+        balance_manager,
+        bm_deposit_cap,
+        bm_withdraw_cap,
+        bm_trade_cap,
+    ) = balance_manager::new_with_custom_owner_caps_v2(
+        PredictApp {},
+        deepbook_registry,
+        owner_address,
+        ctx,
+    );
+
+    let mut manager = PredictManager {
+        id,
+        balance_manager,
+        deposit_cap: bm_deposit_cap,
+        withdraw_cap: bm_withdraw_cap,
+        bm_trade_cap: option::some(bm_trade_cap),
+        allow_listed: vec_set::empty(),
+        builder_code_id: option::none(),
+        positions: table::new(ctx),
+        expiry_summaries: table::new(ctx),
+        active_stake: 0,
+        inactive_stake: 0,
+        stake_epoch: ctx.epoch(),
+    };
+    let manager_id = manager.id();
+    account_events::emit_predict_manager_created(manager_id, manager.owner());
+
+    let predict_trade_cap = manager.mint_trade_cap_internal(manager_id, ctx);
+    let predict_deposit_cap = manager.mint_deposit_cap_internal(manager_id, ctx);
+    let predict_withdraw_cap = manager.mint_withdraw_cap_internal(manager_id, ctx);
+
+    (manager, predict_deposit_cap, predict_withdraw_cap, predict_trade_cap)
+}
+
+/// Deposit protocol payouts without requiring any authorization. Used for
+/// settled redemptions, which any caller may trigger.
 public(package) fun deposit_permissionless(
     self: &mut PredictManager,
     coin: Coin<DUSDC>,
     ctx: &TxContext,
 ) {
     self.balance_manager.deposit_with_cap(&self.deposit_cap, coin, ctx);
+}
+
+/// Deposit DUSDC into the manager using a validated `PredictTradeProof`.
+public(package) fun deposit_with_proof(
+    self: &mut PredictManager,
+    proof: &PredictTradeProof,
+    coin: Coin<DUSDC>,
+    ctx: &TxContext,
+) {
+    self.validate_proof(proof);
+    self.balance_manager.deposit_with_cap(&self.deposit_cap, coin, ctx);
+}
+
+/// Withdraw DUSDC from the manager using a validated `PredictTradeProof`.
+public(package) fun withdraw_with_proof(
+    self: &mut PredictManager,
+    proof: &PredictTradeProof,
+    amount: u64,
+    ctx: &mut TxContext,
+): Coin<DUSDC> {
+    self.validate_proof(proof);
+    self.balance_manager.withdraw_with_cap(&self.withdraw_cap, amount, ctx)
 }
 
 /// Add an order position.
@@ -300,6 +542,8 @@ public(package) fun assert_owner(self: &PredictManager, ctx: &TxContext) {
     assert!(ctx.sender() == self.balance_manager.owner(), ENotOwner);
 }
 
+// === Private Functions ===
+
 fun ensure_expiry_summary(self: &mut PredictManager, expiry_market_id: ID) {
     if (!self.expiry_summaries.contains(expiry_market_id)) {
         let summary = ExpiryTradingSummary {
@@ -314,4 +558,62 @@ fun ensure_expiry_summary(self: &mut PredictManager, expiry_market_id: ID) {
 
 fun position_key(expiry_market_id: ID, order_id: u256): PositionKey {
     PositionKey { expiry_market_id, order_id }
+}
+
+fun assert_caps_capacity(self: &PredictManager) {
+    assert!(self.allow_listed.length() < MAX_CAPS, EMaxCapsReached);
+}
+
+fun validate_trader(self: &PredictManager, trade_cap: &PredictTradeCap) {
+    assert!(self.allow_listed.contains(object::borrow_id(trade_cap)), EInvalidCap);
+}
+
+fun validate_depositor(self: &PredictManager, deposit_cap: &PredictDepositCap) {
+    assert!(self.allow_listed.contains(object::borrow_id(deposit_cap)), EInvalidCap);
+}
+
+fun validate_withdrawer(self: &PredictManager, withdraw_cap: &PredictWithdrawCap) {
+    assert!(self.allow_listed.contains(object::borrow_id(withdraw_cap)), EInvalidCap);
+}
+
+/// Allow-list and emit for a new `PredictTradeCap`. Shared by the owner-gated
+/// `mint_trade_cap` and the `new_self_owned` constructor, so it carries no
+/// owner check of its own.
+fun mint_trade_cap_internal(
+    self: &mut PredictManager,
+    manager_id: ID,
+    ctx: &mut TxContext,
+): PredictTradeCap {
+    self.assert_caps_capacity();
+    let id = object::new(ctx);
+    let cap_id = id.to_inner();
+    self.allow_listed.insert(cap_id);
+    account_events::emit_predict_trade_cap_minted(manager_id, cap_id);
+    PredictTradeCap { id, predict_manager_id: manager_id }
+}
+
+fun mint_deposit_cap_internal(
+    self: &mut PredictManager,
+    manager_id: ID,
+    ctx: &mut TxContext,
+): PredictDepositCap {
+    self.assert_caps_capacity();
+    let id = object::new(ctx);
+    let cap_id = id.to_inner();
+    self.allow_listed.insert(cap_id);
+    account_events::emit_predict_deposit_cap_minted(manager_id, cap_id);
+    PredictDepositCap { id, predict_manager_id: manager_id }
+}
+
+fun mint_withdraw_cap_internal(
+    self: &mut PredictManager,
+    manager_id: ID,
+    ctx: &mut TxContext,
+): PredictWithdrawCap {
+    self.assert_caps_capacity();
+    let id = object::new(ctx);
+    let cap_id = id.to_inner();
+    self.allow_listed.insert(cap_id);
+    account_events::emit_predict_withdraw_cap_minted(manager_id, cap_id);
+    PredictWithdrawCap { id, predict_manager_id: manager_id }
 }

--- a/packages/predict/sources/registry.move
+++ b/packages/predict/sources/registry.move
@@ -9,6 +9,7 @@
 /// owning modules.
 module deepbook_predict::registry;
 
+use deepbook::registry::Registry as DeepbookRegistry;
 use deepbook_predict::{
     admin::{Self, AdminCap},
     builder_code,
@@ -18,7 +19,7 @@ use deepbook_predict::{
     expiry_market::{Self, ExpiryMarket},
     market_oracle::{Self, MarketOracle, MarketOracleCap},
     plp::PoolVault,
-    predict_manager::{Self, PredictManager},
+    predict_manager::{Self, PredictDepositCap, PredictManager, PredictTradeCap, PredictWithdrawCap},
     pricing,
     protocol_config::{Self, ProtocolConfig},
     pyth_source::{Self, PythSource}
@@ -477,6 +478,22 @@ public fun create_manager(registry: &mut Registry, ctx: &mut TxContext): Predict
 /// Create and share a derived PredictManager for the caller.
 public fun create_and_share_manager(registry: &mut Registry, ctx: &mut TxContext) {
     create_manager(registry, ctx).share();
+}
+
+/// Create a derived self-owned PredictManager for callers that don't want a
+/// deployer-key trust anchor (vaults, structured products). The inner
+/// BalanceManager owner is set to the manager's own ID-as-address, so the
+/// returned caps are the only authority that will ever exist on this manager.
+///
+/// Requires `PredictApp` to be authorized on the deepbook `Registry` via
+/// `deepbook::registry::authorize_app<PredictApp>` — a one-time admin tx on
+/// the deepbook side.
+public fun create_self_owned_manager(
+    registry: &mut Registry,
+    deepbook_registry: &DeepbookRegistry,
+    ctx: &mut TxContext,
+): (PredictManager, PredictDepositCap, PredictWithdrawCap, PredictTradeCap) {
+    predict_manager::new_self_owned(&mut registry.id, deepbook_registry, ctx)
 }
 
 // === Public-Package Functions ===

--- a/packages/predict/tests/expiry_market_tests.move
+++ b/packages/predict/tests/expiry_market_tests.move
@@ -82,8 +82,10 @@ fun rebate_eligibility_offsets_fee_reserve_by_gross_profit() {
         scenario.ctx(),
     );
 
+    let proof = manager.generate_proof_as_owner(scenario.ctx());
     let order_id = market.mint(
         &mut manager,
+        &proof,
         &config,
         &oracle,
         &pyth,

--- a/packages/predict/tests/flows/plp_rebate_flow_tests.move
+++ b/packages/predict/tests/flows/plp_rebate_flow_tests.move
@@ -8,7 +8,7 @@ use deepbook_predict::{
     admin::AdminCap,
     config_constants,
     constants::{Self, float_scaling as float},
-    expiry_market::ExpiryMarket,
+    expiry_market::{Self, ExpiryMarket},
     i64,
     market_oracle::{Self, MarketOracle, MarketOracleCap},
     order,
@@ -78,8 +78,10 @@ fun same_expiry_residual_rebate_cash_materializes_new_terminal_profit() {
         coin::mint_for_testing<DUSDC>(MIN_FEE_MINT_DEPOSIT, fixture.scenario.ctx()),
         fixture.scenario.ctx(),
     );
+    let proof = manager.generate_proof_as_owner(fixture.scenario.ctx());
     let order_id = market.mint(
         &mut manager,
+        &proof,
         &fixture.config,
         &oracle,
         &pyth,
@@ -105,7 +107,8 @@ fun same_expiry_residual_rebate_cash_materializes_new_terminal_profit() {
         constants::expiry_cash_floor!() + MIN_FEE_TERMINAL_MATERIALIZED_PROFIT,
     );
 
-    let (closed_order_id, replacement_order_id) = market.redeem(
+    // Settled redeem is permissionless, so it takes no trade proof.
+    let (closed_order_id, replacement_order_id) = market.redeem_settled(
         &mut manager,
         &fixture.config,
         &oracle,
@@ -151,6 +154,55 @@ fun same_expiry_residual_rebate_cash_materializes_new_terminal_profit() {
     return_shared(pyth);
     destroy(manager);
     finish(fixture);
+}
+
+#[test, expected_failure(abort_code = expiry_market::EProofRequiredForLiveRedeem)]
+fun redeem_settled_on_live_order_aborts() {
+    let mut fixture = setup_pool_with_pyth();
+    let (expiry_id, oracle_id) = create_expiry(&mut fixture, EXPIRY_MS);
+    let mut manager = create_manager_for_testing(&mut fixture);
+
+    let mut pyth = fixture.scenario.take_shared_by_id<PythSource>(fixture.pyth_id);
+    let mut vault = fixture.scenario.take_shared_by_id<PoolVault>(fixture.vault_id);
+    let mut market = fixture.scenario.take_shared_by_id<ExpiryMarket>(expiry_id);
+    let mut oracle = fixture.scenario.take_shared_by_id<MarketOracle>(oracle_id);
+
+    prepare_live_oracle_for_trading(&fixture, &mut oracle, &mut pyth);
+    sync_expiry_for_testing(&mut fixture, &mut vault, &mut market, &oracle, &pyth);
+
+    manager.deposit(
+        coin::mint_for_testing<DUSDC>(MIN_FEE_MINT_DEPOSIT, fixture.scenario.ctx()),
+        fixture.scenario.ctx(),
+    );
+    let proof = manager.generate_proof_as_owner(fixture.scenario.ctx());
+    let order_id = market.mint(
+        &mut manager,
+        &proof,
+        &fixture.config,
+        &oracle,
+        &pyth,
+        MIN_FEE_LOWER_STRIKE,
+        constants::pos_inf!(),
+        MIN_FEE_MINT_QUANTITY,
+        order::leverage_one_x(),
+        &fixture.clock,
+        fixture.scenario.ctx(),
+    );
+
+    // Oracle is not settled, so the order is still live: the permissionless
+    // redeem_settled path must reject it (closing live risk requires a proof).
+    market.redeem_settled(
+        &mut manager,
+        &fixture.config,
+        &oracle,
+        &pyth,
+        order_id,
+        MIN_FEE_MINT_QUANTITY,
+        &fixture.clock,
+        fixture.scenario.ctx(),
+    );
+
+    abort 999
 }
 
 fun setup_pool_with_pyth(): Fixture {

--- a/packages/predict/tests/predict_manager_tests.move
+++ b/packages/predict/tests/predict_manager_tests.move
@@ -494,3 +494,127 @@ fun remove_all_stake_returns_active_plus_inactive_and_zeroes() {
     destroy(manager);
     scenario.end();
 }
+
+// === Cap system / trade proofs ===
+
+#[test]
+fun owner_can_mint_and_revoke_caps() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+
+    let trade_cap = manager.mint_trade_cap(scenario.ctx());
+    let deposit_cap = manager.mint_deposit_cap(scenario.ctx());
+    let withdraw_cap = manager.mint_withdraw_cap(scenario.ctx());
+
+    // Revoke each by id; the cap object remains but can no longer authorize.
+    manager.revoke_cap(object::borrow_id(&trade_cap), scenario.ctx());
+    manager.revoke_cap(object::borrow_id(&deposit_cap), scenario.ctx());
+    manager.revoke_cap(object::borrow_id(&withdraw_cap), scenario.ctx());
+
+    destroy(trade_cap);
+    destroy(deposit_cap);
+    destroy(withdraw_cap);
+    destroy(manager);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = predict_manager::ENotOwner)]
+fun non_owner_cannot_mint_trade_cap() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+
+    scenario.next_tx(test_constants::bob());
+    let _cap = manager.mint_trade_cap(scenario.ctx());
+
+    abort 999
+}
+
+#[test]
+fun owner_can_generate_proof() {
+    let (mut scenario, registry_id) = setup();
+    let manager = create_alice_manager(&mut scenario, registry_id);
+
+    let proof = manager.generate_proof_as_owner(scenario.ctx());
+    manager.validate_proof(&proof);
+
+    destroy(manager);
+    scenario.end();
+}
+
+#[test]
+fun trade_cap_holder_can_generate_proof() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+    let trade_cap = manager.mint_trade_cap(scenario.ctx());
+
+    scenario.next_tx(test_constants::bob());
+    let proof = manager.generate_proof_as_trader(&trade_cap, scenario.ctx());
+    manager.validate_proof(&proof);
+
+    destroy(trade_cap);
+    destroy(manager);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = predict_manager::EInvalidCap)]
+fun revoked_trade_cap_cannot_generate_proof() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+    let trade_cap = manager.mint_trade_cap(scenario.ctx());
+
+    manager.revoke_cap(object::borrow_id(&trade_cap), scenario.ctx());
+
+    scenario.next_tx(test_constants::bob());
+    let _proof = manager.generate_proof_as_trader(&trade_cap, scenario.ctx());
+
+    abort 999
+}
+
+#[test, expected_failure(abort_code = predict_manager::ECapNotInList)]
+fun revoking_unknown_cap_aborts() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+
+    let fake_id = object::id_from_address(@0xDEAD);
+    manager.revoke_cap(&fake_id, scenario.ctx());
+
+    abort 999
+}
+
+#[test]
+fun proof_from_one_manager_does_not_validate_against_another() {
+    let (mut scenario, registry_id) = setup();
+    let manager_a = create_alice_manager(&mut scenario, registry_id);
+
+    scenario.next_tx(test_constants::bob());
+    let mut reg = scenario.take_shared_by_id<registry::Registry>(registry_id);
+    let manager_b = registry::create_manager(&mut reg, scenario.ctx());
+    return_shared(reg);
+
+    scenario.next_tx(test_constants::alice());
+    let proof_a = manager_a.generate_proof_as_owner(scenario.ctx());
+    // The two managers are distinct; A's proof validates against A only.
+    assert!(manager_a.id() != manager_b.id());
+    manager_a.validate_proof(&proof_a);
+
+    destroy(manager_a);
+    destroy(manager_b);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = predict_manager::EInvalidProof)]
+fun cross_manager_proof_validation_aborts() {
+    let (mut scenario, registry_id) = setup();
+    let manager_a = create_alice_manager(&mut scenario, registry_id);
+
+    scenario.next_tx(test_constants::bob());
+    let mut reg = scenario.take_shared_by_id<registry::Registry>(registry_id);
+    let manager_b = registry::create_manager(&mut reg, scenario.ctx());
+    return_shared(reg);
+
+    scenario.next_tx(test_constants::alice());
+    let proof_a = manager_a.generate_proof_as_owner(scenario.ctx());
+    manager_b.validate_proof(&proof_a);
+
+    abort 999
+}


### PR DESCRIPTION
## Summary
- Add `PredictTradeCap`, `PredictDepositCap`, `PredictWithdrawCap` on `PredictManager` (owner-minted, tracked in a per-manager `allow_listed: VecSet<ID>`), plus a per-tx `PredictTradeProof` generated by the owner or any `PredictTradeCap` holder. Cap mints emit events; `revoke_cap` is uniform.
- Stash the inner BalanceManager `WithdrawCap` on `PredictManager` alongside the existing `DepositCap`. All custody routes through these inner caps so the inner BM owner check never fires from a cap-holder call.
- `expiry_market::mint` now requires `&PredictTradeProof`. `expiry_market::redeem` takes `Option<PredictTradeProof>` — live path requires it; settled path is permissionless and drops the proof (`drop` ability lets keepers pass `none`).
- `predict_manager::new_self_owned` (via `registry::create_self_owned_manager`) sets the inner BalanceManager owner to the manager's own ID-as-address using `balance_manager::new_with_custom_owner_caps_v2`. `ctx.sender()` can never match, so the caps returned at construction are the only authority that will ever exist on this manager. For vaults / structured products that don't want a deployer-key trust anchor.
- Reserve `PredictManagerKey` slot 0 for sender-owned, slot 1 for self-owned, named via `constants::{sender,self}_owned_manager_slot!()`.

Closes the old reimplementation attempt at #1028 (closed because its base predated 7+ predict PRs).

DBU-413

## Key decisions
- **Single proof type, multiple cap types.** One `allow_listed` set covers all three cap types; `revoke_cap` works for any ID. Each cap type only authorizes its own action (`PredictTradeCap` → mint proof, `PredictDepositCap` → deposit_with_cap, `PredictWithdrawCap` → withdraw_with_cap).
- **`Option<PredictTradeProof>` on `redeem` instead of `redeem` + `redeem_permissionless`.** Keeps one entrypoint; live asserts `is_some`, settled drops via the proof's `drop` ability. Compacted state doesn't exist on current main, so this is just live vs settled.
- **Inner BM `TradeCap` stashed in `Option<TradeCap>`.** PredictManager doesn't trade on deepbook pools; we hold the cap because BalanceManager doesn't expose a public destroy. Sender-owned managers (`new`) don't go through `_v2`, so they store `option::none`. Removable when upstream adds `destroy_trade_cap`.
- **`PredictManager` stays `has key` (no `store`).** Apps that want to wrap the manager inside another object's field would need `store`; we kept the surface minimal. Easy to add later if a wrapping use case appears.
- **Initial cap mints inside `new_self_owned` bypass the `assert_owner` check.** They're in private `mint_initial_*_cap` helpers callable only from `new_self_owned`, so a self-owned manager always starts with the bootstrap set returned to the constructor caller — there's no other route to mint caps on it (`ctx.sender()` can never match the self-owner address).
- **Existing `mint`/`redeem` signatures changed (not duplicated).** Predict isn't published yet and the only on-chain caller is the simulation runtime (updated in this PR). No script or indexer callers exist.

## Test plan
- [x] `sui move build` clean for `packages/predict`
- [x] `sui move test --gas-limit 100000000000` passes (35/35, +8 new)
- [x] `bunx prettier-move -c` clean on edited files
- [x] Predict sim `SIM_MAX_ROWS=1 bash run.sh --skip-analysis` setup + execute completes without failure (manager creation, oracle setup, action through proof-threaded mint path all succeed)
- [ ] One-time deepbook admin tx to authorize `PredictApp` before `new_self_owned` can run on chain

## Out of scope
- TS SDK / scripts wrappers for the new entrypoints (follow-up).
- Deepbook admin `authorize_app<PredictApp>` tx (one-time external op).