### PR TITLE
DBU-418: Predict tests for registry and market_key/order

### DIFF
--- a/packages/predict/sources/registry.move
+++ b/packages/predict/sources/registry.move
@@ -577,3 +577,19 @@ public fun destroy_registry_for_testing(registry: Registry) {
     pyth_source_ids.destroy_empty();
     expiry_market_ids.destroy_empty();
 }
+
+/// Variant for tests that exercise registration paths: drops the uniqueness
+/// tables without requiring them to be empty.
+#[test_only]
+public fun destroy_registry_drop_for_testing(registry: Registry) {
+    let Registry {
+        id,
+        pyth_source_ids,
+        expiry_market_ids,
+        allowed_pause_caps: _,
+        allowed_versions: _,
+    } = registry;
+    id.delete();
+    pyth_source_ids.drop();
+    expiry_market_ids.drop();
+}

--- a/packages/predict/tests/market_key/order_tests.move
+++ b/packages/predict/tests/market_key/order_tests.move
@@ -1,0 +1,324 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module deepbook_predict::order_tests;
+
+use deepbook_predict::{constants, order};
+use std::unit_test::assert_eq;
+
+// Position lot size is 10_000 (from constants::position_lot_size!()), so a
+// quantity must be a multiple of 10_000.
+const ONE_LOT_QTY: u64 = 10_000;
+const TWO_LOTS_QTY: u64 = 20_000;
+const SEQUENCE_ZERO: u64 = 0;
+const OPENED_AT_MS: u64 = 1_700_000_000_000;
+// Strikes are indices into the 100_000-tick grid; pick safe values.
+const STRIKE_INDEX_LO: u64 = 100;
+const STRIKE_INDEX_HI: u64 = 200;
+
+// === Leverage constants ===
+
+#[test]
+fun leverage_constants_are_distinct_and_ordered() {
+    let l1 = order::leverage_one_x();
+    let l15 = order::leverage_one_and_half_x();
+    let l2 = order::leverage_two_x();
+    let l25 = order::leverage_two_and_half_x();
+    let l3 = order::leverage_three_x();
+
+    assert_eq!(l1, 0);
+    assert!(l1 < l15);
+    assert!(l15 < l2);
+    assert!(l2 < l25);
+    assert!(l25 < l3);
+    assert_eq!(l3, 4);
+}
+
+// === open_strike_index sentinel ===
+
+#[test]
+fun open_strike_index_is_above_grid() {
+    // The sentinel is one above the maximum valid finite strike index.
+    assert_eq!(order::open_strike_index(), constants::oracle_strike_grid_ticks!() + 1);
+}
+
+// === assert_valid_quantity ===
+
+#[test]
+fun assert_valid_quantity_accepts_lot_multiples() {
+    order::assert_valid_quantity(ONE_LOT_QTY);
+    order::assert_valid_quantity(TWO_LOTS_QTY);
+    order::assert_valid_quantity(ONE_LOT_QTY * 12345);
+}
+
+#[test, expected_failure(abort_code = order::EInvalidQuantity)]
+fun assert_valid_quantity_zero_aborts() {
+    order::assert_valid_quantity(0);
+    abort 999
+}
+
+#[test, expected_failure(abort_code = order::EInvalidQuantity)]
+fun assert_valid_quantity_not_a_lot_multiple_aborts() {
+    order::assert_valid_quantity(ONE_LOT_QTY + 1);
+    abort 999
+}
+
+// === new_from_strike_indices: happy path + getters ===
+
+#[test]
+fun new_from_strike_indices_round_trips_through_getters() {
+    let leverage = order::leverage_one_x();
+    let entry_probability = 500_000_000; // 0.5 in 1e9
+    let o = order::new_from_strike_indices(
+        OPENED_AT_MS,
+        STRIKE_INDEX_LO,
+        STRIKE_INDEX_HI,
+        leverage,
+        entry_probability,
+        TWO_LOTS_QTY,
+        SEQUENCE_ZERO,
+    );
+
+    assert_eq!(o.opened_at_ms(), OPENED_AT_MS);
+    assert_eq!(o.min_strike_index(), STRIKE_INDEX_LO);
+    assert_eq!(o.max_strike_index(), STRIKE_INDEX_HI);
+    assert_eq!(o.leverage(), leverage);
+    assert_eq!(o.entry_probability(), entry_probability);
+    assert_eq!(o.quantity(), TWO_LOTS_QTY);
+    assert_eq!(o.quantity_lots(), TWO_LOTS_QTY / constants::position_lot_size!());
+    assert_eq!(o.sequence(), SEQUENCE_ZERO);
+}
+
+#[test]
+fun from_order_id_round_trips_through_id_getter() {
+    let leverage = order::leverage_one_x();
+    let o = order::new_from_strike_indices(
+        OPENED_AT_MS,
+        STRIKE_INDEX_LO,
+        STRIKE_INDEX_HI,
+        leverage,
+        0,
+        ONE_LOT_QTY,
+        0,
+    );
+    let packed_id = o.id();
+
+    let parsed = order::from_order_id(packed_id);
+    assert_eq!(parsed.id(), packed_id);
+    assert_eq!(parsed.opened_at_ms(), o.opened_at_ms());
+    assert_eq!(parsed.min_strike_index(), o.min_strike_index());
+}
+
+#[test]
+fun is_leveraged_distinguishes_one_x_from_others() {
+    let o1 = order::new_from_strike_indices(
+        OPENED_AT_MS,
+        STRIKE_INDEX_LO,
+        STRIKE_INDEX_HI,
+        order::leverage_one_x(),
+        0,
+        ONE_LOT_QTY,
+        0,
+    );
+    assert!(!o1.is_leveraged());
+
+    // Leveraged orders must have one side at the open sentinel.
+    let o2 = order::new_from_strike_indices(
+        OPENED_AT_MS,
+        order::open_strike_index(),
+        STRIKE_INDEX_HI,
+        order::leverage_two_x(),
+        0,
+        ONE_LOT_QTY,
+        0,
+    );
+    assert!(o2.is_leveraged());
+}
+
+// === new_from_strike_indices abort cases ===
+
+#[test, expected_failure(abort_code = order::EInvalidOpenedAt)]
+fun new_opened_at_above_u48_aborts() {
+    let above_u48: u64 = 1 << 48;
+    order::new_from_strike_indices(
+        above_u48,
+        STRIKE_INDEX_LO,
+        STRIKE_INDEX_HI,
+        order::leverage_one_x(),
+        0,
+        ONE_LOT_QTY,
+        0,
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = order::EInvalidStrikeIndex)]
+fun new_strike_index_above_u24_aborts() {
+    let above_u24: u64 = 1 << 24;
+    order::new_from_strike_indices(
+        OPENED_AT_MS,
+        above_u24,
+        above_u24 + 1,
+        order::leverage_one_x(),
+        0,
+        ONE_LOT_QTY,
+        0,
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = order::EInvalidEntryProbability)]
+fun new_entry_probability_above_one_aborts() {
+    order::new_from_strike_indices(
+        OPENED_AT_MS,
+        STRIKE_INDEX_LO,
+        STRIKE_INDEX_HI,
+        order::leverage_one_x(),
+        constants::float_scaling!() + 1,
+        ONE_LOT_QTY,
+        0,
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = order::EInvalidQuantity)]
+fun new_zero_quantity_aborts() {
+    order::new_from_strike_indices(
+        OPENED_AT_MS,
+        STRIKE_INDEX_LO,
+        STRIKE_INDEX_HI,
+        order::leverage_one_x(),
+        0,
+        0,
+        0,
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = order::EInvalidLeverage)]
+fun new_leverage_above_three_x_aborts() {
+    order::new_from_strike_indices(
+        OPENED_AT_MS,
+        STRIKE_INDEX_LO,
+        STRIKE_INDEX_HI,
+        order::leverage_three_x() + 1,
+        0,
+        ONE_LOT_QTY,
+        0,
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = order::EInvalidStrikeRange)]
+fun new_swapped_finite_strike_range_aborts() {
+    // Both sides finite -> require min < max strictly.
+    order::new_from_strike_indices(
+        OPENED_AT_MS,
+        STRIKE_INDEX_HI,
+        STRIKE_INDEX_LO,
+        order::leverage_one_x(),
+        0,
+        ONE_LOT_QTY,
+        0,
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = order::EInvalidStrikeRange)]
+fun new_both_sides_open_aborts() {
+    // (open, open] is rejected: the order would have no range at all.
+    order::new_from_strike_indices(
+        OPENED_AT_MS,
+        order::open_strike_index(),
+        order::open_strike_index(),
+        order::leverage_one_x(),
+        0,
+        ONE_LOT_QTY,
+        0,
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = order::EInvalidStrikeRange)]
+fun new_leveraged_with_both_sides_finite_aborts() {
+    // Leveraged orders must have exactly one side at the open sentinel.
+    order::new_from_strike_indices(
+        OPENED_AT_MS,
+        STRIKE_INDEX_LO,
+        STRIKE_INDEX_HI,
+        order::leverage_two_x(),
+        0,
+        ONE_LOT_QTY,
+        0,
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = order::EInvalidSequence)]
+fun new_sequence_above_u40_aborts() {
+    let above_u40: u64 = 1 << 40;
+    order::new_from_strike_indices(
+        OPENED_AT_MS,
+        STRIKE_INDEX_LO,
+        STRIKE_INDEX_HI,
+        order::leverage_one_x(),
+        0,
+        ONE_LOT_QTY,
+        above_u40,
+    );
+    abort 999
+}
+
+// === from_order_id validation ===
+
+#[test, expected_failure(abort_code = order::EInvalidOrderId)]
+fun from_order_id_with_bits_above_payload_aborts() {
+    // Setting any bit above ORDER_ID_BITS=208 must be rejected.
+    let bad_id: u256 = 1u256 << 208;
+    order::from_order_id(bad_id);
+    abort 999
+}
+
+// === replacement ===
+
+#[test]
+fun replacement_inherits_terms_and_uses_new_sequence() {
+    let original = order::new_from_strike_indices(
+        OPENED_AT_MS,
+        STRIKE_INDEX_LO,
+        STRIKE_INDEX_HI,
+        order::leverage_one_x(),
+        500_000_000,
+        TWO_LOTS_QTY,
+        0,
+    );
+    let next_sequence = 1;
+    let replaced = original.replacement(ONE_LOT_QTY, next_sequence);
+
+    // Inherits the original strike range, leverage, entry probability, and open
+    // time; only quantity and sequence change.
+    assert_eq!(replaced.opened_at_ms(), original.opened_at_ms());
+    assert_eq!(replaced.min_strike_index(), original.min_strike_index());
+    assert_eq!(replaced.max_strike_index(), original.max_strike_index());
+    assert_eq!(replaced.leverage(), original.leverage());
+    assert_eq!(replaced.entry_probability(), original.entry_probability());
+    assert_eq!(replaced.quantity(), ONE_LOT_QTY);
+    assert_eq!(replaced.sequence(), next_sequence);
+}
+
+#[test, expected_failure(abort_code = order::EInvalidQuantity)]
+fun replacement_at_or_above_original_quantity_aborts() {
+    // Replacement quantity must be strictly less than original.
+    let original = order::new_from_strike_indices(
+        OPENED_AT_MS,
+        STRIKE_INDEX_LO,
+        STRIKE_INDEX_HI,
+        order::leverage_one_x(),
+        0,
+        ONE_LOT_QTY,
+        0,
+    );
+    let _ = original.replacement(ONE_LOT_QTY, 1);
+    abort 999
+}

