### PR TITLE
DBU-417: Predict tests for market_oracle deep coverage

### DIFF
--- a/packages/predict/sources/oracle/market_oracle.move
+++ b/packages/predict/sources/oracle/market_oracle.move
@@ -741,6 +741,19 @@ fun emit_bounds_updated(market: &MarketOracle) {
 
 // === Test-Only Functions ===
 
+/// Variant of `create_test_market_oracle` that binds to a real `PythSource`,
+/// so flows that call `assert_pyth_source(pyth)` (update_block_scholes_prices,
+/// settle_if_possible) can exercise the matched-source happy path.
+#[test_only]
+public(package) fun create_test_market_oracle_with_pyth(
+    pyth: &PythSource,
+    expiry: u64,
+    cap: &MarketOracleCap,
+    ctx: &mut TxContext,
+): MarketOracle {
+    create_test_market_oracle_with_pyth_id(pyth.id(), expiry, cap, ctx)
+}
+
 #[test_only]
 public(package) fun create_test_market_oracle(
     expiry: u64,
@@ -750,7 +763,16 @@ public(package) fun create_test_market_oracle(
     let pyth_uid = object::new(ctx);
     let pyth_source_id = pyth_uid.to_inner();
     pyth_uid.delete();
+    create_test_market_oracle_with_pyth_id(pyth_source_id, expiry, cap, ctx)
+}
 
+#[test_only]
+fun create_test_market_oracle_with_pyth_id(
+    pyth_source_id: ID,
+    expiry: u64,
+    cap: &MarketOracleCap,
+    ctx: &mut TxContext,
+): MarketOracle {
     let mut authorized_cap_ids = vec_set::empty();
     authorized_cap_ids.insert(cap.cap_id());
 

--- a/packages/predict/sources/oracle/pyth_source.move
+++ b/packages/predict/sources/oracle/pyth_source.move
@@ -199,3 +199,19 @@ public fun new_for_testing(ctx: &mut TxContext): PythSource {
         expiry_fee_max_multiplier: deepbook_predict::test_constants::default_expiry_fee_max_multiplier!(),
     }
 }
+
+/// Drive spot and timestamps directly without going through `update_from_lazer`
+/// (which needs a `pyth_lazer::Update` that has no Move-side test constructor).
+/// Used by oracle settlement tests that need a "Pyth has fresh post-expiry data"
+/// state.
+#[test_only]
+public fun set_state_for_testing(
+    source: &mut PythSource,
+    spot: u64,
+    source_timestamp_ms: u64,
+    update_timestamp_ms: u64,
+) {
+    source.spot = spot;
+    source.source_timestamp_ms = source_timestamp_ms;
+    source.update_timestamp_ms = update_timestamp_ms;
+}

--- a/packages/predict/sources/registry.move
+++ b/packages/predict/sources/registry.move
@@ -577,3 +577,19 @@ public fun destroy_registry_for_testing(registry: Registry) {
     pyth_source_ids.destroy_empty();
     expiry_market_ids.destroy_empty();
 }
+
+/// Variant for tests that exercise registration paths: drops the uniqueness
+/// tables without requiring them to be empty.
+#[test_only]
+public fun destroy_registry_drop_for_testing(registry: Registry) {
+    let Registry {
+        id,
+        pyth_source_ids,
+        expiry_market_ids,
+        allowed_pause_caps: _,
+        allowed_versions: _,
+    } = registry;
+    id.delete();
+    pyth_source_ids.drop();
+    expiry_market_ids.drop();
+}

--- a/packages/predict/tests/market_key/order_tests.move
+++ b/packages/predict/tests/market_key/order_tests.move
@@ -1,0 +1,324 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module deepbook_predict::order_tests;
+
+use deepbook_predict::{constants, order};
+use std::unit_test::assert_eq;
+
+// Position lot size is 10_000 (from constants::position_lot_size!()), so a
+// quantity must be a multiple of 10_000.
+const ONE_LOT_QTY: u64 = 10_000;
+const TWO_LOTS_QTY: u64 = 20_000;
+const SEQUENCE_ZERO: u64 = 0;
+const OPENED_AT_MS: u64 = 1_700_000_000_000;
+// Strikes are indices into the 100_000-tick grid; pick safe values.
+const STRIKE_INDEX_LO: u64 = 100;
+const STRIKE_INDEX_HI: u64 = 200;
+
+// === Leverage constants ===
+
+#[test]
+fun leverage_constants_are_distinct_and_ordered() {
+    let l1 = order::leverage_one_x();
+    let l15 = order::leverage_one_and_half_x();
+    let l2 = order::leverage_two_x();
+    let l25 = order::leverage_two_and_half_x();
+    let l3 = order::leverage_three_x();
+
+    assert_eq!(l1, 0);
+    assert!(l1 < l15);
+    assert!(l15 < l2);
+    assert!(l2 < l25);
+    assert!(l25 < l3);
+    assert_eq!(l3, 4);
+}
+
+// === open_strike_index sentinel ===
+
+#[test]
+fun open_strike_index_is_above_grid() {
+    // The sentinel is one above the maximum valid finite strike index.
+    assert_eq!(order::open_strike_index(), constants::oracle_strike_grid_ticks!() + 1);
+}
+
+// === assert_valid_quantity ===
+
+#[test]
+fun assert_valid_quantity_accepts_lot_multiples() {
+    order::assert_valid_quantity(ONE_LOT_QTY);
+    order::assert_valid_quantity(TWO_LOTS_QTY);
+    order::assert_valid_quantity(ONE_LOT_QTY * 12345);
+}
+
+#[test, expected_failure(abort_code = order::EInvalidQuantity)]
+fun assert_valid_quantity_zero_aborts() {
+    order::assert_valid_quantity(0);
+    abort 999
+}
+
+#[test, expected_failure(abort_code = order::EInvalidQuantity)]
+fun assert_valid_quantity_not_a_lot_multiple_aborts() {
+    order::assert_valid_quantity(ONE_LOT_QTY + 1);
+    abort 999
+}
+
+// === new_from_strike_indices: happy path + getters ===
+
+#[test]
+fun new_from_strike_indices_round_trips_through_getters() {
+    let leverage = order::leverage_one_x();
+    let entry_probability = 500_000_000; // 0.5 in 1e9
+    let o = order::new_from_strike_indices(
+        OPENED_AT_MS,
+        STRIKE_INDEX_LO,
+        STRIKE_INDEX_HI,
+        leverage,
+        entry_probability,
+        TWO_LOTS_QTY,
+        SEQUENCE_ZERO,
+    );
+
+    assert_eq!(o.opened_at_ms(), OPENED_AT_MS);
+    assert_eq!(o.min_strike_index(), STRIKE_INDEX_LO);
+    assert_eq!(o.max_strike_index(), STRIKE_INDEX_HI);
+    assert_eq!(o.leverage(), leverage);
+    assert_eq!(o.entry_probability(), entry_probability);
+    assert_eq!(o.quantity(), TWO_LOTS_QTY);
+    assert_eq!(o.quantity_lots(), TWO_LOTS_QTY / constants::position_lot_size!());
+    assert_eq!(o.sequence(), SEQUENCE_ZERO);
+}
+
+#[test]
+fun from_order_id_round_trips_through_id_getter() {
+    let leverage = order::leverage_one_x();
+    let o = order::new_from_strike_indices(
+        OPENED_AT_MS,
+        STRIKE_INDEX_LO,
+        STRIKE_INDEX_HI,
+        leverage,
+        0,
+        ONE_LOT_QTY,
+        0,
+    );
+    let packed_id = o.id();
+
+    let parsed = order::from_order_id(packed_id);
+    assert_eq!(parsed.id(), packed_id);
+    assert_eq!(parsed.opened_at_ms(), o.opened_at_ms());
+    assert_eq!(parsed.min_strike_index(), o.min_strike_index());
+}
+
+#[test]
+fun is_leveraged_distinguishes_one_x_from_others() {
+    let o1 = order::new_from_strike_indices(
+        OPENED_AT_MS,
+        STRIKE_INDEX_LO,
+        STRIKE_INDEX_HI,
+        order::leverage_one_x(),
+        0,
+        ONE_LOT_QTY,
+        0,
+    );
+    assert!(!o1.is_leveraged());
+
+    // Leveraged orders must have one side at the open sentinel.
+    let o2 = order::new_from_strike_indices(
+        OPENED_AT_MS,
+        order::open_strike_index(),
+        STRIKE_INDEX_HI,
+        order::leverage_two_x(),
+        0,
+        ONE_LOT_QTY,
+        0,
+    );
+    assert!(o2.is_leveraged());
+}
+
+// === new_from_strike_indices abort cases ===
+
+#[test, expected_failure(abort_code = order::EInvalidOpenedAt)]
+fun new_opened_at_above_u48_aborts() {
+    let above_u48: u64 = 1 << 48;
+    order::new_from_strike_indices(
+        above_u48,
+        STRIKE_INDEX_LO,
+        STRIKE_INDEX_HI,
+        order::leverage_one_x(),
+        0,
+        ONE_LOT_QTY,
+        0,
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = order::EInvalidStrikeIndex)]
+fun new_strike_index_above_u24_aborts() {
+    let above_u24: u64 = 1 << 24;
+    order::new_from_strike_indices(
+        OPENED_AT_MS,
+        above_u24,
+        above_u24 + 1,
+        order::leverage_one_x(),
+        0,
+        ONE_LOT_QTY,
+        0,
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = order::EInvalidEntryProbability)]
+fun new_entry_probability_above_one_aborts() {
+    order::new_from_strike_indices(
+        OPENED_AT_MS,
+        STRIKE_INDEX_LO,
+        STRIKE_INDEX_HI,
+        order::leverage_one_x(),
+        constants::float_scaling!() + 1,
+        ONE_LOT_QTY,
+        0,
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = order::EInvalidQuantity)]
+fun new_zero_quantity_aborts() {
+    order::new_from_strike_indices(
+        OPENED_AT_MS,
+        STRIKE_INDEX_LO,
+        STRIKE_INDEX_HI,
+        order::leverage_one_x(),
+        0,
+        0,
+        0,
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = order::EInvalidLeverage)]
+fun new_leverage_above_three_x_aborts() {
+    order::new_from_strike_indices(
+        OPENED_AT_MS,
+        STRIKE_INDEX_LO,
+        STRIKE_INDEX_HI,
+        order::leverage_three_x() + 1,
+        0,
+        ONE_LOT_QTY,
+        0,
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = order::EInvalidStrikeRange)]
+fun new_swapped_finite_strike_range_aborts() {
+    // Both sides finite -> require min < max strictly.
+    order::new_from_strike_indices(
+        OPENED_AT_MS,
+        STRIKE_INDEX_HI,
+        STRIKE_INDEX_LO,
+        order::leverage_one_x(),
+        0,
+        ONE_LOT_QTY,
+        0,
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = order::EInvalidStrikeRange)]
+fun new_both_sides_open_aborts() {
+    // (open, open] is rejected: the order would have no range at all.
+    order::new_from_strike_indices(
+        OPENED_AT_MS,
+        order::open_strike_index(),
+        order::open_strike_index(),
+        order::leverage_one_x(),
+        0,
+        ONE_LOT_QTY,
+        0,
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = order::EInvalidStrikeRange)]
+fun new_leveraged_with_both_sides_finite_aborts() {
+    // Leveraged orders must have exactly one side at the open sentinel.
+    order::new_from_strike_indices(
+        OPENED_AT_MS,
+        STRIKE_INDEX_LO,
+        STRIKE_INDEX_HI,
+        order::leverage_two_x(),
+        0,
+        ONE_LOT_QTY,
+        0,
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = order::EInvalidSequence)]
+fun new_sequence_above_u40_aborts() {
+    let above_u40: u64 = 1 << 40;
+    order::new_from_strike_indices(
+        OPENED_AT_MS,
+        STRIKE_INDEX_LO,
+        STRIKE_INDEX_HI,
+        order::leverage_one_x(),
+        0,
+        ONE_LOT_QTY,
+        above_u40,
+    );
+    abort 999
+}
+
+// === from_order_id validation ===
+
+#[test, expected_failure(abort_code = order::EInvalidOrderId)]
+fun from_order_id_with_bits_above_payload_aborts() {
+    // Setting any bit above ORDER_ID_BITS=208 must be rejected.
+    let bad_id: u256 = 1u256 << 208;
+    order::from_order_id(bad_id);
+    abort 999
+}
+
+// === replacement ===
+
+#[test]
+fun replacement_inherits_terms_and_uses_new_sequence() {
+    let original = order::new_from_strike_indices(
+        OPENED_AT_MS,
+        STRIKE_INDEX_LO,
+        STRIKE_INDEX_HI,
+        order::leverage_one_x(),
+        500_000_000,
+        TWO_LOTS_QTY,
+        0,
+    );
+    let next_sequence = 1;
+    let replaced = original.replacement(ONE_LOT_QTY, next_sequence);
+
+    // Inherits the original strike range, leverage, entry probability, and open
+    // time; only quantity and sequence change.
+    assert_eq!(replaced.opened_at_ms(), original.opened_at_ms());
+    assert_eq!(replaced.min_strike_index(), original.min_strike_index());
+    assert_eq!(replaced.max_strike_index(), original.max_strike_index());
+    assert_eq!(replaced.leverage(), original.leverage());
+    assert_eq!(replaced.entry_probability(), original.entry_probability());
+    assert_eq!(replaced.quantity(), ONE_LOT_QTY);
+    assert_eq!(replaced.sequence(), next_sequence);
+}
+
+#[test, expected_failure(abort_code = order::EInvalidQuantity)]
+fun replacement_at_or_above_original_quantity_aborts() {
+    // Replacement quantity must be strictly less than original.
+    let original = order::new_from_strike_indices(
+        OPENED_AT_MS,
+        STRIKE_INDEX_LO,
+        STRIKE_INDEX_HI,
+        order::leverage_one_x(),
+        0,
+        ONE_LOT_QTY,
+        0,
+    );
+    let _ = original.replacement(ONE_LOT_QTY, 1);
+    abort 999
+}

--- a/packages/predict/tests/oracle/market_oracle_basis_tests.move
+++ b/packages/predict/tests/oracle/market_oracle_basis_tests.move
@@ -1,0 +1,27 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module deepbook_predict::market_oracle_basis_tests;
+
+use deepbook_predict::{market_oracle, registry};
+
+const EXPIRY_MS: u64 = 100_000;
+
+#[test, expected_failure(abort_code = market_oracle::EZeroSpot)]
+fun basis_aborts_when_spot_zero() {
+    // Fresh market has block_scholes_spot = 0; basis() guards against
+    // division-by-zero before forward is even read.
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+
+    let _ = market.block_scholes_basis();
+    abort 999
+}
+
+// Exercising EZeroForward and the basis-computation happy path requires
+// driving block_scholes_spot/forward through update_block_scholes_prices,
+// which needs a matched PythSource. Those paths are covered in
+// market_oracle_update_prices_tests.move.

--- a/packages/predict/tests/oracle/market_oracle_getters_tests.move
+++ b/packages/predict/tests/oracle/market_oracle_getters_tests.move
@@ -1,0 +1,219 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module deepbook_predict::market_oracle_getters_tests;
+
+use deepbook_predict::{constants, i64, market_oracle, registry};
+use std::unit_test::{assert_eq, destroy};
+use sui::clock;
+
+const EXPIRY_MS: u64 = 100_000;
+const BEFORE_EXPIRY: u64 = 10_000;
+const AT_EXPIRY: u64 = 100_000;
+const AFTER_EXPIRY: u64 = 200_000;
+
+// === Constructor + identity ===
+
+#[test]
+fun id_round_trips_through_object() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+
+    let id = market.id();
+    assert_eq!(id, market.id()); // second read matches the first
+
+    destroy(market);
+    destroy(cap);
+    destroy(admin_cap);
+}
+
+#[test]
+fun cap_id_round_trips() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+
+    let cap_id_first = cap.cap_id();
+    assert_eq!(cap.cap_id(), cap_id_first);
+
+    destroy(cap);
+    destroy(admin_cap);
+}
+
+#[test]
+fun expiry_returns_constructor_value() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+
+    assert_eq!(market.expiry(), EXPIRY_MS);
+
+    destroy(market);
+    destroy(cap);
+    destroy(admin_cap);
+}
+
+#[test]
+fun allowed_versions_seeded_with_current() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+
+    let versions = market.allowed_versions();
+    assert!(versions.contains(&constants::current_version!()));
+    assert_eq!(versions.length(), 1);
+
+    destroy(market);
+    destroy(cap);
+    destroy(admin_cap);
+}
+
+#[test]
+fun pyth_source_id_is_persisted() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+
+    // Stable binding identity (same value across reads).
+    assert_eq!(market.pyth_source_id(), market.pyth_source_id());
+
+    destroy(market);
+    destroy(cap);
+    destroy(admin_cap);
+}
+
+// === is_settled / raw_settlement_price ===
+
+#[test]
+fun is_settled_false_on_fresh_market() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+
+    assert!(!market.is_settled());
+    assert!(market.raw_settlement_price().is_none());
+
+    destroy(market);
+    destroy(cap);
+    destroy(admin_cap);
+}
+
+// === status state machine ===
+
+#[test]
+fun status_is_active_before_expiry() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+    let mut clock = clock::create_for_testing(ctx);
+    clock.set_for_testing(BEFORE_EXPIRY);
+
+    assert_eq!(market.status(&clock), market_oracle::status_active());
+
+    destroy(market);
+    destroy(cap);
+    destroy(admin_cap);
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun status_pending_at_and_after_expiry() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+    let mut clock = clock::create_for_testing(ctx);
+
+    // Exactly at expiry: status flips to pending_settlement.
+    clock.set_for_testing(AT_EXPIRY);
+    assert_eq!(market.status(&clock), market_oracle::status_pending_settlement());
+
+    // After expiry: stays pending until settle_if_possible runs.
+    clock.set_for_testing(AFTER_EXPIRY);
+    assert_eq!(market.status(&clock), market_oracle::status_pending_settlement());
+
+    destroy(market);
+    destroy(cap);
+    destroy(admin_cap);
+    clock.destroy_for_testing();
+}
+
+// === Status / source code accessors ===
+
+#[test]
+fun status_constants_are_distinct() {
+    // Other modules switch on these codes; they must be pairwise distinct.
+    assert!(market_oracle::status_active() != market_oracle::status_pending_settlement());
+    assert!(market_oracle::status_active() != market_oracle::status_settled());
+    assert!(market_oracle::status_pending_settlement() != market_oracle::status_settled());
+}
+
+#[test]
+fun source_constants_are_distinct() {
+    assert!(market_oracle::source_pyth() != market_oracle::source_block_scholes());
+}
+
+// === Block Scholes default getters ===
+
+#[test]
+fun default_block_scholes_state_is_zero() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+
+    assert_eq!(market.block_scholes_spot(), 0);
+    assert_eq!(market.block_scholes_forward(), 0);
+    assert_eq!(market.block_scholes_price_source_timestamp_ms(), 0);
+    assert_eq!(market.block_scholes_price_update_timestamp_ms(), 0);
+    assert_eq!(market.block_scholes_svi_source_timestamp_ms(), 0);
+    assert_eq!(market.block_scholes_svi_update_timestamp_ms(), 0);
+
+    let svi = market.block_scholes_svi();
+    assert_eq!(svi.a(), 0);
+    assert_eq!(svi.b(), 0);
+    assert!(svi.rho().is_zero());
+    assert!(svi.m().is_zero());
+    assert_eq!(svi.sigma(), 0);
+
+    destroy(market);
+    destroy(cap);
+    destroy(admin_cap);
+}
+
+// === new_svi_params constructor ===
+
+#[test]
+fun new_svi_params_round_trips_all_five_fields() {
+    let rho = i64::from_parts(123_456_789, true); // negative non-zero
+    let m = i64::from_u64(987_654_321);
+    let svi = market_oracle::new_svi_params(11, 22, rho, m, 33);
+
+    assert_eq!(svi.a(), 11);
+    assert_eq!(svi.b(), 22);
+    let svi_rho = svi.rho();
+    assert_eq!(svi_rho.magnitude(), 123_456_789);
+    assert!(svi_rho.is_negative());
+    let svi_m = svi.m();
+    assert_eq!(svi_m.magnitude(), 987_654_321);
+    assert!(!svi_m.is_negative());
+    assert_eq!(svi.sigma(), 33);
+}
+
+#[test]
+fun new_svi_params_accepts_zero_fields() {
+    let svi = market_oracle::new_svi_params(0, 0, i64::zero(), i64::zero(), 0);
+    assert_eq!(svi.a(), 0);
+    assert_eq!(svi.b(), 0);
+    assert!(svi.rho().is_zero());
+    assert!(svi.m().is_zero());
+    assert_eq!(svi.sigma(), 0);
+}

