### PR TITLE
predict: store leverage multipliers directly

### DIFF
--- a/packages/predict/LEVERAGE.md
+++ b/packages/predict/LEVERAGE.md
@@ -96,7 +96,7 @@ terms:
 
 - opened timestamp
 - lower and upper strike indices
-- leverage code
+- fixed-point leverage multiplier
 - entry probability
 - quantity
 - expiry-local sequence

--- a/packages/predict/sources/market_key/order.move
+++ b/packages/predict/sources/market_key/order.move
@@ -4,11 +4,12 @@
 /// Immutable contract terms encoded in a Predict order ID.
 ///
 /// An `Order` represents the contract sold to a user: a range, entry
-/// probability, quantity, leverage code, and original open time. Leverage changes
-/// the contract's deterministic floor schedule; 1x is the special case where the
-/// floor is zero and the behavior looks like a plain range payout. The packed ID
-/// is the single source of truth at protocol boundaries, while concrete strike
-/// grids and floor-index timing are interpreted by `StrikeExposure`.
+/// probability, quantity, fixed-point leverage multiplier, and original open
+/// time. Leverage changes the contract's deterministic floor schedule; 1x is the
+/// special case where the floor is zero and the behavior looks like a plain range
+/// payout. The packed ID is the single source of truth at protocol boundaries,
+/// while concrete strike grids and floor-index timing are interpreted by
+/// `StrikeExposure`.
 module deepbook_predict::order;
 
 use deepbook::math as deepbook_math;
@@ -23,25 +24,24 @@ const EInvalidQuantity: u64 = 5;
 const EInvalidSequence: u64 = 6;
 const EInvalidEntryProbability: u64 = 7;
 
-const OPENED_AT_OFFSET: u8 = 160;
-const MIN_STRIKE_INDEX_OFFSET: u8 = 136;
-const MAX_STRIKE_INDEX_OFFSET: u8 = 112;
+const OPENED_AT_OFFSET: u8 = 184;
+const MIN_STRIKE_INDEX_OFFSET: u8 = 160;
+const MAX_STRIKE_INDEX_OFFSET: u8 = 136;
 const LEVERAGE_OFFSET: u8 = 104;
 const ENTRY_PROBABILITY_OFFSET: u8 = 72;
 const QUANTITY_LOTS_OFFSET: u8 = 40;
-const ORDER_ID_BITS: u8 = 208;
+const ORDER_ID_BITS: u8 = 232;
 
-const U8_MASK: u256 = (1u256 << 8) - 1;
 const U24_MASK: u256 = (1u256 << 24) - 1;
 const U32_MASK: u256 = (1u256 << 32) - 1;
 const U40_MASK: u256 = (1u256 << 40) - 1;
 const U48_MASK: u256 = (1u256 << 48) - 1;
 