--- a/packages/predict/tests/predict_manager_tests.move
+++ b/packages/predict/tests/predict_manager_tests.move
@@ -1,0 +1,407 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module deepbook_predict::predict_manager_tests;
+
+use deepbook_predict::{
+    builder_code,
+    predict_manager::{Self, PredictManager},
+    registry,
+    test_constants
+};
+use dusdc::dusdc::DUSDC;
+use std::unit_test::{assert_eq, destroy};
+use sui::{coin, test_scenario::{Self as test, return_shared}};
+
+const DEPOSIT_AMOUNT: u64 = 1_000_000;
+const WITHDRAW_AMOUNT: u64 = 400_000;
+const FAKE_EXPIRY_ID: address = @0xCAFE;
+const FAKE_EXPIRY_ID_2: address = @0xBABE;
+const ORDER_ID_A: u256 = 42;
+const ORDER_ID_B: u256 = 43;
+const BUILDER_INDEX: u64 = 7;
+const FEE_AMOUNT: u64 = 5_000;
+const CASH_PAID: u64 = 100_000;
+const CASH_RECEIVED: u64 = 60_000;
+
+// === Helpers ===
+
+fun setup(): (test::Scenario, ID) {
+    let mut scenario = test::begin(test_constants::alice());
+    let registry_id = registry::init_for_testing(scenario.ctx());
+    (scenario, registry_id)
+}
+
+fun create_alice_manager(scenario: &mut test::Scenario, registry_id: ID): PredictManager {
+    scenario.next_tx(test_constants::alice());
+    let mut reg = scenario.take_shared_by_id<registry::Registry>(registry_id);
+    let manager = registry::create_manager(&mut reg, scenario.ctx());
+    return_shared(reg);
+    manager
+}
+
+// === id / owner / balance ===
+
+#[test]
+fun fresh_manager_has_alice_owner_and_zero_balance() {
+    let (mut scenario, registry_id) = setup();
+    let manager = create_alice_manager(&mut scenario, registry_id);
+
+    assert_eq!(manager.owner(), test_constants::alice());
+    assert_eq!(manager.balance(), 0);
+
+    destroy(manager);
+    scenario.end();
+}
+
+#[test]
+fun id_is_stable_across_reads() {
+    let (mut scenario, registry_id) = setup();
+    let manager = create_alice_manager(&mut scenario, registry_id);
+
+    assert_eq!(manager.id(), manager.id());
+
+    destroy(manager);
+    scenario.end();
+}
+
+// === deposit / withdraw ===
+
+#[test]
+fun deposit_increases_balance() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+
+    let coin = coin::mint_for_testing<DUSDC>(DEPOSIT_AMOUNT, scenario.ctx());
+    manager.deposit(coin, scenario.ctx());
+    assert_eq!(manager.balance(), DEPOSIT_AMOUNT);
+
+    destroy(manager);
+    scenario.end();
+}
+
+#[test]
+fun withdraw_decreases_balance_and_returns_coin() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+
+    let coin = coin::mint_for_testing<DUSDC>(DEPOSIT_AMOUNT, scenario.ctx());
+    manager.deposit(coin, scenario.ctx());
+
+    let withdrawn = manager.withdraw(WITHDRAW_AMOUNT, scenario.ctx());
+    assert_eq!(withdrawn.value(), WITHDRAW_AMOUNT);
+    assert_eq!(manager.balance(), DEPOSIT_AMOUNT - WITHDRAW_AMOUNT);
+
+    destroy(manager);
+    destroy(withdrawn);
+    scenario.end();
+}
+
+#[test]
+fun deposit_permissionless_works_without_owner_sender() {
+    // deposit_permissionless uses the manager's stored DepositCap so anyone
+    // can credit the manager (used for protocol-driven payouts).
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+
+    scenario.next_tx(test_constants::bob());
+    let coin = coin::mint_for_testing<DUSDC>(DEPOSIT_AMOUNT, scenario.ctx());
+    manager.deposit_permissionless(coin, scenario.ctx());
+    assert_eq!(manager.balance(), DEPOSIT_AMOUNT);
+
+    destroy(manager);
+    scenario.end();
+}
+
+// === share ===
+
+#[test]
+fun share_makes_manager_take_shared() {
+    let (mut scenario, registry_id) = setup();
+    let manager = create_alice_manager(&mut scenario, registry_id);
+    let manager_id = manager.id();
+    manager.share();
+
+    scenario.next_tx(test_constants::alice());
+    let taken = scenario.take_shared_by_id<PredictManager>(manager_id);
+    assert_eq!(taken.id(), manager_id);
+    return_shared(taken);
+
+    scenario.end();
+}
+
+// === builder_code_id setter / unsetter ===
+
+#[test]
+fun builder_code_id_starts_none_then_set_and_unset() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+
+    assert!(manager.builder_code_id().is_none());
+
+    // Alice creates a builder code for herself.
+    let code = builder_code::new_for_testing(
+        test_constants::alice(),
+        BUILDER_INDEX,
+        scenario.ctx(),
+    );
+    manager.set_builder_code(&code, scenario.ctx());
+
+    let stored = manager.builder_code_id();
+    assert!(stored.is_some());
+    assert_eq!(*stored.borrow(), code.id());
+
+    manager.unset_builder_code(scenario.ctx());
+    assert!(manager.builder_code_id().is_none());
+
+    destroy(manager);
+    builder_code::destroy_for_testing(code);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = predict_manager::ENotOwner)]
+fun set_builder_code_by_non_owner_aborts() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+    let code = builder_code::new_for_testing(
+        test_constants::alice(),
+        BUILDER_INDEX,
+        scenario.ctx(),
+    );
+
+    scenario.next_tx(test_constants::bob());
+    manager.set_builder_code(&code, scenario.ctx());
+    abort 999
+}
+
+#[test, expected_failure(abort_code = predict_manager::ENotOwner)]
+fun unset_builder_code_by_non_owner_aborts() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+
+    scenario.next_tx(test_constants::bob());
+    manager.unset_builder_code(scenario.ctx());
+    abort 999
+}
+
+// === Position bookkeeping ===
+
+#[test]
+fun has_position_returns_false_for_unknown_position() {
+    let (mut scenario, registry_id) = setup();
+    let manager = create_alice_manager(&mut scenario, registry_id);
+
+    assert!(!manager.has_position(FAKE_EXPIRY_ID.to_id(), ORDER_ID_A));
+
+    destroy(manager);
+    scenario.end();
+}
+
+#[test]
+fun add_position_then_remove_round_trip() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+    let expiry = FAKE_EXPIRY_ID.to_id();
+
+    manager.add_position(expiry, ORDER_ID_A);
+    assert!(manager.has_position(expiry, ORDER_ID_A));
+    assert_eq!(manager.expiry_position_count(expiry), 1);
+
+    manager.add_position(expiry, ORDER_ID_B);
+    assert_eq!(manager.expiry_position_count(expiry), 2);
+
+    manager.remove_position(expiry, ORDER_ID_A);
+    assert!(!manager.has_position(expiry, ORDER_ID_A));
+    assert_eq!(manager.expiry_position_count(expiry), 1);
+    // The other position is unchanged.
+    assert!(manager.has_position(expiry, ORDER_ID_B));
+
+    manager.remove_position(expiry, ORDER_ID_B);
+
+    destroy(manager);
+    scenario.end();
+}
+
+#[test]
+fun positions_are_scoped_per_expiry() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+    let expiry_a = FAKE_EXPIRY_ID.to_id();
+    let expiry_b = FAKE_EXPIRY_ID_2.to_id();
+
+    // Same order_id under two different expiries is two distinct positions.
+    manager.add_position(expiry_a, ORDER_ID_A);
+    manager.add_position(expiry_b, ORDER_ID_A);
+
+    assert!(manager.has_position(expiry_a, ORDER_ID_A));
+    assert!(manager.has_position(expiry_b, ORDER_ID_A));
+    assert_eq!(manager.expiry_position_count(expiry_a), 1);
+    assert_eq!(manager.expiry_position_count(expiry_b), 1);
+
+    destroy(manager);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = predict_manager::EPositionAlreadyExists)]
+fun add_position_duplicate_aborts() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+
+    manager.add_position(FAKE_EXPIRY_ID.to_id(), ORDER_ID_A);
+    manager.add_position(FAKE_EXPIRY_ID.to_id(), ORDER_ID_A);
+    abort 999
+}
+
+#[test, expected_failure(abort_code = predict_manager::EInsufficientPosition)]
+fun remove_position_that_does_not_exist_aborts() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+
+    manager.remove_position(FAKE_EXPIRY_ID.to_id(), ORDER_ID_A);
+    abort 999
+}
+
+#[test]
+fun expiry_position_count_unknown_expiry_returns_zero() {
+    let (mut scenario, registry_id) = setup();
+    let manager = create_alice_manager(&mut scenario, registry_id);
+
+    assert_eq!(manager.expiry_position_count(FAKE_EXPIRY_ID.to_id()), 0);
+
+    destroy(manager);
+    scenario.end();
+}
+
+// === Cash flow recording ===
+
+#[test]
+fun record_helpers_accumulate_per_expiry() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+    let expiry = FAKE_EXPIRY_ID.to_id();
+
+    manager.record_trading_fee_paid(expiry, FEE_AMOUNT);
+    manager.record_trading_fee_paid(expiry, FEE_AMOUNT);
+    manager.record_cash_paid_to_expiry(expiry, CASH_PAID);
+    manager.record_cash_received_from_expiry(expiry, CASH_RECEIVED);
+
+    assert_eq!(manager.trading_fees_paid(expiry), 2 * FEE_AMOUNT);
+    assert_eq!(manager.cash_paid_to_expiry(expiry), CASH_PAID);
+    assert_eq!(manager.cash_received_from_expiry(expiry), CASH_RECEIVED);
+
+    destroy(manager);
+    scenario.end();
+}
+
+#[test]
+fun record_helpers_zero_amount_is_no_op() {
+    // The record_* helpers short-circuit on amount == 0 and do not even
+    // ensure the expiry summary exists. The getters then return 0 from
+    // the unknown-expiry fallback.
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+    let expiry = FAKE_EXPIRY_ID.to_id();
+
+    manager.record_trading_fee_paid(expiry, 0);
+    manager.record_cash_paid_to_expiry(expiry, 0);
+    manager.record_cash_received_from_expiry(expiry, 0);
+
+    assert_eq!(manager.trading_fees_paid(expiry), 0);
+    assert_eq!(manager.cash_paid_to_expiry(expiry), 0);
+    assert_eq!(manager.cash_received_from_expiry(expiry), 0);
+
+    destroy(manager);
+    scenario.end();
+}
+
+#[test]
+fun getters_return_zero_for_unknown_expiry() {
+    let (mut scenario, registry_id) = setup();
+    let manager = create_alice_manager(&mut scenario, registry_id);
+    let expiry = FAKE_EXPIRY_ID.to_id();
+
+    assert_eq!(manager.trading_fees_paid(expiry), 0);
+    assert_eq!(manager.cash_paid_to_expiry(expiry), 0);
+    assert_eq!(manager.cash_received_from_expiry(expiry), 0);
+
+    destroy(manager);
+    scenario.end();
+}
+
+// === resolve_expiry_summary ===
+
+#[test]
+fun resolve_expiry_summary_returns_zeros_for_untouched_expiry() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+    let expiry = FAKE_EXPIRY_ID.to_id();
+
+    let (fees, paid, received) = manager.resolve_expiry_summary(expiry);
+    assert_eq!(fees, 0);
+    assert_eq!(paid, 0);
+    assert_eq!(received, 0);
+
+    destroy(manager);
+    scenario.end();
+}
+
+#[test]
+fun resolve_expiry_summary_returns_recorded_cash_flows_when_no_open_positions() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+    let expiry = FAKE_EXPIRY_ID.to_id();
+
+    manager.record_trading_fee_paid(expiry, FEE_AMOUNT);
+    manager.record_cash_paid_to_expiry(expiry, CASH_PAID);
+    manager.record_cash_received_from_expiry(expiry, CASH_RECEIVED);
+
+    let (fees, paid, received) = manager.resolve_expiry_summary(expiry);
+    assert_eq!(fees, FEE_AMOUNT);
+    assert_eq!(paid, CASH_PAID);
+    assert_eq!(received, CASH_RECEIVED);
+
+    // Summary entry has been removed — second call returns zeros.
+    let (fees_again, paid_again, received_again) = manager.resolve_expiry_summary(expiry);
+    assert_eq!(fees_again, 0);
+    assert_eq!(paid_again, 0);
+    assert_eq!(received_again, 0);
+
+    destroy(manager);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = predict_manager::EExpirySummaryHasOpenPositions)]
+fun resolve_expiry_summary_with_open_positions_aborts() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+    let expiry = FAKE_EXPIRY_ID.to_id();
+
+    manager.add_position(expiry, ORDER_ID_A);
+    let (_, _, _) = manager.resolve_expiry_summary(expiry);
+    abort 999
+}
+
+// === assert_owner ===
+
+#[test]
+fun assert_owner_passes_for_creator() {
+    let (mut scenario, registry_id) = setup();
+    let manager = create_alice_manager(&mut scenario, registry_id);
+
+    // Alice is the manager owner.
+    manager.assert_owner(scenario.ctx());
+
+    destroy(manager);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = predict_manager::ENotOwner)]
+fun assert_owner_aborts_for_non_owner() {
+    let (mut scenario, registry_id) = setup();
+    let manager = create_alice_manager(&mut scenario, registry_id);
+
+    scenario.next_tx(test_constants::bob());
+    manager.assert_owner(scenario.ctx());
+    abort 999
+}

