### PR TITLE
DBU-419: Predict tests for protocol_config + predict_manager

### DIFF
--- a/packages/predict/tests/predict_manager_tests.move
+++ b/packages/predict/tests/predict_manager_tests.move
@@ -1,0 +1,407 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module deepbook_predict::predict_manager_tests;
+
+use deepbook_predict::{
+    builder_code,
+    predict_manager::{Self, PredictManager},
+    registry,
+    test_constants
+};
+use dusdc::dusdc::DUSDC;
+use std::unit_test::{assert_eq, destroy};
+use sui::{coin, test_scenario::{Self as test, return_shared}};
+
+const DEPOSIT_AMOUNT: u64 = 1_000_000;
+const WITHDRAW_AMOUNT: u64 = 400_000;
+const FAKE_EXPIRY_ID: address = @0xCAFE;
+const FAKE_EXPIRY_ID_2: address = @0xBABE;
+const ORDER_ID_A: u256 = 42;
+const ORDER_ID_B: u256 = 43;
+const BUILDER_INDEX: u64 = 7;
+const FEE_AMOUNT: u64 = 5_000;
+const CASH_PAID: u64 = 100_000;
+const CASH_RECEIVED: u64 = 60_000;
+
+// === Helpers ===
+
+fun setup(): (test::Scenario, ID) {
+    let mut scenario = test::begin(test_constants::alice());
+    let registry_id = registry::init_for_testing(scenario.ctx());
+    (scenario, registry_id)
+}
+
+fun create_alice_manager(scenario: &mut test::Scenario, registry_id: ID): PredictManager {
+    scenario.next_tx(test_constants::alice());
+    let mut reg = scenario.take_shared_by_id<registry::Registry>(registry_id);
+    let manager = registry::create_manager(&mut reg, scenario.ctx());
+    return_shared(reg);
+    manager
+}
+
+// === id / owner / balance ===
+
+#[test]
+fun fresh_manager_has_alice_owner_and_zero_balance() {
+    let (mut scenario, registry_id) = setup();
+    let manager = create_alice_manager(&mut scenario, registry_id);
+
+    assert_eq!(manager.owner(), test_constants::alice());
+    assert_eq!(manager.balance(), 0);
+
+    destroy(manager);
+    scenario.end();
+}
+
+#[test]
+fun id_is_stable_across_reads() {
+    let (mut scenario, registry_id) = setup();
+    let manager = create_alice_manager(&mut scenario, registry_id);
+
+    assert_eq!(manager.id(), manager.id());
+
+    destroy(manager);
+    scenario.end();
+}
+
+// === deposit / withdraw ===
+
+#[test]
+fun deposit_increases_balance() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+
+    let coin = coin::mint_for_testing<DUSDC>(DEPOSIT_AMOUNT, scenario.ctx());
+    manager.deposit(coin, scenario.ctx());
+    assert_eq!(manager.balance(), DEPOSIT_AMOUNT);
+
+    destroy(manager);
+    scenario.end();
+}
+
+#[test]
+fun withdraw_decreases_balance_and_returns_coin() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+
+    let coin = coin::mint_for_testing<DUSDC>(DEPOSIT_AMOUNT, scenario.ctx());
+    manager.deposit(coin, scenario.ctx());
+
+    let withdrawn = manager.withdraw(WITHDRAW_AMOUNT, scenario.ctx());
+    assert_eq!(withdrawn.value(), WITHDRAW_AMOUNT);
+    assert_eq!(manager.balance(), DEPOSIT_AMOUNT - WITHDRAW_AMOUNT);
+
+    destroy(manager);
+    destroy(withdrawn);
+    scenario.end();
+}
+
+#[test]
+fun deposit_permissionless_works_without_owner_sender() {
+    // deposit_permissionless uses the manager's stored DepositCap so anyone
+    // can credit the manager (used for protocol-driven payouts).
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+
+    scenario.next_tx(test_constants::bob());
+    let coin = coin::mint_for_testing<DUSDC>(DEPOSIT_AMOUNT, scenario.ctx());
+    manager.deposit_permissionless(coin, scenario.ctx());
+    assert_eq!(manager.balance(), DEPOSIT_AMOUNT);
+
+    destroy(manager);
+    scenario.end();
+}
+
+// === share ===
+
+#[test]
+fun share_makes_manager_take_shared() {
+    let (mut scenario, registry_id) = setup();
+    let manager = create_alice_manager(&mut scenario, registry_id);
+    let manager_id = manager.id();
+    manager.share();
+
+    scenario.next_tx(test_constants::alice());
+    let taken = scenario.take_shared_by_id<PredictManager>(manager_id);
+    assert_eq!(taken.id(), manager_id);
+    return_shared(taken);
+
+    scenario.end();
+}
+
+// === builder_code_id setter / unsetter ===
+
+#[test]
+fun builder_code_id_starts_none_then_set_and_unset() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+
+    assert!(manager.builder_code_id().is_none());
+
+    // Alice creates a builder code for herself.
+    let code = builder_code::new_for_testing(
+        test_constants::alice(),
+        BUILDER_INDEX,
+        scenario.ctx(),
+    );
+    manager.set_builder_code(&code, scenario.ctx());
+
+    let stored = manager.builder_code_id();
+    assert!(stored.is_some());
+    assert_eq!(*stored.borrow(), code.id());
+
+    manager.unset_builder_code(scenario.ctx());
+    assert!(manager.builder_code_id().is_none());
+
+    destroy(manager);
+    builder_code::destroy_for_testing(code);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = predict_manager::ENotOwner)]
+fun set_builder_code_by_non_owner_aborts() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+    let code = builder_code::new_for_testing(
+        test_constants::alice(),
+        BUILDER_INDEX,
+        scenario.ctx(),
+    );
+
+    scenario.next_tx(test_constants::bob());
+    manager.set_builder_code(&code, scenario.ctx());
+    abort 999
+}
+
+#[test, expected_failure(abort_code = predict_manager::ENotOwner)]
+fun unset_builder_code_by_non_owner_aborts() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+
+    scenario.next_tx(test_constants::bob());
+    manager.unset_builder_code(scenario.ctx());
+    abort 999
+}
+
+// === Position bookkeeping ===
+
+#[test]
+fun has_position_returns_false_for_unknown_position() {
+    let (mut scenario, registry_id) = setup();
+    let manager = create_alice_manager(&mut scenario, registry_id);
+
+    assert!(!manager.has_position(FAKE_EXPIRY_ID.to_id(), ORDER_ID_A));
+
+    destroy(manager);
+    scenario.end();
+}
+
+#[test]
+fun add_position_then_remove_round_trip() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+    let expiry = FAKE_EXPIRY_ID.to_id();
+
+    manager.add_position(expiry, ORDER_ID_A);
+    assert!(manager.has_position(expiry, ORDER_ID_A));
+    assert_eq!(manager.expiry_position_count(expiry), 1);
+
+    manager.add_position(expiry, ORDER_ID_B);
+    assert_eq!(manager.expiry_position_count(expiry), 2);
+
+    manager.remove_position(expiry, ORDER_ID_A);
+    assert!(!manager.has_position(expiry, ORDER_ID_A));
+    assert_eq!(manager.expiry_position_count(expiry), 1);
+    // The other position is unchanged.
+    assert!(manager.has_position(expiry, ORDER_ID_B));
+
+    manager.remove_position(expiry, ORDER_ID_B);
+
+    destroy(manager);
+    scenario.end();
+}
+
+#[test]
+fun positions_are_scoped_per_expiry() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+    let expiry_a = FAKE_EXPIRY_ID.to_id();
+    let expiry_b = FAKE_EXPIRY_ID_2.to_id();
+
+    // Same order_id under two different expiries is two distinct positions.
+    manager.add_position(expiry_a, ORDER_ID_A);
+    manager.add_position(expiry_b, ORDER_ID_A);
+
+    assert!(manager.has_position(expiry_a, ORDER_ID_A));
+    assert!(manager.has_position(expiry_b, ORDER_ID_A));
+    assert_eq!(manager.expiry_position_count(expiry_a), 1);
+    assert_eq!(manager.expiry_position_count(expiry_b), 1);
+
+    destroy(manager);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = predict_manager::EPositionAlreadyExists)]
+fun add_position_duplicate_aborts() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+
+    manager.add_position(FAKE_EXPIRY_ID.to_id(), ORDER_ID_A);
+    manager.add_position(FAKE_EXPIRY_ID.to_id(), ORDER_ID_A);
+    abort 999
+}
+
+#[test, expected_failure(abort_code = predict_manager::EInsufficientPosition)]
+fun remove_position_that_does_not_exist_aborts() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+
+    manager.remove_position(FAKE_EXPIRY_ID.to_id(), ORDER_ID_A);
+    abort 999
+}
+
+#[test]
+fun expiry_position_count_unknown_expiry_returns_zero() {
+    let (mut scenario, registry_id) = setup();
+    let manager = create_alice_manager(&mut scenario, registry_id);
+
+    assert_eq!(manager.expiry_position_count(FAKE_EXPIRY_ID.to_id()), 0);
+
+    destroy(manager);
+    scenario.end();
+}
+
+// === Cash flow recording ===
+
+#[test]
+fun record_helpers_accumulate_per_expiry() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+    let expiry = FAKE_EXPIRY_ID.to_id();
+
+    manager.record_trading_fee_paid(expiry, FEE_AMOUNT);
+    manager.record_trading_fee_paid(expiry, FEE_AMOUNT);
+    manager.record_cash_paid_to_expiry(expiry, CASH_PAID);
+    manager.record_cash_received_from_expiry(expiry, CASH_RECEIVED);
+
+    assert_eq!(manager.trading_fees_paid(expiry), 2 * FEE_AMOUNT);
+    assert_eq!(manager.cash_paid_to_expiry(expiry), CASH_PAID);
+    assert_eq!(manager.cash_received_from_expiry(expiry), CASH_RECEIVED);
+
+    destroy(manager);
+    scenario.end();
+}
+
+#[test]
+fun record_helpers_zero_amount_is_no_op() {
+    // The record_* helpers short-circuit on amount == 0 and do not even
+    // ensure the expiry summary exists. The getters then return 0 from
+    // the unknown-expiry fallback.
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+    let expiry = FAKE_EXPIRY_ID.to_id();
+
+    manager.record_trading_fee_paid(expiry, 0);
+    manager.record_cash_paid_to_expiry(expiry, 0);
+    manager.record_cash_received_from_expiry(expiry, 0);
+
+    assert_eq!(manager.trading_fees_paid(expiry), 0);
+    assert_eq!(manager.cash_paid_to_expiry(expiry), 0);
+    assert_eq!(manager.cash_received_from_expiry(expiry), 0);
+
+    destroy(manager);
+    scenario.end();
+}
+
+#[test]
+fun getters_return_zero_for_unknown_expiry() {
+    let (mut scenario, registry_id) = setup();
+    let manager = create_alice_manager(&mut scenario, registry_id);
+    let expiry = FAKE_EXPIRY_ID.to_id();
+
+    assert_eq!(manager.trading_fees_paid(expiry), 0);
+    assert_eq!(manager.cash_paid_to_expiry(expiry), 0);
+    assert_eq!(manager.cash_received_from_expiry(expiry), 0);
+
+    destroy(manager);
+    scenario.end();
+}
+
+// === resolve_expiry_summary ===
+
+#[test]
+fun resolve_expiry_summary_returns_zeros_for_untouched_expiry() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+    let expiry = FAKE_EXPIRY_ID.to_id();
+
+    let (fees, paid, received) = manager.resolve_expiry_summary(expiry);
+    assert_eq!(fees, 0);
+    assert_eq!(paid, 0);
+    assert_eq!(received, 0);
+
+    destroy(manager);
+    scenario.end();
+}
+
+#[test]
+fun resolve_expiry_summary_returns_recorded_cash_flows_when_no_open_positions() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+    let expiry = FAKE_EXPIRY_ID.to_id();
+
+    manager.record_trading_fee_paid(expiry, FEE_AMOUNT);
+    manager.record_cash_paid_to_expiry(expiry, CASH_PAID);
+    manager.record_cash_received_from_expiry(expiry, CASH_RECEIVED);
+
+    let (fees, paid, received) = manager.resolve_expiry_summary(expiry);
+    assert_eq!(fees, FEE_AMOUNT);
+    assert_eq!(paid, CASH_PAID);
+    assert_eq!(received, CASH_RECEIVED);
+
+    // Summary entry has been removed — second call returns zeros.
+    let (fees_again, paid_again, received_again) = manager.resolve_expiry_summary(expiry);
+    assert_eq!(fees_again, 0);
+    assert_eq!(paid_again, 0);
+    assert_eq!(received_again, 0);
+
+    destroy(manager);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = predict_manager::EExpirySummaryHasOpenPositions)]
+fun resolve_expiry_summary_with_open_positions_aborts() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+    let expiry = FAKE_EXPIRY_ID.to_id();
+
+    manager.add_position(expiry, ORDER_ID_A);
+    let (_, _, _) = manager.resolve_expiry_summary(expiry);
+    abort 999
+}
+
+// === assert_owner ===
+
+#[test]
+fun assert_owner_passes_for_creator() {
+    let (mut scenario, registry_id) = setup();
+    let manager = create_alice_manager(&mut scenario, registry_id);
+
+    // Alice is the manager owner.
+    manager.assert_owner(scenario.ctx());
+
+    destroy(manager);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = predict_manager::ENotOwner)]
+fun assert_owner_aborts_for_non_owner() {
+    let (mut scenario, registry_id) = setup();
+    let manager = create_alice_manager(&mut scenario, registry_id);
+
+    scenario.next_tx(test_constants::bob());
+    manager.assert_owner(scenario.ctx());
+    abort 999
+}