-const LEVERAGE_ONE_X: u64 = 0;
-const LEVERAGE_ONE_AND_HALF_X: u64 = 1;
-const LEVERAGE_TWO_X: u64 = 2;
-const LEVERAGE_TWO_AND_HALF_X: u64 = 3;
-const LEVERAGE_THREE_X: u64 = 4;
+const LEVERAGE_ONE_X: u64 = 1_000_000_000;
+const LEVERAGE_ONE_AND_HALF_X: u64 = 1_500_000_000;
+const LEVERAGE_TWO_X: u64 = 2_000_000_000;
+const LEVERAGE_TWO_AND_HALF_X: u64 = 2_500_000_000;
+const LEVERAGE_THREE_X: u64 = 3_000_000_000;
 
 /// Validated typed view over one packed Predict order ID.
 public struct Order has copy, drop {
@@ -50,27 +50,27 @@ public struct Order has copy, drop {
 
 // === Public Functions ===
 
-/// Return the leverage code for a 1x position.
+/// Return the 1e9-scaled leverage multiplier for a 1x position.
 public fun leverage_one_x(): u64 {
     LEVERAGE_ONE_X
 }
 
-/// Return the leverage code for a 1.5x position.
+/// Return the 1e9-scaled leverage multiplier for a 1.5x position.
 public fun leverage_one_and_half_x(): u64 {
     LEVERAGE_ONE_AND_HALF_X
 }
 
-/// Return the leverage code for a 2x position.
+/// Return the 1e9-scaled leverage multiplier for a 2x position.
 public fun leverage_two_x(): u64 {
     LEVERAGE_TWO_X
 }
 
-/// Return the leverage code for a 2.5x position.
+/// Return the 1e9-scaled leverage multiplier for a 2.5x position.
 public fun leverage_two_and_half_x(): u64 {
     LEVERAGE_TWO_AND_HALF_X
 }
 
-/// Return the leverage code for a 3x position.
+/// Return the 1e9-scaled leverage multiplier for a 3x position.
 public fun leverage_three_x(): u64 {
     LEVERAGE_THREE_X
 }
@@ -102,9 +102,9 @@ public fun max_strike_index(order: &Order): u64 {
     decode_u24(order.id, MAX_STRIKE_INDEX_OFFSET)
 }
 
-/// Return the leverage code encoded in this order.
+/// Return the 1e9-scaled leverage multiplier encoded in this order.
 public fun leverage(order: &Order): u64 {
-    decode_u8(order.id, LEVERAGE_OFFSET)
+    decode_u32(order.id, LEVERAGE_OFFSET)
 }
 
 /// Return the 1e9-scaled raw range probability encoded at order entry.
@@ -180,7 +180,7 @@ public(package) fun is_leveraged(order: &Order): bool {
     order.leverage() != LEVERAGE_ONE_X
 }
 
-/// Return user contribution, rounded up so leverage never exceeds its code.
+/// Return user contribution, rounded up so effective leverage never exceeds the multiplier.
 public(package) fun user_contribution(order: &Order): u64 {
     user_contribution_from_exposure_value(order.entry_exposure_value(), order.leverage())
 }
@@ -222,10 +222,6 @@ fun new(
 
 // === Private Functions ===
 
-fun decode_u8(id: u256, offset: u8): u64 {
-    ((id >> offset) & U8_MASK) as u64
-}
-
 fun decode_u24(id: u256, offset: u8): u64 {
     ((id >> offset) & U24_MASK) as u64
 }
@@ -252,16 +248,8 @@ fun assert_valid(order: &Order) {
 }
 
 fun user_contribution_from_exposure_value(exposure_value: u64, leverage: u64): u64 {
-    math::mul_div_round_up(
-        exposure_value,
-        constants::float_scaling!(),
-        leverage_multiplier(leverage),
-    )
-}
-
-fun leverage_multiplier(leverage: u64): u64 {
     assert_valid_leverage(leverage);
-    constants::float_scaling!() + leverage * constants::float_scaling!() / 2
+    math::mul_div_round_up(exposure_value, constants::float_scaling!(), leverage)
 }
 
 fun entry_exposure_value(order: &Order): u64 {
@@ -269,7 +257,14 @@ fun entry_exposure_value(order: &Order): u64 {
 }
 
 fun assert_valid_leverage(leverage: u64) {
-    assert!(leverage <= LEVERAGE_THREE_X, EInvalidLeverage);
+    assert!(
+        leverage == LEVERAGE_ONE_X
+            || leverage == LEVERAGE_ONE_AND_HALF_X
+            || leverage == LEVERAGE_TWO_X
+            || leverage == LEVERAGE_TWO_AND_HALF_X
+            || leverage == LEVERAGE_THREE_X,
+        EInvalidLeverage,
+    );
 }
 
 fun assert_valid_order_shape(min_strike_index: u64, max_strike_index: u64, leverage: u64) {

--- a/packages/predict/tests/market_key/order_tests.move
+++ b/packages/predict/tests/market_key/order_tests.move
@@ -27,12 +27,15 @@ fun leverage_constants_are_distinct_and_ordered() {
     let l25 = order::leverage_two_and_half_x();
     let l3 = order::leverage_three_x();
 
-    assert_eq!(l1, 0);
+    assert_eq!(l1, constants::float_scaling!());
     assert!(l1 < l15);
+    assert_eq!(l15, constants::float_scaling!() + constants::float_scaling!() / 2);
     assert!(l15 < l2);
+    assert_eq!(l2, 2 * constants::float_scaling!());
     assert!(l2 < l25);
+    assert_eq!(l25, 2 * constants::float_scaling!() + constants::float_scaling!() / 2);
     assert!(l25 < l3);
-    assert_eq!(l3, 4);
+    assert_eq!(l3, 3 * constants::float_scaling!());
 }
 
 // === open_strike_index sentinel ===
@@ -210,6 +213,20 @@ fun new_leverage_above_three_x_aborts() {
     abort 999
 }
 
+#[test, expected_failure(abort_code = order::EInvalidLeverage)]
+fun new_unsupported_leverage_multiplier_aborts() {
+    order::new_from_strike_indices(
+        OPENED_AT_MS,
+        STRIKE_INDEX_LO,
+        STRIKE_INDEX_HI,
+        order::leverage_one_x() + 1,
+        0,
+        ONE_LOT_QTY,
+        0,
+    );
+    abort 999
+}
+
 #[test, expected_failure(abort_code = order::EInvalidStrikeRange)]
 fun new_swapped_finite_strike_range_aborts() {
     // Both sides finite -> require min < max strictly.
@@ -274,8 +291,8 @@ fun new_sequence_above_u40_aborts() {
 
 #[test, expected_failure(abort_code = order::EInvalidOrderId)]
 fun from_order_id_with_bits_above_payload_aborts() {
-    // Setting any bit above ORDER_ID_BITS=208 must be rejected.
-    let bad_id: u256 = 1u256 << 208;
+    // Setting any bit above ORDER_ID_BITS=232 must be rejected.
+    let bad_id: u256 = 1u256 << 232;
     order::from_order_id(bad_id);
     abort 999
 }


### PR DESCRIPTION
## Summary
- Store Predict order leverage as direct 1e9-scaled multipliers instead of half-step codes.
- Widen the packed order leverage field from 8 bits to 32 bits and update the order payload width.
- Update leverage docs and order tests to cover supported multiplier values and reject unsupported in-between multipliers.

## Key decisions
- Supported leverage choices are unchanged: 1x, 1.5x, 2x, 2.5x, and 3x.
- This intentionally changes the packed order ID format so the order terms are easier to read and less error-prone while leverage economics are still in review.

## Test plan
- [x] `sui move test --path packages/predict order_tests --gas-limit 100000000000`
- [x] `sui move test --path packages/predict --gas-limit 100000000000`
- [x] `sui move build --path packages/predict`
- [x] `git diff --check`