--- a/packages/predict/tests/protocol_config_tests.move
+++ b/packages/predict/tests/protocol_config_tests.move
@@ -1,0 +1,181 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module deepbook_predict::protocol_config_tests;
+
+use deepbook_predict::protocol_config;
+use std::unit_test::destroy;
+
+// === trading_paused / pause_trading ===
+
+#[test]
+fun new_for_testing_is_not_paused() {
+    let ctx = &mut tx_context::dummy();
+    let config = protocol_config::new_for_testing(ctx);
+
+    assert!(!config.trading_paused());
+
+    destroy(config);
+}
+
+#[test]
+fun pause_trading_is_one_way_from_package() {
+    // The package-internal pause_trading is the PauseCap path; it cannot
+    // unpause. Verifies it sets the flag.
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    config.pause_trading();
+    assert!(config.trading_paused());
+    // Calling it again is idempotent.
+    config.pause_trading();
+    assert!(config.trading_paused());
+
+    destroy(config);
+}
+
+#[test]
+fun set_trading_paused_round_trips_both_directions() {
+    // The package-internal set_trading_paused is the admin path; it can flip
+    // either direction.
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    config.set_trading_paused(true);
+    assert!(config.trading_paused());
+    config.set_trading_paused(false);
+    assert!(!config.trading_paused());
+
+    destroy(config);
+}
+
+// === assert_trading_allowed ===
+
+#[test]
+fun assert_trading_allowed_passes_when_not_paused_and_no_valuation() {
+    let ctx = &mut tx_context::dummy();
+    let config = protocol_config::new_for_testing(ctx);
+
+    config.assert_trading_allowed();
+
+    destroy(config);
+}
+
+#[test, expected_failure(abort_code = protocol_config::ETradingPaused)]
+fun assert_trading_allowed_aborts_when_paused() {
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+    config.set_trading_paused(true);
+
+    config.assert_trading_allowed();
+    abort 999
+}
+
+#[test, expected_failure(abort_code = protocol_config::EValuationInProgress)]
+fun assert_trading_allowed_aborts_during_valuation() {
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+    config.begin_valuation();
+
+    config.assert_trading_allowed();
+    abort 999
+}
+
+// === Valuation lock lifecycle ===
+
+#[test]
+fun begin_then_end_valuation_succeeds() {
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    config.begin_valuation();
+    config.assert_valuation_in_progress();
+    config.end_valuation();
+    config.assert_not_valuation_in_progress();
+
+    destroy(config);
+}
+
+#[test, expected_failure(abort_code = protocol_config::EValuationInProgress)]
+fun begin_valuation_twice_aborts() {
+    // The lock is transaction-local; nesting is not allowed.
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+    config.begin_valuation();
+
+    config.begin_valuation();
+    abort 999
+}
+
+#[test, expected_failure(abort_code = protocol_config::EValuationNotInProgress)]
+fun end_valuation_without_begin_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    config.end_valuation();
+    abort 999
+}
+
+#[test, expected_failure(abort_code = protocol_config::EValuationNotInProgress)]
+fun assert_valuation_in_progress_aborts_when_not_held() {
+    let ctx = &mut tx_context::dummy();
+    let config = protocol_config::new_for_testing(ctx);
+
+    config.assert_valuation_in_progress();
+    abort 999
+}
+
+#[test, expected_failure(abort_code = protocol_config::EValuationInProgress)]
+fun assert_not_valuation_in_progress_aborts_when_held() {
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+    config.begin_valuation();
+
+    config.assert_not_valuation_in_progress();
+    abort 999
+}
+
+// === Sub-config getters return stable references ===
+
+#[test]
+fun pricing_config_getter_returns_stable_reference() {
+    // The getters return &PricingConfig / &FeeConfig / etc. — just verify
+    // they're callable and reading them does not abort. The sub-config
+    // contents are tested in their own modules' test files.
+    let ctx = &mut tx_context::dummy();
+    let config = protocol_config::new_for_testing(ctx);
+
+    let _ = config.pricing_config();
+    let _ = config.fee_config();
+    let _ = config.risk_config();
+    let _ = config.market_oracle_config();
+    let _ = config.leverage_config();
+
+    destroy(config);
+}
+
+// === pause_trading interaction with valuation lock ===
+
+#[test, expected_failure(abort_code = protocol_config::EValuationInProgress)]
+fun pause_trading_during_valuation_aborts() {
+    // Even the PauseCap-driven pause must wait for the valuation lock to
+    // clear; otherwise a kill-switch mid-valuation could leave invariants
+    // inconsistent.
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+    config.begin_valuation();
+
+    config.pause_trading();
+    abort 999
+}
+
+#[test, expected_failure(abort_code = protocol_config::EValuationInProgress)]
+fun set_trading_paused_during_valuation_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+    config.begin_valuation();
+
+    config.set_trading_paused(true);
+    abort 999
+}