--- a/packages/predict/tests/oracle/market_oracle_set_bounds_tests.move
+++ b/packages/predict/tests/oracle/market_oracle_set_bounds_tests.move
@@ -1,0 +1,270 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module deepbook_predict::market_oracle_set_bounds_tests;
+
+use deepbook_predict::{config_constants, market_oracle, protocol_config, registry};
+use std::unit_test::destroy;
+
+const EXPIRY_MS: u64 = 100_000;
+const VALID_FRESHNESS_MS: u64 = 5_000;
+const VALID_MAX_SPOT_DEVIATION: u64 = 50_000_000;
+const VALID_MAX_BASIS_DEVIATION: u64 = 60_000_000;
+const VALID_MIN_BASIS: u64 = 950_000_000;
+const VALID_MAX_BASIS: u64 = 1_050_000_000;
+
+// === set_settlement_freshness_ms ===
+
+#[test]
+fun set_settlement_freshness_ms_round_trip_succeeds() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let config = protocol_config::new_for_testing(ctx);
+    let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+
+    // No abort -> the setter accepted the value and emitted bounds-updated.
+    market.set_settlement_freshness_ms(&config, &cap, VALID_FRESHNESS_MS);
+
+    cleanup(market, config, cap, admin_cap);
+}
+
+#[test, expected_failure(abort_code = config_constants::EInvalidSettlementFreshnessMs)]
+fun set_settlement_freshness_ms_below_min_aborts() {
+    // Envelope min = 1; 0 must be rejected by the config_constants guard.
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let config = protocol_config::new_for_testing(ctx);
+    let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+    market.set_settlement_freshness_ms(&config, &cap, 0);
+    abort 999
+}
+
+#[test, expected_failure(abort_code = config_constants::EInvalidSettlementFreshnessMs)]
+fun set_settlement_freshness_ms_above_max_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let config = protocol_config::new_for_testing(ctx);
+    let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+    market.set_settlement_freshness_ms(&config, &cap, 60_001);
+    abort 999
+}
+
+#[test, expected_failure(abort_code = market_oracle::EInvalidMarketOracleCap)]
+fun set_settlement_freshness_ms_with_unregistered_cap_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let unregistered_cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let config = protocol_config::new_for_testing(ctx);
+    let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+    market.set_settlement_freshness_ms(&config, &unregistered_cap, VALID_FRESHNESS_MS);
+    abort 999
+}
+
+#[test, expected_failure(abort_code = protocol_config::EValuationInProgress)]
+fun set_settlement_freshness_ms_during_valuation_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+    let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+    config.begin_valuation();
+
+    market.set_settlement_freshness_ms(&config, &cap, VALID_FRESHNESS_MS);
+    abort 999
+}
+
+// === set_basis_bounds: happy path and cross-field invariant ===
+
+#[test]
+fun set_basis_bounds_round_trip_succeeds() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let config = protocol_config::new_for_testing(ctx);
+    let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+
+    market.set_basis_bounds(
+        &config,
+        &cap,
+        VALID_MAX_SPOT_DEVIATION,
+        VALID_MAX_BASIS_DEVIATION,
+        VALID_MIN_BASIS,
+        VALID_MAX_BASIS,
+    );
+
+    cleanup(market, config, cap, admin_cap);
+}
+
+#[test, expected_failure(abort_code = market_oracle::EInvalidBasisBounds)]
+fun set_basis_bounds_min_equal_to_max_aborts() {
+    // Module-level invariant: min_basis < max_basis strictly.
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let config = protocol_config::new_for_testing(ctx);
+    let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+
+    market.set_basis_bounds(
+        &config,
+        &cap,
+        VALID_MAX_SPOT_DEVIATION,
+        VALID_MAX_BASIS_DEVIATION,
+        VALID_MIN_BASIS,
+        VALID_MIN_BASIS, // equal
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = market_oracle::EInvalidBasisBounds)]
+fun set_basis_bounds_min_above_max_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let config = protocol_config::new_for_testing(ctx);
+    let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+
+    market.set_basis_bounds(
+        &config,
+        &cap,
+        VALID_MAX_SPOT_DEVIATION,
+        VALID_MAX_BASIS_DEVIATION,
+        VALID_MAX_BASIS, // swapped
+        VALID_MIN_BASIS,
+    );
+    abort 999
+}
+
+// === set_basis_bounds: per-field config_constants envelope aborts ===
+
+#[test, expected_failure(abort_code = config_constants::EInvalidMaxSpotDeviation)]
+fun set_basis_bounds_max_spot_deviation_zero_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let config = protocol_config::new_for_testing(ctx);
+    let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+
+    market.set_basis_bounds(
+        &config,
+        &cap,
+        0,
+        VALID_MAX_BASIS_DEVIATION,
+        VALID_MIN_BASIS,
+        VALID_MAX_BASIS,
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = config_constants::EInvalidMaxBasisDeviation)]
+fun set_basis_bounds_max_basis_deviation_zero_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let config = protocol_config::new_for_testing(ctx);
+    let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+
+    market.set_basis_bounds(
+        &config,
+        &cap,
+        VALID_MAX_SPOT_DEVIATION,
+        0,
+        VALID_MIN_BASIS,
+        VALID_MAX_BASIS,
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = config_constants::EInvalidMinBasis)]
+fun set_basis_bounds_min_basis_below_envelope_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let config = protocol_config::new_for_testing(ctx);
+    let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+
+    market.set_basis_bounds(
+        &config,
+        &cap,
+        VALID_MAX_SPOT_DEVIATION,
+        VALID_MAX_BASIS_DEVIATION,
+        499_999_999, // envelope min is 500_000_000
+        VALID_MAX_BASIS,
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = config_constants::EInvalidMaxBasis)]
+fun set_basis_bounds_max_basis_above_envelope_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let config = protocol_config::new_for_testing(ctx);
+    let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+
+    market.set_basis_bounds(
+        &config,
+        &cap,
+        VALID_MAX_SPOT_DEVIATION,
+        VALID_MAX_BASIS_DEVIATION,
+        VALID_MIN_BASIS,
+        2_000_000_001, // envelope max is 2_000_000_000
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = market_oracle::EInvalidMarketOracleCap)]
+fun set_basis_bounds_with_unregistered_cap_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let unregistered_cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let config = protocol_config::new_for_testing(ctx);
+    let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+
+    market.set_basis_bounds(
+        &config,
+        &unregistered_cap,
+        VALID_MAX_SPOT_DEVIATION,
+        VALID_MAX_BASIS_DEVIATION,
+        VALID_MIN_BASIS,
+        VALID_MAX_BASIS,
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = protocol_config::EValuationInProgress)]
+fun set_basis_bounds_during_valuation_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+    let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+    config.begin_valuation();
+
+    market.set_basis_bounds(
+        &config,
+        &cap,
+        VALID_MAX_SPOT_DEVIATION,
+        VALID_MAX_BASIS_DEVIATION,
+        VALID_MIN_BASIS,
+        VALID_MAX_BASIS,
+    );
+    abort 999
+}
+
+fun cleanup(
+    market: market_oracle::MarketOracle,
+    config: protocol_config::ProtocolConfig,
+    cap: market_oracle::MarketOracleCap,
+    admin_cap: registry::AdminCap,
+) {
+    destroy(market);
+    destroy(config);
+    destroy(cap);
+    destroy(admin_cap);
+}