--- a/packages/predict/tests/protocol_config_tests.move
+++ b/packages/predict/tests/protocol_config_tests.move
@@ -1,0 +1,181 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module deepbook_predict::protocol_config_tests;
+
+use deepbook_predict::protocol_config;
+use std::unit_test::destroy;
+
+// === trading_paused / pause_trading ===
+
+#[test]
+fun new_for_testing_is_not_paused() {
+    let ctx = &mut tx_context::dummy();
+    let config = protocol_config::new_for_testing(ctx);
+
+    assert!(!config.trading_paused());
+
+    destroy(config);
+}
+
+#[test]
+fun pause_trading_is_one_way_from_package() {
+    // The package-internal pause_trading is the PauseCap path; it cannot
+    // unpause. Verifies it sets the flag.
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    config.pause_trading();
+    assert!(config.trading_paused());
+    // Calling it again is idempotent.
+    config.pause_trading();
+    assert!(config.trading_paused());
+
+    destroy(config);
+}
+
+#[test]
+fun set_trading_paused_round_trips_both_directions() {
+    // The package-internal set_trading_paused is the admin path; it can flip
+    // either direction.
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    config.set_trading_paused(true);
+    assert!(config.trading_paused());
+    config.set_trading_paused(false);
+    assert!(!config.trading_paused());
+
+    destroy(config);
+}
+
+// === assert_trading_allowed ===
+
+#[test]
+fun assert_trading_allowed_passes_when_not_paused_and_no_valuation() {
+    let ctx = &mut tx_context::dummy();
+    let config = protocol_config::new_for_testing(ctx);
+
+    config.assert_trading_allowed();
+
+    destroy(config);
+}
+
+#[test, expected_failure(abort_code = protocol_config::ETradingPaused)]
+fun assert_trading_allowed_aborts_when_paused() {
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+    config.set_trading_paused(true);
+
+    config.assert_trading_allowed();
+    abort 999
+}
+
+#[test, expected_failure(abort_code = protocol_config::EValuationInProgress)]
+fun assert_trading_allowed_aborts_during_valuation() {
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+    config.begin_valuation();
+
+    config.assert_trading_allowed();
+    abort 999
+}
+
+// === Valuation lock lifecycle ===
+
+#[test]
+fun begin_then_end_valuation_succeeds() {
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    config.begin_valuation();
+    config.assert_valuation_in_progress();
+    config.end_valuation();
+    config.assert_not_valuation_in_progress();
+
+    destroy(config);
+}
+
+#[test, expected_failure(abort_code = protocol_config::EValuationInProgress)]
+fun begin_valuation_twice_aborts() {
+    // The lock is transaction-local; nesting is not allowed.
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+    config.begin_valuation();
+
+    config.begin_valuation();
+    abort 999
+}
+
+#[test, expected_failure(abort_code = protocol_config::EValuationNotInProgress)]
+fun end_valuation_without_begin_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+
+    config.end_valuation();
+    abort 999
+}
+
+#[test, expected_failure(abort_code = protocol_config::EValuationNotInProgress)]
+fun assert_valuation_in_progress_aborts_when_not_held() {
+    let ctx = &mut tx_context::dummy();
+    let config = protocol_config::new_for_testing(ctx);
+
+    config.assert_valuation_in_progress();
+    abort 999
+}
+
+#[test, expected_failure(abort_code = protocol_config::EValuationInProgress)]
+fun assert_not_valuation_in_progress_aborts_when_held() {
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+    config.begin_valuation();
+
+    config.assert_not_valuation_in_progress();
+    abort 999
+}
+
+// === Sub-config getters return stable references ===
+
+#[test]
+fun pricing_config_getter_returns_stable_reference() {
+    // The getters return &PricingConfig / &FeeConfig / etc. — just verify
+    // they're callable and reading them does not abort. The sub-config
+    // contents are tested in their own modules' test files.
+    let ctx = &mut tx_context::dummy();
+    let config = protocol_config::new_for_testing(ctx);
+
+    let _ = config.pricing_config();
+    let _ = config.fee_config();
+    let _ = config.risk_config();
+    let _ = config.market_oracle_config();
+    let _ = config.leverage_config();
+
+    destroy(config);
+}
+
+// === pause_trading interaction with valuation lock ===
+
+#[test, expected_failure(abort_code = protocol_config::EValuationInProgress)]
+fun pause_trading_during_valuation_aborts() {
+    // Even the PauseCap-driven pause must wait for the valuation lock to
+    // clear; otherwise a kill-switch mid-valuation could leave invariants
+    // inconsistent.
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+    config.begin_valuation();
+
+    config.pause_trading();
+    abort 999
+}
+
+#[test, expected_failure(abort_code = protocol_config::EValuationInProgress)]
+fun set_trading_paused_during_valuation_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let mut config = protocol_config::new_for_testing(ctx);
+    config.begin_valuation();
+
+    config.set_trading_paused(true);
+    abort 999
+}