--- a/packages/predict/tests/registry_create_tests.move
+++ b/packages/predict/tests/registry_create_tests.move
@@ -1,0 +1,157 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module deepbook_predict::registry_create_tests;
+
+use deepbook_predict::{constants, registry, test_constants};
+use std::unit_test::destroy;
+use sui::test_scenario::{Self as test, return_shared};
+
+const PYTH_FEED_BTC: u32 = 100;
+const PYTH_FEED_ETH: u32 = 200;
+const EXPIRY_FEE_WINDOW_DISABLED: u64 = 0;
+const EXPIRY_FEE_MAX_MULTIPLIER_DISABLED: u64 = 1_000_000_000; // 1.0 — sentinel disables ramp
+
+// === create_pyth_source ===
+
+#[test]
+fun create_pyth_source_returns_id_and_registers() {
+    let ctx = &mut tx_context::dummy();
+    let (mut reg, admin_cap) = registry::new_for_testing(ctx);
+
+    let pyth_id = registry::create_pyth_source(
+        &mut reg,
+        &admin_cap,
+        PYTH_FEED_BTC,
+        EXPIRY_FEE_WINDOW_DISABLED,
+        EXPIRY_FEE_MAX_MULTIPLIER_DISABLED,
+        ctx,
+    );
+    let registered = registry::pyth_source_id(&reg, PYTH_FEED_BTC);
+    assert!(registered.is_some());
+    assert!(*registered.borrow() == pyth_id);
+    // Other feed ids must remain unmapped.
+    assert!(registry::pyth_source_id(&reg, PYTH_FEED_ETH).is_none());
+
+    registry::destroy_registry_drop_for_testing(reg);
+    destroy(admin_cap);
+}
+
+#[test]
+fun create_pyth_source_distinct_feeds_yield_distinct_ids() {
+    let ctx = &mut tx_context::dummy();
+    let (mut reg, admin_cap) = registry::new_for_testing(ctx);
+
+    let btc_id = registry::create_pyth_source(
+        &mut reg,
+        &admin_cap,
+        PYTH_FEED_BTC,
+        EXPIRY_FEE_WINDOW_DISABLED,
+        EXPIRY_FEE_MAX_MULTIPLIER_DISABLED,
+        ctx,
+    );
+    let eth_id = registry::create_pyth_source(
+        &mut reg,
+        &admin_cap,
+        PYTH_FEED_ETH,
+        EXPIRY_FEE_WINDOW_DISABLED,
+        EXPIRY_FEE_MAX_MULTIPLIER_DISABLED,
+        ctx,
+    );
+    assert!(btc_id != eth_id);
+
+    registry::destroy_registry_drop_for_testing(reg);
+    destroy(admin_cap);
+}
+
+#[test, expected_failure(abort_code = registry::EPythSourceAlreadyCreated)]
+fun create_pyth_source_duplicate_feed_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let (mut reg, admin_cap) = registry::new_for_testing(ctx);
+
+    registry::create_pyth_source(
+        &mut reg,
+        &admin_cap,
+        PYTH_FEED_BTC,
+        EXPIRY_FEE_WINDOW_DISABLED,
+        EXPIRY_FEE_MAX_MULTIPLIER_DISABLED,
+        ctx,
+    );
+    registry::create_pyth_source(
+        &mut reg,
+        &admin_cap,
+        PYTH_FEED_BTC,
+        EXPIRY_FEE_WINDOW_DISABLED,
+        EXPIRY_FEE_MAX_MULTIPLIER_DISABLED,
+        ctx,
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = registry::EPackageVersionDisabled)]
+fun create_pyth_source_with_current_version_disabled_aborts() {
+    // Admin can disable current_version via the version-management path (which
+    // bypasses the version gate). Subsequent create_pyth_source then fails the
+    // mirrored-version check.
+    let ctx = &mut tx_context::dummy();
+    let (mut reg, admin_cap) = registry::new_for_testing(ctx);
+    let current = constants::current_version!();
+    let next = current + 1;
+    registry::enable_version(&mut reg, &admin_cap, next);
+    registry::disable_version(&mut reg, &admin_cap, current);
+
+    registry::create_pyth_source(
+        &mut reg,
+        &admin_cap,
+        PYTH_FEED_BTC,
+        EXPIRY_FEE_WINDOW_DISABLED,
+        EXPIRY_FEE_MAX_MULTIPLIER_DISABLED,
+        ctx,
+    );
+    abort 999
+}
+
+// === pyth_source_id getter for unknown feed ===
+
+#[test]
+fun pyth_source_id_returns_none_for_unmapped_feed() {
+    let ctx = &mut tx_context::dummy();
+    let (reg, admin_cap) = registry::new_for_testing(ctx);
+
+    assert!(registry::pyth_source_id(&reg, PYTH_FEED_BTC).is_none());
+
+    registry::destroy_registry_for_testing(reg);
+    destroy(admin_cap);
+}
+
+// === create_manager / create_and_share_manager ===
+
+#[test]
+fun create_manager_yields_distinct_objects_per_caller() {
+    // The PredictManager key includes the sender, so two different addresses
+    // can each claim their own derived manager.
+    let mut scenario = test::begin(test_constants::alice());
+    let registry_id = registry::init_for_testing(scenario.ctx());
+
+    scenario.next_tx(test_constants::alice());
+    let mut reg = scenario.take_shared_by_id<registry::Registry>(registry_id);
+    let alice_mgr = registry::create_manager(&mut reg, scenario.ctx());
+    return_shared(reg);
+
+    scenario.next_tx(test_constants::bob());
+    let mut reg = scenario.take_shared_by_id<registry::Registry>(registry_id);
+    let bob_mgr = registry::create_manager(&mut reg, scenario.ctx());
+    return_shared(reg);
+
+    // Different senders produce different derived ids.
+    assert!(object::id(&alice_mgr) != object::id(&bob_mgr));
+
+    destroy(alice_mgr);
+    destroy(bob_mgr);
+    scenario.end();
+}
+
+// create_expiry_market requires PoolVault and is the largest end-to-end
+// constructor in the package. Covered in the PR that adds plp / expiry_market
+// scaffolding (PR 6).