--- a/packages/predict/tests/oracle/market_oracle_settlement_tests.move
+++ b/packages/predict/tests/oracle/market_oracle_settlement_tests.move
@@ -1,0 +1,243 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+#[allow(unused_variable)]
+module deepbook_predict::market_oracle_settlement_tests;
+
+use deepbook_predict::{market_oracle, protocol_config, pyth_source, registry};
+use std::unit_test::{assert_eq, destroy};
+use sui::clock;
+
+const EXPIRY_MS: u64 = 100_000;
+const SETTLE_TS: u64 = 150_000;
+const NOW_MS: u64 = 151_000; // settlement_freshness default is 3000 ms
+const ACTIVE_NOW_MS: u64 = 50_000;
+const SPOT_1000: u64 = 1_000_000_000_000;
+const FORWARD_AT_BASIS_1: u64 = 1_000_000_000_000;
+
+// === settle_if_possible: status gating ===
+
+#[test]
+fun settle_if_possible_returns_false_when_active() {
+    let (mut market, config, cap, admin_cap, pyth, clock) = setup(ACTIVE_NOW_MS);
+
+    assert!(!market.settle_if_possible(&config, &pyth, &cap, &clock));
+    assert!(!market.is_settled());
+
+    cleanup(market, config, cap, admin_cap, pyth, clock);
+}
+
+#[test]
+fun settle_if_possible_returns_false_when_no_valid_source() {
+    // Pending settlement (clock > expiry) but neither Pyth nor BS has data.
+    let (mut market, config, cap, admin_cap, pyth, clock) = setup(NOW_MS);
+    assert_eq!(market.status(&clock), market_oracle::status_pending_settlement());
+
+    assert!(!market.settle_if_possible(&config, &pyth, &cap, &clock));
+    assert!(!market.is_settled());
+
+    cleanup(market, config, cap, admin_cap, pyth, clock);
+}
+
+// === settle_if_possible: Pyth path ===
+
+#[test]
+fun settle_if_possible_uses_pyth_when_fresh() {
+    let (mut market, config, cap, admin_cap, mut pyth, clock) = setup(NOW_MS);
+    // Drive pyth state so its source_ts > expiry and freshness is within
+    // settlement_freshness (3000ms default).
+    pyth.set_state_for_testing(SPOT_1000, SETTLE_TS, NOW_MS);
+
+    assert!(market.settle_if_possible(&config, &pyth, &cap, &clock));
+    assert!(market.is_settled());
+    let raw = market.raw_settlement_price();
+    assert!(raw.is_some());
+    assert_eq!(*raw.borrow(), SPOT_1000);
+
+    cleanup(market, config, cap, admin_cap, pyth, clock);
+}
+
+#[test]
+fun settle_if_possible_returns_false_when_pyth_stale() {
+    // Pyth update too old relative to settlement_freshness (3000 ms default).
+    let (mut market, config, cap, admin_cap, mut pyth, clock) = setup(NOW_MS);
+    // freshness_timestamp = min(source_ts, update_ts) = 100_001. now - 100_001
+    // = 50_999 > 3_000, so Pyth fails the freshness check.
+    pyth.set_state_for_testing(SPOT_1000, 100_001, 100_001);
+
+    assert!(!market.settle_if_possible(&config, &pyth, &cap, &clock));
+    assert!(!market.is_settled());
+
+    cleanup(market, config, cap, admin_cap, pyth, clock);
+}
+
+#[test]
+fun settle_if_possible_returns_false_when_pyth_source_at_expiry() {
+    // source_ts must be strictly greater than expiry, not equal.
+    let (mut market, config, cap, admin_cap, mut pyth, clock) = setup(NOW_MS);
+    pyth.set_state_for_testing(SPOT_1000, EXPIRY_MS, NOW_MS);
+
+    assert!(!market.settle_if_possible(&config, &pyth, &cap, &clock));
+
+    cleanup(market, config, cap, admin_cap, pyth, clock);
+}
+
+// === settle_if_possible: Block Scholes fallback via update_block_scholes_prices ===
+
+#[test]
+fun update_prices_at_pending_settles_via_block_scholes_when_pyth_empty() {
+    // Pyth has no data, but a Block Scholes update lands after expiry with
+    // source_ts > expiry. The internal settle_if_possible_internal at the end
+    // of update_block_scholes_prices uses the BS fallback.
+    let (mut market, config, cap, admin_cap, pyth, clock) = setup(NOW_MS);
+    market.update_block_scholes_prices(
+        &config,
+        &pyth,
+        &cap,
+        SPOT_1000,
+        FORWARD_AT_BASIS_1,
+        SETTLE_TS,
+        &clock,
+    );
+
+    assert!(market.is_settled());
+    let raw = market.raw_settlement_price();
+    assert!(raw.is_some());
+    assert_eq!(*raw.borrow(), SPOT_1000);
+
+    cleanup(market, config, cap, admin_cap, pyth, clock);
+}
+
+#[test]
+fun update_prices_at_pending_does_not_settle_when_source_ts_at_expiry() {
+    // source_ts must be strictly greater than expiry to qualify as settlement data.
+    let (mut market, config, cap, admin_cap, pyth, clock) = setup(NOW_MS);
+    market.update_block_scholes_prices(
+        &config,
+        &pyth,
+        &cap,
+        SPOT_1000,
+        FORWARD_AT_BASIS_1,
+        EXPIRY_MS,
+        &clock,
+    );
+
+    assert!(!market.is_settled());
+
+    cleanup(market, config, cap, admin_cap, pyth, clock);
+}
+
+// === update_block_scholes_prices aborts EMarketSettled after settle ===
+
+#[test, expected_failure(abort_code = market_oracle::EMarketSettled)]
+fun update_prices_after_settle_aborts() {
+    let (mut market, config, cap, admin_cap, mut pyth, clock) = setup(NOW_MS);
+    pyth.set_state_for_testing(SPOT_1000, SETTLE_TS, NOW_MS);
+    market.settle_if_possible(&config, &pyth, &cap, &clock);
+    assert!(market.is_settled());
+
+    // Second price push is now an attempt to mutate a settled market.
+    market.update_block_scholes_prices(
+        &config,
+        &pyth,
+        &cap,
+        SPOT_1000,
+        FORWARD_AT_BASIS_1,
+        SETTLE_TS + 1,
+        &clock,
+    );
+    abort 999
+}
+
+// === assert_not_pending_settlement ===
+
+#[test]
+fun assert_not_pending_settlement_passes_when_active() {
+    let (market, config, cap, admin_cap, pyth, clock) = setup(ACTIVE_NOW_MS);
+    market.assert_not_pending_settlement(&clock);
+    cleanup(market, config, cap, admin_cap, pyth, clock);
+}
+
+#[test]
+fun assert_not_pending_settlement_passes_when_settled() {
+    let (mut market, config, cap, admin_cap, mut pyth, clock) = setup(NOW_MS);
+    pyth.set_state_for_testing(SPOT_1000, SETTLE_TS, NOW_MS);
+    market.settle_if_possible(&config, &pyth, &cap, &clock);
+
+    market.assert_not_pending_settlement(&clock);
+
+    cleanup(market, config, cap, admin_cap, pyth, clock);
+}
+
+#[test, expected_failure(abort_code = market_oracle::EPendingSettlement)]
+fun assert_not_pending_settlement_aborts_when_pending() {
+    let (market, config, cap, admin_cap, pyth, clock) = setup(NOW_MS);
+    assert_eq!(market.status(&clock), market_oracle::status_pending_settlement());
+
+    market.assert_not_pending_settlement(&clock);
+    abort 999
+}
+
+// === settlement_price ===
+
+#[test, expected_failure(abort_code = market_oracle::EMarketNotSettled)]
+fun settlement_price_on_unsettled_aborts() {
+    let (market, config, cap, admin_cap, pyth, clock) = setup(NOW_MS);
+    let _ = market.settlement_price();
+    abort 999
+}
+
+#[test]
+fun settlement_price_returns_settled_value() {
+    let (mut market, config, cap, admin_cap, mut pyth, clock) = setup(NOW_MS);
+    pyth.set_state_for_testing(SPOT_1000, SETTLE_TS, NOW_MS);
+    market.settle_if_possible(&config, &pyth, &cap, &clock);
+
+    assert_eq!(market.settlement_price(), SPOT_1000);
+
+    cleanup(market, config, cap, admin_cap, pyth, clock);
+}
+
+// EInvalidSettlementTimestamp guards against a settled state where
+// settlement_source_timestamp_ms <= expiry. valid_settlement_spot_source
+// always requires source_ts > expiry before calling settle(), so this is
+// defense-in-depth that cannot be triggered through any production path
+// without a test-only bypass — not exercised here.
+
+fun setup(
+    now_ms: u64,
+): (
+    market_oracle::MarketOracle,
+    protocol_config::ProtocolConfig,
+    market_oracle::MarketOracleCap,
+    registry::AdminCap,
+    pyth_source::PythSource,
+    clock::Clock,
+) {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let config = protocol_config::new_for_testing(ctx);
+    let pyth = pyth_source::new_for_testing(ctx);
+    let market = market_oracle::create_test_market_oracle_with_pyth(&pyth, EXPIRY_MS, &cap, ctx);
+    let mut clock = clock::create_for_testing(ctx);
+    clock.set_for_testing(now_ms);
+    (market, config, cap, admin_cap, pyth, clock)
+}
+
+fun cleanup(
+    market: market_oracle::MarketOracle,
+    config: protocol_config::ProtocolConfig,
+    cap: market_oracle::MarketOracleCap,
+    admin_cap: registry::AdminCap,
+    pyth: pyth_source::PythSource,
+    clock: clock::Clock,
+) {
+    destroy(market);
+    destroy(config);
+    destroy(cap);
+    destroy(admin_cap);
+    destroy(pyth);
+    clock.destroy_for_testing();
+}