### PR DESCRIPTION
## Summary
- **Stacked on #1047 (DBU-418).** Covers `protocol_config.move` and `predict_manager.move`. The remaining two core modules (`expiry_market.move` 785 lines, `plp.move` 543 lines) are large enough each to warrant their own PR — splitting them out of this one keeps blast radius manageable.
- Suite grows from **375 → 412 tests, all passing**. +37 net new tests. No source-side changes.

## Key decisions
- **Scope explicitly does not include `expiry_market` or `plp`.** Each is the central object of a multi-step trading flow that needs MarketOracle + PythSource + PoolVault + PredictManager + Clock + DUSDC coins + valid SVI data all wired together. Doing that scaffolding inside this PR would have produced a thousand-line test file that mixes unrelated coverage. Following the pattern from earlier PRs, the integration coverage will come in dedicated follow-up PRs once the existing helpers are settled.
- **`protocol_config` tests are mostly about the valuation lock + pause interaction.** The setter delegations to sub-configs are already covered in #1044 (config modules) and #1047 (registry setters). What's *not* covered there is the valuation lock lifecycle and the rule that even the PauseCap-driven `pause_trading` is blocked during a valuation. Both are exercised here.
- **`predict_manager` tests cover the package-internal bookkeeping API too** because `expiry_market` and `plp` will call those methods in PR-N+1; pinning the contracts now means the integration tests can lean on assertions about `expiry_position_count` / `trading_fees_paid` / `cash_*_expiry` without re-establishing them. Includes the `(lower, higher]` per-expiry scoping (same `order_id` can exist under two expiries), `record_*` short-circuit on amount = 0, and `resolve_expiry_summary` removing the entry on success.

## Test plan
- [x] `sui move test --gas-limit 100000000000` in `packages/predict` — 412 tests, 0 failures.
- [x] `bunx prettier-move -c` on all touched files — clean.
- [x] Every `public fun` and `public(package) fun` in both modules is called by at least one test, with the documented exception of `create_and_share` on `protocol_config` (exercised transitively via `registry::init_for_testing`).
- [x] Every `E*` abort code in both modules has an `expected_failure` test with a distinct `abort 999` guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)