--- a/packages/predict/tests/registry_setters_tests.move
+++ b/packages/predict/tests/registry_setters_tests.move
@@ -1,0 +1,251 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Cover the registry's admin setter surface. Each setter is a thin wrapper
+/// around the corresponding ProtocolConfig (or PythSource) write — so the
+/// tests just verify the value reaches the destination, then read it back
+/// through the sub-config getter.
+#[test_only]
+module deepbook_predict::registry_setters_tests;
+
+use deepbook_predict::{
+    constants::float_scaling as float,
+    fee_config,
+    leverage_config,
+    market_oracle_config,
+    pricing_config,
+    protocol_config,
+    pyth_source,
+    registry,
+    risk_config
+};
+use std::unit_test::{assert_eq, destroy};
+
+// === Pricing config setters ===
+
+#[test]
+fun set_base_fee_forwards_to_pricing_config() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    registry::set_base_fee(&mut config, &admin_cap, 30_000_000);
+    assert_eq!(pricing_config::base_fee(config.pricing_config()), 30_000_000);
+
+    destroy(config);
+    destroy(admin_cap);
+}
+
+#[test]
+fun set_min_fee_forwards_to_pricing_config() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    registry::set_min_fee(&mut config, &admin_cap, 4_000_000);
+    assert_eq!(pricing_config::min_fee(config.pricing_config()), 4_000_000);
+
+    destroy(config);
+    destroy(admin_cap);
+}
+
+#[test]
+fun set_min_and_max_ask_price_forward_to_pricing_config() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    registry::set_min_ask_price(&mut config, &admin_cap, 20_000_000);
+    registry::set_max_ask_price(&mut config, &admin_cap, 980_000_000);
+    assert_eq!(pricing_config::min_ask_price(config.pricing_config()), 20_000_000);
+    assert_eq!(pricing_config::max_ask_price(config.pricing_config()), 980_000_000);
+
+    destroy(config);
+    destroy(admin_cap);
+}
+
+#[test]
+fun set_freshness_setters_forward_to_pricing_config() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    registry::set_pyth_spot_freshness_ms(&mut config, &admin_cap, 5_000);
+    registry::set_block_scholes_prices_freshness_ms(&mut config, &admin_cap, 4_000);
+    registry::set_block_scholes_svi_freshness_ms(&mut config, &admin_cap, 30_000);
+    assert_eq!(pricing_config::pyth_spot_freshness_ms(config.pricing_config()), 5_000);
+    assert_eq!(pricing_config::block_scholes_prices_freshness_ms(config.pricing_config()), 4_000);
+    assert_eq!(pricing_config::block_scholes_svi_freshness_ms(config.pricing_config()), 30_000);
+
+    destroy(config);
+    destroy(admin_cap);
+}
+
+// === Fee config setters ===
+
+#[test]
+fun set_fee_shares_forwards_all_three_to_fee_config() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    registry::set_fee_shares(&mut config, &admin_cap, 700_000_000, 200_000_000, 100_000_000);
+    assert_eq!(fee_config::lp_fee_share(config.fee_config()), 700_000_000);
+    assert_eq!(fee_config::protocol_fee_share(config.fee_config()), 200_000_000);
+    assert_eq!(fee_config::insurance_fee_share(config.fee_config()), 100_000_000);
+
+    destroy(config);
+    destroy(admin_cap);
+}
+
+#[test]
+fun set_template_trading_loss_rebate_rate_forwards_to_fee_config() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    registry::set_template_trading_loss_rebate_rate(&mut config, &admin_cap, 250_000_000);
+    assert_eq!(fee_config::trading_loss_rebate_rate(config.fee_config()), 250_000_000);
+
+    destroy(config);
+    destroy(admin_cap);
+}
+
+// === Risk config setters ===
+
+#[test]
+fun set_max_total_exposure_pct_forwards_to_risk_config() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    registry::set_max_total_exposure_pct(&mut config, &admin_cap, 500_000_000);
+    assert_eq!(risk_config::max_total_exposure_pct(config.risk_config()), 500_000_000);
+
+    destroy(config);
+    destroy(admin_cap);
+}
+
+#[test]
+fun set_expiry_allocation_forwards_to_risk_config() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    registry::set_expiry_allocation(&mut config, &admin_cap, 100_000_000_000);
+    assert_eq!(risk_config::expiry_allocation(config.risk_config()), 100_000_000_000);
+
+    destroy(config);
+    destroy(admin_cap);
+}
+
+#[test]
+fun set_resize_setters_forward_to_risk_config() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    registry::set_grow_utilization_threshold(&mut config, &admin_cap, 900_000_000);
+    registry::set_shrink_utilization_threshold(&mut config, &admin_cap, 200_000_000);
+    registry::set_grow_factor(&mut config, &admin_cap, 3 * float!());
+    registry::set_shrink_factor(&mut config, &admin_cap, 400_000_000);
+
+    assert_eq!(risk_config::grow_utilization_threshold(config.risk_config()), 900_000_000);
+    assert_eq!(risk_config::shrink_utilization_threshold(config.risk_config()), 200_000_000);
+    assert_eq!(risk_config::grow_factor(config.risk_config()), 3 * float!());
+    assert_eq!(risk_config::shrink_factor(config.risk_config()), 400_000_000);
+
+    destroy(config);
+    destroy(admin_cap);
+}
+
+// === Leverage config setter ===
+
+#[test]
+fun set_template_max_expiry_floor_premium_forwards_to_leverage_config() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    registry::set_template_max_expiry_floor_premium(&mut config, &admin_cap, 300_000_000);
+    assert_eq!(leverage_config::max_expiry_floor_premium(config.leverage_config()), 300_000_000);
+
+    destroy(config);
+    destroy(admin_cap);
+}
+
+// === Market oracle template setters ===
+
+#[test]
+fun set_market_oracle_template_settlement_freshness_forwards() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    registry::set_market_oracle_template_settlement_freshness_ms(&mut config, &admin_cap, 5_000);
+    assert_eq!(market_oracle_config::settlement_freshness_ms(config.market_oracle_config()), 5_000);
+
+    destroy(config);
+    destroy(admin_cap);
+}
+
+#[test]
+fun set_market_oracle_template_basis_bounds_forwards_all_four() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    registry::set_market_oracle_template_basis_bounds(
+        &mut config,
+        &admin_cap,
+        50_000_000,
+        60_000_000,
+        950_000_000,
+        1_050_000_000,
+    );
+    assert_eq!(market_oracle_config::max_spot_deviation(config.market_oracle_config()), 50_000_000);
+    assert_eq!(
+        market_oracle_config::max_basis_deviation(config.market_oracle_config()),
+        60_000_000,
+    );
+    assert_eq!(market_oracle_config::min_basis(config.market_oracle_config()), 950_000_000);
+    assert_eq!(market_oracle_config::max_basis(config.market_oracle_config()), 1_050_000_000);
+
+    destroy(config);
+    destroy(admin_cap);
+}
+
+// === trading_paused round-trip ===
+
+#[test]
+fun set_trading_paused_round_trips_through_config_getter() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    assert!(!config.trading_paused());
+    registry::set_trading_paused(&mut config, &admin_cap, true);
+    assert!(config.trading_paused());
+    // Admin can also unpause (unlike PauseCap which is one-way).
+    registry::set_trading_paused(&mut config, &admin_cap, false);
+    assert!(!config.trading_paused());
+
+    destroy(config);
+    destroy(admin_cap);
+}
+
+// === Pyth source expiry-fee setter ===
+
+#[test]
+fun set_pyth_source_expiry_fee_params_forwards_to_pyth() {
+    let ctx = &mut tx_context::dummy();
+    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let mut pyth = pyth_source::new_for_testing(ctx);
+
+    registry::set_pyth_source_expiry_fee_params(&mut pyth, &admin_cap, 3_600_000, 2 * float!());
+    assert_eq!(pyth.expiry_fee_window_ms(), 3_600_000);
+    assert_eq!(pyth.expiry_fee_max_multiplier(), 2 * float!());
+
+    destroy(pyth);
+    destroy(admin_cap);
+}