--- a/packages/predict/tests/oracle/market_oracle_update_prices_tests.move
+++ b/packages/predict/tests/oracle/market_oracle_update_prices_tests.move
@@ -1,0 +1,364 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// `expected_failure` tests abort before reaching cleanup, leaving some
+// bindings unused on the abort path. Suppress the per-test warning at the
+// module level; happy-path tests still consume every returned value.
+#[test_only]
+#[allow(unused_variable)]
+module deepbook_predict::market_oracle_update_prices_tests;
+
+use deepbook_predict::{
+    constants::float_scaling as float,
+    market_oracle,
+    protocol_config,
+    pyth_source,
+    registry
+};
+use std::unit_test::{assert_eq, destroy};
+use sui::clock;
+
+// Strikes/prices use the package's 1e9 scaling. SPOT = $1000.
+const EXPIRY_MS: u64 = 100_000;
+const NOW_MS: u64 = 10_000;
+const FIRST_SOURCE_TIMESTAMP_MS: u64 = 1_000;
+const SECOND_SOURCE_TIMESTAMP_MS: u64 = 2_000;
+
+const SPOT_1000: u64 = 1_000_000_000_000; // 1000.0
+const FORWARD_AT_BASIS_1: u64 = 1_000_000_000_000; // basis = 1.0
+const FORWARD_AT_BASIS_0_95: u64 = 950_000_000_000;
+const FORWARD_AT_BASIS_1_05: u64 = 1_050_000_000_000;
+// 1100 spot * 0.95 basis = 1045 forward
+const SPOT_1100: u64 = 1_100_000_000_000;
+const FORWARD_FOR_1100_AT_BASIS_0_95: u64 = 1_045_000_000_000;
+
+// === update_block_scholes_prices: happy path ===
+
+#[test]
+fun update_prices_stores_values_and_emits_basis_one() {
+    // basis = forward/spot = 1.0 falls inside the default envelope [0.9, 1.1].
+    let (mut market, config, cap, admin_cap, pyth, clock) = setup_active(NOW_MS);
+
+    market.update_block_scholes_prices(
+        &config,
+        &pyth,
+        &cap,
+        SPOT_1000,
+        FORWARD_AT_BASIS_1,
+        FIRST_SOURCE_TIMESTAMP_MS,
+        &clock,
+    );
+
+    assert_eq!(market.block_scholes_spot(), SPOT_1000);
+    assert_eq!(market.block_scholes_forward(), FORWARD_AT_BASIS_1);
+    assert_eq!(market.block_scholes_price_source_timestamp_ms(), FIRST_SOURCE_TIMESTAMP_MS);
+    assert_eq!(market.block_scholes_price_update_timestamp_ms(), NOW_MS);
+    // Once both spot and forward are stored, basis() returns forward/spot in 1e9 scale.
+    assert_eq!(market.block_scholes_basis(), float!());
+
+    cleanup(market, config, cap, admin_cap, pyth, clock);
+}
+
+#[test]
+fun update_prices_accepts_envelope_endpoint_basis() {
+    // Default basis envelope is [0.9, 1.1]; both endpoints must be valid.
+    let (mut market, config, cap, admin_cap, pyth, clock) = setup_active(NOW_MS);
+
+    market.update_block_scholes_prices(
+        &config,
+        &pyth,
+        &cap,
+        SPOT_1000,
+        FORWARD_AT_BASIS_0_95,
+        FIRST_SOURCE_TIMESTAMP_MS,
+        &clock,
+    );
+    assert_eq!(market.block_scholes_basis(), 950_000_000);
+
+    cleanup(market, config, cap, admin_cap, pyth, clock);
+}
+
+#[test]
+fun update_prices_strictly_advances_source_timestamp() {
+    let (mut market, config, cap, admin_cap, pyth, clock) = setup_active(NOW_MS);
+
+    market.update_block_scholes_prices(
+        &config,
+        &pyth,
+        &cap,
+        SPOT_1000,
+        FORWARD_AT_BASIS_1,
+        FIRST_SOURCE_TIMESTAMP_MS,
+        &clock,
+    );
+    market.update_block_scholes_prices(
+        &config,
+        &pyth,
+        &cap,
+        SPOT_1000,
+        FORWARD_AT_BASIS_1,
+        SECOND_SOURCE_TIMESTAMP_MS,
+        &clock,
+    );
+    assert_eq!(market.block_scholes_price_source_timestamp_ms(), SECOND_SOURCE_TIMESTAMP_MS);
+
+    cleanup(market, config, cap, admin_cap, pyth, clock);
+}
+
+// === Validation aborts ===
+
+#[test, expected_failure(abort_code = market_oracle::EZeroSpot)]
+fun update_prices_zero_spot_aborts() {
+    let (mut market, config, cap, _admin_cap, pyth, clock) = setup_active(NOW_MS);
+    market.update_block_scholes_prices(
+        &config,
+        &pyth,
+        &cap,
+        0,
+        FORWARD_AT_BASIS_1,
+        FIRST_SOURCE_TIMESTAMP_MS,
+        &clock,
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = market_oracle::EZeroForward)]
+fun update_prices_zero_forward_aborts() {
+    let (mut market, config, cap, _admin_cap, pyth, clock) = setup_active(NOW_MS);
+    market.update_block_scholes_prices(
+        &config,
+        &pyth,
+        &cap,
+        SPOT_1000,
+        0,
+        FIRST_SOURCE_TIMESTAMP_MS,
+        &clock,
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = market_oracle::EStalePriceSourceUpdate)]
+fun update_prices_equal_source_timestamp_aborts() {
+    let (mut market, config, cap, _admin_cap, pyth, clock) = setup_active(NOW_MS);
+    market.update_block_scholes_prices(
+        &config,
+        &pyth,
+        &cap,
+        SPOT_1000,
+        FORWARD_AT_BASIS_1,
+        FIRST_SOURCE_TIMESTAMP_MS,
+        &clock,
+    );
+    market.update_block_scholes_prices(
+        &config,
+        &pyth,
+        &cap,
+        SPOT_1000,
+        FORWARD_AT_BASIS_1,
+        FIRST_SOURCE_TIMESTAMP_MS,
+        &clock,
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = market_oracle::EFuturePriceSourceUpdate)]
+fun update_prices_source_after_now_aborts() {
+    let (mut market, config, cap, _admin_cap, pyth, clock) = setup_active(NOW_MS);
+    market.update_block_scholes_prices(
+        &config,
+        &pyth,
+        &cap,
+        SPOT_1000,
+        FORWARD_AT_BASIS_1,
+        NOW_MS + 1,
+        &clock,
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = market_oracle::EBasisOutOfRange)]
+fun update_prices_basis_below_min_aborts() {
+    // forward = 800, spot = 1000 -> basis = 0.8 which is < envelope min 0.9.
+    let (mut market, config, cap, _admin_cap, pyth, clock) = setup_active(NOW_MS);
+    market.update_block_scholes_prices(
+        &config,
+        &pyth,
+        &cap,
+        SPOT_1000,
+        800_000_000_000,
+        FIRST_SOURCE_TIMESTAMP_MS,
+        &clock,
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = market_oracle::EBasisOutOfRange)]
+fun update_prices_basis_above_max_aborts() {
+    // forward = 1200, spot = 1000 -> basis = 1.2 which is > envelope max 1.1.
+    let (mut market, config, cap, _admin_cap, pyth, clock) = setup_active(NOW_MS);
+    market.update_block_scholes_prices(
+        &config,
+        &pyth,
+        &cap,
+        SPOT_1000,
+        1_200_000_000_000,
+        FIRST_SOURCE_TIMESTAMP_MS,
+        &clock,
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = market_oracle::ESpotDeviationTooLarge)]
+fun update_prices_second_push_spot_deviation_too_large_aborts() {
+    // Default max_spot_deviation = 2% (20_000_000). Jumping spot by 10%
+    // breaches the deviation cap, even though the new basis is still in range.
+    let (mut market, config, cap, _admin_cap, pyth, clock) = setup_active(NOW_MS);
+    market.update_block_scholes_prices(
+        &config,
+        &pyth,
+        &cap,
+        SPOT_1000,
+        FORWARD_AT_BASIS_1,
+        FIRST_SOURCE_TIMESTAMP_MS,
+        &clock,
+    );
+    // SPOT_1100 is +10% vs SPOT_1000.
+    market.update_block_scholes_prices(
+        &config,
+        &pyth,
+        &cap,
+        SPOT_1100,
+        FORWARD_FOR_1100_AT_BASIS_0_95, // basis stays at 0.95 to isolate the spot check
+        SECOND_SOURCE_TIMESTAMP_MS,
+        &clock,
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = market_oracle::EBasisDeviationTooLarge)]
+fun update_prices_second_push_basis_deviation_too_large_aborts() {
+    // Default max_basis_deviation = 2% (20_000_000). Hold spot constant so
+    // the spot-deviation check passes, then jump basis from 0.95 to 1.05.
+    let (mut market, config, cap, _admin_cap, pyth, clock) = setup_active(NOW_MS);
+    market.update_block_scholes_prices(
+        &config,
+        &pyth,
+        &cap,
+        SPOT_1000,
+        FORWARD_AT_BASIS_0_95,
+        FIRST_SOURCE_TIMESTAMP_MS,
+        &clock,
+    );
+    market.update_block_scholes_prices(
+        &config,
+        &pyth,
+        &cap,
+        SPOT_1000,
+        FORWARD_AT_BASIS_1_05,
+        SECOND_SOURCE_TIMESTAMP_MS,
+        &clock,
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = market_oracle::EInvalidMarketOracleCap)]
+fun update_prices_with_unregistered_cap_aborts() {
+    let (mut market, config, cap, admin_cap, pyth, clock) = setup_active(NOW_MS);
+    let unregistered_cap = registry::create_market_oracle_cap(&admin_cap, &mut tx_context::dummy());
+    market.update_block_scholes_prices(
+        &config,
+        &pyth,
+        &unregistered_cap,
+        SPOT_1000,
+        FORWARD_AT_BASIS_1,
+        FIRST_SOURCE_TIMESTAMP_MS,
+        &clock,
+    );
+    destroy(unregistered_cap);
+    abort 999
+}
+
+#[test, expected_failure(abort_code = market_oracle::EWrongPythSource)]
+fun update_prices_with_wrong_pyth_source_aborts() {
+    let (mut market, config, cap, _admin_cap, pyth, clock) = setup_active(NOW_MS);
+    let wrong_pyth = pyth_source::new_for_testing(&mut tx_context::dummy());
+    market.update_block_scholes_prices(
+        &config,
+        &wrong_pyth,
+        &cap,
+        SPOT_1000,
+        FORWARD_AT_BASIS_1,
+        FIRST_SOURCE_TIMESTAMP_MS,
+        &clock,
+    );
+    destroy(wrong_pyth);
+    abort 999
+}
+
+#[test, expected_failure(abort_code = protocol_config::EValuationInProgress)]
+fun update_prices_during_valuation_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+    let pyth = pyth_source::new_for_testing(ctx);
+    let mut market = market_oracle::create_test_market_oracle_with_pyth(
+        &pyth,
+        EXPIRY_MS,
+        &cap,
+        ctx,
+    );
+    let mut clock = clock::create_for_testing(ctx);
+    clock.set_for_testing(NOW_MS);
+    config.begin_valuation();
+
+    market.update_block_scholes_prices(
+        &config,
+        &pyth,
+        &cap,
+        SPOT_1000,
+        FORWARD_AT_BASIS_1,
+        FIRST_SOURCE_TIMESTAMP_MS,
+        &clock,
+    );
+    abort 999
+}
+
+// === Helpers ===
+
+fun setup_active(
+    now_ms: u64,
+): (
+    market_oracle::MarketOracle,
+    protocol_config::ProtocolConfig,
+    market_oracle::MarketOracleCap,
+    registry::AdminCap,
+    pyth_source::PythSource,
+    clock::Clock,
+) {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let config = protocol_config::new_for_testing(ctx);
+    let pyth = pyth_source::new_for_testing(ctx);
+    let market = market_oracle::create_test_market_oracle_with_pyth(&pyth, EXPIRY_MS, &cap, ctx);
+    let mut clock = clock::create_for_testing(ctx);
+    clock.set_for_testing(now_ms);
+    (market, config, cap, admin_cap, pyth, clock)
+}
+
+fun cleanup(
+    market: market_oracle::MarketOracle,
+    config: protocol_config::ProtocolConfig,
+    cap: market_oracle::MarketOracleCap,
+    admin_cap: registry::AdminCap,
+    pyth: pyth_source::PythSource,
+    clock: clock::Clock,
+) {
+    destroy(market);
+    destroy(config);
+    destroy(cap);
+    destroy(admin_cap);
+    destroy(pyth);
+    clock.destroy_for_testing();
+}

--- a/packages/predict/tests/oracle/market_oracle_update_svi_tests.move
+++ b/packages/predict/tests/oracle/market_oracle_update_svi_tests.move
@@ -1,0 +1,181 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module deepbook_predict::market_oracle_update_svi_tests;
+
+use deepbook_predict::{i64, market_oracle, protocol_config, registry};
+use std::unit_test::{assert_eq, destroy};
+use sui::clock;
+
+const EXPIRY_MS: u64 = 100_000;
+const NOW_MS: u64 = 10_000;
+const FIRST_SVI_SOURCE_TIMESTAMP_MS: u64 = 1_000;
+const SECOND_SVI_SOURCE_TIMESTAMP_MS: u64 = 2_000;
+const AFTER_EXPIRY_MS: u64 = 200_000;
+
+// Cap-authorization paths (success / unregistered / register / unregister /
+// self_unregister) are covered in oracle_cap_tests.move; this file focuses on
+// staleness, future-source-timestamp, and lifecycle aborts plus the assertion
+// that updated values land in the stored state.
+
+#[test]
+fun update_svi_stores_values_and_advances_timestamps() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let config = protocol_config::new_for_testing(ctx);
+    let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+    let mut clock = clock::create_for_testing(ctx);
+    clock.set_for_testing(NOW_MS);
+
+    let svi = market_oracle::new_svi_params(11, 22, i64::from_u64(33), i64::from_u64(44), 55);
+    market.update_svi(&config, &cap, svi, FIRST_SVI_SOURCE_TIMESTAMP_MS, &clock);
+
+    let stored = market.block_scholes_svi();
+    assert_eq!(stored.a(), 11);
+    assert_eq!(stored.b(), 22);
+    assert_eq!(stored.rho().magnitude(), 33);
+    assert_eq!(stored.m().magnitude(), 44);
+    assert_eq!(stored.sigma(), 55);
+    assert_eq!(market.block_scholes_svi_source_timestamp_ms(), FIRST_SVI_SOURCE_TIMESTAMP_MS);
+    assert_eq!(market.block_scholes_svi_update_timestamp_ms(), NOW_MS);
+
+    cleanup(market, config, cap, admin_cap, clock);
+}
+
+#[test]
+fun update_svi_strictly_advances_source_timestamp() {
+    // After a first update at FIRST_SVI_SOURCE_TIMESTAMP_MS, a second update
+    // with a strictly greater source timestamp must succeed.
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let config = protocol_config::new_for_testing(ctx);
+    let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+    let mut clock = clock::create_for_testing(ctx);
+    clock.set_for_testing(NOW_MS);
+
+    let svi = market_oracle::new_svi_params(1, 2, i64::zero(), i64::zero(), 3);
+    market.update_svi(&config, &cap, svi, FIRST_SVI_SOURCE_TIMESTAMP_MS, &clock);
+    market.update_svi(&config, &cap, svi, SECOND_SVI_SOURCE_TIMESTAMP_MS, &clock);
+
+    assert_eq!(market.block_scholes_svi_source_timestamp_ms(), SECOND_SVI_SOURCE_TIMESTAMP_MS);
+
+    cleanup(market, config, cap, admin_cap, clock);
+}
+
+#[test, expected_failure(abort_code = market_oracle::EStaleSVISourceUpdate)]
+fun update_svi_equal_source_timestamp_aborts() {
+    // The check is `source_timestamp_ms > previous`; equal is rejected.
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let config = protocol_config::new_for_testing(ctx);
+    let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+    let mut clock = clock::create_for_testing(ctx);
+    clock.set_for_testing(NOW_MS);
+    let svi = market_oracle::new_svi_params(1, 2, i64::zero(), i64::zero(), 3);
+    market.update_svi(&config, &cap, svi, FIRST_SVI_SOURCE_TIMESTAMP_MS, &clock);
+
+    market.update_svi(&config, &cap, svi, FIRST_SVI_SOURCE_TIMESTAMP_MS, &clock);
+    abort 999
+}
+
+#[test, expected_failure(abort_code = market_oracle::EStaleSVISourceUpdate)]
+fun update_svi_earlier_source_timestamp_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let config = protocol_config::new_for_testing(ctx);
+    let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+    let mut clock = clock::create_for_testing(ctx);
+    clock.set_for_testing(NOW_MS);
+    let svi = market_oracle::new_svi_params(1, 2, i64::zero(), i64::zero(), 3);
+    market.update_svi(&config, &cap, svi, SECOND_SVI_SOURCE_TIMESTAMP_MS, &clock);
+
+    market.update_svi(&config, &cap, svi, FIRST_SVI_SOURCE_TIMESTAMP_MS, &clock);
+    abort 999
+}
+
+#[test, expected_failure(abort_code = market_oracle::EFutureSVISourceUpdate)]
+fun update_svi_source_timestamp_after_now_aborts() {
+    // Source timestamp from the publisher must not be ahead of the on-chain clock.
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let config = protocol_config::new_for_testing(ctx);
+    let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+    let mut clock = clock::create_for_testing(ctx);
+    clock.set_for_testing(NOW_MS);
+
+    let svi = market_oracle::new_svi_params(1, 2, i64::zero(), i64::zero(), 3);
+    market.update_svi(&config, &cap, svi, NOW_MS + 1, &clock);
+    abort 999
+}
+
+#[test]
+fun update_svi_source_equal_to_now_is_allowed() {
+    // The future-timestamp guard is `<=`, so source_ts == now is permitted.
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let config = protocol_config::new_for_testing(ctx);
+    let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+    let mut clock = clock::create_for_testing(ctx);
+    clock.set_for_testing(NOW_MS);
+
+    let svi = market_oracle::new_svi_params(1, 2, i64::zero(), i64::zero(), 3);
+    market.update_svi(&config, &cap, svi, NOW_MS, &clock);
+    assert_eq!(market.block_scholes_svi_source_timestamp_ms(), NOW_MS);
+
+    cleanup(market, config, cap, admin_cap, clock);
+}
+
+#[test, expected_failure(abort_code = market_oracle::EMarketNotActive)]
+fun update_svi_after_expiry_aborts() {
+    // Status switches to pending_settlement at expiry; update_svi is
+    // active-market-only.
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let config = protocol_config::new_for_testing(ctx);
+    let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+    let mut clock = clock::create_for_testing(ctx);
+    clock.set_for_testing(AFTER_EXPIRY_MS);
+
+    let svi = market_oracle::new_svi_params(1, 2, i64::zero(), i64::zero(), 3);
+    market.update_svi(&config, &cap, svi, FIRST_SVI_SOURCE_TIMESTAMP_MS, &clock);
+    abort 999
+}
+
+#[test, expected_failure(abort_code = protocol_config::EValuationInProgress)]
+fun update_svi_during_valuation_aborts() {
+    // protocol_config gates this via assert_not_valuation_in_progress.
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+    let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
+    let mut clock = clock::create_for_testing(ctx);
+    clock.set_for_testing(NOW_MS);
+    config.begin_valuation();
+
+    let svi = market_oracle::new_svi_params(1, 2, i64::zero(), i64::zero(), 3);
+    market.update_svi(&config, &cap, svi, FIRST_SVI_SOURCE_TIMESTAMP_MS, &clock);
+    abort 999
+}
+
+fun cleanup(
+    market: market_oracle::MarketOracle,
+    config: protocol_config::ProtocolConfig,
+    cap: market_oracle::MarketOracleCap,
+    admin_cap: registry::AdminCap,
+    clock: clock::Clock,
+) {
+    destroy(market);
+    destroy(config);
+    destroy(cap);
+    destroy(admin_cap);
+    clock.destroy_for_testing();
+}