### PR DESCRIPTION
## Summary
- **Stacked on #1046 (DBU-417).** Covers `market_key/order.move` and the registry surface not already exercised by `pause_tests` / `oracle_cap_tests`.
- Suite grows from **335 → 375 tests, all passing**. +40 net new tests, +1 small `#[test_only]` helper on the source side.

## Key decisions
- **`destroy_registry_drop_for_testing` complements (does not replace) the strict version.** The existing `destroy_registry_for_testing` requires both uniqueness tables to be empty. Useful for tests that just want to confirm "nothing got registered." The new variant drops the tables permissively — needed by any test that exercises `create_pyth_source` (which registers an entry). Both stay so each test can pick the one that matches its post-condition.
- **Setter tests are a deliberate one-liner-per-setter.** Each registry admin setter is a wrapper around a `public(package)` setter on `ProtocolConfig` (or `PythSource`). Bound aborts and cross-field invariants live in the underlying module's tests (#1044, #1046). What's worth testing at the registry level is the delegation: does the value land in the right field? One test per setter that reads it back through the sub-config getter is enough.
- **`create_and_share_manager` is the only `entry fun` skipped.** Entry funs don't return values, so the test would need to take_shared the result and assert on it — straightforward but requires a `test_scenario` and `take_shared<PredictManager>` round trip. `create_manager` (the composable variant) is covered, which exercises the same derived-object path. If reviewers want the entry-fun variant tested too I can add it.
- **`create_expiry_market` is deferred to PR 6.** It needs `PoolVault` (live LP capital allocator) which is the central object of `plp.move`. Building scaffolding for that here and then again in PR 6 would be churn; it's natural to do the full integration once.

## Test plan
- [x] `sui move test --gas-limit 100000000000` in `packages/predict` — 375 tests, 0 failures.
- [x] `bunx prettier-move -c` on all touched files — clean.
- [x] Every `public fun` and `public(package) fun` in `order.move` is exercised, with the documented exceptions of `user_contribution` and `floor_seed_amount` (math-heavy, scipy-anchored snapshots to come in a later PR).
- [x] Every `E*` abort code in `order.move` has an `expected_failure` test with a distinct `abort 999` guard.
- [x] Every admin setter on `registry.move` is exercised. `create_expiry_market` deferred to PR 6 as noted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)