--- a/packages/predict/tests/predict_manager_tests.move
+++ b/packages/predict/tests/predict_manager_tests.move
@@ -1,0 +1,407 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module deepbook_predict::predict_manager_tests;
+
+use deepbook_predict::{
+    builder_code,
+    predict_manager::{Self, PredictManager},
+    registry,
+    test_constants
+};
+use dusdc::dusdc::DUSDC;
+use std::unit_test::{assert_eq, destroy};
+use sui::{coin, test_scenario::{Self as test, return_shared}};
+
+const DEPOSIT_AMOUNT: u64 = 1_000_000;
+const WITHDRAW_AMOUNT: u64 = 400_000;
+const FAKE_EXPIRY_ID: address = @0xCAFE;
+const FAKE_EXPIRY_ID_2: address = @0xBABE;
+const ORDER_ID_A: u256 = 42;
+const ORDER_ID_B: u256 = 43;
+const BUILDER_INDEX: u64 = 7;
+const FEE_AMOUNT: u64 = 5_000;
+const CASH_PAID: u64 = 100_000;
+const CASH_RECEIVED: u64 = 60_000;
+
+// === Helpers ===
+
+fun setup(): (test::Scenario, ID) {
+    let mut scenario = test::begin(test_constants::alice());
+    let registry_id = registry::init_for_testing(scenario.ctx());
+    (scenario, registry_id)
+}
+
+fun create_alice_manager(scenario: &mut test::Scenario, registry_id: ID): PredictManager {
+    scenario.next_tx(test_constants::alice());
+    let mut reg = scenario.take_shared_by_id<registry::Registry>(registry_id);
+    let manager = registry::create_manager(&mut reg, scenario.ctx());
+    return_shared(reg);
+    manager
+}
+
+// === id / owner / balance ===
+
+#[test]
+fun fresh_manager_has_alice_owner_and_zero_balance() {
+    let (mut scenario, registry_id) = setup();
+    let manager = create_alice_manager(&mut scenario, registry_id);
+
+    assert_eq!(manager.owner(), test_constants::alice());
+    assert_eq!(manager.balance(), 0);
+
+    destroy(manager);
+    scenario.end();
+}
+
+#[test]
+fun id_is_stable_across_reads() {
+    let (mut scenario, registry_id) = setup();
+    let manager = create_alice_manager(&mut scenario, registry_id);
+
+    assert_eq!(manager.id(), manager.id());
+
+    destroy(manager);
+    scenario.end();
+}
+
+// === deposit / withdraw ===
+
+#[test]
+fun deposit_increases_balance() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+
+    let coin = coin::mint_for_testing<DUSDC>(DEPOSIT_AMOUNT, scenario.ctx());
+    manager.deposit(coin, scenario.ctx());
+    assert_eq!(manager.balance(), DEPOSIT_AMOUNT);
+
+    destroy(manager);
+    scenario.end();
+}
+
+#[test]
+fun withdraw_decreases_balance_and_returns_coin() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+
+    let coin = coin::mint_for_testing<DUSDC>(DEPOSIT_AMOUNT, scenario.ctx());
+    manager.deposit(coin, scenario.ctx());
+
+    let withdrawn = manager.withdraw(WITHDRAW_AMOUNT, scenario.ctx());
+    assert_eq!(withdrawn.value(), WITHDRAW_AMOUNT);
+    assert_eq!(manager.balance(), DEPOSIT_AMOUNT - WITHDRAW_AMOUNT);
+
+    destroy(manager);
+    destroy(withdrawn);
+    scenario.end();
+}
+
+#[test]
+fun deposit_permissionless_works_without_owner_sender() {
+    // deposit_permissionless uses the manager's stored DepositCap so anyone
+    // can credit the manager (used for protocol-driven payouts).
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+
+    scenario.next_tx(test_constants::bob());
+    let coin = coin::mint_for_testing<DUSDC>(DEPOSIT_AMOUNT, scenario.ctx());
+    manager.deposit_permissionless(coin, scenario.ctx());
+    assert_eq!(manager.balance(), DEPOSIT_AMOUNT);
+
+    destroy(manager);
+    scenario.end();
+}
+
+// === share ===
+
+#[test]
+fun share_makes_manager_take_shared() {
+    let (mut scenario, registry_id) = setup();
+    let manager = create_alice_manager(&mut scenario, registry_id);
+    let manager_id = manager.id();
+    manager.share();
+
+    scenario.next_tx(test_constants::alice());
+    let taken = scenario.take_shared_by_id<PredictManager>(manager_id);
+    assert_eq!(taken.id(), manager_id);
+    return_shared(taken);
+
+    scenario.end();
+}
+
+// === builder_code_id setter / unsetter ===
+
+#[test]
+fun builder_code_id_starts_none_then_set_and_unset() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+
+    assert!(manager.builder_code_id().is_none());
+
+    // Alice creates a builder code for herself.
+    let code = builder_code::new_for_testing(
+        test_constants::alice(),
+        BUILDER_INDEX,
+        scenario.ctx(),
+    );
+    manager.set_builder_code(&code, scenario.ctx());
+
+    let stored = manager.builder_code_id();
+    assert!(stored.is_some());
+    assert_eq!(*stored.borrow(), code.id());
+
+    manager.unset_builder_code(scenario.ctx());
+    assert!(manager.builder_code_id().is_none());
+
+    destroy(manager);
+    builder_code::destroy_for_testing(code);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = predict_manager::ENotOwner)]
+fun set_builder_code_by_non_owner_aborts() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+    let code = builder_code::new_for_testing(
+        test_constants::alice(),
+        BUILDER_INDEX,
+        scenario.ctx(),
+    );
+
+    scenario.next_tx(test_constants::bob());
+    manager.set_builder_code(&code, scenario.ctx());
+    abort 999
+}
+
+#[test, expected_failure(abort_code = predict_manager::ENotOwner)]
+fun unset_builder_code_by_non_owner_aborts() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+
+    scenario.next_tx(test_constants::bob());
+    manager.unset_builder_code(scenario.ctx());
+    abort 999
+}
+
+// === Position bookkeeping ===
+
+#[test]
+fun has_position_returns_false_for_unknown_position() {
+    let (mut scenario, registry_id) = setup();
+    let manager = create_alice_manager(&mut scenario, registry_id);
+
+    assert!(!manager.has_position(FAKE_EXPIRY_ID.to_id(), ORDER_ID_A));
+
+    destroy(manager);
+    scenario.end();
+}
+
+#[test]
+fun add_position_then_remove_round_trip() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+    let expiry = FAKE_EXPIRY_ID.to_id();
+
+    manager.add_position(expiry, ORDER_ID_A);
+    assert!(manager.has_position(expiry, ORDER_ID_A));
+    assert_eq!(manager.expiry_position_count(expiry), 1);
+
+    manager.add_position(expiry, ORDER_ID_B);
+    assert_eq!(manager.expiry_position_count(expiry), 2);
+
+    manager.remove_position(expiry, ORDER_ID_A);
+    assert!(!manager.has_position(expiry, ORDER_ID_A));
+    assert_eq!(manager.expiry_position_count(expiry), 1);
+    // The other position is unchanged.
+    assert!(manager.has_position(expiry, ORDER_ID_B));
+
+    manager.remove_position(expiry, ORDER_ID_B);
+
+    destroy(manager);
+    scenario.end();
+}
+
+#[test]
+fun positions_are_scoped_per_expiry() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+    let expiry_a = FAKE_EXPIRY_ID.to_id();
+    let expiry_b = FAKE_EXPIRY_ID_2.to_id();
+
+    // Same order_id under two different expiries is two distinct positions.
+    manager.add_position(expiry_a, ORDER_ID_A);
+    manager.add_position(expiry_b, ORDER_ID_A);
+
+    assert!(manager.has_position(expiry_a, ORDER_ID_A));
+    assert!(manager.has_position(expiry_b, ORDER_ID_A));
+    assert_eq!(manager.expiry_position_count(expiry_a), 1);
+    assert_eq!(manager.expiry_position_count(expiry_b), 1);
+
+    destroy(manager);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = predict_manager::EPositionAlreadyExists)]
+fun add_position_duplicate_aborts() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+
+    manager.add_position(FAKE_EXPIRY_ID.to_id(), ORDER_ID_A);
+    manager.add_position(FAKE_EXPIRY_ID.to_id(), ORDER_ID_A);
+    abort 999
+}
+
+#[test, expected_failure(abort_code = predict_manager::EInsufficientPosition)]
+fun remove_position_that_does_not_exist_aborts() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+
+    manager.remove_position(FAKE_EXPIRY_ID.to_id(), ORDER_ID_A);
+    abort 999
+}
+
+#[test]
+fun expiry_position_count_unknown_expiry_returns_zero() {
+    let (mut scenario, registry_id) = setup();
+    let manager = create_alice_manager(&mut scenario, registry_id);
+
+    assert_eq!(manager.expiry_position_count(FAKE_EXPIRY_ID.to_id()), 0);
+
+    destroy(manager);
+    scenario.end();
+}
+
+// === Cash flow recording ===
+
+#[test]
+fun record_helpers_accumulate_per_expiry() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+    let expiry = FAKE_EXPIRY_ID.to_id();
+
+    manager.record_trading_fee_paid(expiry, FEE_AMOUNT);
+    manager.record_trading_fee_paid(expiry, FEE_AMOUNT);
+    manager.record_cash_paid_to_expiry(expiry, CASH_PAID);
+    manager.record_cash_received_from_expiry(expiry, CASH_RECEIVED);
+
+    assert_eq!(manager.trading_fees_paid(expiry), 2 * FEE_AMOUNT);
+    assert_eq!(manager.cash_paid_to_expiry(expiry), CASH_PAID);
+    assert_eq!(manager.cash_received_from_expiry(expiry), CASH_RECEIVED);
+
+    destroy(manager);
+    scenario.end();
+}
+
+#[test]
+fun record_helpers_zero_amount_is_no_op() {
+    // The record_* helpers short-circuit on amount == 0 and do not even
+    // ensure the expiry summary exists. The getters then return 0 from
+    // the unknown-expiry fallback.
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+    let expiry = FAKE_EXPIRY_ID.to_id();
+
+    manager.record_trading_fee_paid(expiry, 0);
+    manager.record_cash_paid_to_expiry(expiry, 0);
+    manager.record_cash_received_from_expiry(expiry, 0);
+
+    assert_eq!(manager.trading_fees_paid(expiry), 0);
+    assert_eq!(manager.cash_paid_to_expiry(expiry), 0);
+    assert_eq!(manager.cash_received_from_expiry(expiry), 0);
+
+    destroy(manager);
+    scenario.end();
+}
+
+#[test]
+fun getters_return_zero_for_unknown_expiry() {
+    let (mut scenario, registry_id) = setup();
+    let manager = create_alice_manager(&mut scenario, registry_id);
+    let expiry = FAKE_EXPIRY_ID.to_id();
+
+    assert_eq!(manager.trading_fees_paid(expiry), 0);
+    assert_eq!(manager.cash_paid_to_expiry(expiry), 0);
+    assert_eq!(manager.cash_received_from_expiry(expiry), 0);
+
+    destroy(manager);
+    scenario.end();
+}
+
+// === resolve_expiry_summary ===
+
+#[test]
+fun resolve_expiry_summary_returns_zeros_for_untouched_expiry() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+    let expiry = FAKE_EXPIRY_ID.to_id();
+
+    let (fees, paid, received) = manager.resolve_expiry_summary(expiry);
+    assert_eq!(fees, 0);
+    assert_eq!(paid, 0);
+    assert_eq!(received, 0);
+
+    destroy(manager);
+    scenario.end();
+}
+
+#[test]
+fun resolve_expiry_summary_returns_recorded_cash_flows_when_no_open_positions() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+    let expiry = FAKE_EXPIRY_ID.to_id();
+
+    manager.record_trading_fee_paid(expiry, FEE_AMOUNT);
+    manager.record_cash_paid_to_expiry(expiry, CASH_PAID);
+    manager.record_cash_received_from_expiry(expiry, CASH_RECEIVED);
+
+    let (fees, paid, received) = manager.resolve_expiry_summary(expiry);
+    assert_eq!(fees, FEE_AMOUNT);
+    assert_eq!(paid, CASH_PAID);
+    assert_eq!(received, CASH_RECEIVED);
+
+    // Summary entry has been removed — second call returns zeros.
+    let (fees_again, paid_again, received_again) = manager.resolve_expiry_summary(expiry);
+    assert_eq!(fees_again, 0);
+    assert_eq!(paid_again, 0);
+    assert_eq!(received_again, 0);
+
+    destroy(manager);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = predict_manager::EExpirySummaryHasOpenPositions)]
+fun resolve_expiry_summary_with_open_positions_aborts() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+    let expiry = FAKE_EXPIRY_ID.to_id();
+
+    manager.add_position(expiry, ORDER_ID_A);
+    let (_, _, _) = manager.resolve_expiry_summary(expiry);
+    abort 999
+}
+
+// === assert_owner ===
+
+#[test]
+fun assert_owner_passes_for_creator() {
+    let (mut scenario, registry_id) = setup();
+    let manager = create_alice_manager(&mut scenario, registry_id);
+
+    // Alice is the manager owner.
+    manager.assert_owner(scenario.ctx());
+
+    destroy(manager);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = predict_manager::ENotOwner)]
+fun assert_owner_aborts_for_non_owner() {
+    let (mut scenario, registry_id) = setup();
+    let manager = create_alice_manager(&mut scenario, registry_id);
+
+    scenario.next_tx(test_constants::bob());
+    manager.assert_owner(scenario.ctx());
+    abort 999
+}

--- a/packages/predict/tests/protocol_config_tests.move
+++ b/packages/predict/tests/protocol_config_tests.move
@@ -1,0 +1,181 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module deepbook_predict::protocol_config_tests;
+
+use deepbook_predict::protocol_config;
+use std::unit_test::destroy;
+
+// === trading_paused / pause_trading ===
+
+#[test]
+fun new_for_testing_is_not_paused() {
+    let ctx = &mut tx_context::dummy();
+    let config = protocol_config::new_for_testing(ctx);
+
+    assert!(!config.trading_paused());
+
+    destroy(config);
+}
+
+#[test]
+fun pause_trading_is_one_way_from_package() {
+    // The package-internal pause_trading is the PauseCap path; it cannot
+    // unpause. Verifies it sets the flag.
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    config.pause_trading();
+    assert!(config.trading_paused());
+    // Calling it again is idempotent.
+    config.pause_trading();
+    assert!(config.trading_paused());
+
+    destroy(config);
+}
+
+#[test]
+fun set_trading_paused_round_trips_both_directions() {
+    // The package-internal set_trading_paused is the admin path; it can flip
+    // either direction.
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    config.set_trading_paused(true);
+    assert!(config.trading_paused());
+    config.set_trading_paused(false);
+    assert!(!config.trading_paused());
+
+    destroy(config);
+}
+
+// === assert_trading_allowed ===
+
+#[test]
+fun assert_trading_allowed_passes_when_not_paused_and_no_valuation() {
+    let ctx = &mut tx_context::dummy();
+    let config = protocol_config::new_for_testing(ctx);
+
+    config.assert_trading_allowed();
+
+    destroy(config);
+}
+
+#[test, expected_failure(abort_code = protocol_config::ETradingPaused)]
+fun assert_trading_allowed_aborts_when_paused() {
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+    config.set_trading_paused(true);
+
+    config.assert_trading_allowed();
+    abort 999
+}
+
+#[test, expected_failure(abort_code = protocol_config::EValuationInProgress)]
+fun assert_trading_allowed_aborts_during_valuation() {
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+    config.begin_valuation();
+
+    config.assert_trading_allowed();
+    abort 999
+}
+
+// === Valuation lock lifecycle ===
+
+#[test]
+fun begin_then_end_valuation_succeeds() {
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    config.begin_valuation();
+    config.assert_valuation_in_progress();
+    config.end_valuation();
+    config.assert_not_valuation_in_progress();
+
+    destroy(config);
+}
+
+#[test, expected_failure(abort_code = protocol_config::EValuationInProgress)]
+fun begin_valuation_twice_aborts() {
+    // The lock is transaction-local; nesting is not allowed.
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+    config.begin_valuation();
+
+    config.begin_valuation();
+    abort 999
+}
+
+#[test, expected_failure(abort_code = protocol_config::EValuationNotInProgress)]
+fun end_valuation_without_begin_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    config.end_valuation();
+    abort 999
+}
+
+#[test, expected_failure(abort_code = protocol_config::EValuationNotInProgress)]
+fun assert_valuation_in_progress_aborts_when_not_held() {
+    let ctx = &mut tx_context::dummy();
+    let config = protocol_config::new_for_testing(ctx);
+
+    config.assert_valuation_in_progress();
+    abort 999
+}
+
+#[test, expected_failure(abort_code = protocol_config::EValuationInProgress)]
+fun assert_not_valuation_in_progress_aborts_when_held() {
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+    config.begin_valuation();
+
+    config.assert_not_valuation_in_progress();
+    abort 999
+}
+
+// === Sub-config getters return stable references ===
+
+#[test]
+fun pricing_config_getter_returns_stable_reference() {
+    // The getters return &PricingConfig / &FeeConfig / etc. — just verify
+    // they're callable and reading them does not abort. The sub-config
+    // contents are tested in their own modules' test files.
+    let ctx = &mut tx_context::dummy();
+    let config = protocol_config::new_for_testing(ctx);
+
+    let _ = config.pricing_config();
+    let _ = config.fee_config();
+    let _ = config.risk_config();
+    let _ = config.market_oracle_config();
+    let _ = config.leverage_config();
+
+    destroy(config);
+}
+
+// === pause_trading interaction with valuation lock ===
+
+#[test, expected_failure(abort_code = protocol_config::EValuationInProgress)]
+fun pause_trading_during_valuation_aborts() {
+    // Even the PauseCap-driven pause must wait for the valuation lock to
+    // clear; otherwise a kill-switch mid-valuation could leave invariants
+    // inconsistent.
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+    config.begin_valuation();
+
+    config.pause_trading();
+    abort 999
+}
+
+#[test, expected_failure(abort_code = protocol_config::EValuationInProgress)]
+fun set_trading_paused_during_valuation_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+    config.begin_valuation();
+
+    config.set_trading_paused(true);
+    abort 999
+}

--- a/packages/predict/tests/registry_create_tests.move
+++ b/packages/predict/tests/registry_create_tests.move
@@ -1,0 +1,157 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module deepbook_predict::registry_create_tests;
+
+use deepbook_predict::{constants, registry, test_constants};
+use std::unit_test::destroy;
+use sui::test_scenario::{Self as test, return_shared};
+
+const PYTH_FEED_BTC: u32 = 100;
+const PYTH_FEED_ETH: u32 = 200;
+const EXPIRY_FEE_WINDOW_DISABLED: u64 = 0;
+const EXPIRY_FEE_MAX_MULTIPLIER_DISABLED: u64 = 1_000_000_000; // 1.0 — sentinel disables ramp
+
+// === create_pyth_source ===
+
+#[test]
+fun create_pyth_source_returns_id_and_registers() {
+    let ctx = &mut tx_context::dummy();
+    let (mut reg, admin_cap) = registry::new_for_testing(ctx);
+
+    let pyth_id = registry::create_pyth_source(
+        &mut reg,
+        &admin_cap,
+        PYTH_FEED_BTC,
+        EXPIRY_FEE_WINDOW_DISABLED,
+        EXPIRY_FEE_MAX_MULTIPLIER_DISABLED,
+        ctx,
+    );
+    let registered = registry::pyth_source_id(&reg, PYTH_FEED_BTC);
+    assert!(registered.is_some());
+    assert!(*registered.borrow() == pyth_id);
+    // Other feed ids must remain unmapped.
+    assert!(registry::pyth_source_id(&reg, PYTH_FEED_ETH).is_none());
+
+    registry::destroy_registry_drop_for_testing(reg);
+    destroy(admin_cap);
+}
+
+#[test]
+fun create_pyth_source_distinct_feeds_yield_distinct_ids() {
+    let ctx = &mut tx_context::dummy();
+    let (mut reg, admin_cap) = registry::new_for_testing(ctx);
+
+    let btc_id = registry::create_pyth_source(
+        &mut reg,
+        &admin_cap,
+        PYTH_FEED_BTC,
+        EXPIRY_FEE_WINDOW_DISABLED,
+        EXPIRY_FEE_MAX_MULTIPLIER_DISABLED,
+        ctx,
+    );
+    let eth_id = registry::create_pyth_source(
+        &mut reg,
+        &admin_cap,
+        PYTH_FEED_ETH,
+        EXPIRY_FEE_WINDOW_DISABLED,
+        EXPIRY_FEE_MAX_MULTIPLIER_DISABLED,
+        ctx,
+    );
+    assert!(btc_id != eth_id);
+
+    registry::destroy_registry_drop_for_testing(reg);
+    destroy(admin_cap);
+}
+
+#[test, expected_failure(abort_code = registry::EPythSourceAlreadyCreated)]
+fun create_pyth_source_duplicate_feed_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let (mut reg, admin_cap) = registry::new_for_testing(ctx);
+
+    registry::create_pyth_source(
+        &mut reg,
+        &admin_cap,
+        PYTH_FEED_BTC,
+        EXPIRY_FEE_WINDOW_DISABLED,
+        EXPIRY_FEE_MAX_MULTIPLIER_DISABLED,
+        ctx,
+    );
+    registry::create_pyth_source(
+        &mut reg,
+        &admin_cap,
+        PYTH_FEED_BTC,
+        EXPIRY_FEE_WINDOW_DISABLED,
+        EXPIRY_FEE_MAX_MULTIPLIER_DISABLED,
+        ctx,
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = registry::EPackageVersionDisabled)]
+fun create_pyth_source_with_current_version_disabled_aborts() {
+    // Admin can disable current_version via the version-management path (which
+    // bypasses the version gate). Subsequent create_pyth_source then fails the
+    // mirrored-version check.
+    let ctx = &mut tx_context::dummy();
+    let (mut reg, admin_cap) = registry::new_for_testing(ctx);
+    let current = constants::current_version!();
+    let next = current + 1;
+    registry::enable_version(&mut reg, &admin_cap, next);
+    registry::disable_version(&mut reg, &admin_cap, current);
+
+    registry::create_pyth_source(
+        &mut reg,
+        &admin_cap,
+        PYTH_FEED_BTC,
+        EXPIRY_FEE_WINDOW_DISABLED,
+        EXPIRY_FEE_MAX_MULTIPLIER_DISABLED,
+        ctx,
+    );
+    abort 999
+}
+
+// === pyth_source_id getter for unknown feed ===
+
+#[test]
+fun pyth_source_id_returns_none_for_unmapped_feed() {
+    let ctx = &mut tx_context::dummy();
+    let (reg, admin_cap) = registry::new_for_testing(ctx);
+
+    assert!(registry::pyth_source_id(&reg, PYTH_FEED_BTC).is_none());
+
+    registry::destroy_registry_for_testing(reg);
+    destroy(admin_cap);
+}
+
+// === create_manager / create_and_share_manager ===
+
+#[test]
+fun create_manager_yields_distinct_objects_per_caller() {
+    // The PredictManager key includes the sender, so two different addresses
+    // can each claim their own derived manager.
+    let mut scenario = test::begin(test_constants::alice());
+    let registry_id = registry::init_for_testing(scenario.ctx());
+
+    scenario.next_tx(test_constants::alice());
+    let mut reg = scenario.take_shared_by_id<registry::Registry>(registry_id);
+    let alice_mgr = registry::create_manager(&mut reg, scenario.ctx());
+    return_shared(reg);
+
+    scenario.next_tx(test_constants::bob());
+    let mut reg = scenario.take_shared_by_id<registry::Registry>(registry_id);
+    let bob_mgr = registry::create_manager(&mut reg, scenario.ctx());
+    return_shared(reg);
+
+    // Different senders produce different derived ids.
+    assert!(object::id(&alice_mgr) != object::id(&bob_mgr));
+
+    destroy(alice_mgr);
+    destroy(bob_mgr);
+    scenario.end();
+}
+
+// create_expiry_market requires PoolVault and is the largest end-to-end
+// constructor in the package. Covered in the PR that adds plp / expiry_market
+// scaffolding (PR 6).

--- a/packages/predict/tests/registry_setters_tests.move
+++ b/packages/predict/tests/registry_setters_tests.move
@@ -1,0 +1,251 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Cover the registry's admin setter surface. Each setter is a thin wrapper
+/// around the corresponding ProtocolConfig (or PythSource) write — so the
+/// tests just verify the value reaches the destination, then read it back
+/// through the sub-config getter.
+#[test_only]
+module deepbook_predict::registry_setters_tests;
+
+use deepbook_predict::{
+    constants::float_scaling as float,
+    fee_config,
+    leverage_config,
+    market_oracle_config,
+    pricing_config,
+    protocol_config,
+    pyth_source,
+    registry,
+    risk_config
+};
+use std::unit_test::{assert_eq, destroy};
+
+// === Pricing config setters ===
+
+#[test]
+fun set_base_fee_forwards_to_pricing_config() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    registry::set_base_fee(&mut config, &admin_cap, 30_000_000);
+    assert_eq!(pricing_config::base_fee(config.pricing_config()), 30_000_000);
+
+    destroy(config);
+    destroy(admin_cap);
+}
+
+#[test]
+fun set_min_fee_forwards_to_pricing_config() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    registry::set_min_fee(&mut config, &admin_cap, 4_000_000);
+    assert_eq!(pricing_config::min_fee(config.pricing_config()), 4_000_000);
+
+    destroy(config);
+    destroy(admin_cap);
+}
+
+#[test]
+fun set_min_and_max_ask_price_forward_to_pricing_config() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    registry::set_min_ask_price(&mut config, &admin_cap, 20_000_000);
+    registry::set_max_ask_price(&mut config, &admin_cap, 980_000_000);
+    assert_eq!(pricing_config::min_ask_price(config.pricing_config()), 20_000_000);
+    assert_eq!(pricing_config::max_ask_price(config.pricing_config()), 980_000_000);
+
+    destroy(config);
+    destroy(admin_cap);
+}
+
+#[test]
+fun set_freshness_setters_forward_to_pricing_config() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    registry::set_pyth_spot_freshness_ms(&mut config, &admin_cap, 5_000);
+    registry::set_block_scholes_prices_freshness_ms(&mut config, &admin_cap, 4_000);
+    registry::set_block_scholes_svi_freshness_ms(&mut config, &admin_cap, 30_000);
+    assert_eq!(pricing_config::pyth_spot_freshness_ms(config.pricing_config()), 5_000);
+    assert_eq!(pricing_config::block_scholes_prices_freshness_ms(config.pricing_config()), 4_000);
+    assert_eq!(pricing_config::block_scholes_svi_freshness_ms(config.pricing_config()), 30_000);
+
+    destroy(config);
+    destroy(admin_cap);
+}
+
+// === Fee config setters ===
+
+#[test]
+fun set_fee_shares_forwards_all_three_to_fee_config() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    registry::set_fee_shares(&mut config, &admin_cap, 700_000_000, 200_000_000, 100_000_000);
+    assert_eq!(fee_config::lp_fee_share(config.fee_config()), 700_000_000);
+    assert_eq!(fee_config::protocol_fee_share(config.fee_config()), 200_000_000);
+    assert_eq!(fee_config::insurance_fee_share(config.fee_config()), 100_000_000);
+
+    destroy(config);
+    destroy(admin_cap);
+}
+
+#[test]
+fun set_template_trading_loss_rebate_rate_forwards_to_fee_config() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    registry::set_template_trading_loss_rebate_rate(&mut config, &admin_cap, 250_000_000);
+    assert_eq!(fee_config::trading_loss_rebate_rate(config.fee_config()), 250_000_000);
+
+    destroy(config);
+    destroy(admin_cap);
+}
+
+// === Risk config setters ===
+
+#[test]
+fun set_max_total_exposure_pct_forwards_to_risk_config() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    registry::set_max_total_exposure_pct(&mut config, &admin_cap, 500_000_000);
+    assert_eq!(risk_config::max_total_exposure_pct(config.risk_config()), 500_000_000);
+
+    destroy(config);
+    destroy(admin_cap);
+}
+
+#[test]
+fun set_expiry_allocation_forwards_to_risk_config() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    registry::set_expiry_allocation(&mut config, &admin_cap, 100_000_000_000);
+    assert_eq!(risk_config::expiry_allocation(config.risk_config()), 100_000_000_000);
+
+    destroy(config);
+    destroy(admin_cap);
+}
+
+#[test]
+fun set_resize_setters_forward_to_risk_config() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    registry::set_grow_utilization_threshold(&mut config, &admin_cap, 900_000_000);
+    registry::set_shrink_utilization_threshold(&mut config, &admin_cap, 200_000_000);
+    registry::set_grow_factor(&mut config, &admin_cap, 3 * float!());
+    registry::set_shrink_factor(&mut config, &admin_cap, 400_000_000);
+
+    assert_eq!(risk_config::grow_utilization_threshold(config.risk_config()), 900_000_000);
+    assert_eq!(risk_config::shrink_utilization_threshold(config.risk_config()), 200_000_000);
+    assert_eq!(risk_config::grow_factor(config.risk_config()), 3 * float!());
+    assert_eq!(risk_config::shrink_factor(config.risk_config()), 400_000_000);
+
+    destroy(config);
+    destroy(admin_cap);
+}
+
+// === Leverage config setter ===
+
+#[test]
+fun set_template_max_expiry_floor_premium_forwards_to_leverage_config() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    registry::set_template_max_expiry_floor_premium(&mut config, &admin_cap, 300_000_000);
+    assert_eq!(leverage_config::max_expiry_floor_premium(config.leverage_config()), 300_000_000);
+
+    destroy(config);
+    destroy(admin_cap);
+}
+
+// === Market oracle template setters ===
+
+#[test]
+fun set_market_oracle_template_settlement_freshness_forwards() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    registry::set_market_oracle_template_settlement_freshness_ms(&mut config, &admin_cap, 5_000);
+    assert_eq!(market_oracle_config::settlement_freshness_ms(config.market_oracle_config()), 5_000);
+
+    destroy(config);
+    destroy(admin_cap);
+}
+
+#[test]
+fun set_market_oracle_template_basis_bounds_forwards_all_four() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    registry::set_market_oracle_template_basis_bounds(
+        &mut config,
+        &admin_cap,
+        50_000_000,
+        60_000_000,
+        950_000_000,
+        1_050_000_000,
+    );
+    assert_eq!(market_oracle_config::max_spot_deviation(config.market_oracle_config()), 50_000_000);
+    assert_eq!(
+        market_oracle_config::max_basis_deviation(config.market_oracle_config()),
+        60_000_000,
+    );
+    assert_eq!(market_oracle_config::min_basis(config.market_oracle_config()), 950_000_000);
+    assert_eq!(market_oracle_config::max_basis(config.market_oracle_config()), 1_050_000_000);
+
+    destroy(config);
+    destroy(admin_cap);
+}
+
+// === trading_paused round-trip ===
+
+#[test]
+fun set_trading_paused_round_trips_through_config_getter() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    assert!(!config.trading_paused());
+    registry::set_trading_paused(&mut config, &admin_cap, true);
+    assert!(config.trading_paused());
+    // Admin can also unpause (unlike PauseCap which is one-way).
+    registry::set_trading_paused(&mut config, &admin_cap, false);
+    assert!(!config.trading_paused());
+
+    destroy(config);
+    destroy(admin_cap);
+}
+
+// === Pyth source expiry-fee setter ===
+
+#[test]
+fun set_pyth_source_expiry_fee_params_forwards_to_pyth() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let mut pyth = pyth_source::new_for_testing(ctx);
+
+    registry::set_pyth_source_expiry_fee_params(&mut pyth, &admin_cap, 3_600_000, 2 * float!());
+    assert_eq!(pyth.expiry_fee_window_ms(), 3_600_000);
+    assert_eq!(pyth.expiry_fee_max_multiplier(), 2 * float!());
+
+    destroy(pyth);
+    destroy(admin_cap);
+}


### PR DESCRIPTION
## Summary
- **Stacked on #1045 (DBU-416).** Adds extensive coverage for `oracle/market_oracle.move` — the largest single source file in the package (786 lines, 48 public functions, 18 abort codes) — split across five new test files organized by area.
- Suite grows from **272 → 335 tests, all passing**. +63 net new tests, +2 small `#[test_only]` helpers on the source side.

## Key decisions
- **Two minimal test-only source additions made the rest possible:**
  - `market_oracle::create_test_market_oracle_with_pyth(pyth, expiry, cap, ctx)` binds a test oracle to a real `PythSource` so flows that call `assert_pyth_source(pyth)` (`update_block_scholes_prices`, `settle_if_possible`) can exercise the matched-source happy path. The existing `create_test_market_oracle` synthesizes a random pyth_source_id, which is only useful for cap/expiry/getters tests.
  - `pyth_source::set_state_for_testing(source, spot, source_ts, update_ts)` drives spot and timestamps directly. The production setter is `update_from_lazer`, which needs a `pyth_lazer::Update` that has no Move-side test constructor (same situation as `AccumulatorRoot` in #1043 and `Update` in #1045). This helper unblocks the "Pyth has fresh post-expiry data" state the settlement tests need.
- **Tests organized by source-module section, one file per area.** Putting all 63 tests in one file would have been unwieldy; the five files line up with the source's section comments (`Public Functions` / `Public-Package Functions` / per-flow). `oracle_cap_tests.move` and `pause_tests.move` already cover the cap-authorization and version-sync paths so those aren't duplicated.
- **Settlement coverage is end-to-end via two natural paths:** Pyth settlement is driven by `set_state_for_testing` + `settle_if_possible`. Block Scholes settlement is driven entirely through production-shaped calls — `update_block_scholes_prices` after expiry runs `settle_if_possible_internal` at the end, so a post-expiry price push with a valid source_ts auto-settles via the BS fallback. No additional helper was needed for the BS path, which is worth pointing out: it covers the same code paths real settlement would take.
- **`EInvalidSettlementTimestamp` is documented as un-triggerable through any production path.** It guards `settlement_price` when `settlement_source_timestamp_ms <= expiry`, but `valid_settlement_spot_source` always requires `source_ts > expiry` before calling the private `settle()`. So this assertion is defense-in-depth that would only fire if a future change weakened the validation. Triggering it would require a test-only `settle_for_testing` bypass; deferred until there's a reason to add one.

## Test plan
- [x] `sui move test --gas-limit 100000000000` in `packages/predict` — 335 tests, 0 failures.
- [x] `bunx prettier-move -c` on all touched files — clean.
- [x] Every `public fun` and `public(package) fun` in `market_oracle.move` has at least one test, with the following documented exceptions: `create_and_share` (registry-level integration, PR 6), `block_scholes_*_freshness_timestamp_ms` (covered transitively by `settle_if_possible` tests; not directly).
- [x] Every `E*` abort code in `market_oracle.move` is exercised, with the noted exception of `EInvalidSettlementTimestamp` (defense-in-depth, no production-reachable path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)