### PR TITLE
Refactor Predict pool accounting

### DIFF
--- a/packages/predict/simulations/README.md
+++ b/packages/predict/simulations/README.md
@@ -212,7 +212,7 @@ Full localnet runs can produce:
 - `artifacts/chart_vault_pnl_fee_coverage.png`: cumulative fees, net
   liquidation, and live pre-terminal MTM risk-compensation mark.
 - `artifacts/chart_vault_risk_profile.png`: PnL, fees, liquidation losses, and
-  backlog normalized against allocated capital and active liability.
+  backlog normalized against expiry funding and active liability.
 - `artifacts/chart_liquidation_coverage.png`: normalized backlog pressure and
   liquidated value by passive trigger.
 - `artifacts/chart_liquidation_execution_quality.png`: liquidation execution
@@ -256,13 +256,13 @@ mirror, then use the long Python run for economic tuning.
 
 ## Derived Data
 
-`python_derived.json` uses schema `predict_derived_v1`. It is Python-only and is
+`python_derived.json` uses schema `predict_derived_v2`. It is Python-only and is
 never compared against localnet.
 
 Important fields:
 
-- `valuation.lp_live_mtm_pnl`: LP cash above the initial expiry allocation plus
-  LP fee surplus, minus current live position liability.
+- `valuation.lp_live_mtm_pnl`: active expiry value after pending protocol-profit
+  exclusion, minus current expiry funding basis.
 - `valuation.active_book_live_pnl`: open-order contribution minus current live
   liability.
 - `flows.trading_fee`: trading fee collected in that transaction.
@@ -283,14 +283,13 @@ Important fields:
   only mint/redeem passive flows.
 - `scan_active_count` is sampled before that transaction's liquidation pass, so
   `scan_coverage` uses the same denominator the scanner saw.
-- `risk.allocated_capital`: current capital allocated from the vault into the
-  expiry.
-- `risk.position_liability_over_allocated`: live liability divided by allocated
-  capital.
-- `risk.lp_live_mtm_pnl_over_allocated`: live LP MTM PnL divided by allocated
-  capital.
-- `risk.active_book_live_pnl_over_allocated`: active open-book PnL divided by
-  allocated capital.
+- `risk.expiry_funding_basis`: current net pool funding basis for the expiry.
+- `risk.position_liability_over_funding`: live liability divided by expiry
+  funding basis.
+- `risk.lp_live_mtm_pnl_over_funding`: live LP MTM PnL divided by expiry
+  funding basis.
+- `risk.active_book_live_pnl_over_funding`: active open-book PnL divided by
+  expiry funding basis.
 - `risk.liquidatable_value_over_liability`: standing liquidatable floor value
   divided by live liability.
 
@@ -311,8 +310,9 @@ Important fields:
   defaults, admin setup, fee policy, liquidation policy, or settlement
   assumptions change, update the Python mirror and this config in the same PR.
   Localnet does not run admin setters for every mirrored protocol field; fields
-  such as liquidation budgets, fee shares, LTV, and floor premium should remain
-  equal to Move defaults unless the localnet setup is intentionally extended.
+  such as liquidation budgets, protocol reserve fee share, LTV, and floor
+  premium should remain equal to Move defaults unless the localnet setup is
+  intentionally extended.
   Small fixed pricing defaults are intentionally mirrored manually in
   `python_replay.py` to keep the harness lightweight.
 - Keep raw long-run data temporary by default. Use
@@ -329,9 +329,9 @@ Important fields:
   settlement inputs used by the long Python replay. If Move defaults, admin
   setup, fee-ramp policy, liquidation policy, capital sizing, or settlement
   assumptions change, update this file at the same time.
-- Long-run capital sizing is intentionally allowed to exceed the current
-  on-chain per-expiry allocation bound. It is an off-chain scale-up for Python
-  economic analysis, not a deployable allocation policy.
+- Long-run vault and manager seeds can be larger than normal mode, but initial
+  expiry funding stays at the protocol cash floor unless the simulator adds an
+  existing protocol top-up flow.
 - Full localnet replay can be gas-heavy when supply/withdraw valuation finds a
   liquidation backlog. The runner default transaction gas budget is currently
   `1_000_000_000` MIST.

--- a/packages/predict/simulations/README.md
+++ b/packages/predict/simulations/README.md
@@ -310,7 +310,7 @@ Important fields:
   defaults, admin setup, fee policy, liquidation policy, or settlement
   assumptions change, update the Python mirror and this config in the same PR.
   Localnet does not run admin setters for every mirrored protocol field; fields
-  such as liquidation budgets, protocol reserve fee share, LTV, and floor
+  such as liquidation budgets, protocol reserve profit share, LTV, and floor
   premium should remain equal to Move defaults unless the localnet setup is
   intentionally extended.
   Small fixed pricing defaults are intentionally mirrored manually in

--- a/packages/predict/simulations/README.md
+++ b/packages/predict/simulations/README.md
@@ -229,13 +229,18 @@ canonical live economics for the same generated CSV rows: oracle refreshes,
 mints, redeems, passive liquidations, supply, withdraw, normalized event fields,
 and tracked state deltas.
 
+Live pool-sync sweeps increase aggregate pricing credits but do not materialize
+protocol profit. Protocol reserves move only when terminal expiry accounting
+materializes profit after that expiry's terminal losses and watermarks are
+applied.
+
 The long Python replay intentionally extends that validated live mirror with
 features the localnet runner cannot model practically: exact replay timestamps,
 real expiry/settlement inputs from `data/scenario_config.json`, exact-time
 fee-ramp economics, and direct terminal closeout. The parity path assumes the
-localnet manager has no active stake and therefore no terminal trading-loss
-rebate. The long Python closeout intentionally applies the full eligible
-trading-loss rebate to the manager as a worst-case vault-risk assumption. Use
+localnet manager has no active stake and therefore no terminal rebate payout.
+The long Python closeout intentionally applies the full eligible rebate after
+the protocol's gross-profit offset as a worst-case vault-risk assumption. Use
 long-run outputs for tuning with this boundary in mind: parity validates the
 shared live transaction engine; Python-specific assertions guard the extra
 terminal analysis layer.
@@ -284,6 +289,8 @@ Important fields:
 - `scan_active_count` is sampled before that transaction's liquidation pass, so
   `scan_coverage` uses the same denominator the scanner saw.
 - `risk.expiry_funding_basis`: current net pool funding basis for the expiry.
+  This starts at zero after market creation and rises only when PLP pool sync
+  sends cash into the expiry; it falls when that same expiry returns cash.
 - `risk.position_liability_over_funding`: live liability divided by expiry
   funding basis.
 - `risk.lp_live_mtm_pnl_over_funding`: live LP MTM PnL divided by expiry
@@ -329,9 +336,9 @@ Important fields:
   settlement inputs used by the long Python replay. If Move defaults, admin
   setup, fee-ramp policy, liquidation policy, capital sizing, or settlement
   assumptions change, update this file at the same time.
-- Long-run vault and manager seeds can be larger than normal mode, but initial
-  expiry funding stays at the protocol cash floor unless the simulator adds an
-  existing protocol top-up flow.
+- Long-run vault and manager seeds can be larger than normal mode, but expiry
+  cash starts at zero and reaches the protocol cash floor only through existing
+  PLP pool-sync rebalancing.
 - Full localnet replay can be gas-heavy when supply/withdraw valuation finds a
   liquidation backlog. The runner default transaction gas budget is currently
   `1_000_000_000` MIST.

--- a/packages/predict/simulations/charts/chart_vault_risk_profile.py
+++ b/packages/predict/simulations/charts/chart_vault_risk_profile.py
@@ -39,17 +39,17 @@ def append_scaled(series: dict[str, list[float]], x_key: str, y_key: str, x: flo
 def extract_series(records: list[dict[str, Any]], mode: str, origin: int) -> dict[str, list[float]]:
     series: dict[str, list[float]] = {
         "capital_x": [],
-        "liability_over_allocated": [],
+        "liability_over_funding": [],
         "contribution_x": [],
-        "contribution_over_allocated": [],
+        "contribution_over_funding": [],
         "pnl_x": [],
-        "lp_pnl_over_allocated": [],
+        "lp_pnl_over_funding": [],
         "book_pnl_x": [],
-        "book_pnl_over_allocated": [],
+        "book_pnl_over_funding": [],
         "comp_x": [],
-        "cumulative_trading_fee_over_allocated": [],
-        "cumulative_liquidation_gap_over_allocated": [],
-        "cumulative_net_liquidation_over_allocated": [],
+        "cumulative_trading_fee_over_funding": [],
+        "cumulative_liquidation_gap_over_funding": [],
+        "cumulative_net_liquidation_over_funding": [],
         "backlog_x": [],
         "backlog_over_liability": [],
     }
@@ -68,30 +68,30 @@ def extract_series(records: list[dict[str, Any]], mode: str, origin: int) -> dic
         append_scaled(
             series,
             "capital_x",
-            "liability_over_allocated",
+            "liability_over_funding",
             x,
-            risk.get("position_liability_over_allocated"),
+            risk.get("position_liability_over_funding"),
         )
         append_scaled(
             series,
             "contribution_x",
-            "contribution_over_allocated",
+            "contribution_over_funding",
             x,
-            risk.get("active_open_contribution_over_allocated"),
+            risk.get("active_open_contribution_over_funding"),
         )
         append_scaled(
             series,
             "pnl_x",
-            "lp_pnl_over_allocated",
+            "lp_pnl_over_funding",
             x,
-            risk.get("lp_live_mtm_pnl_over_allocated"),
+            risk.get("lp_live_mtm_pnl_over_funding"),
         )
         append_scaled(
             series,
             "book_pnl_x",
-            "book_pnl_over_allocated",
+            "book_pnl_over_funding",
             x,
-            active_book_pnl_over_allocated(record),
+            active_book_pnl_over_funding(record),
         )
         append_scaled(
             series,
@@ -101,35 +101,35 @@ def extract_series(records: list[dict[str, Any]], mode: str, origin: int) -> dic
             risk.get("liquidatable_value_over_liability"),
         )
 
-        allocated = int_or_none(risk.get("allocated_capital"))
-        if allocated is None or allocated <= 0:
+        funding = int_or_none(risk.get("expiry_funding_basis"))
+        if funding is None or funding <= 0:
             continue
-        trading_ratio = scaled_ratio(cumulative_trading_fee, allocated)
-        gap_ratio = scaled_ratio(cumulative_liquidation_gap, allocated)
+        trading_ratio = scaled_ratio(cumulative_trading_fee, funding)
+        gap_ratio = scaled_ratio(cumulative_liquidation_gap, funding)
         net_liquidation_ratio = scaled_ratio(
             cumulative_liquidation_surplus - cumulative_liquidation_gap,
-            allocated,
+            funding,
         )
         if trading_ratio is None or gap_ratio is None or net_liquidation_ratio is None:
             continue
         series["comp_x"].append(x)
-        series["cumulative_trading_fee_over_allocated"].append(pct_from_scaled(trading_ratio))
-        series["cumulative_liquidation_gap_over_allocated"].append(pct_from_scaled(gap_ratio))
-        series["cumulative_net_liquidation_over_allocated"].append(pct_from_scaled(net_liquidation_ratio))
+        series["cumulative_trading_fee_over_funding"].append(pct_from_scaled(trading_ratio))
+        series["cumulative_liquidation_gap_over_funding"].append(pct_from_scaled(gap_ratio))
+        series["cumulative_net_liquidation_over_funding"].append(pct_from_scaled(net_liquidation_ratio))
 
     return series
 
 
-def active_book_pnl_over_allocated(record: dict[str, Any]) -> int | None:
+def active_book_pnl_over_funding(record: dict[str, Any]) -> int | None:
     risk = record.get("risk", {})
-    existing = int_or_none(risk.get("active_book_live_pnl_over_allocated"))
+    existing = int_or_none(risk.get("active_book_live_pnl_over_funding"))
     if existing is not None:
         return existing
-    allocated = int_or_none(risk.get("allocated_capital"))
+    funding = int_or_none(risk.get("expiry_funding_basis"))
     active_book_pnl = int_or_none(record.get("valuation", {}).get("active_book_live_pnl"))
-    if allocated is None or active_book_pnl is None:
+    if funding is None or active_book_pnl is None:
         return None
-    return scaled_ratio(active_book_pnl, allocated)
+    return scaled_ratio(active_book_pnl, funding)
 
 
 def use_percent_axis(ax: plt.Axes) -> None:
@@ -140,25 +140,25 @@ def use_percent_axis(ax: plt.Axes) -> None:
 def plot_capital_panel(ax: plt.Axes, series: dict[str, list[float]]) -> None:
     ax.plot(
         series["capital_x"],
-        series["liability_over_allocated"],
+        series["liability_over_funding"],
         color="#2563eb",
         linewidth=1.6,
-        label="position liability / allocated capital",
+        label="position liability / expiry funding",
     )
     ax.plot(
         series["contribution_x"],
-        series["contribution_over_allocated"],
+        series["contribution_over_funding"],
         color="#0891b2",
         linewidth=1.4,
-        label="open contribution / allocated capital",
+        label="open contribution / expiry funding",
     )
     ax.set_title(
         "Capital Utilization\n"
-        "Shows how much allocated counterparty capital is represented by current live liability and trader contribution.",
+        "Shows how much expiry funding is represented by current live liability and trader contribution.",
         loc="left",
         fontsize=11,
     )
-    ax.set_ylabel("share of allocation")
+    ax.set_ylabel("share of funding")
     use_percent_axis(ax)
     ax.legend(loc="upper left", ncols=2, fontsize=8, frameon=False)
 
@@ -166,22 +166,22 @@ def plot_capital_panel(ax: plt.Axes, series: dict[str, list[float]]) -> None:
 def plot_return_panel(ax: plt.Axes, series: dict[str, list[float]]) -> None:
     ax.plot(
         series["pnl_x"],
-        series["lp_pnl_over_allocated"],
+        series["lp_pnl_over_funding"],
         color="#9333ea",
         linewidth=1.7,
-        label="LP MTM PnL / allocated capital",
+        label="LP MTM PnL / expiry funding",
     )
     ax.plot(
         series["book_pnl_x"],
-        series["book_pnl_over_allocated"],
+        series["book_pnl_over_funding"],
         color="#059669",
         linewidth=1.4,
-        label="active book PnL / allocated capital",
+        label="active book PnL / expiry funding",
     )
     ax.axhline(0, color="#64748b", linewidth=0.8)
     ax.set_title(
         "Risk-Normalized Return\n"
-        "Compares live vault PnL and open-book PnL against the same allocated-capital denominator.",
+        "Compares live vault PnL and open-book PnL against the same expiry-funding denominator.",
         loc="left",
         fontsize=11,
     )
@@ -193,33 +193,33 @@ def plot_return_panel(ax: plt.Axes, series: dict[str, list[float]]) -> None:
 def plot_compensation_panel(ax: plt.Axes, series: dict[str, list[float]]) -> None:
     ax.plot(
         series["comp_x"],
-        series["cumulative_trading_fee_over_allocated"],
+        series["cumulative_trading_fee_over_funding"],
         color="#2563eb",
         linewidth=1.4,
-        label="cumulative trading fees / allocation",
+        label="cumulative trading fees / funding",
     )
     ax.plot(
         series["comp_x"],
-        series["cumulative_liquidation_gap_over_allocated"],
+        series["cumulative_liquidation_gap_over_funding"],
         color="#dc2626",
         linewidth=1.4,
-        label="cumulative bad debt / allocation",
+        label="cumulative bad debt / funding",
     )
     ax.plot(
         series["comp_x"],
-        series["cumulative_net_liquidation_over_allocated"],
+        series["cumulative_net_liquidation_over_funding"],
         color="#059669",
         linewidth=1.6,
-        label="cumulative net liquidation / allocation",
+        label="cumulative net liquidation / funding",
     )
     ax.axhline(0, color="#64748b", linewidth=0.8)
     ax.set_title(
         "Fees And Liquidation Results On Capital\n"
-        "Normalizes cumulative trading fees, bad debt, and net liquidation surplus against allocated counterparty capital.",
+        "Normalizes cumulative trading fees, bad debt, and net liquidation surplus against expiry funding.",
         loc="left",
         fontsize=11,
     )
-    ax.set_ylabel("share of allocation")
+    ax.set_ylabel("share of funding")
     use_percent_axis(ax)
     ax.legend(loc="upper left", ncols=3, fontsize=8, frameon=False)
 

--- a/packages/predict/simulations/data/generate_scenario.py
+++ b/packages/predict/simulations/data/generate_scenario.py
@@ -93,7 +93,7 @@ class Generator:
         self.lp_amounts: dict[str, int] = {}
         self.withdrawable_lp_refs: list[str] = []
         self.manager_balance = replay.MANAGER_SEED
-        self.vault_idle_balance = replay.VAULT_SEED - replay.INITIAL_EXPIRY_ALLOCATION
+        self.vault_idle_balance = replay.VAULT_SEED - replay.INITIAL_EXPIRY_FUNDING
         self.next_order = 1
         self.next_lp = 1
 

--- a/packages/predict/simulations/data/generate_scenario.py
+++ b/packages/predict/simulations/data/generate_scenario.py
@@ -93,7 +93,7 @@ class Generator:
         self.lp_amounts: dict[str, int] = {}
         self.withdrawable_lp_refs: list[str] = []
         self.manager_balance = replay.MANAGER_SEED
-        self.vault_idle_balance = replay.VAULT_SEED - replay.INITIAL_EXPIRY_FUNDING
+        self.vault_idle_balance = replay.VAULT_SEED
         self.next_order = 1
         self.next_lp = 1
 

--- a/packages/predict/simulations/data/scenario_config.json
+++ b/packages/predict/simulations/data/scenario_config.json
@@ -8,12 +8,12 @@
     "normal": {
       "manager_seed": "500000000000",
       "vault_seed": "500000000000",
-      "initial_expiry_allocation": "50000000000"
+      "initial_expiry_funding": "50000000000"
     },
     "long": {
       "manager_seed": "5000000000000",
       "vault_seed": "5000000000000",
-      "initial_expiry_allocation": "500000000000"
+      "initial_expiry_funding": "50000000000"
     }
   },
   "generation": {
@@ -31,9 +31,7 @@
     "valuation_liquidation_budget": "192",
     "liquidation_head_scan_divisor": "3",
     "curve_samples": "50",
-    "lp_fee_share": "600000000",
-    "protocol_fee_share": "200000000",
-    "insurance_fee_share": "200000000",
+    "protocol_reserve_fee_share": "400000000",
     "trading_loss_rebate_rate": "500000000",
     "expiry_fee_window_ms": "86400000",
     "expiry_fee_max_multiplier": "2000000000",

--- a/packages/predict/simulations/data/scenario_config.json
+++ b/packages/predict/simulations/data/scenario_config.json
@@ -7,13 +7,11 @@
   "capital": {
     "normal": {
       "manager_seed": "500000000000",
-      "vault_seed": "500000000000",
-      "initial_expiry_funding": "50000000000"
+      "vault_seed": "500000000000"
     },
     "long": {
       "manager_seed": "5000000000000",
-      "vault_seed": "5000000000000",
-      "initial_expiry_funding": "50000000000"
+      "vault_seed": "5000000000000"
     }
   },
   "generation": {

--- a/packages/predict/simulations/data/scenario_config.json
+++ b/packages/predict/simulations/data/scenario_config.json
@@ -31,7 +31,7 @@
     "valuation_liquidation_budget": "192",
     "liquidation_head_scan_divisor": "3",
     "curve_samples": "50",
-    "protocol_reserve_fee_share": "400000000",
+    "protocol_reserve_profit_share": "400000000",
     "trading_loss_rebate_rate": "500000000",
     "expiry_fee_window_ms": "86400000",
     "expiry_fee_max_multiplier": "2000000000",

--- a/packages/predict/simulations/docs/ANALYSIS_NOTES.md
+++ b/packages/predict/simulations/docs/ANALYSIS_NOTES.md
@@ -77,27 +77,26 @@ skews became large exposure skews.
 `chart_market_overview.png` uses live pre-terminal vault PnL:
 
 ```text
-expiry LP cash - initial allocation + LP fee surplus - current live position liability
+active expiry value - pending protocol profit exclusion - expiry funding basis
 ```
 
 Fees and realized cash movements are included, but the chart is still a live
 mark. It can fall sharply when liability reprices faster than fees accumulate.
 
-In `may29-1738`, the hour 19-20 drop was mostly liability repricing:
+In the old split-balance `may29-1738` run, the hour 19-20 drop was mostly
+liability repricing:
 
 ```text
 hour 19:
 spot: 74177.91
 position liability: 65031.68 DUSDC
-cash above allocation: 66688.65 DUSDC
-fee surplus: 9170.46 DUSDC
+expiry value above funding basis: 75859.11 DUSDC
 LP MTM PnL: 10827.42 DUSDC
 
 hour 20:
 spot: 73147.74
 position liability: 158460.90 DUSDC
-cash above allocation: 69510.65 DUSDC
-fee surplus: 9886.08 DUSDC
+expiry value above funding basis: 79396.73 DUSDC
 LP MTM PnL: -79064.17 DUSDC
 ```
 
@@ -187,7 +186,7 @@ Key questions for the larger framework:
 - Does independent flow create persistent directional imbalance in expectation?
 - How often does spend-sized random flow generate one-sided open exposure before
   large market moves?
-- Are fees sufficient relative to tail drawdown on allocated capital?
+- Are fees sufficient relative to tail drawdown on expiry funding?
 - Should the protocol charge direction/skew-sensitive fees?
 - Should the vault enforce directional exposure limits, not just aggregate risk
   limits?

--- a/packages/predict/simulations/python_replay.py
+++ b/packages/predict/simulations/python_replay.py
@@ -21,8 +21,8 @@ from python_indexes.strike_payout_tree import StrikePayoutTree
 
 FLOAT_SCALING = 1_000_000_000
 POSITION_LOT_SIZE = 10_000
-ECONOMIC_SCHEMA_VERSION = "predict_economic_v1"
-DERIVED_SCHEMA_VERSION = "predict_derived_v1"
+ECONOMIC_SCHEMA_VERSION = "predict_economic_v2"
+DERIVED_SCHEMA_VERSION = "predict_derived_v2"
 DEFAULT_SCENARIO_CONFIG_PATH = Path(__file__).with_name("data") / "scenario_config.json"
 ORACLE_REFRESH_FIELDS = (
     "spot",
@@ -51,15 +51,13 @@ POS_INF_STRIKE = (1 << 64) - 1
 DUSDC_DECIMALS = 1_000_000
 VAULT_SEED = 500_000 * DUSDC_DECIMALS
 MANAGER_SEED = 500_000 * DUSDC_DECIMALS
-INITIAL_EXPIRY_ALLOCATION = 50_000 * DUSDC_DECIMALS
+INITIAL_EXPIRY_FUNDING = 50_000 * DUSDC_DECIMALS
 INITIAL_TOTAL_PLP_SUPPLY = VAULT_SEED
 TRADE_LIQUIDATION_BUDGET = 24
 VALUATION_LIQUIDATION_BUDGET = 192
 LIQUIDATION_HEAD_SCAN_DIVISOR = 3
 CURVE_SAMPLES = 50
-LP_FEE_SHARE = 600_000_000
-PROTOCOL_FEE_SHARE = 200_000_000
-INSURANCE_FEE_SHARE = 200_000_000
+PROTOCOL_RESERVE_FEE_SHARE = 400_000_000
 TRADING_LOSS_REBATE_RATE = 500_000_000
 TERMINAL_REBATE_FRACTION = 0
 EXPIRY_FEE_WINDOW_MS = 0
@@ -139,15 +137,13 @@ def _capital_int(config: dict[str, Any], mode: str, key: str, default: int) -> i
 def apply_scenario_config(config: dict[str, Any], long_run: bool = False) -> None:
     global VAULT_SEED
     global MANAGER_SEED
-    global INITIAL_EXPIRY_ALLOCATION
+    global INITIAL_EXPIRY_FUNDING
     global INITIAL_TOTAL_PLP_SUPPLY
     global TRADE_LIQUIDATION_BUDGET
     global VALUATION_LIQUIDATION_BUDGET
     global LIQUIDATION_HEAD_SCAN_DIVISOR
     global CURVE_SAMPLES
-    global LP_FEE_SHARE
-    global PROTOCOL_FEE_SHARE
-    global INSURANCE_FEE_SHARE
+    global PROTOCOL_RESERVE_FEE_SHARE
     global TRADING_LOSS_REBATE_RATE
     global TERMINAL_REBATE_FRACTION
     global EXPIRY_FEE_WINDOW_MS
@@ -160,14 +156,14 @@ def apply_scenario_config(config: dict[str, Any], long_run: bool = False) -> Non
     capital_mode = "long" if long_run else "normal"
     VAULT_SEED = _capital_int(config, capital_mode, "vault_seed", VAULT_SEED)
     MANAGER_SEED = _capital_int(config, capital_mode, "manager_seed", MANAGER_SEED)
-    INITIAL_EXPIRY_ALLOCATION = _capital_int(
+    INITIAL_EXPIRY_FUNDING = _capital_int(
         config,
         capital_mode,
-        "initial_expiry_allocation",
-        INITIAL_EXPIRY_ALLOCATION,
+        "initial_expiry_funding",
+        INITIAL_EXPIRY_FUNDING,
     )
-    if INITIAL_EXPIRY_ALLOCATION > VAULT_SEED:
-        raise ValueError(f"{capital_mode} initial_expiry_allocation exceeds vault_seed")
+    if INITIAL_EXPIRY_FUNDING > VAULT_SEED:
+        raise ValueError(f"{capital_mode} initial_expiry_funding exceeds vault_seed")
     INITIAL_TOTAL_PLP_SUPPLY = VAULT_SEED
 
     TRADE_LIQUIDATION_BUDGET = _config_int(config, "protocol", "trade_liquidation_budget", TRADE_LIQUIDATION_BUDGET)
@@ -184,9 +180,12 @@ def apply_scenario_config(config: dict[str, Any], long_run: bool = False) -> Non
         LIQUIDATION_HEAD_SCAN_DIVISOR,
     )
     CURVE_SAMPLES = _config_int(config, "protocol", "curve_samples", CURVE_SAMPLES)
-    LP_FEE_SHARE = _config_int(config, "protocol", "lp_fee_share", LP_FEE_SHARE)
-    PROTOCOL_FEE_SHARE = _config_int(config, "protocol", "protocol_fee_share", PROTOCOL_FEE_SHARE)
-    INSURANCE_FEE_SHARE = _config_int(config, "protocol", "insurance_fee_share", INSURANCE_FEE_SHARE)
+    PROTOCOL_RESERVE_FEE_SHARE = _config_int(
+        config,
+        "protocol",
+        "protocol_reserve_fee_share",
+        PROTOCOL_RESERVE_FEE_SHARE,
+    )
     TRADING_LOSS_REBATE_RATE = _config_int(
         config,
         "protocol",
@@ -1144,13 +1143,20 @@ def compute_pool_value(
     if position_liability is None:
         position_liability = live_position_liability(model, curve)
     rebate_reserve = deepbook_mul(state["expiry_unresolved_trading_fees"], TRADING_LOSS_REBATE_RATE)
-    if state["expiry_lp_cash"] < position_liability:
-        raise ValueError("valuation exceeds LP cash")
-    if state["expiry_fee_balance"] < rebate_reserve:
-        raise ValueError("fee balance below rebate reserve")
-    position_value = state["expiry_lp_cash"] - position_liability
-    lp_fee_surplus = deepbook_mul(state["expiry_fee_balance"] - rebate_reserve, LP_FEE_SHARE)
-    return state["vault_idle_balance"] + position_value + lp_fee_surplus
+    reserved_cash = position_liability + rebate_reserve
+    if state["expiry_cash_balance"] < reserved_cash:
+        raise ValueError("valuation exceeds expiry cash")
+    active_expiry_value = state["expiry_cash_balance"] - reserved_cash
+    pending_protocol_profit = pending_protocol_profit_exclusion(state, active_expiry_value)
+    return state["vault_idle_balance"] + active_expiry_value - pending_protocol_profit
+
+
+def pending_protocol_profit_exclusion(state: dict[str, int], active_expiry_value: int) -> int:
+    aggregate_credits = state["profit_basis_credits"] + active_expiry_value
+    aggregate_debits = state["profit_basis_debits"]
+    if aggregate_credits <= aggregate_debits:
+        return 0
+    return deepbook_mul(aggregate_credits - aggregate_debits, PROTOCOL_RESERVE_FEE_SHARE)
 
 
 def expiry_fee_multiplier(time_to_expiry_ms: int | None) -> int:
@@ -1187,11 +1193,12 @@ def assert_mint_fee_rate(probability: int, time_to_expiry_ms: int | None = None)
 def initial_state() -> dict[str, int]:
     return {
         "manager_balance": MANAGER_SEED,
-        "expiry_lp_cash": INITIAL_EXPIRY_ALLOCATION,
-        "expiry_fee_balance": 0,
+        "expiry_cash_balance": INITIAL_EXPIRY_FUNDING,
         "expiry_unresolved_trading_fees": 0,
-        "vault_idle_balance": VAULT_SEED - INITIAL_EXPIRY_ALLOCATION,
-        "vault_total_allocated": INITIAL_EXPIRY_ALLOCATION,
+        "vault_idle_balance": VAULT_SEED - INITIAL_EXPIRY_FUNDING,
+        "vault_protocol_reserve_balance": 0,
+        "profit_basis_debits": INITIAL_EXPIRY_FUNDING,
+        "profit_basis_credits": 0,
         "vault_total_plp_supply": INITIAL_TOTAL_PLP_SUPPLY,
         "open_order_count": 0,
         "open_order_quantity": 0,
@@ -1314,8 +1321,7 @@ def apply_update(state: dict[str, int], update: dict[str, str]) -> None:
         builder_fee = int(update["builder_fee"])
         quantity = int(update["quantity"])
         state["manager_balance"] -= contribution + trading_fee + builder_fee
-        state["expiry_lp_cash"] += contribution
-        state["expiry_fee_balance"] += trading_fee
+        state["expiry_cash_balance"] += contribution + trading_fee
         state["expiry_unresolved_trading_fees"] += trading_fee
         state["open_order_count"] += 1
         state["open_order_quantity"] += quantity
@@ -1331,8 +1337,8 @@ def apply_update(state: dict[str, int], update: dict[str, str]) -> None:
         quantity_closed = int(update["quantity_closed"])
         remaining_quantity = int(update["remaining_quantity"])
         state["manager_balance"] += redeem_amount - trading_fee - builder_fee
-        state["expiry_lp_cash"] -= redeem_amount
-        state["expiry_fee_balance"] += trading_fee
+        state["expiry_cash_balance"] -= redeem_amount
+        state["expiry_cash_balance"] += trading_fee
         state["expiry_unresolved_trading_fees"] += trading_fee
         state["open_order_quantity"] -= quantity_closed
         if remaining_quantity == 0:
@@ -1343,12 +1349,11 @@ def apply_update(state: dict[str, int], update: dict[str, str]) -> None:
         payout = int(update["payout_amount"])
         quantity_closed = int(update["quantity_closed"])
         state["manager_balance"] += payout
-        state["expiry_lp_cash"] -= payout
+        state["expiry_cash_balance"] -= payout
         state["open_order_count"] -= 1
         state["open_order_quantity"] -= quantity_closed
     elif update["type"] in ("pool_supply", "pool_withdraw"):
         state["vault_idle_balance"] = int(update["idle_balance_after"])
-        state["vault_total_allocated"] = int(update["total_allocated_after"])
         state["vault_total_plp_supply"] = int(update["total_supply_after"])
 
 
@@ -1579,7 +1584,6 @@ def supply_update(
         "pool_value_before": str(pool_value),
         "total_supply_after": str(total_supply + shares),
         "idle_balance_after": str(state["vault_idle_balance"] + row["amount"]),
-        "total_allocated_after": str(state["vault_total_allocated"]),
     }
 
 
@@ -1608,7 +1612,6 @@ def withdraw_update(
         "pool_value_before": str(pool_value),
         "total_supply_after": str(total_supply - shares),
         "idle_balance_after": str(state["vault_idle_balance"] - payout),
-        "total_allocated_after": str(state["vault_total_allocated"]),
     }
 
 
@@ -1666,10 +1669,8 @@ def reset_terminal_model(model: dict[str, Any]) -> None:
 
 def assert_terminal_state_closed(state: dict[str, int]) -> None:
     expected_zero = (
-        "expiry_lp_cash",
-        "expiry_fee_balance",
+        "expiry_cash_balance",
         "expiry_unresolved_trading_fees",
-        "vault_total_allocated",
         "open_order_count",
         "open_order_quantity",
         "liquidated_order_count",
@@ -1706,34 +1707,43 @@ def terminal_closeout_update(
     indexed_payout = model["payout"].settled_payout_liability(settlement_price)
     if indexed_payout != settled_payout:
         raise ValueError(f"terminal payout index drifted: indexed={indexed_payout} scanned={settled_payout}")
-    if settled_payout > state["expiry_lp_cash"]:
-        raise ValueError("terminal payout exceeds expiry LP cash")
+    if settled_payout > state["expiry_cash_balance"]:
+        raise ValueError("terminal payout exceeds expiry cash")
 
     state["manager_balance"] += settled_payout
-    state["expiry_lp_cash"] -= settled_payout
+    state["expiry_cash_balance"] -= settled_payout
     manager_summary["cash_received_from_expiry"] += settled_payout
 
     trading_loss = max(0, manager_summary["cash_paid_to_expiry"] - manager_summary["cash_received_from_expiry"])
-    max_rebate = deepbook_mul(manager_summary["trading_fee_paid"], TRADING_LOSS_REBATE_RATE)
-    eligible_rebate = min(trading_loss, max_rebate, state["expiry_fee_balance"])
+    trading_fees_paid = manager_summary["trading_fee_paid"]
+    if trading_fees_paid > state["expiry_unresolved_trading_fees"]:
+        raise ValueError("terminal trading fee basis exceeds unresolved trading fees")
+    max_rebate = deepbook_mul(trading_fees_paid, TRADING_LOSS_REBATE_RATE)
+    eligible_rebate = min(trading_loss, max_rebate)
     trading_loss_rebate = deepbook_mul(eligible_rebate, TERMINAL_REBATE_FRACTION)
-    trading_loss_rebate_to_lp = eligible_rebate - trading_loss_rebate
+    if trading_loss_rebate > state["expiry_cash_balance"]:
+        raise ValueError("terminal rebate exceeds expiry cash")
+    trading_loss_unpaid_rebate = eligible_rebate - trading_loss_rebate
     state["manager_balance"] += trading_loss_rebate
-    state["expiry_fee_balance"] -= eligible_rebate
-    state["expiry_lp_cash"] += trading_loss_rebate_to_lp
+    state["expiry_cash_balance"] -= trading_loss_rebate
+    state["expiry_unresolved_trading_fees"] -= trading_fees_paid
 
-    fee_surplus = state["expiry_fee_balance"]
-    protocol_fee_surplus = deepbook_mul(fee_surplus, PROTOCOL_FEE_SHARE)
-    insurance_fee_surplus = deepbook_mul(fee_surplus, INSURANCE_FEE_SHARE)
-    lp_fee_surplus = fee_surplus - protocol_fee_surplus - insurance_fee_surplus
-    returned_lp_cash = state["expiry_lp_cash"]
-    allocated_reduction = state["vault_total_allocated"]
+    returned_cash = state["expiry_cash_balance"]
+    state["expiry_cash_balance"] = 0
+    state["vault_idle_balance"] += returned_cash
+    state["profit_basis_credits"] += returned_cash
 
-    state["vault_idle_balance"] += returned_lp_cash + lp_fee_surplus
-    state["vault_total_allocated"] = 0
-    state["expiry_lp_cash"] = 0
-    state["expiry_fee_balance"] = 0
-    state["expiry_unresolved_trading_fees"] = 0
+    materialized_profit = 0
+    protocol_profit = 0
+    lp_profit = 0
+    if state["profit_basis_credits"] > state["profit_basis_debits"]:
+        materialized_profit = state["profit_basis_credits"] - state["profit_basis_debits"]
+        protocol_profit = deepbook_mul(materialized_profit, PROTOCOL_RESERVE_FEE_SHARE)
+        lp_profit = materialized_profit - protocol_profit
+        state["profit_basis_debits"] = state["profit_basis_credits"]
+        state["vault_idle_balance"] -= protocol_profit
+        state["vault_protocol_reserve_balance"] += protocol_profit
+
     state["open_order_count"] = 0
     state["open_order_quantity"] = 0
     state["liquidated_order_count"] = 0
@@ -1758,18 +1768,17 @@ def terminal_closeout_update(
         "trading_loss_eligible_rebate": str(eligible_rebate),
         "trading_loss_rebate_fraction": str(TERMINAL_REBATE_FRACTION),
         "trading_loss_rebate": str(trading_loss_rebate),
-        "trading_loss_rebate_to_lp": str(trading_loss_rebate_to_lp),
-        "returned_lp_cash": str(returned_lp_cash),
-        "fee_surplus": str(fee_surplus),
-        "fee_surplus_to_lp": str(lp_fee_surplus),
-        "fee_surplus_to_protocol": str(protocol_fee_surplus),
-        "fee_surplus_to_insurance": str(insurance_fee_surplus),
-        "allocated_reduction": str(allocated_reduction),
+        "trading_loss_unpaid_rebate": str(trading_loss_unpaid_rebate),
+        "returned_cash": str(returned_cash),
+        "materialized_profit": str(materialized_profit),
+        "lp_profit": str(lp_profit),
+        "protocol_profit": str(protocol_profit),
         "manager_balance_after": str(state["manager_balance"]),
         "vault_idle_balance_after": str(state["vault_idle_balance"]),
-        "vault_total_allocated_after": str(state["vault_total_allocated"]),
-        "expiry_lp_cash_after": str(state["expiry_lp_cash"]),
-        "expiry_fee_balance_after": str(state["expiry_fee_balance"]),
+        "vault_protocol_reserve_balance_after": str(state["vault_protocol_reserve_balance"]),
+        "profit_basis_debits_after": str(state["profit_basis_debits"]),
+        "profit_basis_credits_after": str(state["profit_basis_credits"]),
+        "expiry_cash_balance_after": str(state["expiry_cash_balance"]),
         "expiry_unresolved_trading_fees_after": str(state["expiry_unresolved_trading_fees"]),
         "open_order_count_after": str(state["open_order_count"]),
         "liquidated_order_count_after": str(state["liquidated_order_count"]),
@@ -2104,7 +2113,13 @@ def build_derived_record(
         except ValueError:
             vault_value = None
     rebate_reserve = deepbook_mul(state["expiry_unresolved_trading_fees"], TRADING_LOSS_REBATE_RATE)
-    fee_surplus = deepbook_mul(max(0, state["expiry_fee_balance"] - rebate_reserve), LP_FEE_SHARE)
+    active_expiry_value = None
+    pending_protocol_profit = None
+    if liability is not None:
+        reserved_cash = liability + rebate_reserve
+        if state["expiry_cash_balance"] >= reserved_cash:
+            active_expiry_value = state["expiry_cash_balance"] - reserved_cash
+            pending_protocol_profit = pending_protocol_profit_exclusion(state, active_expiry_value)
 
     liquidation_observability: dict[str, Any] | None = None
     liquidatable_count: int | None = None
@@ -2188,16 +2203,20 @@ def build_derived_record(
             "withdraw": 0,
         }
 
-    allocated_capital = state["vault_total_allocated"]
-    lp_live_mtm_pnl = None if liability is None else state["expiry_lp_cash"] - INITIAL_EXPIRY_ALLOCATION + fee_surplus - liability
-    active_book_live_pnl = None if liability is None else active_contribution - liability
-    position_liability_over_allocated = None if liability is None else ratio_scaled(liability, allocated_capital)
-    active_open_contribution_over_allocated = ratio_scaled(active_contribution, allocated_capital)
-    lp_live_mtm_pnl_over_allocated = (
-        None if lp_live_mtm_pnl is None else signed_ratio_scaled(lp_live_mtm_pnl, allocated_capital)
+    expiry_funding_basis = max(0, state["profit_basis_debits"] - state["profit_basis_credits"])
+    lp_live_mtm_pnl = (
+        None
+        if active_expiry_value is None or pending_protocol_profit is None
+        else active_expiry_value - pending_protocol_profit - expiry_funding_basis
     )
-    active_book_live_pnl_over_allocated = (
-        None if active_book_live_pnl is None else signed_ratio_scaled(active_book_live_pnl, allocated_capital)
+    active_book_live_pnl = None if liability is None else active_contribution - liability
+    position_liability_over_funding = None if liability is None else ratio_scaled(liability, expiry_funding_basis)
+    active_open_contribution_over_funding = ratio_scaled(active_contribution, expiry_funding_basis)
+    lp_live_mtm_pnl_over_funding = (
+        None if lp_live_mtm_pnl is None else signed_ratio_scaled(lp_live_mtm_pnl, expiry_funding_basis)
+    )
+    active_book_live_pnl_over_funding = (
+        None if active_book_live_pnl is None else signed_ratio_scaled(active_book_live_pnl, expiry_funding_basis)
     )
     active_book_live_pnl_over_liability = (
         None if active_book_live_pnl is None or liability is None else signed_ratio_scaled(active_book_live_pnl, liability)
@@ -2205,9 +2224,9 @@ def build_derived_record(
     liquidatable_value_over_liability = (
         None if liquidatable_value is None or liability is None else ratio_scaled(liquidatable_value, liability)
     )
-    step_trading_fee_over_allocated = ratio_scaled(trading_fee, allocated_capital)
-    step_liquidation_gap_over_allocated = ratio_scaled(liquidation_gap, allocated_capital)
-    step_net_liquidation_over_allocated = signed_ratio_scaled(liquidation_surplus - liquidation_gap, allocated_capital)
+    step_trading_fee_over_funding = ratio_scaled(trading_fee, expiry_funding_basis)
+    step_liquidation_gap_over_funding = ratio_scaled(liquidation_gap, expiry_funding_basis)
+    step_net_liquidation_over_funding = signed_ratio_scaled(liquidation_surplus - liquidation_gap, expiry_funding_basis)
 
     return {
         "step": row["step"],
@@ -2219,9 +2238,11 @@ def build_derived_record(
             "vault_value": None if vault_value is None else str(vault_value),
             "total_plp_supply": str(state["vault_total_plp_supply"]),
             "idle": str(state["vault_idle_balance"]),
-            "position_value": None if liability is None else str(state["expiry_lp_cash"] - liability),
+            "expiry_cash_balance": str(state["expiry_cash_balance"]),
+            "active_expiry_value": None if active_expiry_value is None else str(active_expiry_value),
             "position_liability": None if liability is None else str(liability),
-            "lp_fee_surplus": str(fee_surplus),
+            "rebate_reserve": str(rebate_reserve),
+            "pending_protocol_profit": None if pending_protocol_profit is None else str(pending_protocol_profit),
             "active_open_contribution": str(active_contribution),
             "lp_live_mtm_pnl": None if lp_live_mtm_pnl is None else str(lp_live_mtm_pnl),
             "active_book_live_pnl": None if active_book_live_pnl is None else str(active_book_live_pnl),
@@ -2276,36 +2297,36 @@ def build_derived_record(
             "sampled": sampled_global,
         },
         "risk": {
-            "allocated_capital": str(allocated_capital),
+            "expiry_funding_basis": str(expiry_funding_basis),
             "open_order_quantity": str(state["open_order_quantity"]),
             "active_leveraged_count": str(active_count),
-            "position_liability_over_allocated": None
-            if position_liability_over_allocated is None
-            else str(position_liability_over_allocated),
-            "active_open_contribution_over_allocated": None
-            if active_open_contribution_over_allocated is None
-            else str(active_open_contribution_over_allocated),
-            "lp_live_mtm_pnl_over_allocated": None
-            if lp_live_mtm_pnl_over_allocated is None
-            else str(lp_live_mtm_pnl_over_allocated),
-            "active_book_live_pnl_over_allocated": None
-            if active_book_live_pnl_over_allocated is None
-            else str(active_book_live_pnl_over_allocated),
+            "position_liability_over_funding": None
+            if position_liability_over_funding is None
+            else str(position_liability_over_funding),
+            "active_open_contribution_over_funding": None
+            if active_open_contribution_over_funding is None
+            else str(active_open_contribution_over_funding),
+            "lp_live_mtm_pnl_over_funding": None
+            if lp_live_mtm_pnl_over_funding is None
+            else str(lp_live_mtm_pnl_over_funding),
+            "active_book_live_pnl_over_funding": None
+            if active_book_live_pnl_over_funding is None
+            else str(active_book_live_pnl_over_funding),
             "active_book_live_pnl_over_liability": None
             if active_book_live_pnl_over_liability is None
             else str(active_book_live_pnl_over_liability),
             "liquidatable_value_over_liability": None
             if liquidatable_value_over_liability is None
             else str(liquidatable_value_over_liability),
-            "step_trading_fee_over_allocated": None
-            if step_trading_fee_over_allocated is None
-            else str(step_trading_fee_over_allocated),
-            "step_liquidation_gap_over_allocated": None
-            if step_liquidation_gap_over_allocated is None
-            else str(step_liquidation_gap_over_allocated),
-            "step_net_liquidation_over_allocated": None
-            if step_net_liquidation_over_allocated is None
-            else str(step_net_liquidation_over_allocated),
+            "step_trading_fee_over_funding": None
+            if step_trading_fee_over_funding is None
+            else str(step_trading_fee_over_funding),
+            "step_liquidation_gap_over_funding": None
+            if step_liquidation_gap_over_funding is None
+            else str(step_liquidation_gap_over_funding),
+            "step_net_liquidation_over_funding": None
+            if step_net_liquidation_over_funding is None
+            else str(step_net_liquidation_over_funding),
         },
     }
 

--- a/packages/predict/simulations/python_replay.py
+++ b/packages/predict/simulations/python_replay.py
@@ -57,7 +57,7 @@ TRADE_LIQUIDATION_BUDGET = 24
 VALUATION_LIQUIDATION_BUDGET = 192
 LIQUIDATION_HEAD_SCAN_DIVISOR = 3
 CURVE_SAMPLES = 50
-PROTOCOL_RESERVE_FEE_SHARE = 400_000_000
+PROTOCOL_RESERVE_PROFIT_SHARE = 400_000_000
 TRADING_LOSS_REBATE_RATE = 500_000_000
 TERMINAL_REBATE_FRACTION = 0
 EXPIRY_FEE_WINDOW_MS = 0
@@ -143,7 +143,7 @@ def apply_scenario_config(config: dict[str, Any], long_run: bool = False) -> Non
     global VALUATION_LIQUIDATION_BUDGET
     global LIQUIDATION_HEAD_SCAN_DIVISOR
     global CURVE_SAMPLES
-    global PROTOCOL_RESERVE_FEE_SHARE
+    global PROTOCOL_RESERVE_PROFIT_SHARE
     global TRADING_LOSS_REBATE_RATE
     global TERMINAL_REBATE_FRACTION
     global EXPIRY_FEE_WINDOW_MS
@@ -180,11 +180,11 @@ def apply_scenario_config(config: dict[str, Any], long_run: bool = False) -> Non
         LIQUIDATION_HEAD_SCAN_DIVISOR,
     )
     CURVE_SAMPLES = _config_int(config, "protocol", "curve_samples", CURVE_SAMPLES)
-    PROTOCOL_RESERVE_FEE_SHARE = _config_int(
+    PROTOCOL_RESERVE_PROFIT_SHARE = _config_int(
         config,
         "protocol",
-        "protocol_reserve_fee_share",
-        PROTOCOL_RESERVE_FEE_SHARE,
+        "protocol_reserve_profit_share",
+        PROTOCOL_RESERVE_PROFIT_SHARE,
     )
     TRADING_LOSS_REBATE_RATE = _config_int(
         config,
@@ -1156,7 +1156,7 @@ def pending_protocol_profit_exclusion(state: dict[str, int], active_expiry_value
     aggregate_debits = state["profit_basis_debits"]
     if aggregate_credits <= aggregate_debits:
         return 0
-    return deepbook_mul(aggregate_credits - aggregate_debits, PROTOCOL_RESERVE_FEE_SHARE)
+    return deepbook_mul(aggregate_credits - aggregate_debits, PROTOCOL_RESERVE_PROFIT_SHARE)
 
 
 def expiry_fee_multiplier(time_to_expiry_ms: int | None) -> int:
@@ -1738,7 +1738,7 @@ def terminal_closeout_update(
     lp_profit = 0
     if state["profit_basis_credits"] > state["profit_basis_debits"]:
         materialized_profit = state["profit_basis_credits"] - state["profit_basis_debits"]
-        protocol_profit = deepbook_mul(materialized_profit, PROTOCOL_RESERVE_FEE_SHARE)
+        protocol_profit = deepbook_mul(materialized_profit, PROTOCOL_RESERVE_PROFIT_SHARE)
         lp_profit = materialized_profit - protocol_profit
         state["profit_basis_debits"] = state["profit_basis_credits"]
         state["vault_idle_balance"] -= protocol_profit

--- a/packages/predict/simulations/python_replay.py
+++ b/packages/predict/simulations/python_replay.py
@@ -51,8 +51,10 @@ POS_INF_STRIKE = (1 << 64) - 1
 DUSDC_DECIMALS = 1_000_000
 VAULT_SEED = 500_000 * DUSDC_DECIMALS
 MANAGER_SEED = 500_000 * DUSDC_DECIMALS
-INITIAL_EXPIRY_FUNDING = 50_000 * DUSDC_DECIMALS
 INITIAL_TOTAL_PLP_SUPPLY = VAULT_SEED
+EXPIRY_CASH_FLOOR = 50_000 * DUSDC_DECIMALS
+EXPIRY_REBALANCE_PCT = 100_000_000
+MAX_EXPIRY_FUNDING = 250_000 * DUSDC_DECIMALS
 TRADE_LIQUIDATION_BUDGET = 24
 VALUATION_LIQUIDATION_BUDGET = 192
 LIQUIDATION_HEAD_SCAN_DIVISOR = 3
@@ -137,7 +139,6 @@ def _capital_int(config: dict[str, Any], mode: str, key: str, default: int) -> i
 def apply_scenario_config(config: dict[str, Any], long_run: bool = False) -> None:
     global VAULT_SEED
     global MANAGER_SEED
-    global INITIAL_EXPIRY_FUNDING
     global INITIAL_TOTAL_PLP_SUPPLY
     global TRADE_LIQUIDATION_BUDGET
     global VALUATION_LIQUIDATION_BUDGET
@@ -156,14 +157,6 @@ def apply_scenario_config(config: dict[str, Any], long_run: bool = False) -> Non
     capital_mode = "long" if long_run else "normal"
     VAULT_SEED = _capital_int(config, capital_mode, "vault_seed", VAULT_SEED)
     MANAGER_SEED = _capital_int(config, capital_mode, "manager_seed", MANAGER_SEED)
-    INITIAL_EXPIRY_FUNDING = _capital_int(
-        config,
-        capital_mode,
-        "initial_expiry_funding",
-        INITIAL_EXPIRY_FUNDING,
-    )
-    if INITIAL_EXPIRY_FUNDING > VAULT_SEED:
-        raise ValueError(f"{capital_mode} initial_expiry_funding exceeds vault_seed")
     INITIAL_TOTAL_PLP_SUPPLY = VAULT_SEED
 
     TRADE_LIQUIDATION_BUDGET = _config_int(config, "protocol", "trade_liquidation_budget", TRADE_LIQUIDATION_BUDGET)
@@ -802,35 +795,6 @@ def compute_range_price(svi: dict[str, Any], forward: int, lower: int, higher: i
     return compute_range_price_cached(forward, *svi_cache_key(svi), lower, higher)
 
 
-def directional_probability_upper_bound(curve: list[dict[str, int]], lower: int, higher: int) -> int:
-    if lower >= higher or ((lower == NEG_INF_STRIKE) == (higher == POS_INF_STRIKE)):
-        raise ValueError("invalid liquidation range")
-    if not curve:
-        raise ValueError("empty liquidation curve")
-    is_up = higher == POS_INF_STRIKE
-    strike = lower if is_up else higher
-    if strike < curve[0]["strike"] or strike > curve[-1]["strike"]:
-        raise ValueError("strike outside liquidation curve")
-
-    lo = 0
-    hi = len(curve)
-    while lo < hi:
-        mid = (lo + hi) // 2
-        if curve[mid]["strike"] < strike:
-            lo = mid + 1
-        else:
-            hi = mid
-
-    point = curve[lo]
-    if point["strike"] == strike:
-        return point["up_price"] if is_up else FLOAT_SCALING - point["up_price"]
-
-    lo_point = curve[lo - 1]
-    if lo_point["up_price"] < point["up_price"]:
-        raise ValueError("curve price underflow")
-    return lo_point["up_price"] if is_up else FLOAT_SCALING - point["up_price"]
-
-
 def directional_probability_bounds(curve: list[dict[str, int]], lower: int, higher: int) -> tuple[int, int]:
     if lower >= higher or ((lower == NEG_INF_STRIKE) == (higher == POS_INF_STRIKE)):
         raise ValueError("invalid liquidation range")
@@ -1151,6 +1115,129 @@ def compute_pool_value(
     return state["vault_idle_balance"] + active_expiry_value - pending_protocol_profit
 
 
+def expiry_net_funding(state: dict[str, int]) -> int:
+    return max(0, state["expiry_sent_to_expiry"] - state["expiry_received_from_expiry"])
+
+
+def available_expiry_funding(state: dict[str, int]) -> int:
+    return max(0, MAX_EXPIRY_FUNDING - expiry_net_funding(state))
+
+
+def record_sent_to_expiry(state: dict[str, int], amount: int) -> None:
+    if amount == 0:
+        return
+    if state["terminal_accounting_started"]:
+        raise ValueError("cannot send cash after terminal accounting starts")
+    state["expiry_sent_to_expiry"] += amount
+    state["profit_basis_debits"] += amount
+
+
+def record_received_from_expiry(state: dict[str, int], amount: int) -> None:
+    if amount == 0:
+        return
+    state["expiry_received_from_expiry"] += amount
+    state["profit_basis_credits"] += amount
+
+
+def materialize_expiry_profit(state: dict[str, int]) -> tuple[int, int, int]:
+    initial_loss = 0
+    if not state["terminal_accounting_started"]:
+        state["terminal_accounting_started"] = 1
+        if state["expiry_sent_to_expiry"] > state["expiry_received_from_expiry"]:
+            state["terminal_received_watermark"] = state["expiry_received_from_expiry"]
+            initial_loss = state["expiry_sent_to_expiry"] - state["expiry_received_from_expiry"]
+        else:
+            state["terminal_received_watermark"] = state["expiry_sent_to_expiry"]
+
+    received = state["expiry_received_from_expiry"]
+    if received > state["terminal_received_watermark"]:
+        profit = received - state["terminal_received_watermark"]
+        state["terminal_received_watermark"] = received
+    else:
+        profit = 0
+
+    state["net_losses_to_fill"] += initial_loss
+    if profit == 0:
+        return (0, 0, 0)
+    if profit <= state["net_losses_to_fill"]:
+        state["net_losses_to_fill"] -= profit
+        return (0, 0, 0)
+
+    materialized_profit = profit - state["net_losses_to_fill"]
+    state["net_losses_to_fill"] = 0
+    state["profit_basis_debits"] += materialized_profit
+    protocol_profit = deepbook_mul(materialized_profit, PROTOCOL_RESERVE_PROFIT_SHARE)
+    lp_profit = materialized_profit - protocol_profit
+    state["vault_idle_balance"] -= protocol_profit
+    state["vault_protocol_reserve_balance"] += protocol_profit
+    return (materialized_profit, lp_profit, protocol_profit)
+
+
+def expiry_rebalance_cash_terms(model: dict[str, Any], state: dict[str, int]) -> tuple[int, int, int]:
+    required_cash = model["payout"].max_live_backing_payout() + deepbook_mul(
+        state["expiry_unresolved_trading_fees"],
+        TRADING_LOSS_REBATE_RATE,
+    )
+    target_buffer = deepbook_mul(required_cash, EXPIRY_REBALANCE_PCT)
+    target_cash = max(required_cash + target_buffer, EXPIRY_CASH_FLOOR)
+    sweep_threshold_cash = max(required_cash + target_buffer + target_buffer, EXPIRY_CASH_FLOOR)
+    return state["expiry_cash_balance"], target_cash, sweep_threshold_cash
+
+
+def sync_active_expiry_cash_updates(model: dict[str, Any], state: dict[str, int]) -> list[dict[str, Any]]:
+    cash_balance, target_cash, sweep_threshold_cash = expiry_rebalance_cash_terms(model, state)
+    if cash_balance < target_cash:
+        top_up = min(target_cash - cash_balance, state["vault_idle_balance"], available_expiry_funding(state))
+        if top_up <= 0:
+            return []
+        state["vault_idle_balance"] -= top_up
+        state["expiry_cash_balance"] += top_up
+        record_sent_to_expiry(state, top_up)
+        return [
+            {
+                "type": "expiry_cash_rebalanced",
+                "amount": str(top_up),
+                "to_expiry": True,
+                "target_cash": str(target_cash),
+                "expiry_cash_after": str(state["expiry_cash_balance"]),
+                "idle_balance_after": str(state["vault_idle_balance"]),
+                "sent_to_expiry_after": str(state["expiry_sent_to_expiry"]),
+                "received_from_expiry_after": str(state["expiry_received_from_expiry"]),
+            }
+        ]
+    if cash_balance <= sweep_threshold_cash:
+        return []
+
+    returned_cash = cash_balance - target_cash
+    state["expiry_cash_balance"] -= returned_cash
+    state["vault_idle_balance"] += returned_cash
+    record_received_from_expiry(state, returned_cash)
+    return [
+        {
+            "type": "expiry_cash_rebalanced",
+            "amount": str(returned_cash),
+            "to_expiry": False,
+            "target_cash": str(target_cash),
+            "expiry_cash_after": str(state["expiry_cash_balance"]),
+            "idle_balance_after": str(state["vault_idle_balance"]),
+            "sent_to_expiry_after": str(state["expiry_sent_to_expiry"]),
+            "received_from_expiry_after": str(state["expiry_received_from_expiry"]),
+        }
+    ]
+
+
+def pool_sync_updates_and_value(
+    model: dict[str, Any],
+    state: dict[str, int],
+    curve: list[dict[str, int]] | None = None,
+) -> tuple[list[dict[str, Any]], int, dict[str, int]]:
+    position_liability = live_position_liability(model, curve)
+    synced_state = dict(state)
+    updates = sync_active_expiry_cash_updates(model, synced_state)
+    pool_value = compute_pool_value(model, synced_state, curve, position_liability)
+    return updates, pool_value, synced_state
+
+
 def pending_protocol_profit_exclusion(state: dict[str, int], active_expiry_value: int) -> int:
     aggregate_credits = state["profit_basis_credits"] + active_expiry_value
     aggregate_debits = state["profit_basis_debits"]
@@ -1193,11 +1280,16 @@ def assert_mint_fee_rate(probability: int, time_to_expiry_ms: int | None = None)
 def initial_state() -> dict[str, int]:
     return {
         "manager_balance": MANAGER_SEED,
-        "expiry_cash_balance": INITIAL_EXPIRY_FUNDING,
+        "expiry_cash_balance": 0,
         "expiry_unresolved_trading_fees": 0,
-        "vault_idle_balance": VAULT_SEED - INITIAL_EXPIRY_FUNDING,
+        "vault_idle_balance": VAULT_SEED,
         "vault_protocol_reserve_balance": 0,
-        "profit_basis_debits": INITIAL_EXPIRY_FUNDING,
+        "expiry_sent_to_expiry": 0,
+        "expiry_received_from_expiry": 0,
+        "terminal_accounting_started": 0,
+        "terminal_received_watermark": 0,
+        "net_losses_to_fill": 0,
+        "profit_basis_debits": 0,
         "profit_basis_credits": 0,
         "vault_total_plp_supply": INITIAL_TOTAL_PLP_SUPPLY,
         "open_order_count": 0,
@@ -1206,8 +1298,28 @@ def initial_state() -> dict[str, int]:
     }
 
 
+CANONICAL_STATE_KEYS = (
+    "manager_balance",
+    "expiry_cash_balance",
+    "expiry_unresolved_trading_fees",
+    "vault_idle_balance",
+    "vault_protocol_reserve_balance",
+    "profit_basis_debits",
+    "profit_basis_credits",
+    "vault_total_plp_supply",
+    "open_order_count",
+    "open_order_quantity",
+    "liquidated_order_count",
+)
+
+
 def state_snapshot(state: dict[str, int]) -> dict[str, str]:
-    return {key: str(value) for key, value in state.items()}
+    return {key: str(state[key]) for key in CANONICAL_STATE_KEYS}
+
+
+def apply_expiry_flow_after(state: dict[str, int], update: dict[str, Any]) -> None:
+    state["expiry_sent_to_expiry"] = int(update["sent_to_expiry_after"])
+    state["expiry_received_from_expiry"] = int(update["received_from_expiry_after"])
 
 
 def svi_input(row: dict[str, Any]) -> dict[str, str]:
@@ -1314,7 +1426,7 @@ def order_minted_update(
     }
 
 
-def apply_update(state: dict[str, int], update: dict[str, str]) -> None:
+def apply_update(state: dict[str, int], update: dict[str, Any]) -> None:
     if update["type"] == "order_minted":
         contribution = int(update["contribution"])
         trading_fee = int(update["trading_fee"])
@@ -1352,6 +1464,26 @@ def apply_update(state: dict[str, int], update: dict[str, str]) -> None:
         state["expiry_cash_balance"] -= payout
         state["open_order_count"] -= 1
         state["open_order_quantity"] -= quantity_closed
+    elif update["type"] == "expiry_cash_rebalanced":
+        amount = int(update["amount"])
+        state["expiry_cash_balance"] = int(update["expiry_cash_after"])
+        state["vault_idle_balance"] = int(update["idle_balance_after"])
+        if update["to_expiry"]:
+            record_sent_to_expiry(state, amount)
+        else:
+            record_received_from_expiry(state, amount)
+        apply_expiry_flow_after(state, update)
+    elif update["type"] == "expiry_cash_received":
+        amount = int(update["amount"])
+        state["expiry_cash_balance"] -= amount
+        state["vault_idle_balance"] = int(update["idle_balance_after"])
+        record_received_from_expiry(state, amount)
+        apply_expiry_flow_after(state, update)
+    elif update["type"] == "expiry_profit_materialized":
+        profit_basis_after = int(update["profit_basis_after"])
+        state["vault_idle_balance"] = int(update["idle_balance_after"])
+        state["vault_protocol_reserve_balance"] = int(update["protocol_reserve_balance_after"])
+        state["profit_basis_debits"] = profit_basis_after
     elif update["type"] in ("pool_supply", "pool_withdraw"):
         state["vault_idle_balance"] = int(update["idle_balance_after"])
         state["vault_total_plp_supply"] = int(update["total_supply_after"])
@@ -1402,7 +1534,6 @@ def assert_liquidation_inputs(model: dict[str, Any]) -> None:
 def run_liquidation_pass(
     model: dict[str, Any],
     budget: int,
-    curve: list[dict[str, int]] | None = None,
 ) -> list[dict[str, str]]:
     candidates = select_liquidation_candidates(model, budget)
     if not candidates:
@@ -1413,15 +1544,11 @@ def run_liquidation_pass(
         order = model["orders"][ref]
         if order["status"] != "active":
             continue
-        probability = (
-            directional_probability_upper_bound(curve, order["lower"], order["higher"])
-            if curve is not None
-            else compute_range_price(
-                model["current_svi"],
-                model["current_forward"],
-                order["lower"],
-                order["higher"],
-            )
+        probability = compute_range_price(
+            model["current_svi"],
+            model["current_forward"],
+            order["lower"],
+            order["higher"],
         )
         gross_value = deepbook_mul(probability, order["quantity"])
         floor_amount = current_order_floor_amount(model, order)
@@ -1443,6 +1570,18 @@ def run_liquidation_pass(
             }
         )
     return updates
+
+
+def append_pool_sync_phase(
+    model: dict[str, Any],
+    state: dict[str, int],
+    updates: list[dict[str, Any]],
+) -> tuple[int, dict[str, int]]:
+    updates.extend(run_liquidation_pass(model, VALUATION_LIQUIDATION_BUDGET))
+    curve = build_valuation_curve(model)
+    sync_updates, pool_value, synced_state = pool_sync_updates_and_value(model, state, curve)
+    updates.extend(sync_updates)
+    return pool_value, synced_state
 
 
 def track_minted_boundaries(model: dict[str, Any], lower: int, higher: int) -> None:
@@ -1564,14 +1703,13 @@ def redeem_order(model: dict[str, Any], row: dict[str, Any]) -> dict[str, str]:
 
 def supply_update(
     model: dict[str, Any],
-    state: dict[str, int],
     row: dict[str, Any],
-    curve: list[dict[str, int]] | None = None,
+    pool_value: int,
+    synced_state: dict[str, int],
 ) -> dict[str, str]:
     if row["lpRef"] in model["lp_refs"]:
         raise ValueError(f"duplicate lp_ref {row['lpRef']}")
-    pool_value = compute_pool_value(model, state, curve)
-    total_supply = state["vault_total_plp_supply"]
+    total_supply = synced_state["vault_total_plp_supply"]
     shares = row["amount"] if total_supply == 0 else mul_div_round_down(row["amount"], total_supply, pool_value)
     if shares <= 0:
         raise ValueError("supply would mint zero shares")
@@ -1583,25 +1721,24 @@ def supply_update(
         "shares_minted": str(shares),
         "pool_value_before": str(pool_value),
         "total_supply_after": str(total_supply + shares),
-        "idle_balance_after": str(state["vault_idle_balance"] + row["amount"]),
+        "idle_balance_after": str(synced_state["vault_idle_balance"] + row["amount"]),
     }
 
 
 def withdraw_update(
     model: dict[str, Any],
-    state: dict[str, int],
     row: dict[str, Any],
-    curve: list[dict[str, int]] | None = None,
+    pool_value: int,
+    synced_state: dict[str, int],
 ) -> dict[str, str]:
     shares = model["lp_refs"].get(row["lpRef"])
     if shares is None:
         raise ValueError(f"unknown lp_ref {row['lpRef']}")
-    pool_value = compute_pool_value(model, state, curve)
-    total_supply = state["vault_total_plp_supply"]
+    total_supply = synced_state["vault_total_plp_supply"]
     payout = mul_div_round_down(shares, pool_value, total_supply)
     if payout <= 0:
         raise ValueError("withdraw would pay zero")
-    if state["vault_idle_balance"] < payout:
+    if synced_state["vault_idle_balance"] < payout:
         raise ValueError("insufficient idle balance for withdraw")
     del model["lp_refs"][row["lpRef"]]
     return {
@@ -1611,30 +1748,28 @@ def withdraw_update(
         "payout": str(payout),
         "pool_value_before": str(pool_value),
         "total_supply_after": str(total_supply - shares),
-        "idle_balance_after": str(state["vault_idle_balance"] - payout),
+        "idle_balance_after": str(synced_state["vault_idle_balance"] - payout),
     }
 
 
 def initial_manager_summary() -> dict[str, int]:
     return {
-        "cash_paid_to_expiry": 0,
-        "cash_received_from_expiry": 0,
-        "trading_fee_paid": 0,
+        "gross_paid_to_expiry": 0,
+        "gross_received_from_expiry": 0,
+        "trading_fees_paid": 0,
     }
 
 
 def apply_manager_summary_update(summary: dict[str, int], update: dict[str, Any]) -> None:
     update_type = update["type"]
     if update_type == "order_minted":
-        summary["cash_paid_to_expiry"] += int(update["contribution"]) + int(update["trading_fee"])
-        summary["trading_fee_paid"] += int(update["trading_fee"])
+        summary["gross_paid_to_expiry"] += int(update["contribution"])
+        summary["trading_fees_paid"] += int(update["trading_fee"])
     elif update_type == "live_order_redeemed":
-        summary["cash_received_from_expiry"] += (
-            int(update["redeem_amount"]) - int(update["trading_fee"]) - int(update["builder_fee"])
-        )
-        summary["trading_fee_paid"] += int(update["trading_fee"])
+        summary["gross_received_from_expiry"] += int(update["redeem_amount"])
+        summary["trading_fees_paid"] += int(update["trading_fee"])
     elif update_type == "settled_order_redeemed":
-        summary["cash_received_from_expiry"] += int(update["payout_amount"])
+        summary["gross_received_from_expiry"] += int(update["payout_amount"])
 
 
 def settled_order_payout(order: dict[str, Any], settlement_price: int) -> int:
@@ -1712,37 +1847,49 @@ def terminal_closeout_update(
 
     state["manager_balance"] += settled_payout
     state["expiry_cash_balance"] -= settled_payout
-    manager_summary["cash_received_from_expiry"] += settled_payout
+    manager_summary["gross_received_from_expiry"] += settled_payout
 
-    trading_loss = max(0, manager_summary["cash_paid_to_expiry"] - manager_summary["cash_received_from_expiry"])
-    trading_fees_paid = manager_summary["trading_fee_paid"]
+    gross_profit = max(
+        0,
+        manager_summary["gross_received_from_expiry"] - manager_summary["gross_paid_to_expiry"],
+    )
+    trading_fees_paid = manager_summary["trading_fees_paid"]
     if trading_fees_paid > state["expiry_unresolved_trading_fees"]:
         raise ValueError("terminal trading fee basis exceeds unresolved trading fees")
-    max_rebate = deepbook_mul(trading_fees_paid, TRADING_LOSS_REBATE_RATE)
-    eligible_rebate = min(trading_loss, max_rebate)
-    trading_loss_rebate = deepbook_mul(eligible_rebate, TERMINAL_REBATE_FRACTION)
-    if trading_loss_rebate > state["expiry_cash_balance"]:
+    resolved_rebate_reserve = deepbook_mul(trading_fees_paid, TRADING_LOSS_REBATE_RATE)
+    eligible_rebate = max(0, resolved_rebate_reserve - gross_profit)
+    rebate_amount = deepbook_mul(eligible_rebate, TERMINAL_REBATE_FRACTION)
+    if rebate_amount > state["expiry_cash_balance"]:
         raise ValueError("terminal rebate exceeds expiry cash")
-    trading_loss_unpaid_rebate = eligible_rebate - trading_loss_rebate
-    state["manager_balance"] += trading_loss_rebate
-    state["expiry_cash_balance"] -= trading_loss_rebate
+    residual_rebate_reserve = resolved_rebate_reserve - rebate_amount
+    state["manager_balance"] += rebate_amount
+    state["expiry_cash_balance"] -= rebate_amount
     state["expiry_unresolved_trading_fees"] -= trading_fees_paid
-
-    returned_cash = state["expiry_cash_balance"]
-    state["expiry_cash_balance"] = 0
-    state["vault_idle_balance"] += returned_cash
-    state["profit_basis_credits"] += returned_cash
+    if residual_rebate_reserve > state["expiry_cash_balance"]:
+        raise ValueError("terminal residual rebate reserve exceeds expiry cash")
 
     materialized_profit = 0
     protocol_profit = 0
     lp_profit = 0
-    if state["profit_basis_credits"] > state["profit_basis_debits"]:
-        materialized_profit = state["profit_basis_credits"] - state["profit_basis_debits"]
-        protocol_profit = deepbook_mul(materialized_profit, PROTOCOL_RESERVE_PROFIT_SHARE)
-        lp_profit = materialized_profit - protocol_profit
-        state["profit_basis_debits"] = state["profit_basis_credits"]
-        state["vault_idle_balance"] -= protocol_profit
-        state["vault_protocol_reserve_balance"] += protocol_profit
+
+    def materialize_terminal_return(amount: int) -> None:
+        nonlocal materialized_profit, protocol_profit, lp_profit
+        record_received_from_expiry(state, amount)
+        update_materialized_profit, update_lp_profit, update_protocol_profit = materialize_expiry_profit(state)
+        materialized_profit += update_materialized_profit
+        lp_profit += update_lp_profit
+        protocol_profit += update_protocol_profit
+
+    returned_rebate_reserve = residual_rebate_reserve
+    state["expiry_cash_balance"] -= returned_rebate_reserve
+    state["vault_idle_balance"] += returned_rebate_reserve
+    materialize_terminal_return(returned_rebate_reserve)
+
+    returned_pool_cash = state["expiry_cash_balance"]
+    state["expiry_cash_balance"] = 0
+    state["vault_idle_balance"] += returned_pool_cash
+    materialize_terminal_return(returned_pool_cash)
+    returned_cash = returned_rebate_reserve + returned_pool_cash
 
     state["open_order_count"] = 0
     state["open_order_quantity"] = 0
@@ -1761,14 +1908,17 @@ def terminal_closeout_update(
         "winning_quantity": str(winning_quantity),
         "settled_payout_amount": str(settled_payout),
         "liquidated_orders_cleared": str(len(liquidated_orders)),
-        "cash_paid_to_expiry": str(manager_summary["cash_paid_to_expiry"]),
-        "cash_received_from_expiry": str(manager_summary["cash_received_from_expiry"]),
-        "trading_fee_paid": str(manager_summary["trading_fee_paid"]),
-        "trading_loss_before_rebate": str(trading_loss),
-        "trading_loss_eligible_rebate": str(eligible_rebate),
-        "trading_loss_rebate_fraction": str(TERMINAL_REBATE_FRACTION),
-        "trading_loss_rebate": str(trading_loss_rebate),
-        "trading_loss_unpaid_rebate": str(trading_loss_unpaid_rebate),
+        "gross_paid_to_expiry": str(manager_summary["gross_paid_to_expiry"]),
+        "gross_received_from_expiry": str(manager_summary["gross_received_from_expiry"]),
+        "trading_fees_paid": str(manager_summary["trading_fees_paid"]),
+        "gross_profit_before_rebate": str(gross_profit),
+        "resolved_rebate_reserve": str(resolved_rebate_reserve),
+        "eligible_rebate": str(eligible_rebate),
+        "rebate_fraction": str(TERMINAL_REBATE_FRACTION),
+        "rebate_amount": str(rebate_amount),
+        "residual_rebate_reserve": str(residual_rebate_reserve),
+        "returned_rebate_reserve": str(returned_rebate_reserve),
+        "returned_pool_cash": str(returned_pool_cash),
         "returned_cash": str(returned_cash),
         "materialized_profit": str(materialized_profit),
         "lp_profit": str(lp_profit),
@@ -2203,7 +2353,7 @@ def build_derived_record(
             "withdraw": 0,
         }
 
-    expiry_funding_basis = max(0, state["profit_basis_debits"] - state["profit_basis_credits"])
+    expiry_funding_basis = expiry_net_funding(state)
     lp_live_mtm_pnl = (
         None
         if active_expiry_value is None or pending_protocol_profit is None
@@ -2427,28 +2577,28 @@ def replay(
             updates.append(oracle_prices_update(row))
             updates.append(oracle_svi_update(row))
             scan_active_count = active_order_count(model)
+            append_pool_sync_phase(model, state, updates)
             updates.extend(run_liquidation_pass(model, TRADE_LIQUIDATION_BUDGET))
             updates.append(mint_order(model, row, row_timestamp_ms))
         elif action == "redeem":
             apply_inline_oracle_refresh(model, row, updates)
             ref = row["orderRef"]
-            order = model["orders"].get(ref)
             scan_active_count = active_order_count(model)
+            append_pool_sync_phase(model, state, updates)
+            order = model["orders"].get(ref)
             if order is None or order["status"] != "liquidated":
                 updates.extend(run_liquidation_pass(model, TRADE_LIQUIDATION_BUDGET))
             updates.append(redeem_order(model, row))
         elif action == "supply":
             apply_inline_oracle_refresh(model, row, updates)
-            curve = build_valuation_curve(model)
             scan_active_count = active_order_count(model)
-            updates.extend(run_liquidation_pass(model, VALUATION_LIQUIDATION_BUDGET, curve))
-            updates.append(supply_update(model, state, row, curve))
+            pool_value, synced_state = append_pool_sync_phase(model, state, updates)
+            updates.append(supply_update(model, row, pool_value, synced_state))
         elif action == "withdraw":
             apply_inline_oracle_refresh(model, row, updates)
-            curve = build_valuation_curve(model)
             scan_active_count = active_order_count(model)
-            updates.extend(run_liquidation_pass(model, VALUATION_LIQUIDATION_BUDGET, curve))
-            updates.append(withdraw_update(model, state, row, curve))
+            pool_value, synced_state = append_pool_sync_phase(model, state, updates)
+            updates.append(withdraw_update(model, row, pool_value, synced_state))
         else:
             raise ValueError(f"unsupported action {action}")
 

--- a/packages/predict/simulations/sim_artifacts.py
+++ b/packages/predict/simulations/sim_artifacts.py
@@ -6,8 +6,8 @@ import json
 from pathlib import Path
 from typing import Any, Sequence, TypeVar
 
-PREDICT_ECONOMIC_SCHEMA_VERSION = "predict_economic_v1"
-PREDICT_DERIVED_SCHEMA_VERSION = "predict_derived_v1"
+PREDICT_ECONOMIC_SCHEMA_VERSION = "predict_economic_v2"
+PREDICT_DERIVED_SCHEMA_VERSION = "predict_derived_v2"
 
 DUSDC_DECIMALS = 1_000_000
 DUSDC_SCALING = DUSDC_DECIMALS

--- a/packages/predict/simulations/src/runtime.ts
+++ b/packages/predict/simulations/src/runtime.ts
@@ -238,6 +238,14 @@ function startPoolSyncWithExpiry(tx: Transaction, params: ExpiryPoolSyncParams) 
   return sync;
 }
 
+function finishPoolSyncWithExpiry(tx: Transaction, params: ExpiryPoolSyncParams): void {
+  const sync = startPoolSyncWithExpiry(tx, params);
+  tx.moveCall({
+    target: target("plp", "finish_pool_sync"),
+    arguments: [tx.object(params.poolVaultId), tx.object(params.protocolConfigId), sync],
+  });
+}
+
 function addMint(tx: Transaction, params: MintParams): void {
   const { lower, higher } = binaryRangeBounds(params.strike, params.isUp);
   tx.moveCall({
@@ -454,16 +462,18 @@ export function depositToManagerTx(managerId: string, amount: bigint): Transacti
   return tx;
 }
 
-export function refreshOracleAndMintTx(params: OracleRefreshParams & MintParams): Transaction {
+export function refreshOracleAndMintTx(params: OracleRefreshParams & ExpiryPoolSyncParams & MintParams): Transaction {
   const tx = new Transaction();
   addOracleRefresh(tx, params);
+  finishPoolSyncWithExpiry(tx, params);
   addMint(tx, params);
   return tx;
 }
 
-export function refreshOracleAndRedeemTx(params: OracleRefreshParams & RedeemParams): Transaction {
+export function refreshOracleAndRedeemTx(params: OracleRefreshParams & ExpiryPoolSyncParams & RedeemParams): Transaction {
   const tx = new Transaction();
   addOracleRefresh(tx, params);
+  finishPoolSyncWithExpiry(tx, params);
   addRedeem(tx, params);
   return tx;
 }

--- a/packages/predict/simulations/src/runtime.ts
+++ b/packages/predict/simulations/src/runtime.ts
@@ -125,7 +125,7 @@ interface OracleRefreshParams {
   };
 }
 
-interface ExpiryValuationParams {
+interface ExpiryPoolSyncParams {
   poolVaultId: string;
   protocolConfigId: string;
   expiryMarketId: string;
@@ -133,11 +133,11 @@ interface ExpiryValuationParams {
   pythSourceId: string;
 }
 
-interface SupplyWithExpiryValuationParams extends ExpiryValuationParams {
+interface SupplyWithExpiryPoolSyncParams extends ExpiryPoolSyncParams {
   amount: bigint;
 }
 
-interface WithdrawWithExpiryValuationParams extends ExpiryValuationParams {
+interface WithdrawWithExpiryPoolSyncParams extends ExpiryPoolSyncParams {
   lpCoinId: string;
 }
 
@@ -218,14 +218,16 @@ function mintDusdc(tx: Transaction, amount: bigint) {
   return coin;
 }
 
-function startPlpValuationWithExpiry(tx: Transaction, params: ExpiryValuationParams) {
-  const valuation = tx.moveCall({
-    target: target("plp", "start_valuation"),
+function startPoolSyncWithExpiry(tx: Transaction, params: ExpiryPoolSyncParams) {
+  const sync = tx.moveCall({
+    target: target("plp", "start_pool_sync"),
     arguments: [tx.object(params.protocolConfigId), tx.object(params.poolVaultId)],
   });
-  const expiryValuation = tx.moveCall({
-    target: target("expiry_market", "produce_valuation"),
+  tx.moveCall({
+    target: target("plp", "sync_expiry"),
     arguments: [
+      sync,
+      tx.object(params.poolVaultId),
       tx.object(params.expiryMarketId),
       tx.object(params.protocolConfigId),
       tx.object(params.oracleId),
@@ -233,11 +235,7 @@ function startPlpValuationWithExpiry(tx: Transaction, params: ExpiryValuationPar
       tx.object(CLOCK_ID),
     ],
   });
-  tx.moveCall({
-    target: target("plp", "add_expiry_valuation"),
-    arguments: [valuation, expiryValuation],
-  });
-  return valuation;
+  return sync;
 }
 
 function addMint(tx: Transaction, params: MintParams): void {
@@ -375,45 +373,45 @@ export function setMarketOracleBasisBoundsTx(
 export function supplyTx(poolVaultId: string, protocolConfigId: string, amount: bigint): Transaction {
   const tx = new Transaction();
   const dusdc = mintDusdc(tx, amount);
-  const valuation = tx.moveCall({
-    target: target("plp", "start_valuation"),
+  const sync = tx.moveCall({
+    target: target("plp", "start_pool_sync"),
     arguments: [tx.object(protocolConfigId), tx.object(poolVaultId)],
   });
   const [plpCoin] = tx.moveCall({
     target: target("plp", "supply"),
-    arguments: [tx.object(poolVaultId), tx.object(protocolConfigId), valuation, dusdc],
+    arguments: [tx.object(poolVaultId), tx.object(protocolConfigId), sync, dusdc],
   });
   tx.transferObjects([plpCoin], tx.pure.address(address));
   return tx;
 }
 
-export function refreshOracleAndSupplyWithExpiryValuationTx(
-  params: OracleRefreshParams & SupplyWithExpiryValuationParams
+export function refreshOracleAndSupplyWithExpiryPoolSyncTx(
+  params: OracleRefreshParams & SupplyWithExpiryPoolSyncParams
 ): Transaction {
   const tx = new Transaction();
   addOracleRefresh(tx, params);
   const dusdc = mintDusdc(tx, params.amount);
-  const valuation = startPlpValuationWithExpiry(tx, params);
+  const sync = startPoolSyncWithExpiry(tx, params);
   const [plpCoin] = tx.moveCall({
     target: target("plp", "supply"),
-    arguments: [tx.object(params.poolVaultId), tx.object(params.protocolConfigId), valuation, dusdc],
+    arguments: [tx.object(params.poolVaultId), tx.object(params.protocolConfigId), sync, dusdc],
   });
   tx.transferObjects([plpCoin], tx.pure.address(address));
   return tx;
 }
 
-export function refreshOracleAndWithdrawWithExpiryValuationTx(
-  params: OracleRefreshParams & WithdrawWithExpiryValuationParams
+export function refreshOracleAndWithdrawWithExpiryPoolSyncTx(
+  params: OracleRefreshParams & WithdrawWithExpiryPoolSyncParams
 ): Transaction {
   const tx = new Transaction();
   addOracleRefresh(tx, params);
-  const valuation = startPlpValuationWithExpiry(tx, params);
+  const sync = startPoolSyncWithExpiry(tx, params);
   const [dusdc] = tx.moveCall({
     target: target("plp", "withdraw"),
     arguments: [
       tx.object(params.poolVaultId),
       tx.object(params.protocolConfigId),
-      valuation,
+      sync,
       tx.object(params.lpCoinId),
     ],
   });

--- a/packages/predict/simulations/src/shared.ts
+++ b/packages/predict/simulations/src/shared.ts
@@ -332,7 +332,7 @@ function parseRow(row: RawScenarioRow, lineNumber: number): ScenarioRow {
 
 const instanceDir = resolveInstanceDir();
 
-export const ECONOMIC_SCHEMA_VERSION = "predict_economic_v1";
+export const ECONOMIC_SCHEMA_VERSION = "predict_economic_v2";
 export const LOCAL_TRACE_SCHEMA_VERSION = "predict_local_trace_v2";
 export const SCENARIO_PATH = fileURLToPath(new URL("../data/generated/normal_scenario.csv", import.meta.url));
 export const STATE_PATH = path.join(instanceDir, "artifacts", "state.json");

--- a/packages/predict/simulations/src/sim.ts
+++ b/packages/predict/simulations/src/sim.ts
@@ -49,7 +49,6 @@ import {
 const DUSDC_DECIMALS = 1_000_000n;
 const DEFAULT_VAULT_SEED = 500_000n * DUSDC_DECIMALS;
 const DEFAULT_MANAGER_SEED = 500_000n * DUSDC_DECIMALS;
-const DEFAULT_INITIAL_EXPIRY_FUNDING = 50_000n * DUSDC_DECIMALS;
 const EXPIRY_MS = BigInt(Date.now()) + 400n * 24n * 60n * 60n * 1000n;
 const FLOAT_SCALING = 1_000_000_000n;
 const SCENARIO_CONFIG_PATH = fileURLToPath(new URL("../data/scenario_config.json", import.meta.url));
@@ -63,7 +62,6 @@ const ORDER_SEQUENCE_MASK = (1n << 40n) - 1n;
 interface SimulationCapital {
   vaultSeed: bigint;
   managerSeed: bigint;
-  initialExpiryFunding: bigint;
   initialTotalPlpSupply: bigint;
 }
 
@@ -117,11 +115,11 @@ function scenarioPath(): string {
 function initialEconomicState(capital: SimulationCapital): EconomicState {
   return {
     managerBalance: capital.managerSeed,
-    expiryCashBalance: capital.initialExpiryFunding,
+    expiryCashBalance: 0n,
     expiryUnresolvedTradingFees: 0n,
-    vaultIdleBalance: capital.vaultSeed - capital.initialExpiryFunding,
+    vaultIdleBalance: capital.vaultSeed,
     vaultProtocolReserveBalance: 0n,
-    profitBasisDebits: capital.initialExpiryFunding,
+    profitBasisDebits: 0n,
     profitBasisCredits: 0n,
     vaultTotalPlpSupply: capital.initialTotalPlpSupply,
     openOrderCount: 0n,
@@ -400,6 +398,45 @@ function normalizeWithdrawExecuted(event: any, row: ScenarioRow): Record<string,
   };
 }
 
+function normalizeExpiryCashRebalanced(event: any): Record<string, unknown> {
+  const json = event.parsedJson ?? {};
+  return {
+    type: "expiry_cash_rebalanced",
+    amount: decimal(json.amount),
+    to_expiry: booleanField(json.to_expiry),
+    target_cash: decimal(json.target_cash),
+    expiry_cash_after: decimal(json.expiry_cash_after),
+    idle_balance_after: decimal(json.idle_balance_after),
+    sent_to_expiry_after: decimal(json.sent_to_expiry_after),
+    received_from_expiry_after: decimal(json.received_from_expiry_after),
+  };
+}
+
+function normalizeExpiryCashReceived(event: any): Record<string, unknown> {
+  const json = event.parsedJson ?? {};
+  return {
+    type: "expiry_cash_received",
+    settlement_price: decimal(json.settlement_price),
+    amount: decimal(json.amount),
+    idle_balance_after: decimal(json.idle_balance_after),
+    sent_to_expiry_after: decimal(json.sent_to_expiry_after),
+    received_from_expiry_after: decimal(json.received_from_expiry_after),
+  };
+}
+
+function normalizeExpiryProfitMaterialized(event: any): Record<string, unknown> {
+  const json = event.parsedJson ?? {};
+  return {
+    type: "expiry_profit_materialized",
+    expiry_market_id: json.expiry_market_id ?? null,
+    lp_profit: decimal(json.lp_profit),
+    protocol_profit: decimal(json.protocol_profit),
+    idle_balance_after: decimal(json.idle_balance_after),
+    protocol_reserve_balance_after: decimal(json.protocol_reserve_balance_after),
+    profit_basis_after: decimal(json.profit_basis_after),
+  };
+}
+
 function normalizeUpdates(row: ScenarioRow, receipt: ExecutionReceipt, aliases: AliasState): Record<string, unknown>[] {
   const updates: Record<string, unknown>[] = [];
   for (const event of receipt.events) {
@@ -413,6 +450,9 @@ function normalizeUpdates(row: ScenarioRow, receipt: ExecutionReceipt, aliases: 
     else if (name === "SettledOrderRedeemed") updates.push(normalizeSettledOrderRedeemed(event, row));
     else if (name === "SupplyExecuted") updates.push(normalizeSupplyExecuted(event, row));
     else if (name === "WithdrawExecuted") updates.push(normalizeWithdrawExecuted(event, row));
+    else if (name === "ExpiryCashRebalanced") updates.push(normalizeExpiryCashRebalanced(event));
+    else if (name === "ExpiryCashReceived") updates.push(normalizeExpiryCashReceived(event));
+    else if (name === "ExpiryProfitMaterialized") updates.push(normalizeExpiryProfitMaterialized(event));
   }
   return updates;
 }
@@ -454,6 +494,25 @@ function applyUpdate(state: EconomicState, update: Record<string, unknown>) {
     state.expiryCashBalance -= payout;
     state.openOrderCount -= 1n;
     state.openOrderQuantity -= quantityClosed;
+  } else if (update.type === "expiry_cash_rebalanced") {
+    const amount = BigInt(decimal(update.amount));
+    state.expiryCashBalance = BigInt(decimal(update.expiry_cash_after));
+    state.vaultIdleBalance = BigInt(decimal(update.idle_balance_after));
+    if (update.to_expiry === true) {
+      state.profitBasisDebits += amount;
+    } else {
+      state.profitBasisCredits += amount;
+    }
+  } else if (update.type === "expiry_cash_received") {
+    const amount = BigInt(decimal(update.amount));
+    state.expiryCashBalance -= amount;
+    state.vaultIdleBalance = BigInt(decimal(update.idle_balance_after));
+    state.profitBasisCredits += amount;
+  } else if (update.type === "expiry_profit_materialized") {
+    const profitBasisAfter = BigInt(decimal(update.profit_basis_after));
+    state.vaultIdleBalance = BigInt(decimal(update.idle_balance_after));
+    state.vaultProtocolReserveBalance = BigInt(decimal(update.protocol_reserve_balance_after));
+    state.profitBasisDebits = profitBasisAfter;
   } else if (update.type === "pool_supply") {
     state.vaultIdleBalance = BigInt(decimal(update.idle_balance_after));
     state.vaultTotalPlpSupply = BigInt(decimal(update.total_supply_after));
@@ -597,19 +656,9 @@ function capitalConfigValue(config: any, mode: string, key: string, fallback: bi
 
 function simulationCapital(config: any, mode: "normal" | "long"): SimulationCapital {
   const vaultSeed = capitalConfigValue(config, mode, "vault_seed", DEFAULT_VAULT_SEED);
-  const initialExpiryFunding = capitalConfigValue(
-    config,
-    mode,
-    "initial_expiry_funding",
-    DEFAULT_INITIAL_EXPIRY_FUNDING,
-  );
-  if (initialExpiryFunding > vaultSeed) {
-    throw new Error(`${mode} initial_expiry_funding exceeds vault_seed`);
-  }
   return {
     vaultSeed,
     managerSeed: capitalConfigValue(config, mode, "manager_seed", DEFAULT_MANAGER_SEED),
-    initialExpiryFunding,
     initialTotalPlpSupply: vaultSeed,
   };
 }
@@ -733,6 +782,7 @@ async function executeRow(row: ScenarioRow, state: SimState, aliases: AliasState
     const alignedStrike = alignStrikeToGrid(row.strike);
     return execute(
       () => refreshOracleAndMintTx({
+        poolVaultId: state.poolVaultId,
         expiryMarketId: state.expiryMarketId,
         protocolConfigId: state.protocolConfigId,
         managerId: state.managerId,
@@ -764,6 +814,7 @@ async function executeRow(row: ScenarioRow, state: SimState, aliases: AliasState
     if (!orderId) throw new Error(`Unknown order_ref ${row.orderRef}`);
     return execute(
       () => refreshOracleAndRedeemTx({
+        poolVaultId: state.poolVaultId,
         expiryMarketId: state.expiryMarketId,
         protocolConfigId: state.protocolConfigId,
         managerId: state.managerId,

--- a/packages/predict/simulations/src/sim.ts
+++ b/packages/predict/simulations/src/sim.ts
@@ -49,7 +49,7 @@ import {
 const DUSDC_DECIMALS = 1_000_000n;
 const DEFAULT_VAULT_SEED = 500_000n * DUSDC_DECIMALS;
 const DEFAULT_MANAGER_SEED = 500_000n * DUSDC_DECIMALS;
-const DEFAULT_INITIAL_EXPIRY_ALLOCATION = 50_000n * DUSDC_DECIMALS;
+const DEFAULT_INITIAL_EXPIRY_FUNDING = 50_000n * DUSDC_DECIMALS;
 const EXPIRY_MS = BigInt(Date.now()) + 400n * 24n * 60n * 60n * 1000n;
 const FLOAT_SCALING = 1_000_000_000n;
 const SCENARIO_CONFIG_PATH = fileURLToPath(new URL("../data/scenario_config.json", import.meta.url));
@@ -63,17 +63,18 @@ const ORDER_SEQUENCE_MASK = (1n << 40n) - 1n;
 interface SimulationCapital {
   vaultSeed: bigint;
   managerSeed: bigint;
-  initialExpiryAllocation: bigint;
+  initialExpiryFunding: bigint;
   initialTotalPlpSupply: bigint;
 }
 
 interface EconomicState {
   managerBalance: bigint;
-  expiryLpCash: bigint;
-  expiryFeeBalance: bigint;
+  expiryCashBalance: bigint;
   expiryUnresolvedTradingFees: bigint;
   vaultIdleBalance: bigint;
-  vaultTotalAllocated: bigint;
+  vaultProtocolReserveBalance: bigint;
+  profitBasisDebits: bigint;
+  profitBasisCredits: bigint;
   vaultTotalPlpSupply: bigint;
   openOrderCount: bigint;
   openOrderQuantity: bigint;
@@ -116,11 +117,12 @@ function scenarioPath(): string {
 function initialEconomicState(capital: SimulationCapital): EconomicState {
   return {
     managerBalance: capital.managerSeed,
-    expiryLpCash: capital.initialExpiryAllocation,
-    expiryFeeBalance: 0n,
+    expiryCashBalance: capital.initialExpiryFunding,
     expiryUnresolvedTradingFees: 0n,
-    vaultIdleBalance: capital.vaultSeed - capital.initialExpiryAllocation,
-    vaultTotalAllocated: capital.initialExpiryAllocation,
+    vaultIdleBalance: capital.vaultSeed - capital.initialExpiryFunding,
+    vaultProtocolReserveBalance: 0n,
+    profitBasisDebits: capital.initialExpiryFunding,
+    profitBasisCredits: 0n,
     vaultTotalPlpSupply: capital.initialTotalPlpSupply,
     openOrderCount: 0n,
     openOrderQuantity: 0n,
@@ -382,7 +384,6 @@ function normalizeSupplyExecuted(event: any, row: ScenarioRow): Record<string, u
     pool_value_before: decimal(json.pool_value_before),
     total_supply_after: decimal(json.total_supply_after),
     idle_balance_after: decimal(json.idle_balance_after),
-    total_allocated_after: decimal(json.total_allocated_after),
   };
 }
 
@@ -396,7 +397,6 @@ function normalizeWithdrawExecuted(event: any, row: ScenarioRow): Record<string,
     pool_value_before: decimal(json.pool_value_before),
     total_supply_after: decimal(json.total_supply_after),
     idle_balance_after: decimal(json.idle_balance_after),
-    total_allocated_after: decimal(json.total_allocated_after),
   };
 }
 
@@ -424,8 +424,7 @@ function applyUpdate(state: EconomicState, update: Record<string, unknown>) {
     const builderFee = BigInt(decimal(update.builder_fee));
     const quantity = BigInt(decimal(update.quantity));
     state.managerBalance -= contribution + tradingFee + builderFee;
-    state.expiryLpCash += contribution;
-    state.expiryFeeBalance += tradingFee;
+    state.expiryCashBalance += contribution + tradingFee;
     state.expiryUnresolvedTradingFees += tradingFee;
     state.openOrderCount += 1n;
     state.openOrderQuantity += quantity;
@@ -441,8 +440,8 @@ function applyUpdate(state: EconomicState, update: Record<string, unknown>) {
     const quantityClosed = BigInt(decimal(update.quantity_closed));
     const remainingQuantity = BigInt(decimal(update.remaining_quantity));
     state.managerBalance += redeemAmount - tradingFee - builderFee;
-    state.expiryLpCash -= redeemAmount;
-    state.expiryFeeBalance += tradingFee;
+    state.expiryCashBalance -= redeemAmount;
+    state.expiryCashBalance += tradingFee;
     state.expiryUnresolvedTradingFees += tradingFee;
     state.openOrderQuantity -= quantityClosed;
     if (remainingQuantity === 0n) state.openOrderCount -= 1n;
@@ -452,16 +451,14 @@ function applyUpdate(state: EconomicState, update: Record<string, unknown>) {
     const payout = BigInt(decimal(update.payout_amount));
     const quantityClosed = BigInt(decimal(update.quantity_closed));
     state.managerBalance += payout;
-    state.expiryLpCash -= payout;
+    state.expiryCashBalance -= payout;
     state.openOrderCount -= 1n;
     state.openOrderQuantity -= quantityClosed;
   } else if (update.type === "pool_supply") {
     state.vaultIdleBalance = BigInt(decimal(update.idle_balance_after));
-    state.vaultTotalAllocated = BigInt(decimal(update.total_allocated_after));
     state.vaultTotalPlpSupply = BigInt(decimal(update.total_supply_after));
   } else if (update.type === "pool_withdraw") {
     state.vaultIdleBalance = BigInt(decimal(update.idle_balance_after));
-    state.vaultTotalAllocated = BigInt(decimal(update.total_allocated_after));
     state.vaultTotalPlpSupply = BigInt(decimal(update.total_supply_after));
   }
 }
@@ -469,11 +466,12 @@ function applyUpdate(state: EconomicState, update: Record<string, unknown>) {
 function stateSnapshot(state: EconomicState): Record<string, string> {
   return {
     manager_balance: state.managerBalance.toString(),
-    expiry_lp_cash: state.expiryLpCash.toString(),
-    expiry_fee_balance: state.expiryFeeBalance.toString(),
+    expiry_cash_balance: state.expiryCashBalance.toString(),
     expiry_unresolved_trading_fees: state.expiryUnresolvedTradingFees.toString(),
     vault_idle_balance: state.vaultIdleBalance.toString(),
-    vault_total_allocated: state.vaultTotalAllocated.toString(),
+    vault_protocol_reserve_balance: state.vaultProtocolReserveBalance.toString(),
+    profit_basis_debits: state.profitBasisDebits.toString(),
+    profit_basis_credits: state.profitBasisCredits.toString(),
     vault_total_plp_supply: state.vaultTotalPlpSupply.toString(),
     open_order_count: state.openOrderCount.toString(),
     open_order_quantity: state.openOrderQuantity.toString(),
@@ -599,19 +597,19 @@ function capitalConfigValue(config: any, mode: string, key: string, fallback: bi
 
 function simulationCapital(config: any, mode: "normal" | "long"): SimulationCapital {
   const vaultSeed = capitalConfigValue(config, mode, "vault_seed", DEFAULT_VAULT_SEED);
-  const initialExpiryAllocation = capitalConfigValue(
+  const initialExpiryFunding = capitalConfigValue(
     config,
     mode,
-    "initial_expiry_allocation",
-    DEFAULT_INITIAL_EXPIRY_ALLOCATION,
+    "initial_expiry_funding",
+    DEFAULT_INITIAL_EXPIRY_FUNDING,
   );
-  if (initialExpiryAllocation > vaultSeed) {
-    throw new Error(`${mode} initial_expiry_allocation exceeds vault_seed`);
+  if (initialExpiryFunding > vaultSeed) {
+    throw new Error(`${mode} initial_expiry_funding exceeds vault_seed`);
   }
   return {
     vaultSeed,
     managerSeed: capitalConfigValue(config, mode, "manager_seed", DEFAULT_MANAGER_SEED),
-    initialExpiryAllocation,
+    initialExpiryFunding,
     initialTotalPlpSupply: vaultSeed,
   };
 }

--- a/packages/predict/simulations/src/sim.ts
+++ b/packages/predict/simulations/src/sim.ts
@@ -39,8 +39,8 @@ import {
   finalizeDusdcCurrencyRegistrationTx,
   refreshOracleAndMintTx,
   refreshOracleAndRedeemTx,
-  refreshOracleAndSupplyWithExpiryValuationTx,
-  refreshOracleAndWithdrawWithExpiryValuationTx,
+  refreshOracleAndSupplyWithExpiryPoolSyncTx,
+  refreshOracleAndWithdrawWithExpiryPoolSyncTx,
   setMarketOracleBasisBoundsTx,
   supplyTx,
   type ExecutionReceipt,
@@ -782,7 +782,7 @@ async function executeRow(row: ScenarioRow, state: SimState, aliases: AliasState
 
   if (row.action === "supply") {
     return execute(
-      () => refreshOracleAndSupplyWithExpiryValuationTx({
+      () => refreshOracleAndSupplyWithExpiryPoolSyncTx({
         poolVaultId: state.poolVaultId,
         protocolConfigId: state.protocolConfigId,
         expiryMarketId: state.expiryMarketId,
@@ -801,7 +801,7 @@ async function executeRow(row: ScenarioRow, state: SimState, aliases: AliasState
   const lpCoinId = aliases.lpCoinIdsByRef.get(row.lpRef);
   if (!lpCoinId) throw new Error(`Unknown lp_ref ${row.lpRef}`);
   return execute(
-    () => refreshOracleAndWithdrawWithExpiryValuationTx({
+    () => refreshOracleAndWithdrawWithExpiryPoolSyncTx({
       poolVaultId: state.poolVaultId,
       protocolConfigId: state.protocolConfigId,
       expiryMarketId: state.expiryMarketId,

--- a/packages/predict/simulations/summarize_economics.py
+++ b/packages/predict/simulations/summarize_economics.py
@@ -20,7 +20,7 @@ from sim_artifacts import (
     write_json,
 )
 
-SCHEMA_VERSION = "predict_economic_summary_v2"
+SCHEMA_VERSION = "predict_economic_summary_v3"
 
 
 def integer_stats(values: list[int]) -> dict[str, int] | None:
@@ -95,13 +95,13 @@ def update_totals(records: list[dict[str, Any]]) -> dict[str, int]:
                     update.get("trading_loss_eligible_rebate", "0")
                 )
                 totals["terminal_trading_loss_rebate"] += int(update["trading_loss_rebate"])
-                totals["terminal_trading_loss_rebate_to_lp"] += int(update.get("trading_loss_rebate_to_lp", "0"))
-                totals["terminal_returned_lp_cash"] += int(update["returned_lp_cash"])
-                totals["terminal_fee_surplus"] += int(update["fee_surplus"])
-                totals["terminal_fee_surplus_to_lp"] += int(update["fee_surplus_to_lp"])
-                totals["terminal_fee_surplus_to_protocol"] += int(update["fee_surplus_to_protocol"])
-                totals["terminal_fee_surplus_to_insurance"] += int(update["fee_surplus_to_insurance"])
-                totals["terminal_allocated_reduction"] += int(update["allocated_reduction"])
+                totals["terminal_trading_loss_unpaid_rebate"] += int(
+                    update.get("trading_loss_unpaid_rebate", "0")
+                )
+                totals["terminal_returned_cash"] += int(update["returned_cash"])
+                totals["terminal_materialized_profit"] += int(update["materialized_profit"])
+                totals["terminal_lp_profit"] += int(update["lp_profit"])
+                totals["terminal_protocol_profit"] += int(update["protocol_profit"])
             elif update_type == "order_liquidated":
                 floor_value = int(update["floor_amount"])
                 gross_value = int(update["gross_value"])
@@ -273,18 +273,18 @@ def summarize_derived(data: dict[str, Any] | None) -> dict[str, Any] | None:
             else dusdc(int(last_live_liability)),
         },
         "risk": {
-            "allocated_capital": dusdc_stats(field_values(records, ("risk", "allocated_capital"))),
-            "position_liability_over_allocated": ratio_stats(
-                field_values(records, ("risk", "position_liability_over_allocated"))
+            "expiry_funding_basis": dusdc_stats(field_values(records, ("risk", "expiry_funding_basis"))),
+            "position_liability_over_funding": ratio_stats(
+                field_values(records, ("risk", "position_liability_over_funding"))
             ),
-            "active_open_contribution_over_allocated": ratio_stats(
-                field_values(records, ("risk", "active_open_contribution_over_allocated"))
+            "active_open_contribution_over_funding": ratio_stats(
+                field_values(records, ("risk", "active_open_contribution_over_funding"))
             ),
-            "lp_live_mtm_pnl_over_allocated": ratio_stats(
-                field_values(records, ("risk", "lp_live_mtm_pnl_over_allocated"))
+            "lp_live_mtm_pnl_over_funding": ratio_stats(
+                field_values(records, ("risk", "lp_live_mtm_pnl_over_funding"))
             ),
-            "active_book_live_pnl_over_allocated": ratio_stats(
-                field_values(records, ("risk", "active_book_live_pnl_over_allocated"))
+            "active_book_live_pnl_over_funding": ratio_stats(
+                field_values(records, ("risk", "active_book_live_pnl_over_funding"))
             ),
             "active_book_live_pnl_over_liability": ratio_stats(
                 field_values(records, ("risk", "active_book_live_pnl_over_liability"))
@@ -292,14 +292,14 @@ def summarize_derived(data: dict[str, Any] | None) -> dict[str, Any] | None:
             "liquidatable_value_over_liability": ratio_stats(
                 field_values(records, ("risk", "liquidatable_value_over_liability"))
             ),
-            "step_trading_fee_over_allocated": ratio_stats(
-                field_values(records, ("risk", "step_trading_fee_over_allocated"))
+            "step_trading_fee_over_funding": ratio_stats(
+                field_values(records, ("risk", "step_trading_fee_over_funding"))
             ),
-            "step_liquidation_gap_over_allocated": ratio_stats(
-                field_values(records, ("risk", "step_liquidation_gap_over_allocated"))
+            "step_liquidation_gap_over_funding": ratio_stats(
+                field_values(records, ("risk", "step_liquidation_gap_over_funding"))
             ),
-            "step_net_liquidation_over_allocated": ratio_stats(
-                field_values(records, ("risk", "step_net_liquidation_over_allocated"))
+            "step_net_liquidation_over_funding": ratio_stats(
+                field_values(records, ("risk", "step_net_liquidation_over_funding"))
             ),
         },
         "liquidation": {

--- a/packages/predict/simulations/summarize_economics.py
+++ b/packages/predict/simulations/summarize_economics.py
@@ -91,13 +91,13 @@ def update_totals(records: list[dict[str, Any]]) -> dict[str, int]:
                 settled_payout = int(update["settled_payout_amount"])
                 totals["redeem_payout"] += settled_payout
                 totals["terminal_settled_payout"] += settled_payout
-                totals["terminal_trading_loss_eligible_rebate"] += int(
-                    update.get("trading_loss_eligible_rebate", "0")
-                )
-                totals["terminal_trading_loss_rebate"] += int(update["trading_loss_rebate"])
-                totals["terminal_trading_loss_unpaid_rebate"] += int(
-                    update.get("trading_loss_unpaid_rebate", "0")
-                )
+                totals["terminal_gross_profit_before_rebate"] += int(update["gross_profit_before_rebate"])
+                totals["terminal_resolved_rebate_reserve"] += int(update["resolved_rebate_reserve"])
+                totals["terminal_eligible_rebate"] += int(update["eligible_rebate"])
+                totals["terminal_rebate_amount"] += int(update["rebate_amount"])
+                totals["terminal_residual_rebate_reserve"] += int(update["residual_rebate_reserve"])
+                totals["terminal_returned_rebate_reserve"] += int(update["returned_rebate_reserve"])
+                totals["terminal_returned_pool_cash"] += int(update["returned_pool_cash"])
                 totals["terminal_returned_cash"] += int(update["returned_cash"])
                 totals["terminal_materialized_profit"] += int(update["materialized_profit"])
                 totals["terminal_lp_profit"] += int(update["lp_profit"])

--- a/packages/predict/simulations/tools/analyze_liquidation_priority_encodings.py
+++ b/packages/predict/simulations/tools/analyze_liquidation_priority_encodings.py
@@ -867,7 +867,7 @@ def main() -> None:
             raise SystemExit("scenario config must include source.expiry_ms")
         economic_data = load_json_object(args.python_long_data)
         if economic_data.get("schema_version") != replay.ECONOMIC_SCHEMA_VERSION:
-            raise SystemExit("input must use predict_economic_v1 schema")
+            raise SystemExit(f"input must use {replay.ECONOMIC_SCHEMA_VERSION} schema")
         dataset = build_ranking_dataset(
             economic_data,
             expiry_ms,

--- a/packages/predict/sources/config/config_constants.move
+++ b/packages/predict/sources/config/config_constants.move
@@ -7,30 +7,30 @@
 /// envelope admin setters can tune within. Changing a bound requires a package upgrade.
 module deepbook_predict::config_constants;
 
-const EInvalidBaseFee: u64 = 1;
-const EInvalidMinFee: u64 = 2;
-const EInvalidMinAskPrice: u64 = 3;
-const EInvalidMaxAskPrice: u64 = 4;
-const EInvalidPythSpotFreshnessMs: u64 = 5;
-const EInvalidBlockScholesPricesFreshnessMs: u64 = 6;
-const EInvalidBlockScholesSVIFreshnessMs: u64 = 7;
-const EInvalidProtocolReserveFeeShare: u64 = 9;
-const EInvalidSettlementFreshnessMs: u64 = 11;
-const EInvalidMaxSpotDeviation: u64 = 12;
-const EInvalidMaxBasisDeviation: u64 = 13;
-const EInvalidMinBasis: u64 = 14;
-const EInvalidMaxBasis: u64 = 15;
-const EInvalidMaxExpiryFunding: u64 = 16;
-const EInvalidTradingLossRebateRate: u64 = 21;
-const EInvalidMaxExpiryFloorPremium: u64 = 22;
-const EInvalidExpiryFeeWindowMs: u64 = 23;
-const EInvalidExpiryFeeMaxMultiplier: u64 = 24;
-const EInvalidLowerBenefitPower: u64 = 25;
-const EInvalidUpperBenefitPower: u64 = 26;
-const EInvalidBenefitPowers: u64 = 27;
-const EInvalidValuationLiquidationBudget: u64 = 28;
-const EInvalidTradeLiquidationBudget: u64 = 29;
-const EInvalidLiquidationLtv: u64 = 30;
+const EInvalidBaseFee: u64 = 0;
+const EInvalidMinFee: u64 = 1;
+const EInvalidMinAskPrice: u64 = 2;
+const EInvalidMaxAskPrice: u64 = 3;
+const EInvalidPythSpotFreshnessMs: u64 = 4;
+const EInvalidBlockScholesPricesFreshnessMs: u64 = 5;
+const EInvalidBlockScholesSVIFreshnessMs: u64 = 6;
+const EInvalidProtocolReserveProfitShare: u64 = 7;
+const EInvalidSettlementFreshnessMs: u64 = 8;
+const EInvalidMaxSpotDeviation: u64 = 9;
+const EInvalidMaxBasisDeviation: u64 = 10;
+const EInvalidMinBasis: u64 = 11;
+const EInvalidMaxBasis: u64 = 12;
+const EInvalidMaxExpiryFunding: u64 = 13;
+const EInvalidTradingLossRebateRate: u64 = 14;
+const EInvalidMaxExpiryFloorPremium: u64 = 15;
+const EInvalidExpiryFeeWindowMs: u64 = 16;
+const EInvalidExpiryFeeMaxMultiplier: u64 = 17;
+const EInvalidLowerBenefitPower: u64 = 18;
+const EInvalidUpperBenefitPower: u64 = 19;
+const EInvalidBenefitPowers: u64 = 20;
+const EInvalidValuationLiquidationBudget: u64 = 21;
+const EInvalidTradeLiquidationBudget: u64 = 22;
+const EInvalidLiquidationLtv: u64 = 23;
 
 // === Expiry Funding and Liquidation ===
 
@@ -203,17 +203,17 @@ public(package) fun assert_block_scholes_svi_freshness_ms(value: u64) {
 
 // === Fees ===
 
-public(package) macro fun default_protocol_reserve_fee_share(): u64 { 400_000_000 }
-public(package) macro fun min_protocol_reserve_fee_share(): u64 { 0 }
-public(package) macro fun max_protocol_reserve_fee_share(): u64 {
+public(package) macro fun default_protocol_reserve_profit_share(): u64 { 400_000_000 }
+public(package) macro fun min_protocol_reserve_profit_share(): u64 { 0 }
+public(package) macro fun max_protocol_reserve_profit_share(): u64 {
     deepbook_predict::constants::float_scaling!()
 }
 
-public(package) fun assert_protocol_reserve_fee_share(value: u64) {
+public(package) fun assert_protocol_reserve_profit_share(value: u64) {
     assert!(
-        value >= min_protocol_reserve_fee_share!()
-            && value <= max_protocol_reserve_fee_share!(),
-        EInvalidProtocolReserveFeeShare,
+        value >= min_protocol_reserve_profit_share!()
+            && value <= max_protocol_reserve_profit_share!(),
+        EInvalidProtocolReserveProfitShare,
     );
 }
 

--- a/packages/predict/sources/config/config_constants.move
+++ b/packages/predict/sources/config/config_constants.move
@@ -1,14 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Constants and validation helpers for admin-tunable config.
+/// Constants and validation helpers for admin-tunable policy.
 ///
-/// Default values seed stored config objects at creation. Bounds define the hard
-/// envelope admin setters can tune within. Changing a bound requires a package
-/// upgrade.
+/// Default values seed stored policy state at creation. Bounds define the hard
+/// envelope admin setters can tune within. Changing a bound requires a package upgrade.
 module deepbook_predict::config_constants;
 
-const EInvalidMaxTotalExposurePct: u64 = 0;
 const EInvalidBaseFee: u64 = 1;
 const EInvalidMinFee: u64 = 2;
 const EInvalidMinAskPrice: u64 = 3;
@@ -16,19 +14,13 @@ const EInvalidMaxAskPrice: u64 = 4;
 const EInvalidPythSpotFreshnessMs: u64 = 5;
 const EInvalidBlockScholesPricesFreshnessMs: u64 = 6;
 const EInvalidBlockScholesSVIFreshnessMs: u64 = 7;
-const EInvalidLpFeeShare: u64 = 8;
-const EInvalidProtocolFeeShare: u64 = 9;
-const EInvalidInsuranceFeeShare: u64 = 10;
+const EInvalidProtocolReserveFeeShare: u64 = 9;
 const EInvalidSettlementFreshnessMs: u64 = 11;
 const EInvalidMaxSpotDeviation: u64 = 12;
 const EInvalidMaxBasisDeviation: u64 = 13;
 const EInvalidMinBasis: u64 = 14;
 const EInvalidMaxBasis: u64 = 15;
-const EInvalidExpiryAllocation: u64 = 16;
-const EInvalidGrowUtilizationThreshold: u64 = 17;
-const EInvalidShrinkUtilizationThreshold: u64 = 18;
-const EInvalidGrowFactor: u64 = 19;
-const EInvalidShrinkFactor: u64 = 20;
+const EInvalidMaxExpiryFunding: u64 = 16;
 const EInvalidTradingLossRebateRate: u64 = 21;
 const EInvalidMaxExpiryFloorPremium: u64 = 22;
 const EInvalidExpiryFeeWindowMs: u64 = 23;
@@ -40,74 +32,19 @@ const EInvalidValuationLiquidationBudget: u64 = 28;
 const EInvalidTradeLiquidationBudget: u64 = 29;
 const EInvalidLiquidationLtv: u64 = 30;
 
-// === Pool Risk ===
+// === Expiry Funding and Liquidation ===
 
-public(package) macro fun default_max_total_exposure_pct(): u64 { 800_000_000 }
-public(package) macro fun min_max_total_exposure_pct(): u64 { 1 }
-public(package) macro fun max_max_total_exposure_pct(): u64 {
-    deepbook_predict::constants::float_scaling!()
+public(package) macro fun default_max_expiry_funding(): u64 { 250_000_000_000 }
+public(package) macro fun min_max_expiry_funding(): u64 {
+    deepbook_predict::constants::expiry_cash_floor!()
 }
+public(package) macro fun max_max_expiry_funding(): u64 { 250_000_000_000 }
 
-public(package) fun assert_max_total_exposure_pct(value: u64) {
+public(package) fun assert_max_expiry_funding(value: u64) {
     assert!(
-        value >= min_max_total_exposure_pct!() && value <= max_max_total_exposure_pct!(),
-        EInvalidMaxTotalExposurePct,
+        value >= min_max_expiry_funding!() && value <= max_max_expiry_funding!(),
+        EInvalidMaxExpiryFunding,
     );
-}
-
-public(package) macro fun default_allocation(): u64 { 50_000_000_000 }
-public(package) macro fun min_allocation(): u64 { 50_000_000_000 }
-public(package) macro fun max_allocation(): u64 { 250_000_000_000 }
-
-public(package) fun assert_expiry_allocation(value: u64) {
-    assert!(value >= min_allocation!() && value <= max_allocation!(), EInvalidExpiryAllocation);
-}
-
-public(package) macro fun default_grow_utilization_threshold(): u64 { 800_000_000 }
-public(package) macro fun min_grow_utilization_threshold(): u64 { 0 }
-public(package) macro fun max_grow_utilization_threshold(): u64 {
-    deepbook_predict::constants::float_scaling!()
-}
-
-public(package) fun assert_grow_utilization_threshold(value: u64) {
-    assert!(
-        value >= min_grow_utilization_threshold!() && value <= max_grow_utilization_threshold!(),
-        EInvalidGrowUtilizationThreshold,
-    );
-}
-
-public(package) macro fun default_shrink_utilization_threshold(): u64 { 300_000_000 }
-public(package) macro fun min_shrink_utilization_threshold(): u64 { 0 }
-public(package) macro fun max_shrink_utilization_threshold(): u64 {
-    deepbook_predict::constants::float_scaling!()
-}
-
-public(package) fun assert_shrink_utilization_threshold(value: u64) {
-    assert!(
-        value >= min_shrink_utilization_threshold!()
-            && value <= max_shrink_utilization_threshold!(),
-        EInvalidShrinkUtilizationThreshold,
-    );
-}
-
-public(package) macro fun default_grow_factor(): u64 { 2_000_000_000 }
-public(package) macro fun min_grow_factor(): u64 {
-    deepbook_predict::constants::float_scaling!() + 1
-}
-public(package) macro fun max_grow_factor(): u64 { 10_000_000_000 }
-
-public(package) fun assert_grow_factor(value: u64) {
-    assert!(value >= min_grow_factor!() && value <= max_grow_factor!(), EInvalidGrowFactor);
-}
-
-public(package) macro fun default_shrink_factor(): u64 { 500_000_000 }
-public(package) macro fun min_shrink_factor(): u64 { 0 }
-public(package) macro fun max_shrink_factor(): u64 {
-    deepbook_predict::constants::float_scaling!() - 1
-}
-
-public(package) fun assert_shrink_factor(value: u64) {
-    assert!(value >= min_shrink_factor!() && value <= max_shrink_factor!(), EInvalidShrinkFactor);
 }
 
 public(package) macro fun default_valuation_liquidation_budget(): u64 { 192 }
@@ -266,37 +203,17 @@ public(package) fun assert_block_scholes_svi_freshness_ms(value: u64) {
 
 // === Fees ===
 
-public(package) macro fun default_lp_fee_share(): u64 { 600_000_000 }
-public(package) macro fun min_lp_fee_share(): u64 { 0 }
-public(package) macro fun max_lp_fee_share(): u64 { deepbook_predict::constants::float_scaling!() }
-
-public(package) fun assert_lp_fee_share(value: u64) {
-    assert!(value >= min_lp_fee_share!() && value <= max_lp_fee_share!(), EInvalidLpFeeShare);
-}
-
-public(package) macro fun default_protocol_fee_share(): u64 { 200_000_000 }
-public(package) macro fun min_protocol_fee_share(): u64 { 0 }
-public(package) macro fun max_protocol_fee_share(): u64 {
+public(package) macro fun default_protocol_reserve_fee_share(): u64 { 400_000_000 }
+public(package) macro fun min_protocol_reserve_fee_share(): u64 { 0 }
+public(package) macro fun max_protocol_reserve_fee_share(): u64 {
     deepbook_predict::constants::float_scaling!()
 }
 
-public(package) fun assert_protocol_fee_share(value: u64) {
+public(package) fun assert_protocol_reserve_fee_share(value: u64) {
     assert!(
-        value >= min_protocol_fee_share!() && value <= max_protocol_fee_share!(),
-        EInvalidProtocolFeeShare,
-    );
-}
-
-public(package) macro fun default_insurance_fee_share(): u64 { 200_000_000 }
-public(package) macro fun min_insurance_fee_share(): u64 { 0 }
-public(package) macro fun max_insurance_fee_share(): u64 {
-    deepbook_predict::constants::float_scaling!()
-}
-
-public(package) fun assert_insurance_fee_share(value: u64) {
-    assert!(
-        value >= min_insurance_fee_share!() && value <= max_insurance_fee_share!(),
-        EInvalidInsuranceFeeShare,
+        value >= min_protocol_reserve_fee_share!()
+            && value <= max_protocol_reserve_fee_share!(),
+        EInvalidProtocolReserveFeeShare,
     );
 }
 

--- a/packages/predict/sources/config/fee_config.move
+++ b/packages/predict/sources/config/fee_config.move
@@ -3,38 +3,24 @@
 
 /// Stored fee policy config.
 ///
-/// PoolVault reads the current fee-share policy when sweeping settled expiry fee surplus.
+/// PoolVault reads the current reserve share when materializing aggregate expiry profit.
 /// Expiry markets snapshot the trading loss rebate rate at creation.
 module deepbook_predict::fee_config;
 
-use deepbook_predict::{config_constants, constants};
+use deepbook_predict::config_constants;
 
-const EInvalidFeeSplit: u64 = 0;
-
-/// Fee surplus distribution and trading loss rebate policy.
+/// Profit split and trading loss rebate policy.
 public struct FeeConfig has store {
-    /// LP fee share in FLOAT_SCALING; returned into pool idle liquidity.
-    lp_fee_share: u64,
-    /// Protocol revenue share in FLOAT_SCALING.
-    protocol_fee_share: u64,
-    /// Insurance fund share in FLOAT_SCALING.
-    insurance_fee_share: u64,
+    /// Merged protocol and insurance reserve share in FLOAT_SCALING.
+    protocol_reserve_fee_share: u64,
     /// Fraction of aggregate expiry trading fees reserved for loss rebates.
     trading_loss_rebate_rate: u64,
 }
 
 // === Public-Package Functions ===
 
-public(package) fun lp_fee_share(config: &FeeConfig): u64 {
-    config.lp_fee_share
-}
-
-public(package) fun protocol_fee_share(config: &FeeConfig): u64 {
-    config.protocol_fee_share
-}
-
-public(package) fun insurance_fee_share(config: &FeeConfig): u64 {
-    config.insurance_fee_share
+public(package) fun protocol_reserve_fee_share(config: &FeeConfig): u64 {
+    config.protocol_reserve_fee_share
 }
 
 public(package) fun trading_loss_rebate_rate(config: &FeeConfig): u64 {
@@ -43,27 +29,17 @@ public(package) fun trading_loss_rebate_rate(config: &FeeConfig): u64 {
 
 public(package) fun new(): FeeConfig {
     FeeConfig {
-        lp_fee_share: config_constants::default_lp_fee_share!(),
-        protocol_fee_share: config_constants::default_protocol_fee_share!(),
-        insurance_fee_share: config_constants::default_insurance_fee_share!(),
+        protocol_reserve_fee_share: config_constants::default_protocol_reserve_fee_share!(),
         trading_loss_rebate_rate: config_constants::default_trading_loss_rebate_rate!(),
     }
 }
 
-public(package) fun set_fee_shares(
+public(package) fun set_protocol_reserve_fee_share(
     config: &mut FeeConfig,
-    lp_fee_share: u64,
-    protocol_fee_share: u64,
-    insurance_fee_share: u64,
+    protocol_reserve_fee_share: u64,
 ) {
-    config_constants::assert_lp_fee_share(lp_fee_share);
-    config_constants::assert_protocol_fee_share(protocol_fee_share);
-    config_constants::assert_insurance_fee_share(insurance_fee_share);
-    let total_share = lp_fee_share + protocol_fee_share + insurance_fee_share;
-    assert!(total_share == constants::float_scaling!(), EInvalidFeeSplit);
-    config.lp_fee_share = lp_fee_share;
-    config.protocol_fee_share = protocol_fee_share;
-    config.insurance_fee_share = insurance_fee_share;
+    config_constants::assert_protocol_reserve_fee_share(protocol_reserve_fee_share);
+    config.protocol_reserve_fee_share = protocol_reserve_fee_share;
 }
 
 public(package) fun set_trading_loss_rebate_rate(config: &mut FeeConfig, value: u64) {

--- a/packages/predict/sources/config/fee_config.move
+++ b/packages/predict/sources/config/fee_config.move
@@ -12,15 +12,15 @@ use deepbook_predict::config_constants;
 /// Profit split and trading loss rebate policy.
 public struct FeeConfig has store {
     /// Merged protocol and insurance reserve share in FLOAT_SCALING.
-    protocol_reserve_fee_share: u64,
+    protocol_reserve_profit_share: u64,
     /// Fraction of aggregate expiry trading fees reserved for loss rebates.
     trading_loss_rebate_rate: u64,
 }
 
 // === Public-Package Functions ===
 
-public(package) fun protocol_reserve_fee_share(config: &FeeConfig): u64 {
-    config.protocol_reserve_fee_share
+public(package) fun protocol_reserve_profit_share(config: &FeeConfig): u64 {
+    config.protocol_reserve_profit_share
 }
 
 public(package) fun trading_loss_rebate_rate(config: &FeeConfig): u64 {
@@ -29,17 +29,17 @@ public(package) fun trading_loss_rebate_rate(config: &FeeConfig): u64 {
 
 public(package) fun new(): FeeConfig {
     FeeConfig {
-        protocol_reserve_fee_share: config_constants::default_protocol_reserve_fee_share!(),
+        protocol_reserve_profit_share: config_constants::default_protocol_reserve_profit_share!(),
         trading_loss_rebate_rate: config_constants::default_trading_loss_rebate_rate!(),
     }
 }
 
-public(package) fun set_protocol_reserve_fee_share(
+public(package) fun set_protocol_reserve_profit_share(
     config: &mut FeeConfig,
-    protocol_reserve_fee_share: u64,
+    protocol_reserve_profit_share: u64,
 ) {
-    config_constants::assert_protocol_reserve_fee_share(protocol_reserve_fee_share);
-    config.protocol_reserve_fee_share = protocol_reserve_fee_share;
+    config_constants::assert_protocol_reserve_profit_share(protocol_reserve_profit_share);
+    config.protocol_reserve_profit_share = protocol_reserve_profit_share;
 }
 
 public(package) fun set_trading_loss_rebate_rate(config: &mut FeeConfig, value: u64) {

--- a/packages/predict/sources/config/risk_config.move
+++ b/packages/predict/sources/config/risk_config.move
@@ -1,30 +1,16 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Stored risk configuration for pool and expiry allocation limits.
+/// Stored risk configuration for liquidation budgets.
 ///
-/// ProtocolConfig owns this mutable policy. PoolVault reads it for new expiry
-/// allocations, global pool utilization, and dynamic allocation resizing.
+/// ProtocolConfig owns this mutable policy. Expiry markets read liquidation
+/// budgets before valuation and trade flows.
 module deepbook_predict::risk_config;
 
 use deepbook_predict::config_constants;
 
-const EInvalidResizeThresholds: u64 = 0;
-
-/// Pool risk limits enforced by the parallel pool path.
+/// Liquidation maintenance policy.
 public struct RiskConfig has store {
-    /// Max total allocated exposure as % of pool value (e.g., 800_000_000 = 80%).
-    max_total_exposure_pct: u64,
-    /// Current DUSDC allocation used when creating a new expiry market.
-    expiry_allocation: u64,
-    /// Expiry utilization at or above which permissionless growth is allowed.
-    grow_utilization_threshold: u64,
-    /// Expiry utilization at or below which permissionless shrink is allowed.
-    shrink_utilization_threshold: u64,
-    /// Multiplier used to target a larger allocation during growth.
-    grow_factor: u64,
-    /// Multiplier used to target a smaller allocation during shrink.
-    shrink_factor: u64,
     /// Total liquidation candidates checked before live pool valuation.
     valuation_liquidation_budget: u64,
     /// Total liquidation candidates checked before mint and redeem flows.
@@ -32,30 +18,6 @@ public struct RiskConfig has store {
 }
 
 // === Public-Package Functions ===
-
-public(package) fun max_total_exposure_pct(config: &RiskConfig): u64 {
-    config.max_total_exposure_pct
-}
-
-public(package) fun expiry_allocation(config: &RiskConfig): u64 {
-    config.expiry_allocation
-}
-
-public(package) fun grow_utilization_threshold(config: &RiskConfig): u64 {
-    config.grow_utilization_threshold
-}
-
-public(package) fun shrink_utilization_threshold(config: &RiskConfig): u64 {
-    config.shrink_utilization_threshold
-}
-
-public(package) fun grow_factor(config: &RiskConfig): u64 {
-    config.grow_factor
-}
-
-public(package) fun shrink_factor(config: &RiskConfig): u64 {
-    config.shrink_factor
-}
 
 public(package) fun valuation_liquidation_budget(config: &RiskConfig): u64 {
     config.valuation_liquidation_budget
@@ -67,47 +29,9 @@ public(package) fun trade_liquidation_budget(config: &RiskConfig): u64 {
 
 public(package) fun new(): RiskConfig {
     RiskConfig {
-        max_total_exposure_pct: config_constants::default_max_total_exposure_pct!(),
-        expiry_allocation: config_constants::default_allocation!(),
-        grow_utilization_threshold: config_constants::default_grow_utilization_threshold!(),
-        shrink_utilization_threshold: config_constants::default_shrink_utilization_threshold!(),
-        grow_factor: config_constants::default_grow_factor!(),
-        shrink_factor: config_constants::default_shrink_factor!(),
         valuation_liquidation_budget: config_constants::default_valuation_liquidation_budget!(),
         trade_liquidation_budget: config_constants::default_trade_liquidation_budget!(),
     }
-}
-
-public(package) fun set_max_total_exposure_pct(config: &mut RiskConfig, pct: u64) {
-    config_constants::assert_max_total_exposure_pct(pct);
-    config.max_total_exposure_pct = pct;
-}
-
-public(package) fun set_expiry_allocation(config: &mut RiskConfig, allocation: u64) {
-    config_constants::assert_expiry_allocation(allocation);
-    config.expiry_allocation = allocation;
-}
-
-public(package) fun set_grow_utilization_threshold(config: &mut RiskConfig, threshold: u64) {
-    config_constants::assert_grow_utilization_threshold(threshold);
-    assert!(threshold >= config.shrink_utilization_threshold, EInvalidResizeThresholds);
-    config.grow_utilization_threshold = threshold;
-}
-
-public(package) fun set_shrink_utilization_threshold(config: &mut RiskConfig, threshold: u64) {
-    config_constants::assert_shrink_utilization_threshold(threshold);
-    assert!(threshold <= config.grow_utilization_threshold, EInvalidResizeThresholds);
-    config.shrink_utilization_threshold = threshold;
-}
-
-public(package) fun set_grow_factor(config: &mut RiskConfig, factor: u64) {
-    config_constants::assert_grow_factor(factor);
-    config.grow_factor = factor;
-}
-
-public(package) fun set_shrink_factor(config: &mut RiskConfig, factor: u64) {
-    config_constants::assert_shrink_factor(factor);
-    config.shrink_factor = factor;
 }
 
 public(package) fun set_valuation_liquidation_budget(config: &mut RiskConfig, budget: u64) {

--- a/packages/predict/sources/config/stake_config.move
+++ b/packages/predict/sources/config/stake_config.move
@@ -32,18 +32,26 @@ public(package) fun upper_benefit_power(config: &StakeConfig): u64 {
     config.upper_benefit_power
 }
 
-/// Trading-fee discount for an active stake, in FLOAT_SCALING: the two-segment
-/// benefit ratio scaled by the fixed `max_fee_discount` (50%).
-public(package) fun fee_discount_fraction(config: &StakeConfig, active_stake: u64): u64 {
-    math::mul(config.benefit_ratio(active_stake), constants::max_fee_discount!())
+/// Fee amount remaining after the active stake discount is applied.
+public(package) fun fee_amount_after_discount(
+    config: &StakeConfig,
+    amount: u64,
+    active_stake: u64,
+): u64 {
+    let discount_fraction = math::mul(
+        config.benefit_ratio(active_stake),
+        constants::max_fee_discount!(),
+    );
+    amount - math::mul(amount, discount_fraction)
 }
 
-/// Share of a manager's eligible trading-loss rebate for an active stake, in
-/// FLOAT_SCALING: the two-segment benefit ratio directly (no staking-side cap;
-/// the rebate's size is set by `trading_loss_rebate_rate`). The complement
-/// compounds to LPs.
-public(package) fun rebate_fraction(config: &StakeConfig, active_stake: u64): u64 {
-    config.benefit_ratio(active_stake)
+/// Trading-loss rebate amount paid for an active stake.
+public(package) fun rebate_amount(
+    config: &StakeConfig,
+    eligible_rebate: u64,
+    active_stake: u64,
+): u64 {
+    math::mul(eligible_rebate, config.benefit_ratio(active_stake))
 }
 
 public(package) fun new(): StakeConfig {

--- a/packages/predict/sources/core/constants.move
+++ b/packages/predict/sources/core/constants.move
@@ -37,6 +37,9 @@ public macro fun position_lot_size(): u64 { 10_000 }
 /// DUSDC cash floor targeted by pool rebalancing, in 6-decimal quote units.
 public(package) macro fun expiry_cash_floor(): u64 { 50_000_000_000 }
 
+/// Maximum active expiries that can require full-pool sync processing.
+public(package) macro fun max_active_expiry_markets(): u64 { 10 }
+
 /// Rebalancing band and target buffer fraction, in FLOAT_SCALING.
 public(package) macro fun expiry_rebalance_pct(): u64 { 100_000_000 }
 

--- a/packages/predict/sources/core/constants.move
+++ b/packages/predict/sources/core/constants.move
@@ -32,6 +32,14 @@ public macro fun float_scaling_decimals(): u64 { 9 }
 /// Minimum position quantity increment.
 public macro fun position_lot_size(): u64 { 10_000 }
 
+// === Pool Funding ===
+
+/// DUSDC cash every expiry starts with, in 6-decimal quote units.
+public(package) macro fun expiry_cash_floor(): u64 { 50_000_000_000 }
+
+/// Rebalancing band and target buffer fraction, in FLOAT_SCALING.
+public(package) macro fun expiry_rebalance_pct(): u64 { 100_000_000 }
+
 // === Leverage ===
 
 /// Window before expiry over which the leverage floor index rises.

--- a/packages/predict/sources/core/constants.move
+++ b/packages/predict/sources/core/constants.move
@@ -34,7 +34,7 @@ public macro fun position_lot_size(): u64 { 10_000 }
 
 // === Pool Funding ===
 
-/// DUSDC cash every expiry starts with, in 6-decimal quote units.
+/// DUSDC cash floor targeted by pool rebalancing, in 6-decimal quote units.
 public(package) macro fun expiry_cash_floor(): u64 { 50_000_000_000 }
 
 /// Rebalancing band and target buffer fraction, in FLOAT_SCALING.

--- a/packages/predict/sources/events/claim_events.move
+++ b/packages/predict/sources/events/claim_events.move
@@ -18,8 +18,7 @@ public struct TradingLossRebateClaimed has copy, drop, store {
     expiry_market_id: ID,
     predict_manager_id: ID,
     trading_fees_paid: u64,
-    cash_paid_to_expiry: u64,
-    cash_received_from_expiry: u64,
+    trading_loss: u64,
     rebate_amount: u64,
 }
 
@@ -37,16 +36,14 @@ public(package) fun emit_trading_loss_rebate_claimed(
     expiry_market_id: ID,
     predict_manager_id: ID,
     trading_fees_paid: u64,
-    cash_paid_to_expiry: u64,
-    cash_received_from_expiry: u64,
+    trading_loss: u64,
     rebate_amount: u64,
 ) {
     event::emit(TradingLossRebateClaimed {
         expiry_market_id,
         predict_manager_id,
         trading_fees_paid,
-        cash_paid_to_expiry,
-        cash_received_from_expiry,
+        trading_loss,
         rebate_amount,
     });
 }

--- a/packages/predict/sources/events/claim_events.move
+++ b/packages/predict/sources/events/claim_events.move
@@ -18,7 +18,8 @@ public struct TradingLossRebateClaimed has copy, drop, store {
     expiry_market_id: ID,
     predict_manager_id: ID,
     trading_fees_paid: u64,
-    trading_loss: u64,
+    gross_profit: u64,
+    eligible_rebate: u64,
     rebate_amount: u64,
 }
 
@@ -36,14 +37,16 @@ public(package) fun emit_trading_loss_rebate_claimed(
     expiry_market_id: ID,
     predict_manager_id: ID,
     trading_fees_paid: u64,
-    trading_loss: u64,
+    gross_profit: u64,
+    eligible_rebate: u64,
     rebate_amount: u64,
 ) {
     event::emit(TradingLossRebateClaimed {
         expiry_market_id,
         predict_manager_id,
         trading_fees_paid,
-        trading_loss,
+        gross_profit,
+        eligible_rebate,
         rebate_amount,
     });
 }

--- a/packages/predict/sources/events/config_events.move
+++ b/packages/predict/sources/events/config_events.move
@@ -25,24 +25,16 @@ public struct PricingConfigUpdated has copy, drop, store {
     block_scholes_svi_freshness_ms: u64,
 }
 
-/// Emitted when fee-share or trading-loss rebate policy changes.
+/// Emitted when profit-reserve or trading-loss rebate policy changes.
 public struct FeeConfigUpdated has copy, drop, store {
     protocol_config_id: ID,
-    lp_fee_share: u64,
-    protocol_fee_share: u64,
-    insurance_fee_share: u64,
+    protocol_reserve_fee_share: u64,
     trading_loss_rebate_rate: u64,
 }
 
-/// Emitted when pool risk, allocation, or liquidation-budget policy changes.
+/// Emitted when liquidation-budget policy changes.
 public struct RiskConfigUpdated has copy, drop, store {
     protocol_config_id: ID,
-    max_total_exposure_pct: u64,
-    expiry_allocation: u64,
-    grow_utilization_threshold: u64,
-    shrink_utilization_threshold: u64,
-    grow_factor: u64,
-    shrink_factor: u64,
     valuation_liquidation_budget: u64,
     trade_liquidation_budget: u64,
 }
@@ -122,9 +114,7 @@ public(package) fun emit_pricing_config_updated(protocol_config_id: ID, config: 
 public(package) fun emit_fee_config_updated(protocol_config_id: ID, config: &FeeConfig) {
     event::emit(FeeConfigUpdated {
         protocol_config_id,
-        lp_fee_share: config.lp_fee_share(),
-        protocol_fee_share: config.protocol_fee_share(),
-        insurance_fee_share: config.insurance_fee_share(),
+        protocol_reserve_fee_share: config.protocol_reserve_fee_share(),
         trading_loss_rebate_rate: config.trading_loss_rebate_rate(),
     });
 }
@@ -132,12 +122,6 @@ public(package) fun emit_fee_config_updated(protocol_config_id: ID, config: &Fee
 public(package) fun emit_risk_config_updated(protocol_config_id: ID, config: &RiskConfig) {
     event::emit(RiskConfigUpdated {
         protocol_config_id,
-        max_total_exposure_pct: config.max_total_exposure_pct(),
-        expiry_allocation: config.expiry_allocation(),
-        grow_utilization_threshold: config.grow_utilization_threshold(),
-        shrink_utilization_threshold: config.shrink_utilization_threshold(),
-        grow_factor: config.grow_factor(),
-        shrink_factor: config.shrink_factor(),
         valuation_liquidation_budget: config.valuation_liquidation_budget(),
         trade_liquidation_budget: config.trade_liquidation_budget(),
     });

--- a/packages/predict/sources/events/config_events.move
+++ b/packages/predict/sources/events/config_events.move
@@ -28,7 +28,7 @@ public struct PricingConfigUpdated has copy, drop, store {
 /// Emitted when profit-reserve or trading-loss rebate policy changes.
 public struct FeeConfigUpdated has copy, drop, store {
     protocol_config_id: ID,
-    protocol_reserve_fee_share: u64,
+    protocol_reserve_profit_share: u64,
     trading_loss_rebate_rate: u64,
 }
 
@@ -114,7 +114,7 @@ public(package) fun emit_pricing_config_updated(protocol_config_id: ID, config: 
 public(package) fun emit_fee_config_updated(protocol_config_id: ID, config: &FeeConfig) {
     event::emit(FeeConfigUpdated {
         protocol_config_id,
-        protocol_reserve_fee_share: config.protocol_reserve_fee_share(),
+        protocol_reserve_profit_share: config.protocol_reserve_profit_share(),
         trading_loss_rebate_rate: config.trading_loss_rebate_rate(),
     });
 }

--- a/packages/predict/sources/events/vault_events.move
+++ b/packages/predict/sources/events/vault_events.move
@@ -66,9 +66,10 @@ public struct ExpiryCashReceived has copy, drop, store {
     received_from_expiry_after: u64,
 }
 
-/// Emitted when aggregate returned expiry cash is split between LPs and protocol reserves.
+/// Emitted when terminal expiry profit is split between LPs and protocol reserves.
 public struct ExpiryProfitMaterialized has copy, drop, store {
     pool_vault_id: ID,
+    expiry_market_id: ID,
     lp_profit: u64,
     protocol_profit: u64,
     idle_balance_after: u64,
@@ -174,6 +175,7 @@ public(package) fun emit_expiry_cash_received(
 
 public(package) fun emit_expiry_profit_materialized(
     pool_vault_id: ID,
+    expiry_market_id: ID,
     lp_profit: u64,
     protocol_profit: u64,
     idle_balance_after: u64,
@@ -182,6 +184,7 @@ public(package) fun emit_expiry_profit_materialized(
 ) {
     event::emit(ExpiryProfitMaterialized {
         pool_vault_id,
+        expiry_market_id,
         lp_profit,
         protocol_profit,
         idle_balance_after,

--- a/packages/predict/sources/events/vault_events.move
+++ b/packages/predict/sources/events/vault_events.move
@@ -5,7 +5,7 @@
 ///
 /// These are low-frequency relative to trades, so they are rich: supply and
 /// withdraw carry the pool value used to price shares, and settled-expiry
-/// sweeps carry the raw cash and fee movements.
+/// sweeps carry the pool-owned expiry cash-flow movements.
 module deepbook_predict::vault_events;
 
 use sui::event;
@@ -22,7 +22,6 @@ public struct SupplyExecuted has copy, drop, store {
     pool_value_before: u64,
     total_supply_after: u64,
     idle_balance_after: u64,
-    total_allocated_after: u64,
 }
 
 /// Emitted when PLP shares are burned and DUSDC is withdrawn.
@@ -33,34 +32,61 @@ public struct WithdrawExecuted has copy, drop, store {
     pool_value_before: u64,
     total_supply_after: u64,
     idle_balance_after: u64,
-    total_allocated_after: u64,
 }
 
-/// Emitted when an expiry's allocation is created, grows, or shrinks.
-public struct ExpiryAllocationChanged has copy, drop, store {
+/// Emitted when the pool funds a newly created expiry.
+public struct ExpiryCashFunded has copy, drop, store {
+    pool_vault_id: ID,
+    expiry_market_id: ID,
+    funding: u64,
+    idle_balance_after: u64,
+    sent_to_expiry_after: u64,
+    received_from_expiry_after: u64,
+}
+
+/// Emitted when live expiry cash is rebalanced against current backing needs.
+public struct ExpiryCashRebalanced has copy, drop, store {
     pool_vault_id: ID,
     expiry_market_id: ID,
     amount: u64,
-    /// True when capital moved from pool idle cash into the expiry market.
-    to_expiry_pool: bool,
-    allocation_after: u64,
+    to_expiry: bool,
+    target_cash: u64,
+    expiry_cash_after: u64,
     idle_balance_after: u64,
+    sent_to_expiry_after: u64,
+    received_from_expiry_after: u64,
 }
 
-/// Emitted when a settled expiry returns surplus cash or releases allocation.
+/// Emitted when an expiry's max net pool funding cap changes.
+public struct ExpiryMaxFundingUpdated has copy, drop, store {
+    pool_vault_id: ID,
+    expiry_market_id: ID,
+    max_expiry_funding: u64,
+    net_funding: u64,
+}
+
+/// Emitted when a settled expiry returns surplus cash.
 public struct ExpirySurplusSwept has copy, drop, store {
     pool_vault_id: ID,
     expiry_market_id: ID,
     settlement_price: u64,
-    /// Active allocation retired by this sweep. Zero on residual sweeps.
-    released_allocation: u64,
-    /// Surplus LP cash returned to idle this sweep.
+    /// Surplus cash returned to the pool this sweep.
     returned_cash: u64,
     idle_balance_after: u64,
-    total_allocated_after: u64,
-    fee_surplus_to_protocol: u64,
-    fee_surplus_to_insurance: u64,
-    fee_surplus_to_lp: u64,
+    sent_to_expiry_after: u64,
+    received_from_expiry_after: u64,
+}
+
+/// Emitted when aggregate returned expiry cash is split between LPs and protocol reserves.
+public struct ExpiryProfitMaterialized has copy, drop, store {
+    pool_vault_id: ID,
+    profit: u64,
+    lp_profit: u64,
+    protocol_profit: u64,
+    idle_balance_after: u64,
+    protocol_reserve_balance_after: u64,
+    profit_basis_debits_after: u64,
+    profit_basis_credits_after: u64,
 }
 
 // === Public-Package Functions ===
@@ -72,7 +98,6 @@ public(package) fun emit_supply_executed(
     pool_value_before: u64,
     total_supply_after: u64,
     idle_balance_after: u64,
-    total_allocated_after: u64,
 ) {
     event::emit(SupplyExecuted {
         pool_vault_id,
@@ -81,7 +106,6 @@ public(package) fun emit_supply_executed(
         pool_value_before,
         total_supply_after,
         idle_balance_after,
-        total_allocated_after,
     });
 }
 
@@ -92,7 +116,6 @@ public(package) fun emit_withdraw_executed(
     pool_value_before: u64,
     total_supply_after: u64,
     idle_balance_after: u64,
-    total_allocated_after: u64,
 ) {
     event::emit(WithdrawExecuted {
         pool_vault_id,
@@ -101,25 +124,62 @@ public(package) fun emit_withdraw_executed(
         pool_value_before,
         total_supply_after,
         idle_balance_after,
-        total_allocated_after,
     });
 }
 
-public(package) fun emit_expiry_allocation_changed(
+public(package) fun emit_expiry_cash_funded(
+    pool_vault_id: ID,
+    expiry_market_id: ID,
+    funding: u64,
+    idle_balance_after: u64,
+    sent_to_expiry_after: u64,
+    received_from_expiry_after: u64,
+) {
+    event::emit(ExpiryCashFunded {
+        pool_vault_id,
+        expiry_market_id,
+        funding,
+        idle_balance_after,
+        sent_to_expiry_after,
+        received_from_expiry_after,
+    });
+}
+
+public(package) fun emit_expiry_cash_rebalanced(
     pool_vault_id: ID,
     expiry_market_id: ID,
     amount: u64,
-    to_expiry_pool: bool,
-    allocation_after: u64,
+    to_expiry: bool,
+    target_cash: u64,
+    expiry_cash_after: u64,
     idle_balance_after: u64,
+    sent_to_expiry_after: u64,
+    received_from_expiry_after: u64,
 ) {
-    event::emit(ExpiryAllocationChanged {
+    event::emit(ExpiryCashRebalanced {
         pool_vault_id,
         expiry_market_id,
         amount,
-        to_expiry_pool,
-        allocation_after,
+        to_expiry,
+        target_cash,
+        expiry_cash_after,
         idle_balance_after,
+        sent_to_expiry_after,
+        received_from_expiry_after,
+    });
+}
+
+public(package) fun emit_expiry_max_funding_updated(
+    pool_vault_id: ID,
+    expiry_market_id: ID,
+    max_expiry_funding: u64,
+    net_funding: u64,
+) {
+    event::emit(ExpiryMaxFundingUpdated {
+        pool_vault_id,
+        expiry_market_id,
+        max_expiry_funding,
+        net_funding,
     });
 }
 
@@ -127,24 +187,40 @@ public(package) fun emit_expiry_surplus_swept(
     pool_vault_id: ID,
     expiry_market_id: ID,
     settlement_price: u64,
-    released_allocation: u64,
     returned_cash: u64,
     idle_balance_after: u64,
-    total_allocated_after: u64,
-    fee_surplus_to_protocol: u64,
-    fee_surplus_to_insurance: u64,
-    fee_surplus_to_lp: u64,
+    sent_to_expiry_after: u64,
+    received_from_expiry_after: u64,
 ) {
     event::emit(ExpirySurplusSwept {
         pool_vault_id,
         expiry_market_id,
         settlement_price,
-        released_allocation,
         returned_cash,
         idle_balance_after,
-        total_allocated_after,
-        fee_surplus_to_protocol,
-        fee_surplus_to_insurance,
-        fee_surplus_to_lp,
+        sent_to_expiry_after,
+        received_from_expiry_after,
+    });
+}
+
+public(package) fun emit_expiry_profit_materialized(
+    pool_vault_id: ID,
+    profit: u64,
+    lp_profit: u64,
+    protocol_profit: u64,
+    idle_balance_after: u64,
+    protocol_reserve_balance_after: u64,
+    profit_basis_debits_after: u64,
+    profit_basis_credits_after: u64,
+) {
+    event::emit(ExpiryProfitMaterialized {
+        pool_vault_id,
+        profit,
+        lp_profit,
+        protocol_profit,
+        idle_balance_after,
+        protocol_reserve_balance_after,
+        profit_basis_debits_after,
+        profit_basis_credits_after,
     });
 }

--- a/packages/predict/sources/events/vault_events.move
+++ b/packages/predict/sources/events/vault_events.move
@@ -65,7 +65,7 @@ public struct ExpiryMaxFundingUpdated has copy, drop, store {
     net_funding: u64,
 }
 
-/// Emitted when a settled expiry returns surplus cash.
+/// Emitted when a settled expiry is deactivated or returns surplus cash.
 public struct ExpirySurplusSwept has copy, drop, store {
     pool_vault_id: ID,
     expiry_market_id: ID,
@@ -80,13 +80,11 @@ public struct ExpirySurplusSwept has copy, drop, store {
 /// Emitted when aggregate returned expiry cash is split between LPs and protocol reserves.
 public struct ExpiryProfitMaterialized has copy, drop, store {
     pool_vault_id: ID,
-    profit: u64,
     lp_profit: u64,
     protocol_profit: u64,
     idle_balance_after: u64,
     protocol_reserve_balance_after: u64,
-    profit_basis_debits_after: u64,
-    profit_basis_credits_after: u64,
+    profit_basis_after: u64,
 }
 
 // === Public-Package Functions ===
@@ -205,22 +203,18 @@ public(package) fun emit_expiry_surplus_swept(
 
 public(package) fun emit_expiry_profit_materialized(
     pool_vault_id: ID,
-    profit: u64,
     lp_profit: u64,
     protocol_profit: u64,
     idle_balance_after: u64,
     protocol_reserve_balance_after: u64,
-    profit_basis_debits_after: u64,
-    profit_basis_credits_after: u64,
+    profit_basis_after: u64,
 ) {
     event::emit(ExpiryProfitMaterialized {
         pool_vault_id,
-        profit,
         lp_profit,
         protocol_profit,
         idle_balance_after,
         protocol_reserve_balance_after,
-        profit_basis_debits_after,
-        profit_basis_credits_after,
+        profit_basis_after,
     });
 }

--- a/packages/predict/sources/events/vault_events.move
+++ b/packages/predict/sources/events/vault_events.move
@@ -4,8 +4,8 @@
 /// Pool-vault lifecycle events for Predict.
 ///
 /// These are low-frequency relative to trades, so they are rich: supply and
-/// withdraw carry the pool value used to price shares, and settled-expiry
-/// sweeps carry the pool-owned expiry cash-flow movements.
+/// withdraw carry the pool value used to price shares, and expiry cash receipts
+/// carry the pool-owned expiry cash-flow movements.
 module deepbook_predict::vault_events;
 
 use sui::event;
@@ -34,16 +34,6 @@ public struct WithdrawExecuted has copy, drop, store {
     idle_balance_after: u64,
 }
 
-/// Emitted when the pool funds a newly created expiry.
-public struct ExpiryCashFunded has copy, drop, store {
-    pool_vault_id: ID,
-    expiry_market_id: ID,
-    funding: u64,
-    idle_balance_after: u64,
-    sent_to_expiry_after: u64,
-    received_from_expiry_after: u64,
-}
-
 /// Emitted when live expiry cash is rebalanced against current backing needs.
 public struct ExpiryCashRebalanced has copy, drop, store {
     pool_vault_id: ID,
@@ -65,13 +55,12 @@ public struct ExpiryMaxFundingUpdated has copy, drop, store {
     net_funding: u64,
 }
 
-/// Emitted when a settled expiry is deactivated or returns surplus cash.
-public struct ExpirySurplusSwept has copy, drop, store {
+/// Emitted when an expiry returns cash to the pool.
+public struct ExpiryCashReceived has copy, drop, store {
     pool_vault_id: ID,
     expiry_market_id: ID,
     settlement_price: u64,
-    /// Surplus cash returned to the pool this sweep.
-    returned_cash: u64,
+    amount: u64,
     idle_balance_after: u64,
     sent_to_expiry_after: u64,
     received_from_expiry_after: u64,
@@ -125,24 +114,6 @@ public(package) fun emit_withdraw_executed(
     });
 }
 
-public(package) fun emit_expiry_cash_funded(
-    pool_vault_id: ID,
-    expiry_market_id: ID,
-    funding: u64,
-    idle_balance_after: u64,
-    sent_to_expiry_after: u64,
-    received_from_expiry_after: u64,
-) {
-    event::emit(ExpiryCashFunded {
-        pool_vault_id,
-        expiry_market_id,
-        funding,
-        idle_balance_after,
-        sent_to_expiry_after,
-        received_from_expiry_after,
-    });
-}
-
 public(package) fun emit_expiry_cash_rebalanced(
     pool_vault_id: ID,
     expiry_market_id: ID,
@@ -181,20 +152,20 @@ public(package) fun emit_expiry_max_funding_updated(
     });
 }
 
-public(package) fun emit_expiry_surplus_swept(
+public(package) fun emit_expiry_cash_received(
     pool_vault_id: ID,
     expiry_market_id: ID,
     settlement_price: u64,
-    returned_cash: u64,
+    amount: u64,
     idle_balance_after: u64,
     sent_to_expiry_after: u64,
     received_from_expiry_after: u64,
 ) {
-    event::emit(ExpirySurplusSwept {
+    event::emit(ExpiryCashReceived {
         pool_vault_id,
         expiry_market_id,
         settlement_price,
-        returned_cash,
+        amount,
         idle_balance_after,
         sent_to_expiry_after,
         received_from_expiry_after,

--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -30,11 +30,11 @@ use sui::{balance::{Self, Balance}, clock::Clock, vec_set::VecSet};
 const EWrongMarketOracle: u64 = 0;
 const EWrongPythSource: u64 = 1;
 const EValuationExceedsCash: u64 = 2;
-const EInsufficientCash: u64 = 4;
-const EPackageVersionDisabled: u64 = 6;
-const EMintPaused: u64 = 7;
-const EUnresolvedTradingFeesUnderflow: u64 = 8;
-const EFullCloseRequired: u64 = 9;
+const EInsufficientCash: u64 = 3;
+const EPackageVersionDisabled: u64 = 4;
+const EMintPaused: u64 = 5;
+const EUnresolvedTradingFeesUnderflow: u64 = 6;
+const EFullCloseRequired: u64 = 7;
 
 /// Per-expiry market state.
 public struct ExpiryMarket has key {

--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -5,7 +5,7 @@
 ///
 /// An ExpiryMarket is the hot shared object for one expiry. It owns the
 /// expiry-local DUSDC cash, strike exposure state, rebate reserve basis, trade execution,
-/// valuation witness, and storage cleanup state. Pool-wide PLP accounting and
+/// pool NAV production, and storage cleanup state. Pool-wide PLP accounting and
 /// profit accounting remain outside this module.
 module deepbook_predict::expiry_market;
 
@@ -35,6 +35,7 @@ const EPackageVersionDisabled: u64 = 4;
 const EMintPaused: u64 = 5;
 const EUnresolvedTradingFeesUnderflow: u64 = 6;
 const EFullCloseRequired: u64 = 7;
+const EWrongPreparedPoolNav: u64 = 8;
 
 /// Per-expiry market state.
 public struct ExpiryMarket has key {
@@ -56,12 +57,12 @@ public struct ExpiryMarket has key {
     mint_paused: bool,
 }
 
-/// Transaction-local valuation produced by an expiry market.
-public struct ExpiryValuation {
-    /// Expiry market that produced this valuation.
+/// Transaction-local expiry NAV prepared for a pool sync.
+public struct PreparedPoolNav {
+    /// Expiry market that produced this NAV input.
     expiry_market_id: ID,
-    /// LP NAV contribution for this expiry.
-    value: u64,
+    /// User-position liability sampled during valuation maintenance.
+    position_liability: u64,
 }
 
 // === Public Functions ===
@@ -124,36 +125,6 @@ public fun mint_paused(market: &ExpiryMarket): bool {
 /// Return this market's mirrored set of allowed package versions.
 public fun allowed_versions(market: &ExpiryMarket): VecSet<u64> {
     market.allowed_versions
-}
-
-/// Produce this expiry's valuation witness for a full-pool valuation.
-///
-/// For live markets, valuation first runs a bounded liquidation pass inside
-/// strike exposure, then evaluates NAV against the same pricing curve.
-/// If the oracle is settled, this also caches terminal payout liability in
-/// strike exposure. It does not destroy live indexes; privileged compaction owns that.
-public fun produce_valuation(
-    market: &mut ExpiryMarket,
-    config: &ProtocolConfig,
-    market_oracle: &MarketOracle,
-    pyth: &PythSource,
-    clock: &Clock,
-): ExpiryValuation {
-    market.assert_version_allowed();
-    config.assert_valuation_in_progress();
-    let position_liability = market.position_liability_for_valuation(
-        config,
-        market_oracle,
-        pyth,
-        clock,
-    );
-    let reserved_cash = position_liability + market.rebate_reserve();
-    let cash_balance = market.cash_balance.value();
-    assert!(cash_balance >= reserved_cash, EValuationExceedsCash);
-    ExpiryValuation {
-        expiry_market_id: market.id(),
-        value: cash_balance - reserved_cash,
-    }
 }
 
 /// Mint a live position interval against this expiry market.
@@ -306,15 +277,6 @@ public(package) fun set_allowed_versions(market: &mut ExpiryMarket, allowed_vers
     market.allowed_versions = allowed_versions;
 }
 
-/// Consume an expiry valuation and return its market ID and value.
-public(package) fun unpack(valuation: ExpiryValuation): (ID, u64) {
-    let ExpiryValuation {
-        expiry_market_id,
-        value,
-    } = valuation;
-    (expiry_market_id, value)
-}
-
 /// Assert that a market oracle belongs to this expiry market.
 public(package) fun assert_market_oracle(market: &ExpiryMarket, market_oracle: &MarketOracle) {
     assert!(market.market_oracle_id == market_oracle.id(), EWrongMarketOracle);
@@ -387,6 +349,47 @@ public(package) fun materialize_settled_liability(
     market.assert_market_oracle(market_oracle);
     let settlement = pricing::settlement_price(market_oracle);
     market.strike_exposure.materialize_settled_liability(settlement)
+}
+
+/// Run expiry-local valuation maintenance and return the prepared NAV input.
+public(package) fun prepare_pool_sync(
+    market: &mut ExpiryMarket,
+    config: &ProtocolConfig,
+    market_oracle: &MarketOracle,
+    pyth: &PythSource,
+    clock: &Clock,
+): PreparedPoolNav {
+    market.assert_version_allowed();
+    config.assert_valuation_in_progress();
+    market.assert_market_oracle(market_oracle);
+    market.assert_pyth_feed(pyth);
+    market_oracle.assert_active(clock);
+    let position_liability = market
+        .strike_exposure
+        .prepare_valuation_liability(
+            config.pricing_config(),
+            market_oracle,
+            pyth,
+            config.risk_config().valuation_liquidation_budget(),
+            clock,
+        );
+    PreparedPoolNav {
+        expiry_market_id: market.id(),
+        position_liability,
+    }
+}
+
+/// Consume prepared NAV input and return current pool-owned expiry NAV.
+public(package) fun finish_pool_nav(market: &ExpiryMarket, prepared_nav: PreparedPoolNav): u64 {
+    let PreparedPoolNav {
+        expiry_market_id,
+        position_liability,
+    } = prepared_nav;
+    assert!(expiry_market_id == market.id(), EWrongPreparedPoolNav);
+    let required_cash = position_liability + market.rebate_reserve();
+    let cash_balance = market.cash_balance.value();
+    assert!(cash_balance >= required_cash, EValuationExceedsCash);
+    cash_balance - required_cash
 }
 
 /// Resolve one manager's trading-loss rebate and return unclaimed rebate reserve.
@@ -477,34 +480,6 @@ public(package) fun release_pool_cash(market: &mut ExpiryMarket, amount: u64): B
 }
 
 // === Private Functions ===
-
-fun position_liability_for_valuation(
-    market: &mut ExpiryMarket,
-    config: &ProtocolConfig,
-    market_oracle: &MarketOracle,
-    pyth: &PythSource,
-    clock: &Clock,
-): u64 {
-    market.assert_market_oracle(market_oracle);
-    if (market_oracle.is_settled()) {
-        market.materialize_settled_liability(market_oracle)
-    } else {
-        market.assert_pyth_feed(pyth);
-        market_oracle.assert_not_pending_settlement(clock);
-        // Valuation uses a bounded, policy-tuned liquidation maintenance pass.
-        // Residual underwater-order risk is controlled by the configured budget,
-        // LTV buffer, priority ordering, and off-chain simulation policy.
-        market
-            .strike_exposure
-            .liquidate_and_live_position_liability(
-                config.pricing_config(),
-                market_oracle,
-                pyth,
-                config.risk_config().valuation_liquidation_budget(),
-                clock,
-            )
-    }
-}
 
 fun assert_pyth_feed(market: &ExpiryMarket, pyth: &PythSource) {
     assert!(market.pyth_lazer_feed_id == pyth.feed_id(), EWrongPythSource);

--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -35,7 +35,6 @@ const EPackageVersionDisabled: u64 = 4;
 const EMintPaused: u64 = 5;
 const EUnresolvedTradingFeesUnderflow: u64 = 6;
 const EFullCloseRequired: u64 = 7;
-const EWrongPreparedPoolNav: u64 = 8;
 
 /// Per-expiry market state.
 public struct ExpiryMarket has key {
@@ -55,14 +54,6 @@ public struct ExpiryMarket has key {
     allowed_versions: VecSet<u64>,
     /// When true, `mint` aborts. Other flows (redeem, settle, cleanup) unaffected.
     mint_paused: bool,
-}
-
-/// Transaction-local expiry NAV prepared for a pool sync.
-public struct PreparedPoolNav {
-    /// Expiry market that produced this NAV input.
-    expiry_market_id: ID,
-    /// User-position liability sampled during valuation maintenance.
-    position_liability: u64,
 }
 
 // === Public Functions ===
@@ -196,7 +187,7 @@ public fun redeem(
         market.redeem_settled_internal(manager, market_oracle, &redeemed_order, ctx);
         (redeemed_order.id(), option::none())
     } else {
-        market.run_configured_liquidation_pass(
+        market.run_liquidation_pass(
             config.pricing_config(),
             market_oracle,
             pyth,
@@ -236,17 +227,7 @@ public fun liquidate(
 ): u64 {
     market.assert_version_allowed();
     config.assert_not_valuation_in_progress();
-    market.assert_market_oracle(market_oracle);
-    market.assert_pyth_feed(pyth);
-    market
-        .strike_exposure
-        .liquidate_live_orders(
-            config.pricing_config(),
-            market_oracle,
-            pyth,
-            budget,
-            clock,
-        )
+    market.run_liquidation_pass(config.pricing_config(), market_oracle, pyth, budget, clock)
 }
 
 /// Cache terminal liability if needed, then destroy live exposure indexes.
@@ -351,14 +332,14 @@ public(package) fun materialize_settled_liability(
     market.strike_exposure.materialize_settled_liability(settlement)
 }
 
-/// Run expiry-local valuation maintenance and return the prepared NAV input.
-public(package) fun prepare_pool_sync(
-    market: &mut ExpiryMarket,
+/// Return current pool-owned NAV.
+public(package) fun pool_nav(
+    market: &ExpiryMarket,
     config: &ProtocolConfig,
     market_oracle: &MarketOracle,
     pyth: &PythSource,
     clock: &Clock,
-): PreparedPoolNav {
+): u64 {
     market.assert_version_allowed();
     config.assert_valuation_in_progress();
     market.assert_market_oracle(market_oracle);
@@ -366,30 +347,40 @@ public(package) fun prepare_pool_sync(
     market_oracle.assert_active(clock);
     let position_liability = market
         .strike_exposure
-        .prepare_valuation_liability(
+        .valuation_liability(
             config.pricing_config(),
             market_oracle,
             pyth,
-            config.risk_config().valuation_liquidation_budget(),
             clock,
         );
-    PreparedPoolNav {
-        expiry_market_id: market.id(),
-        position_liability,
-    }
-}
-
-/// Consume prepared NAV input and return current pool-owned expiry NAV.
-public(package) fun finish_pool_nav(market: &ExpiryMarket, prepared_nav: PreparedPoolNav): u64 {
-    let PreparedPoolNav {
-        expiry_market_id,
-        position_liability,
-    } = prepared_nav;
-    assert!(expiry_market_id == market.id(), EWrongPreparedPoolNav);
     let required_cash = position_liability + market.rebate_reserve();
     let cash_balance = market.cash_balance.value();
     assert!(cash_balance >= required_cash, EValuationExceedsCash);
     cash_balance - required_cash
+}
+
+/// Run one expiry-local liquidation pass with the caller-selected budget.
+public(package) fun run_liquidation_pass(
+    market: &mut ExpiryMarket,
+    pricing_config: &PricingConfig,
+    market_oracle: &MarketOracle,
+    pyth: &PythSource,
+    budget: u64,
+    clock: &Clock,
+): u64 {
+    market.assert_version_allowed();
+    market.assert_market_oracle(market_oracle);
+    market.assert_pyth_feed(pyth);
+    market_oracle.assert_active(clock);
+    market
+        .strike_exposure
+        .liquidate_live_orders(
+            pricing_config,
+            market_oracle,
+            pyth,
+            budget,
+            clock,
+        )
 }
 
 /// Resolve one manager's trading-loss rebate and return unclaimed rebate reserve.
@@ -485,31 +476,6 @@ fun assert_pyth_feed(market: &ExpiryMarket, pyth: &PythSource) {
     assert!(market.pyth_lazer_feed_id == pyth.feed_id(), EWrongPythSource);
 }
 
-fun run_configured_liquidation_pass(
-    market: &mut ExpiryMarket,
-    pricing_config: &PricingConfig,
-    market_oracle: &MarketOracle,
-    pyth: &PythSource,
-    budget: u64,
-    clock: &Clock,
-) {
-    if (budget == 0) return;
-
-    market.assert_market_oracle(market_oracle);
-    if (market_oracle.is_settled()) return;
-
-    market.assert_pyth_feed(pyth);
-    market
-        .strike_exposure
-        .liquidate_live_orders(
-            pricing_config,
-            market_oracle,
-            pyth,
-            budget,
-            clock,
-        );
-}
-
 fun builder_fee_amount(builder_code_id: &Option<ID>, fee_amount: u64, quantity: u64): u64 {
     if (builder_code_id.is_some()) {
         math::mul(fee_amount, constants::builder_fee_multiplier!()).min(
@@ -554,7 +520,7 @@ fun mint_internal(
     manager.update_stake(ctx);
     market.assert_market_oracle(market_oracle);
     market.assert_pyth_feed(pyth);
-    market.run_configured_liquidation_pass(
+    market.run_liquidation_pass(
         config.pricing_config(),
         market_oracle,
         pyth,

--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -4,9 +4,9 @@
 /// Per-expiry Predict market.
 ///
 /// An ExpiryMarket is the hot shared object for one expiry. It owns the
-/// expiry-local DUSDC allocation, strike exposure state, fee balance, trade execution,
+/// expiry-local DUSDC cash, strike exposure state, rebate reserve basis, trade execution,
 /// valuation witness, and storage cleanup state. Pool-wide PLP accounting and
-/// allocation coordination remain outside this module.
+/// profit accounting remain outside this module.
 module deepbook_predict::expiry_market;
 
 use deepbook::math;
@@ -30,9 +30,7 @@ use sui::{balance::{Self, Balance}, clock::Clock, vec_set::VecSet};
 const EWrongMarketOracle: u64 = 0;
 const EWrongPythSource: u64 = 1;
 const EValuationExceedsCash: u64 = 2;
-const EAllocationBelowMaxPayout: u64 = 3;
-const EInsufficientLpCash: u64 = 4;
-const EInsufficientFeeBalance: u64 = 5;
+const EInsufficientCash: u64 = 4;
 const EPackageVersionDisabled: u64 = 6;
 const EMintPaused: u64 = 7;
 const EUnresolvedTradingFeesUnderflow: u64 = 8;
@@ -46,13 +44,9 @@ public struct ExpiryMarket has key {
     expiry: u64,
     /// Trading loss rebate rate snapshotted from fee config at creation.
     trading_loss_rebate_rate: u64,
-    /// Active risk budget assigned by the pool.
-    allocated_capital: u64,
-    /// LP-owned DUSDC backing this expiry's liability.
-    lp_cash_balance: Balance<DUSDC>,
-    /// Fee cash held until rebate reserve and settled-expiry fee surplus are resolved.
-    fee_balance: Balance<DUSDC>,
-    /// Trading fees whose rebate eligibility has not been resolved.
+    /// DUSDC backing payout liability, rebate reserve, and residual expiry NAV.
+    cash_balance: Balance<DUSDC>,
+    /// Trading-fee basis whose rebate eligibility has not been resolved.
     unresolved_trading_fees_paid: u64,
     /// Exposure lifecycle state for this expiry's oracle grid.
     strike_exposure: StrikeExposure,
@@ -92,24 +86,14 @@ public fun expiry(market: &ExpiryMarket): u64 {
     market.expiry
 }
 
-/// Return the DUSDC capital currently allocated to this expiry.
-public fun allocated_capital(market: &ExpiryMarket): u64 {
-    market.allocated_capital
+/// Return DUSDC currently held by this expiry.
+public fun cash_balance(market: &ExpiryMarket): u64 {
+    market.cash_balance.value()
 }
 
-/// Return LP-owned DUSDC currently held by this expiry.
-public fun lp_cash_balance(market: &ExpiryMarket): u64 {
-    market.lp_cash_balance.value()
-}
-
-/// Return DUSDC fees held by this expiry.
-public fun fee_balance(market: &ExpiryMarket): u64 {
-    market.fee_balance.value()
-}
-
-/// Return trading fees whose rebate eligibility has not been resolved.
-public fun unresolved_trading_fees_paid(market: &ExpiryMarket): u64 {
-    market.unresolved_trading_fees_paid
+/// Return DUSDC reserved for unresolved trading loss rebates.
+public fun rebate_reserve(market: &ExpiryMarket): u64 {
+    math::mul(market.unresolved_trading_fees_paid, market.trading_loss_rebate_rate)
 }
 
 /// Return the trading loss rebate rate snapshotted for this expiry.
@@ -130,27 +114,6 @@ public fun liquidation_ltv(market: &ExpiryMarket): u64 {
 /// Return conservative max-live backing, or remaining settled payout liability once materialized.
 public fun payout_liability(market: &ExpiryMarket): u64 {
     market.strike_exposure.payout_liability()
-}
-
-/// Return DUSDC allocation that can leave while preserving risk and cash backing.
-///
-/// Live markets use conservative max-live backing; settled markets use remaining
-/// materialized payout liability.
-public fun returnable_capital(market: &ExpiryMarket): u64 {
-    let payout_liability = market.payout_liability();
-    let allocated_capital = market.allocated_capital();
-    let risk_free = if (allocated_capital > payout_liability) {
-        allocated_capital - payout_liability
-    } else {
-        0
-    };
-    let lp_cash_balance = market.lp_cash_balance.value();
-    let cash_free = if (lp_cash_balance > payout_liability) {
-        lp_cash_balance - payout_liability
-    } else {
-        0
-    };
-    risk_free.min(cash_free)
 }
 
 /// Return whether minting is currently paused on this expiry market.
@@ -178,24 +141,18 @@ public fun produce_valuation(
 ): ExpiryValuation {
     market.assert_version_allowed();
     config.assert_valuation_in_progress();
-    let (position_liability, rebate_reserve) = market.current_nav_terms(
+    let position_liability = market.position_liability_for_valuation(
         config,
         market_oracle,
         pyth,
         clock,
     );
-    let lp_cash_balance = market.lp_cash_balance.value();
-    let fee_balance = market.fee_balance.value();
-    assert!(lp_cash_balance >= position_liability, EValuationExceedsCash);
-    let position_value = lp_cash_balance - position_liability;
-    assert!(fee_balance >= rebate_reserve, EInsufficientFeeBalance);
-    let lp_fee_surplus = math::mul(
-        fee_balance - rebate_reserve,
-        config.fee_config().lp_fee_share(),
-    );
+    let reserved_cash = position_liability + market.rebate_reserve();
+    let cash_balance = market.cash_balance.value();
+    assert!(cash_balance >= reserved_cash, EValuationExceedsCash);
     ExpiryValuation {
         expiry_market_id: market.id(),
-        value: position_value + lp_fee_surplus,
+        value: cash_balance - reserved_cash,
     }
 }
 
@@ -203,10 +160,10 @@ public fun produce_valuation(
 ///
 /// Requires the package version to be allowed for this market, per-market mint
 /// pause to be off, trading globally enabled, manager ownership, a live fresh
-/// oracle, enough expiry allocation to back the post-mint max payout, and
-/// leveraged floor terms below this expiry's liquidation LTV at terminal.
-/// Leveraged mints must also satisfy leverage tier policy and be above the
-/// current liquidation threshold at entry.
+/// oracle, enough expiry cash to back the post-mint max payout and rebate reserve,
+/// and leveraged floor terms below this expiry's liquidation LTV at terminal.
+/// Leveraged mints must also satisfy leverage tier policy and be above the current
+/// liquidation threshold at entry.
 /// Returns the minted order ID for future order-scoped flows.
 public fun mint(
     market: &mut ExpiryMarket,
@@ -323,9 +280,9 @@ public fun liquidate(
 
 /// Resolve a manager's aggregate expiry trading-loss rebate after all its
 /// positions close. Permissionless by design: any caller may settle this for a
-/// manager — the rebate is credited to the manager via its deposit cap and the
-/// un-granted remainder compounds into PLP cash, so PLP value accrues without
-/// the owner acting. The rebate share uses the manager's active staking.
+/// manager — the rebate is credited to the manager via its deposit cap and any
+/// un-granted reserve becomes expiry NAV. The rebate share uses the manager's
+/// active staking.
 public fun claim_trading_loss_rebate(
     market: &mut ExpiryMarket,
     manager: &mut PredictManager,
@@ -337,46 +294,33 @@ public fun claim_trading_loss_rebate(
     config.assert_not_valuation_in_progress();
     market.materialize_settled_liability(market_oracle);
 
-    let (
-        trading_fees_paid,
-        cash_paid_to_expiry,
-        cash_received_from_expiry,
-    ) = manager.resolve_expiry_summary(market.id());
-    if (trading_fees_paid == 0 && cash_paid_to_expiry == 0 && cash_received_from_expiry == 0) {
+    let (trading_fees_paid, trading_loss) = manager.resolve_expiry_summary(market.id());
+    if (trading_fees_paid == 0 && trading_loss == 0) {
         return
     };
 
     market.resolve_trading_fee_basis(trading_fees_paid);
-    let trading_loss = if (cash_paid_to_expiry > cash_received_from_expiry) {
-        cash_paid_to_expiry - cash_received_from_expiry
-    } else {
-        0
-    };
     let max_rebate = math::mul(trading_fees_paid, market.trading_loss_rebate_rate);
     let eligible_rebate = trading_loss.min(max_rebate);
 
-    // Active staking decides the manager's share of the eligible rebate; the
-    // remainder compounds into LP cash (returns fully to the pool on the
-    // settlement sweep, no protocol/insurance split).
+    // Active staking decides the manager's share of the eligible rebate. Any
+    // un-granted reserve remains in cash after its rebate basis is resolved.
     manager.update_stake(ctx);
-    let rebate_fraction = config.stake_config().rebate_fraction(manager.active_stake());
-    let (rebate_amount, lp_compound_amount) = apply_stake_benefit(eligible_rebate, rebate_fraction);
+    let rebate_amount = config
+        .stake_config()
+        .rebate_amount(eligible_rebate, manager.active_stake());
 
     if (rebate_amount > 0) {
-        let payout = market.dispense_fee_cash(rebate_amount);
+        let payout = market.dispense_cash(rebate_amount);
         manager.deposit_permissionless(payout.into_coin(ctx), ctx);
     };
-    if (lp_compound_amount > 0) {
-        let lp_cash = market.dispense_fee_cash(lp_compound_amount);
-        market.lp_cash_balance.join(lp_cash);
-    };
+    market.assert_cash_backing();
 
     claim_events::emit_trading_loss_rebate_claimed(
         market.id(),
         manager.id(),
         trading_fees_paid,
-        cash_paid_to_expiry,
-        cash_received_from_expiry,
+        trading_loss,
         rebate_amount,
     );
 }
@@ -384,7 +328,7 @@ public fun claim_trading_loss_rebate(
 /// Cache terminal liability if needed, then destroy live exposure indexes.
 ///
 /// This is cap-gated because index destruction returns storage rebates. Surplus
-/// LP cash and fee cash remain in the expiry until a pool sweep moves them.
+/// cash remains in the expiry until a pool sweep moves it.
 public fun compact_storage(
     market: &mut ExpiryMarket,
     config: &ProtocolConfig,
@@ -434,10 +378,10 @@ public(package) fun assert_version_allowed(market: &ExpiryMarket) {
 /// Create and share a funded expiry market for one market oracle.
 ///
 /// The market snapshots the Pyth feed ID, initializes strike exposure state, and
-/// takes custody of the pool-provided allocation as LP cash.
+/// takes custody of pool-provided funding as expiry cash.
 public(package) fun create_and_share(
     config: &ProtocolConfig,
-    allocation: Balance<DUSDC>,
+    funding: Balance<DUSDC>,
     allowed_versions: VecSet<u64>,
     market_oracle_id: ID,
     pyth_lazer_feed_id: u32,
@@ -446,7 +390,6 @@ public(package) fun create_and_share(
     tick_size: u64,
     ctx: &mut TxContext,
 ): ID {
-    let allocated_capital = allocation.value();
     let id = object::new(ctx);
     let expiry_market_id = id.to_inner();
     let market = ExpiryMarket {
@@ -455,9 +398,7 @@ public(package) fun create_and_share(
         pyth_lazer_feed_id,
         expiry,
         trading_loss_rebate_rate: config.fee_config().trading_loss_rebate_rate(),
-        allocated_capital,
-        lp_cash_balance: allocation,
-        fee_balance: balance::zero(),
+        cash_balance: funding,
         unresolved_trading_fees_paid: 0,
         strike_exposure: strike_exposure::new(
             expiry_market_id,
@@ -473,26 +414,6 @@ public(package) fun create_and_share(
     };
     transfer::share_object(market);
     expiry_market_id
-}
-
-/// Add pool-provided DUSDC to this live expiry's allocation and LP cash.
-public(package) fun receive_allocation(market: &mut ExpiryMarket, allocation: Balance<DUSDC>) {
-    market.assert_version_allowed();
-    let amount = allocation.value();
-    market.allocated_capital = market.allocated_capital + amount;
-    market.lp_cash_balance.join(allocation);
-}
-
-/// Return free DUSDC allocation from this expiry to the pool.
-///
-/// Aborts if the requested amount would reduce allocation or cash below the
-/// expiry's payout backing requirement.
-public(package) fun return_allocation(market: &mut ExpiryMarket, amount: u64): Balance<DUSDC> {
-    market.assert_version_allowed();
-    assert!(amount <= market.returnable_capital(), EAllocationBelowMaxPayout);
-
-    market.allocated_capital = market.allocated_capital - amount;
-    market.lp_cash_balance.split(amount)
 }
 
 /// Set per-market mint pause and emit the pause-state event.
@@ -516,50 +437,63 @@ public(package) fun materialize_settled_liability(
     market.strike_exposure.materialize_settled_liability(settlement)
 }
 
-/// Release settled LP and fee surplus derived from materialized settlement liability.
+/// Release settled surplus derived from materialized settlement liability and rebate reserve.
 public(package) fun release_settled_surplus(
     market: &mut ExpiryMarket,
     market_oracle: &MarketOracle,
-): (Balance<DUSDC>, Balance<DUSDC>) {
+): Balance<DUSDC> {
     market.assert_version_allowed();
     let settled_liability = market.materialize_settled_liability(market_oracle);
-    let rebate_reserve = market.aggregate_rebate_reserve();
-    assert!(market.lp_cash_balance.value() >= settled_liability, EInsufficientLpCash);
-    assert!(market.fee_balance.value() >= rebate_reserve, EInsufficientFeeBalance);
+    let rebate_reserve = market.rebate_reserve();
+    let reserved_cash = settled_liability + rebate_reserve;
+    assert!(market.cash_balance.value() >= reserved_cash, EInsufficientCash);
 
-    if (market.allocated_capital > 0) {
-        assert!(market.allocated_capital >= settled_liability, EAllocationBelowMaxPayout);
-        market.allocated_capital = 0;
-    };
-    let returned_cash_amount = market.lp_cash_balance.value() - settled_liability;
-    let returned_cash = market.lp_cash_balance.split(returned_cash_amount);
-    let returned_fees = market.split_fee_surplus();
+    let returned_cash_amount = market.cash_balance.value() - reserved_cash;
+    let returned_cash = market.cash_balance.split(returned_cash_amount);
     market.assert_cash_backing();
 
-    (returned_cash, returned_fees)
+    returned_cash
+}
+
+/// Receive pool-provided cash without interpreting pool allocation policy.
+public(package) fun receive_pool_cash(market: &mut ExpiryMarket, cash: Balance<DUSDC>) {
+    market.assert_version_allowed();
+    market.cash_balance.join(cash);
+    market.assert_cash_backing();
+}
+
+/// Release pool cash while preserving expiry-local payout and rebate backing.
+public(package) fun release_pool_cash(market: &mut ExpiryMarket, amount: u64): Balance<DUSDC> {
+    market.assert_version_allowed();
+    if (amount == 0) {
+        return balance::zero()
+    };
+    let required_cash = market.payout_liability() + market.rebate_reserve();
+    assert!(market.cash_balance.value() >= required_cash + amount, EInsufficientCash);
+    let released_cash = market.cash_balance.split(amount);
+    market.assert_cash_backing();
+    released_cash
 }
 
 // === Private Functions ===
 
-fun current_nav_terms(
+fun position_liability_for_valuation(
     market: &mut ExpiryMarket,
     config: &ProtocolConfig,
     market_oracle: &MarketOracle,
     pyth: &PythSource,
     clock: &Clock,
-): (u64, u64) {
+): u64 {
     market.assert_market_oracle(market_oracle);
-    let rebate_reserve = market.aggregate_rebate_reserve();
     if (market_oracle.is_settled()) {
-        let settled_liability = market.materialize_settled_liability(market_oracle);
-        (settled_liability, rebate_reserve)
+        market.materialize_settled_liability(market_oracle)
     } else {
         market.assert_pyth_feed(pyth);
         market_oracle.assert_not_pending_settlement(clock);
         // Valuation uses a bounded, policy-tuned liquidation maintenance pass.
         // Residual underwater-order risk is controlled by the configured budget,
         // LTV buffer, priority ordering, and off-chain simulation policy.
-        let live_position_liability = market
+        market
             .strike_exposure
             .liquidate_and_live_position_liability(
                 config.pricing_config(),
@@ -567,28 +501,12 @@ fun current_nav_terms(
                 pyth,
                 config.risk_config().valuation_liquidation_budget(),
                 clock,
-            );
-        (live_position_liability, rebate_reserve)
+            )
     }
-}
-
-fun aggregate_rebate_reserve(market: &ExpiryMarket): u64 {
-    math::mul(market.unresolved_trading_fees_paid, market.trading_loss_rebate_rate)
 }
 
 fun assert_pyth_feed(market: &ExpiryMarket, pyth: &PythSource) {
     assert!(market.pyth_lazer_feed_id == pyth.feed_id(), EWrongPythSource);
-}
-
-/// Split `amount` by a stake benefit `fraction` (FLOAT_SCALING) into the
-/// fraction-weighted part and the remainder. The fee discount discards the
-/// weighted part and charges only the remainder — reducing protocol fee margin
-/// only, never payout backing, so cash-backing invariants are unaffected. The
-/// loss rebate pays the manager the weighted part and compounds the remainder
-/// to LPs.
-fun apply_stake_benefit(amount: u64, fraction: u64): (u64, u64) {
-    let weighted = math::mul(amount, fraction);
-    (weighted, amount - weighted)
 }
 
 fun run_configured_liquidation_pass(
@@ -638,12 +556,9 @@ fun redeem_liquidated_order(
     order_events::emit_liquidated_order_redeemed(market.id(), manager, order);
 }
 
-fun assert_allocation_backing(market: &ExpiryMarket) {
-    assert!(market.allocated_capital >= market.payout_liability(), EAllocationBelowMaxPayout);
-}
-
 fun assert_cash_backing(market: &ExpiryMarket) {
-    assert!(market.lp_cash_balance.value() >= market.payout_liability(), EInsufficientLpCash);
+    let required_cash = market.payout_liability() + market.rebate_reserve();
+    assert!(market.cash_balance.value() >= required_cash, EInsufficientCash);
 }
 
 fun mint_internal(
@@ -683,10 +598,10 @@ fun mint_internal(
             leverage,
             clock,
         );
-    let fee_discount = config.stake_config().fee_discount_fraction(manager.active_stake());
-    let (_, fee_amount) = apply_stake_benefit(fee_amount, fee_discount);
+    let fee_amount = config
+        .stake_config()
+        .fee_amount_after_discount(fee_amount, manager.active_stake());
 
-    market.assert_allocation_backing();
     let builder_fee_amount = market.settle_mint_payment(
         manager,
         &minted_order,
@@ -732,8 +647,9 @@ fun redeem_live_internal(
             close_quantity,
             clock,
         );
-    let fee_discount = config.stake_config().fee_discount_fraction(manager.active_stake());
-    let (_, fee_amount) = apply_stake_benefit(fee_amount, fee_discount);
+    let fee_amount = config
+        .stake_config()
+        .fee_amount_after_discount(fee_amount, manager.active_stake());
 
     let replacement_order_id = if (resulting_order.id() == order.id()) {
         option::none()
@@ -807,7 +723,7 @@ fun settle_mint_payment(
     let payment_amount = payment.value();
     let fee_payment = payment.split(fee_amount);
     market.collect_trade_fee(manager, fee_payment);
-    market.lp_cash_balance.join(payment);
+    market.cash_balance.join(payment);
     manager.record_cash_paid_to_expiry(market.id(), payment_amount);
 
     market.assert_cash_backing();
@@ -832,7 +748,7 @@ fun settle_live_redeem_payment(
         redeem_amount - fee_amount,
     );
 
-    let mut payout = market.dispense_lp_cash(redeem_amount);
+    let mut payout = market.dispense_cash(redeem_amount);
     let fee = payout.split(fee_amount);
     let builder_fee = payout.split(builder_fee_amount);
     market.collect_trade_fee(manager, fee);
@@ -849,7 +765,7 @@ fun settle_settled_redeem_payment(
     payout_amount: u64,
     ctx: &mut TxContext,
 ) {
-    let payout = market.dispense_lp_cash(payout_amount);
+    let payout = market.dispense_cash(payout_amount);
     deposit_permissionless_payout(manager, market, payout, ctx);
 
     market.assert_cash_backing();
@@ -861,7 +777,7 @@ fun collect_trade_fee(
     fee: Balance<DUSDC>,
 ) {
     let fee_amount = fee.value();
-    market.fee_balance.join(fee);
+    market.cash_balance.join(fee);
     if (fee_amount == 0) return;
     manager.record_trading_fee_paid(market.id(), fee_amount);
     market.unresolved_trading_fees_paid = market.unresolved_trading_fees_paid + fee_amount;
@@ -892,21 +808,9 @@ fun resolve_trading_fee_basis(market: &mut ExpiryMarket, amount: u64) {
     market.unresolved_trading_fees_paid = market.unresolved_trading_fees_paid - amount;
 }
 
-fun split_fee_surplus(market: &mut ExpiryMarket): Balance<DUSDC> {
-    let rebate_reserve = market.aggregate_rebate_reserve();
-    let fee_balance = market.fee_balance.value();
-    assert!(fee_balance >= rebate_reserve, EInsufficientFeeBalance);
-    market.fee_balance.split(fee_balance - rebate_reserve)
-}
-
-fun dispense_lp_cash(market: &mut ExpiryMarket, amount: u64): Balance<DUSDC> {
-    assert!(market.lp_cash_balance.value() >= amount, EInsufficientLpCash);
-    market.lp_cash_balance.split(amount)
-}
-
-fun dispense_fee_cash(market: &mut ExpiryMarket, amount: u64): Balance<DUSDC> {
-    assert!(market.fee_balance.value() >= amount, EInsufficientFeeBalance);
-    market.fee_balance.split(amount)
+fun dispense_cash(market: &mut ExpiryMarket, amount: u64): Balance<DUSDC> {
+    assert!(market.cash_balance.value() >= amount, EInsufficientCash);
+    market.cash_balance.split(amount)
 }
 
 fun send_builder_fee(builder_code_id: Option<ID>, fee: Balance<DUSDC>) {

--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -278,57 +278,10 @@ public fun liquidate(
         )
 }
 
-/// Resolve a manager's aggregate expiry trading-loss rebate after all its
-/// positions close. Permissionless by design: any caller may settle this for a
-/// manager — the rebate is credited to the manager via its deposit cap and any
-/// un-granted reserve becomes expiry NAV. The rebate share uses the manager's
-/// active staking.
-public fun claim_trading_loss_rebate(
-    market: &mut ExpiryMarket,
-    manager: &mut PredictManager,
-    config: &ProtocolConfig,
-    market_oracle: &MarketOracle,
-    ctx: &mut TxContext,
-) {
-    market.assert_version_allowed();
-    config.assert_not_valuation_in_progress();
-    market.materialize_settled_liability(market_oracle);
-
-    let (trading_fees_paid, trading_loss) = manager.resolve_expiry_summary(market.id());
-    if (trading_fees_paid == 0 && trading_loss == 0) {
-        return
-    };
-
-    market.resolve_trading_fee_basis(trading_fees_paid);
-    let max_rebate = math::mul(trading_fees_paid, market.trading_loss_rebate_rate);
-    let eligible_rebate = trading_loss.min(max_rebate);
-
-    // Active staking decides the manager's share of the eligible rebate. Any
-    // un-granted reserve remains in cash after its rebate basis is resolved.
-    manager.update_stake(ctx);
-    let rebate_amount = config
-        .stake_config()
-        .rebate_amount(eligible_rebate, manager.active_stake());
-
-    if (rebate_amount > 0) {
-        let payout = market.dispense_cash(rebate_amount);
-        manager.deposit_permissionless(payout.into_coin(ctx), ctx);
-    };
-    market.assert_cash_backing();
-
-    claim_events::emit_trading_loss_rebate_claimed(
-        market.id(),
-        manager.id(),
-        trading_fees_paid,
-        trading_loss,
-        rebate_amount,
-    );
-}
-
 /// Cache terminal liability if needed, then destroy live exposure indexes.
 ///
-/// This is cap-gated because index destruction returns storage rebates. Surplus
-/// cash remains in the expiry until a pool sweep moves it.
+/// This is cap-gated because index destruction returns storage rebates. Settled
+/// pool cash remains in the expiry until PLP rebalancing receives it.
 public fun compact_storage(
     market: &mut ExpiryMarket,
     config: &ProtocolConfig,
@@ -375,13 +328,12 @@ public(package) fun assert_version_allowed(market: &ExpiryMarket) {
     );
 }
 
-/// Create and share a funded expiry market for one market oracle.
+/// Create and share a zero-cash expiry market for one market oracle.
 ///
 /// The market snapshots the Pyth feed ID, initializes strike exposure state, and
-/// takes custody of pool-provided funding as expiry cash.
+/// starts with zero expiry cash. Pool funding only enters through PLP rebalancing.
 public(package) fun create_and_share(
     config: &ProtocolConfig,
-    funding: Balance<DUSDC>,
     allowed_versions: VecSet<u64>,
     market_oracle_id: ID,
     pyth_lazer_feed_id: u32,
@@ -398,7 +350,7 @@ public(package) fun create_and_share(
         pyth_lazer_feed_id,
         expiry,
         trading_loss_rebate_rate: config.fee_config().trading_loss_rebate_rate(),
-        cash_balance: funding,
+        cash_balance: balance::zero(),
         unresolved_trading_fees_paid: 0,
         strike_exposure: strike_exposure::new(
             expiry_market_id,
@@ -437,8 +389,60 @@ public(package) fun materialize_settled_liability(
     market.strike_exposure.materialize_settled_liability(settlement)
 }
 
-/// Release settled surplus derived from materialized settlement liability and rebate reserve.
-public(package) fun release_settled_surplus(
+/// Resolve one manager's trading-loss rebate and return unclaimed rebate reserve.
+public(package) fun claim_trading_loss_rebate(
+    market: &mut ExpiryMarket,
+    manager: &mut PredictManager,
+    config: &ProtocolConfig,
+    market_oracle: &MarketOracle,
+    ctx: &mut TxContext,
+): Balance<DUSDC> {
+    market.assert_version_allowed();
+    market.materialize_settled_liability(market_oracle);
+
+    let (trading_fees_paid, gross_profit) = manager.resolve_expiry_summary(market.id());
+    if (trading_fees_paid == 0 && gross_profit == 0) {
+        return balance::zero()
+    };
+
+    market.resolve_trading_fee_basis(trading_fees_paid);
+    let resolved_rebate_reserve = math::mul(
+        trading_fees_paid,
+        market.trading_loss_rebate_rate,
+    );
+    let eligible_rebate = if (resolved_rebate_reserve > gross_profit) {
+        resolved_rebate_reserve - gross_profit
+    } else {
+        0
+    };
+
+    // Active staking decides the manager's share of the eligible rebate.
+    manager.update_stake(ctx);
+    let rebate_amount = config
+        .stake_config()
+        .rebate_amount(eligible_rebate, manager.active_stake());
+
+    if (rebate_amount > 0) {
+        let payout = market.dispense_cash(rebate_amount);
+        manager.deposit_permissionless(payout.into_coin(ctx), ctx);
+    };
+    let residual_rebate_reserve = resolved_rebate_reserve - rebate_amount;
+    let residual_rebate_cash = market.dispense_cash(residual_rebate_reserve);
+    market.assert_cash_backing();
+
+    claim_events::emit_trading_loss_rebate_claimed(
+        market.id(),
+        manager.id(),
+        trading_fees_paid,
+        gross_profit,
+        eligible_rebate,
+        rebate_amount,
+    );
+    residual_rebate_cash
+}
+
+/// Release settled pool cash above terminal payout liability and rebate reserve.
+public(package) fun release_settled_pool_cash(
     market: &mut ExpiryMarket,
     market_oracle: &MarketOracle,
 ): Balance<DUSDC> {
@@ -449,10 +453,7 @@ public(package) fun release_settled_surplus(
     assert!(market.cash_balance.value() >= reserved_cash, EInsufficientCash);
 
     let returned_cash_amount = market.cash_balance.value() - reserved_cash;
-    let returned_cash = market.cash_balance.split(returned_cash_amount);
-    market.assert_cash_backing();
-
-    returned_cash
+    market.release_pool_cash(returned_cash_amount)
 }
 
 /// Receive pool-provided cash without interpreting pool allocation policy.
@@ -720,11 +721,10 @@ fun settle_mint_payment(
     let mut payment = manager.withdraw(withdraw_amount, ctx).into_balance();
     let builder_fee_payment = payment.split(builder_fee_amount);
     send_builder_fee(builder_code_id, builder_fee_payment);
-    let payment_amount = payment.value();
     let fee_payment = payment.split(fee_amount);
     market.collect_trade_fee(manager, fee_payment);
     market.cash_balance.join(payment);
-    manager.record_cash_paid_to_expiry(market.id(), payment_amount);
+    manager.record_gross_paid_to_expiry(market.id(), user_contribution);
 
     market.assert_cash_backing();
     builder_fee_amount
@@ -755,7 +755,7 @@ fun settle_live_redeem_payment(
     send_builder_fee(builder_code_id, builder_fee);
 
     market.assert_cash_backing();
-    deposit_live_payout(manager, market, payout, ctx);
+    deposit_live_payout(manager, market, payout, redeem_amount, ctx);
     builder_fee_amount
 }
 
@@ -787,9 +787,10 @@ fun deposit_live_payout(
     manager: &mut PredictManager,
     market: &ExpiryMarket,
     payout: Balance<DUSDC>,
+    gross_received_amount: u64,
     ctx: &mut TxContext,
 ) {
-    manager.record_cash_received_from_expiry(market.id(), payout.value());
+    manager.record_gross_received_from_expiry(market.id(), gross_received_amount);
     manager.deposit(payout.into_coin(ctx), ctx);
 }
 
@@ -799,7 +800,7 @@ fun deposit_permissionless_payout(
     payout: Balance<DUSDC>,
     ctx: &mut TxContext,
 ) {
-    manager.record_cash_received_from_expiry(market.id(), payout.value());
+    manager.record_gross_received_from_expiry(market.id(), payout.value());
     manager.deposit_permissionless(payout.into_coin(ctx), ctx);
 }
 

--- a/packages/predict/sources/plp.move
+++ b/packages/predict/sources/plp.move
@@ -194,8 +194,6 @@ public fun sync_expiry(
         return
     };
 
-    assert!(vault.expiry_accounting.is_active_expiry(expiry_market_id), EExpiryMarketNotActive);
-
     market.run_liquidation_pass(
         config.pricing_config(),
         market_oracle,

--- a/packages/predict/sources/plp.move
+++ b/packages/predict/sources/plp.move
@@ -194,16 +194,17 @@ public fun sync_expiry(
         return
     };
 
-    market_oracle.assert_active(clock);
     assert!(vault.expiry_accounting.is_active_expiry(expiry_market_id), EExpiryMarketNotActive);
 
-    let expiry_nav = vault.sync_active_expiry_cash_and_nav(
-        market,
-        config,
+    market.run_liquidation_pass(
+        config.pricing_config(),
         market_oracle,
         pyth,
+        config.risk_config().valuation_liquidation_budget(),
         clock,
     );
+    vault.rebalance_active_expiry_cash(market, config);
+    let expiry_nav = market.pool_nav(config, market_oracle, pyth, clock);
     sync.record_expiry_synced(expiry_market_id, expiry_nav);
 }
 
@@ -453,19 +454,6 @@ fun assert_expiry_ready_to_sync(sync: &PoolSync, expiry_market_id: ID) {
 fun record_expiry_synced(sync: &mut PoolSync, expiry_market_id: ID, expiry_nav: u64) {
     sync.active_expiry_value = sync.active_expiry_value + expiry_nav;
     sync.synced_expiry_markets.push_back(expiry_market_id);
-}
-
-fun sync_active_expiry_cash_and_nav(
-    vault: &mut PoolVault,
-    market: &mut ExpiryMarket,
-    config: &ProtocolConfig,
-    market_oracle: &MarketOracle,
-    pyth: &PythSource,
-    clock: &Clock,
-): u64 {
-    let prepared_nav = market.prepare_pool_sync(config, market_oracle, pyth, clock);
-    vault.rebalance_active_expiry_cash(market, config);
-    market.finish_pool_nav(prepared_nav)
 }
 
 fun rebalance_active_expiry_cash(

--- a/packages/predict/sources/plp.move
+++ b/packages/predict/sources/plp.move
@@ -4,22 +4,22 @@
 /// PLP token and pool vault accounting.
 ///
 /// PoolVault owns idle DUSDC and the PLP treasury cap. Expiry markets own
-/// active trading capital and risk state. This module coordinates full-pool
-/// valuation, PLP supply/withdrawal, allocation resize, and settled-expiry
-/// surplus sweeping. It does not own expiry-local strike, oracle, or position state.
+/// active trading cash and risk state. This module coordinates full-pool
+/// valuation, PLP supply/withdrawal, expiry funding, live expiry cash
+/// rebalancing, profit materialization, and settled-expiry surplus sweeping.
+/// It does not own expiry-local strike, oracle, or position state.
 module deepbook_predict::plp;
 
 use deepbook::math;
 use deepbook_predict::{
-    config_constants,
     constants,
     expiry_market::{ExpiryMarket, ExpiryValuation},
     market_oracle::MarketOracle,
     math as predict_math,
+    pool_accounting::{Self, Ledger},
     predict_manager::PredictManager,
     pricing,
     protocol_config::ProtocolConfig,
-    risk_config::RiskConfig,
     vault_events
 };
 use dusdc::dusdc::DUSDC;
@@ -32,25 +32,19 @@ use sui::{
 };
 use token::deep::DEEP;
 
-const EExpiryMarketAlreadyActive: u64 = 0;
 const EExpiryMarketNotActive: u64 = 1;
 const EInsufficientIdleBalance: u64 = 2;
-const EMaxTotalExposureExceeded: u64 = 3;
 const EWrongPoolVault: u64 = 4;
 const EExpiryMarketAlreadyValued: u64 = 5;
 const EMissingExpiryValuation: u64 = 6;
 const EActiveExpirySetChanged: u64 = 7;
-const EGrowUtilizationBelowThreshold: u64 = 8;
-const EShrinkUtilizationAboveThreshold: u64 = 9;
-const ENoAllocationResize: u64 = 10;
-const EInsufficientTotalAllocatedCapital: u64 = 11;
 const EZeroSupply: u64 = 12;
 const EZeroWithdraw: u64 = 13;
 const EInvalidInitialSupply: u64 = 14;
 const EZeroShares: u64 = 15;
 const EZeroPoolValue: u64 = 16;
 const EPackageVersionDisabled: u64 = 17;
-const EZeroAllocatedCapital: u64 = 18;
+const EInsufficientExpiryCashBacking: u64 = 18;
 
 /// One-time witness type for Predict LP token registration.
 public struct PLP has drop {}
@@ -58,20 +52,16 @@ public struct PLP has drop {}
 /// Pool-level capital and PLP accounting state.
 public struct PoolVault has key {
     id: UID,
-    /// Idle LP-owned DUSDC available for withdrawals and new allocations.
+    /// Idle LP-owned DUSDC available for withdrawals and expiry funding.
     idle_balance: Balance<DUSDC>,
-    /// Protocol revenue swept from settled expiry fee surplus.
-    protocol_fee_balance: Balance<DUSDC>,
-    /// Insurance fees swept from settled expiry fee surplus.
-    insurance_fee_balance: Balance<DUSDC>,
+    /// Protocol-owned DUSDC excluded from PLP redemption.
+    protocol_reserve_balance: Balance<DUSDC>,
     /// Pooled DEEP staked by all managers for trading benefits. Per-manager
     /// active/inactive amounts are mirrored on each `PredictManager`.
     staked_deep: Balance<DEEP>,
     treasury_cap: TreasuryCap<PLP>,
-    /// Expiry markets that still contribute active pool valuation/risk.
-    active_expiry_markets: vector<ID>,
-    /// Sum of active expiry risk budgets allocated out of the pool.
-    total_allocated_capital: u64,
+    /// Active expiry IDs, pool cash-flow rows, profit basis, and per-expiry funding caps.
+    expiry_accounting: Ledger,
     /// Mirror of `ProtocolConfig.allowed_versions`; synced permissionlessly.
     allowed_versions: VecSet<u64>,
 }
@@ -84,8 +74,10 @@ public struct PoolValuation {
     expected_expiry_markets: vector<ID>,
     /// Expiry IDs whose valuation witnesses have been consumed.
     valued_expiry_markets: vector<ID>,
-    /// Running pool value, starting from idle DUSDC and adding each expiry NAV.
+    /// Running gross pool value, starting from idle DUSDC and adding each expiry NAV.
     value: u64,
+    /// Running NAV of active expiries in this valuation.
+    active_expiry_value: u64,
 }
 
 // === Private Functions ===
@@ -128,19 +120,14 @@ public fun staked_deep(vault: &PoolVault): u64 {
     vault.staked_deep.value()
 }
 
-/// Return protocol revenue swept from settled expiry fee surplus.
-public fun protocol_fee_balance(vault: &PoolVault): u64 {
-    vault.protocol_fee_balance.value()
-}
-
-/// Return insurance fees swept from settled expiry fee surplus.
-public fun insurance_fee_balance(vault: &PoolVault): u64 {
-    vault.insurance_fee_balance.value()
+/// Return protocol-owned DUSDC excluded from PLP redemption.
+public fun protocol_reserve_balance(vault: &PoolVault): u64 {
+    vault.protocol_reserve_balance.value()
 }
 
 /// Return active expiry market IDs tracked by the pool.
 public fun active_expiry_markets(vault: &PoolVault): &vector<ID> {
-    &vault.active_expiry_markets
+    vault.expiry_accounting.active_expiry_markets()
 }
 
 /// Return total PLP supply.
@@ -148,9 +135,77 @@ public fun total_supply(vault: &PoolVault): u64 {
     vault.treasury_cap.total_supply()
 }
 
-/// Return total DUSDC allocated as expiry risk budget.
-public fun total_allocated_capital(vault: &PoolVault): u64 {
-    vault.total_allocated_capital
+/// Return the money-out side of aggregate expiry profit basis.
+public fun profit_basis_debits(vault: &PoolVault): u64 {
+    vault.expiry_accounting.profit_basis_debits()
+}
+
+/// Return the money-in side of aggregate expiry profit basis.
+public fun profit_basis_credits(vault: &PoolVault): u64 {
+    vault.expiry_accounting.profit_basis_credits()
+}
+
+/// Return DUSDC sent to and received from one expiry market.
+public fun expiry_flow_amounts(vault: &PoolVault, expiry_market_id: ID): (u64, u64) {
+    vault.expiry_accounting.expiry_flow_amounts(expiry_market_id)
+}
+
+/// Return the max net DUSDC the pool may have funded into an expiry.
+public fun max_expiry_funding(vault: &PoolVault, expiry_market_id: ID): u64 {
+    vault.expiry_accounting.max_expiry_funding(expiry_market_id)
+}
+
+/// Rebalance live expiry cash toward the configured buffer around current backing needs.
+///
+/// PLP owns the allocation policy: it compares expiry cash against payout
+/// liability plus rebate reserve, preserves the fixed expiry cash floor, and
+/// records every cash movement in the pool money-out/money-in ledger. This
+/// remains callable while trading is paused because it manages existing pool
+/// cash rather than creating new risk.
+public fun rebalance_expiry_cash(
+    vault: &mut PoolVault,
+    market: &mut ExpiryMarket,
+    config: &ProtocolConfig,
+    market_oracle: &MarketOracle,
+    clock: &Clock,
+) {
+    vault.assert_version_allowed();
+    market.assert_version_allowed();
+    config.assert_not_valuation_in_progress();
+    market.assert_market_oracle(market_oracle);
+    market_oracle.assert_active(clock);
+
+    let expiry_market_id = market.id();
+    assert!(vault.expiry_accounting.is_active_expiry(expiry_market_id), EExpiryMarketNotActive);
+
+    let (cash_balance, target_cash, sweep_threshold_cash) = expiry_rebalance_cash_terms(
+        market,
+    );
+
+    if (cash_balance < target_cash) {
+        let requested_top_up = target_cash - cash_balance;
+        let funding_room = vault.expiry_accounting.available_expiry_funding(expiry_market_id);
+        let top_up = requested_top_up.min(vault.idle_balance.value()).min(funding_room);
+        if (top_up == 0) return;
+
+        vault.send_expiry_cash(market, expiry_market_id, top_up);
+        vault.emit_expiry_cash_rebalanced(market, expiry_market_id, top_up, true, target_cash);
+    } else if (cash_balance > sweep_threshold_cash) {
+        let cash_to_return = cash_balance - target_cash;
+        let returned_cash = market.release_pool_cash(cash_to_return);
+        let returned_cash_amount = vault.receive_expiry_cash(
+            config,
+            expiry_market_id,
+            returned_cash,
+        );
+        vault.emit_expiry_cash_rebalanced(
+            market,
+            expiry_market_id,
+            returned_cash_amount,
+            false,
+            target_cash,
+        );
+    };
 }
 
 /// Begin a full-pool valuation and lock protocol valuation-sensitive flows.
@@ -163,9 +218,10 @@ public fun start_valuation(config: &mut ProtocolConfig, vault: &PoolVault): Pool
     config.begin_valuation();
     PoolValuation {
         pool_vault_id: vault.id(),
-        expected_expiry_markets: *&vault.active_expiry_markets,
+        expected_expiry_markets: *vault.expiry_accounting.active_expiry_markets(),
         valued_expiry_markets: vector[],
         value: vault.idle_balance.value(),
+        active_expiry_value: 0,
     }
 }
 
@@ -182,78 +238,14 @@ public fun add_expiry_valuation(valuation: &mut PoolValuation, expiry_valuation:
     );
     valuation.valued_expiry_markets.push_back(expiry_market_id);
     valuation.value = valuation.value + expiry_value;
-}
-
-/// Grow an active live expiry allocation when utilization reaches the high watermark.
-///
-/// Moves idle DUSDC from the pool into the expiry while respecting global pool
-/// allocation capacity and the upgrade-required per-expiry hard cap.
-public fun grow_expiry_allocation(
-    vault: &mut PoolVault,
-    market: &mut ExpiryMarket,
-    config: &ProtocolConfig,
-    market_oracle: &MarketOracle,
-    clock: &Clock,
-) {
-    vault.assert_version_allowed();
-    config.assert_trading_allowed();
-    assert!(vault.active_expiry_markets.contains(&market.id()), EExpiryMarketNotActive);
-    market.assert_market_oracle(market_oracle);
-    market_oracle.assert_active(clock);
-    let risk_config = config.risk_config();
-    let amount = vault.grow_amount(risk_config, market);
-    let new_total_allocated = vault.total_allocated_capital + amount;
-    let allocation = vault.idle_balance.split(amount);
-    vault.total_allocated_capital = new_total_allocated;
-    market.receive_allocation(allocation);
-
-    vault_events::emit_expiry_allocation_changed(
-        vault.id(),
-        market.id(),
-        amount,
-        true,
-        market.allocated_capital(),
-        vault.idle_balance.value(),
-    );
-}
-
-/// Shrink an active live expiry allocation when utilization reaches the low watermark.
-///
-/// Moves only returnable free cash back to the pool; expiry payout backing stays
-/// inside the expiry market.
-public fun shrink_expiry_allocation(
-    vault: &mut PoolVault,
-    market: &mut ExpiryMarket,
-    config: &ProtocolConfig,
-    market_oracle: &MarketOracle,
-    clock: &Clock,
-) {
-    vault.assert_version_allowed();
-    config.assert_not_valuation_in_progress();
-    assert!(vault.active_expiry_markets.contains(&market.id()), EExpiryMarketNotActive);
-    market.assert_market_oracle(market_oracle);
-    market_oracle.assert_active(clock);
-    let amount = shrink_amount(config.risk_config(), market);
-    assert!(vault.total_allocated_capital >= amount, EInsufficientTotalAllocatedCapital);
-    let allocation = market.return_allocation(amount);
-    vault.total_allocated_capital = vault.total_allocated_capital - amount;
-    vault.idle_balance.join(allocation);
-
-    vault_events::emit_expiry_allocation_changed(
-        vault.id(),
-        market.id(),
-        amount,
-        false,
-        market.allocated_capital(),
-        vault.idle_balance.value(),
-    );
+    valuation.active_expiry_value = valuation.active_expiry_value + expiry_value;
 }
 
 /// Sweep settled expiry surplus into the pool.
 ///
 /// This no-ops before settlement. Once settled, it caches terminal payout
-/// liability if needed, retires active allocation on the first sweep, and
-/// distributes fee surplus not reserved for unresolved rebates.
+/// liability if needed, deactivates the expiry from active valuation on the
+/// first sweep, and returns sweepable cash to idle pool liquidity.
 public fun sweep_settled_expiry_surplus(
     vault: &mut PoolVault,
     market: &mut ExpiryMarket,
@@ -265,43 +257,43 @@ public fun sweep_settled_expiry_surplus(
     market.assert_market_oracle(market_oracle);
     if (!market_oracle.is_settled()) return;
 
-    let allocated_reduction = market.allocated_capital();
-    if (allocated_reduction > 0) {
-        assert!(vault.active_expiry_markets.contains(&market.id()), EExpiryMarketNotActive);
-        assert!(
-            vault.total_allocated_capital >= allocated_reduction,
-            EInsufficientTotalAllocatedCapital,
-        );
-    };
+    let market_id = market.id();
+    vault.expiry_accounting.deactivate_expiry_if_present(market_id);
+    let returned_cash = market.release_settled_surplus(market_oracle);
+    let returned_cash_amount = vault.receive_expiry_cash(config, market_id, returned_cash);
+    let (sent_to_expiry_after, received_from_expiry_after) = vault
+        .expiry_accounting
+        .expiry_flow_amounts(market_id);
 
-    let (returned_cash, returned_fee_surplus) = market.release_settled_surplus(market_oracle);
-    let returned_cash_amount = returned_cash.value();
-    if (allocated_reduction > 0) {
-        vault.total_allocated_capital = vault.total_allocated_capital - allocated_reduction;
-        vault.unregister_expiry_market(market.id());
-    };
-    vault.idle_balance.join(returned_cash);
-    let (protocol_fee, insurance_fee, lp_fee) = vault.distribute_fee_surplus(
-        config,
-        returned_fee_surplus,
-    );
-
-    if (
-        allocated_reduction > 0 || returned_cash_amount > 0 || protocol_fee > 0 || insurance_fee > 0 || lp_fee > 0
-    ) {
+    if (returned_cash_amount > 0) {
         vault_events::emit_expiry_surplus_swept(
             vault.id(),
-            market.id(),
+            market_id,
             pricing::settlement_price(market_oracle),
-            allocated_reduction,
             returned_cash_amount,
             vault.idle_balance.value(),
-            vault.total_allocated_capital,
-            protocol_fee,
-            insurance_fee,
-            lp_fee,
+            sent_to_expiry_after,
+            received_from_expiry_after,
         );
     };
+}
+
+/// Set the max net DUSDC the pool may have funded into one expiry.
+public(package) fun set_max_expiry_funding(
+    vault: &mut PoolVault,
+    config: &ProtocolConfig,
+    expiry_market_id: ID,
+    funding: u64,
+) {
+    vault.assert_version_allowed();
+    config.assert_not_valuation_in_progress();
+    vault.expiry_accounting.set_max_expiry_funding(expiry_market_id, funding);
+    vault_events::emit_expiry_max_funding_updated(
+        vault.id(),
+        expiry_market_id,
+        funding,
+        vault.expiry_accounting.expiry_net_funding(expiry_market_id),
+    );
 }
 
 /// Supply DUSDC into the pool vault against a complete full-pool valuation.
@@ -341,7 +333,6 @@ public fun supply(
         pool_value,
         vault.treasury_cap.total_supply(),
         vault.idle_balance.value(),
-        vault.total_allocated_capital,
     );
     plp
 }
@@ -349,7 +340,7 @@ public fun supply(
 /// Withdraw DUSDC from the pool vault against a complete full-pool valuation.
 ///
 /// Completes the valuation after flow preconditions pass, burns PLP, and
-/// enforces the pool-level allocated-capital limit after withdrawal.
+/// enforces enough idle liquidity for the withdrawal.
 public fun withdraw(
     vault: &mut PoolVault,
     config: &mut ProtocolConfig,
@@ -367,13 +358,6 @@ public fun withdraw(
     assert!(withdraw_amount > 0, EZeroWithdraw);
     let idle_balance = vault.idle_balance.value();
     assert!(idle_balance >= withdraw_amount, EInsufficientIdleBalance);
-    let pool_capital_after_withdraw =
-        idle_balance - withdraw_amount + vault.total_allocated_capital;
-    let max_allocated = math::mul(
-        pool_capital_after_withdraw,
-        config.risk_config().max_total_exposure_pct(),
-    );
-    assert!(vault.total_allocated_capital <= max_allocated, EMaxTotalExposureExceeded);
 
     finish_valuation(config, valuation);
     vault.treasury_cap.burn(lp_coin);
@@ -385,7 +369,6 @@ public fun withdraw(
         pool_value,
         vault.treasury_cap.total_supply(),
         vault.idle_balance.value(),
-        vault.total_allocated_capital,
     );
     payout
 }
@@ -433,12 +416,10 @@ public(package) fun new(treasury_cap: TreasuryCap<PLP>, ctx: &mut TxContext): Po
     PoolVault {
         id: object::new(ctx),
         idle_balance: balance::zero(),
-        protocol_fee_balance: balance::zero(),
-        insurance_fee_balance: balance::zero(),
+        protocol_reserve_balance: balance::zero(),
         staked_deep: balance::zero(),
         treasury_cap,
-        active_expiry_markets: vector[],
-        total_allocated_capital: 0,
+        expiry_accounting: pool_accounting::new(ctx),
         allowed_versions: vec_set::singleton(constants::current_version!()),
     }
 }
@@ -459,49 +440,31 @@ public(package) fun create_and_share(treasury_cap: TreasuryCap<PLP>, ctx: &mut T
     id
 }
 
-/// Allocate idle DUSDC into a newly created expiry market.
+/// Move initial idle DUSDC funding into a newly created expiry market.
 ///
 /// This is intentionally unusable on a freshly published package until the LP
 /// funding path is implemented; the pool must already hold enough idle DUSDC.
-public(package) fun allocate_to_new_expiry(
-    vault: &mut PoolVault,
-    risk_config: &RiskConfig,
-): Balance<DUSDC> {
-    let amount = risk_config.expiry_allocation();
+public(package) fun fund_new_expiry(vault: &mut PoolVault): Balance<DUSDC> {
+    let amount = constants::expiry_cash_floor!();
     let idle_balance = vault.idle_balance.value();
     assert!(idle_balance >= amount, EInsufficientIdleBalance);
-
-    let pool_capital = idle_balance + vault.total_allocated_capital;
-    let new_total_allocated = vault.total_allocated_capital + amount;
-    let max_allocated = math::mul(pool_capital, risk_config.max_total_exposure_pct());
-    assert!(new_total_allocated <= max_allocated, EMaxTotalExposureExceeded);
-
-    vault.total_allocated_capital = new_total_allocated;
     vault.idle_balance.split(amount)
 }
 
-/// Register an expiry market as active for valuation and pool allocation accounting.
-public(package) fun register_expiry_market(vault: &mut PoolVault, expiry_market_id: ID) {
-    assert!(!vault.active_expiry_markets.contains(&expiry_market_id), EExpiryMarketAlreadyActive);
-    vault.active_expiry_markets.push_back(expiry_market_id);
-}
-
-/// Remove an expiry market from active valuation and pool allocation accounting.
-public(package) fun unregister_expiry_market(vault: &mut PoolVault, expiry_market_id: ID) {
-    let mut i = 0;
-    let len = vault.active_expiry_markets.length();
-    while (i < len && vault.active_expiry_markets[i] != expiry_market_id) {
-        i = i + 1;
-    };
-    assert!(i < len, EExpiryMarketNotActive);
-    vault.active_expiry_markets.swap_remove(i);
+/// Register an expiry market for pool accounting and active valuation.
+public(package) fun register_expiry_market(
+    vault: &mut PoolVault,
+    expiry_market_id: ID,
+    initial_funding: u64,
+) {
+    vault.expiry_accounting.register_expiry(expiry_market_id, initial_funding);
 }
 
 // === Private Functions ===
 
 fun assert_active_set_unchanged(vault: &PoolVault, expected_expiry_markets: &vector<ID>) {
     assert_same_id_set(
-        &vault.active_expiry_markets,
+        vault.expiry_accounting.active_expiry_markets(),
         expected_expiry_markets,
         EActiveExpirySetChanged,
     );
@@ -523,83 +486,69 @@ fun assert_same_id_set(actual: &vector<ID>, expected: &vector<ID>, error: u64) {
     };
 }
 
-fun remaining_global_allocation_capacity(vault: &PoolVault, risk_config: &RiskConfig): u64 {
-    let idle_balance = vault.idle_balance.value();
-    let max_total_allocation = math::mul(
-        idle_balance + vault.total_allocated_capital,
-        risk_config.max_total_exposure_pct(),
+// Returns sampled branch terms and enforces the expiry backing invariant.
+fun expiry_rebalance_cash_terms(market: &ExpiryMarket): (u64, u64, u64) {
+    let required_cash = market.payout_liability() + market.rebate_reserve();
+    let target_buffer = math::mul(required_cash, constants::expiry_rebalance_pct!());
+    let target_cash = (required_cash + target_buffer).max(constants::expiry_cash_floor!());
+    let sweep_threshold_cash = (required_cash + target_buffer + target_buffer).max(
+        constants::expiry_cash_floor!(),
     );
-    if (max_total_allocation > vault.total_allocated_capital) {
-        max_total_allocation - vault.total_allocated_capital
-    } else {
-        0
-    }
+    let cash_balance = market.cash_balance();
+    assert!(cash_balance >= required_cash, EInsufficientExpiryCashBacking);
+    (cash_balance, target_cash, sweep_threshold_cash)
 }
 
-fun grow_amount(vault: &PoolVault, risk_config: &RiskConfig, market: &ExpiryMarket): u64 {
-    let current_allocation = market.allocated_capital();
-    let utilization = allocation_utilization(market.payout_liability(), current_allocation);
-    assert!(
-        utilization >= risk_config.grow_utilization_threshold(),
-        EGrowUtilizationBelowThreshold,
-    );
-
-    let desired_target = math::mul(current_allocation, risk_config.grow_factor()).min(
-        config_constants::max_allocation!(),
-    );
-    assert!(desired_target > current_allocation, ENoAllocationResize);
-    let desired_growth = desired_target - current_allocation;
-    let amount = desired_growth
-        .min(vault.remaining_global_allocation_capacity(risk_config))
-        .min(vault.idle_balance.value());
-    assert!(amount > 0, ENoAllocationResize);
-    amount
+fun send_expiry_cash(
+    vault: &mut PoolVault,
+    market: &mut ExpiryMarket,
+    expiry_market_id: ID,
+    amount: u64,
+) {
+    if (amount == 0) return;
+    let cash = vault.idle_balance.split(amount);
+    market.receive_pool_cash(cash);
+    vault.expiry_accounting.record_sent_to_expiry(expiry_market_id, amount);
 }
 
-fun shrink_amount(risk_config: &RiskConfig, market: &ExpiryMarket): u64 {
-    let current_allocation = market.allocated_capital();
-    let utilization = allocation_utilization(market.payout_liability(), current_allocation);
-    assert!(
-        utilization <= risk_config.shrink_utilization_threshold(),
-        EShrinkUtilizationAboveThreshold,
-    );
-
-    let target_allocation = math::mul(
-        current_allocation,
-        risk_config.shrink_factor(),
-    ).max(risk_config.expiry_allocation());
-    // returnable_capital caps the shrink so allocation and cash remain above payout liability.
-    let amount = if (target_allocation < current_allocation) {
-        current_allocation - target_allocation
-    } else {
-        0
-    }.min(market.returnable_capital());
-    assert!(amount > 0, ENoAllocationResize);
-    amount
-}
-
-fun allocation_utilization(payout_liability: u64, allocated_capital: u64): u64 {
-    assert!(allocated_capital > 0, EZeroAllocatedCapital);
-    math::div(payout_liability, allocated_capital)
-}
-
-/// Split fee surplus to protocol, insurance, and LP, returning the three amounts.
-fun distribute_fee_surplus(
+fun receive_expiry_cash(
     vault: &mut PoolVault,
     config: &ProtocolConfig,
-    fee_surplus: Balance<DUSDC>,
-): (u64, u64, u64) {
-    let total_fee = fee_surplus.value();
-    let protocol_fee = math::mul(total_fee, config.fee_config().protocol_fee_share());
-    let insurance_fee = math::mul(total_fee, config.fee_config().insurance_fee_share());
-    let mut lp_fee = fee_surplus;
-    let protocol_fee_balance = lp_fee.split(protocol_fee);
-    let insurance_fee_balance = lp_fee.split(insurance_fee);
-    let lp_fee_amount = lp_fee.value();
-    vault.idle_balance.join(lp_fee);
-    vault.protocol_fee_balance.join(protocol_fee_balance);
-    vault.insurance_fee_balance.join(insurance_fee_balance);
-    (protocol_fee, insurance_fee, lp_fee_amount)
+    expiry_market_id: ID,
+    cash: Balance<DUSDC>,
+): u64 {
+    let amount = cash.value();
+    vault.idle_balance.join(cash);
+    vault.expiry_accounting.record_received_from_expiry(expiry_market_id, amount);
+    vault.materialize_profit(config);
+    amount
+}
+
+fun materialize_profit(vault: &mut PoolVault, config: &ProtocolConfig) {
+    let profit = vault.expiry_accounting.materialize_profit();
+    if (profit == 0) return;
+
+    // Materialized profit is cash-backed and irreversible: LP profit stays in
+    // idle liquidity, while protocol profit leaves PLP NAV.
+    let protocol_profit = math::mul(profit, config.fee_config().protocol_reserve_fee_share());
+    let lp_profit = profit - protocol_profit;
+    if (protocol_profit > 0) {
+        let protocol_profit_balance = vault.idle_balance.split(protocol_profit);
+        vault.protocol_reserve_balance.join(protocol_profit_balance);
+    };
+    let (profit_basis_debits_after, profit_basis_credits_after) = vault
+        .expiry_accounting
+        .profit_basis_amounts();
+    vault_events::emit_expiry_profit_materialized(
+        vault.id(),
+        profit,
+        lp_profit,
+        protocol_profit,
+        vault.idle_balance.value(),
+        vault.protocol_reserve_balance.value(),
+        profit_basis_debits_after,
+        profit_basis_credits_after,
+    );
 }
 
 fun validated_pool_value(
@@ -614,7 +563,49 @@ fun validated_pool_value(
         &valuation.expected_expiry_markets,
         &valuation.valued_expiry_markets,
     );
-    valuation.value
+    valuation.value - vault.pending_protocol_profit_exclusion(config, valuation.active_expiry_value)
+}
+
+fun pending_protocol_profit_exclusion(
+    vault: &PoolVault,
+    config: &ProtocolConfig,
+    active_expiry_value: u64,
+): u64 {
+    // NAV prices pending protocol profit before it is cash-backed. Actual
+    // reserve custody only changes when expiry cash returns through materialization.
+    let aggregate_credits = vault.expiry_accounting.profit_basis_credits() + active_expiry_value;
+    let aggregate_debits = vault.expiry_accounting.profit_basis_debits();
+    if (aggregate_credits <= aggregate_debits) {
+        return 0
+    };
+    math::mul(
+        aggregate_credits - aggregate_debits,
+        config.fee_config().protocol_reserve_fee_share(),
+    )
+}
+
+fun emit_expiry_cash_rebalanced(
+    vault: &PoolVault,
+    market: &ExpiryMarket,
+    expiry_market_id: ID,
+    amount: u64,
+    to_expiry: bool,
+    target_cash: u64,
+) {
+    let (sent_to_expiry_after, received_from_expiry_after) = vault
+        .expiry_accounting
+        .expiry_flow_amounts(expiry_market_id);
+    vault_events::emit_expiry_cash_rebalanced(
+        vault.id(),
+        expiry_market_id,
+        amount,
+        to_expiry,
+        target_cash,
+        market.cash_balance(),
+        vault.idle_balance.value(),
+        sent_to_expiry_after,
+        received_from_expiry_after,
+    );
 }
 
 fun finish_valuation(config: &mut ProtocolConfig, valuation: PoolValuation) {
@@ -623,6 +614,7 @@ fun finish_valuation(config: &mut ProtocolConfig, valuation: PoolValuation) {
         expected_expiry_markets: _,
         valued_expiry_markets: _,
         value: _,
+        active_expiry_value: _,
     } = valuation;
     config.end_valuation();
 }

--- a/packages/predict/sources/plp.move
+++ b/packages/predict/sources/plp.move
@@ -279,24 +279,6 @@ public fun sweep_settled_expiry_surplus(
     };
 }
 
-/// Set the max net DUSDC the pool may have funded into one expiry.
-public(package) fun set_max_expiry_funding(
-    vault: &mut PoolVault,
-    config: &ProtocolConfig,
-    expiry_market_id: ID,
-    funding: u64,
-) {
-    vault.assert_version_allowed();
-    config.assert_not_valuation_in_progress();
-    vault.expiry_accounting.set_max_expiry_funding(expiry_market_id, funding);
-    vault_events::emit_expiry_max_funding_updated(
-        vault.id(),
-        expiry_market_id,
-        funding,
-        vault.expiry_accounting.expiry_net_funding(expiry_market_id),
-    );
-}
-
 /// Supply DUSDC into the pool vault against a complete full-pool valuation.
 ///
 /// Completes the valuation after flow preconditions pass and mints PLP shares
@@ -405,11 +387,12 @@ public fun unstake_deep(
 
 // === Public-Package Functions ===
 
-/// Overwrite this vault's mirrored `allowed_versions`. The only authorized
-/// caller is `registry::sync_pool_vault_allowed_versions`, which reads the
-/// source of truth from `Registry`.
-public(package) fun set_allowed_versions(vault: &mut PoolVault, allowed_versions: VecSet<u64>) {
-    vault.allowed_versions = allowed_versions;
+/// Abort if the running package version is not allowed for this vault.
+public(package) fun assert_version_allowed(vault: &PoolVault) {
+    assert!(
+        vault.allowed_versions.contains(&constants::current_version!()),
+        EPackageVersionDisabled,
+    );
 }
 
 /// Create an empty pool vault from the PLP treasury cap.
@@ -425,20 +408,19 @@ public(package) fun new(treasury_cap: TreasuryCap<PLP>, ctx: &mut TxContext): Po
     }
 }
 
-/// Abort if the running package version is not allowed for this vault.
-public(package) fun assert_version_allowed(vault: &PoolVault) {
-    assert!(
-        vault.allowed_versions.contains(&constants::current_version!()),
-        EPackageVersionDisabled,
-    );
-}
-
 /// Create and share an empty pool vault from the PLP treasury cap.
 public(package) fun create_and_share(treasury_cap: TreasuryCap<PLP>, ctx: &mut TxContext): ID {
     let vault = new(treasury_cap, ctx);
     let id = vault.id();
     transfer::share_object(vault);
     id
+}
+
+/// Overwrite this vault's mirrored `allowed_versions`. The only authorized
+/// caller is `registry::sync_pool_vault_allowed_versions`, which reads the
+/// source of truth from `Registry`.
+public(package) fun set_allowed_versions(vault: &mut PoolVault, allowed_versions: VecSet<u64>) {
+    vault.allowed_versions = allowed_versions;
 }
 
 /// Move initial idle DUSDC funding into a newly created expiry market.
@@ -459,6 +441,24 @@ public(package) fun register_expiry_market(
     initial_funding: u64,
 ) {
     vault.expiry_accounting.register_expiry(expiry_market_id, initial_funding);
+}
+
+/// Set the max net DUSDC the pool may have funded into one expiry.
+public(package) fun set_max_expiry_funding(
+    vault: &mut PoolVault,
+    config: &ProtocolConfig,
+    expiry_market_id: ID,
+    funding: u64,
+) {
+    vault.assert_version_allowed();
+    config.assert_not_valuation_in_progress();
+    let net_funding = vault.expiry_accounting.set_max_expiry_funding(expiry_market_id, funding);
+    vault_events::emit_expiry_max_funding_updated(
+        vault.id(),
+        expiry_market_id,
+        funding,
+        net_funding,
+    );
 }
 
 // === Private Functions ===

--- a/packages/predict/sources/plp.move
+++ b/packages/predict/sources/plp.move
@@ -6,7 +6,8 @@
 /// PoolVault owns idle DUSDC and the PLP treasury cap. Expiry markets own
 /// active trading cash and risk state. This module coordinates full-pool
 /// valuation, PLP supply/withdrawal, expiry funding, live expiry cash
-/// rebalancing, profit materialization, and settled-expiry surplus sweeping.
+/// rebalancing, rebate-reserve release, profit materialization, and
+/// settled-expiry cash receipt.
 /// It does not own expiry-local strike, oracle, or position state.
 module deepbook_predict::plp;
 
@@ -44,7 +45,6 @@ const EInvalidInitialSupply: u64 = 8;
 const EZeroShares: u64 = 9;
 const EZeroPoolValue: u64 = 10;
 const EPackageVersionDisabled: u64 = 11;
-const EInsufficientExpiryCashBacking: u64 = 12;
 
 /// One-time witness type for Predict LP token registration.
 public struct PLP has drop {}
@@ -155,13 +155,14 @@ public fun max_expiry_funding(vault: &PoolVault, expiry_market_id: ID): u64 {
     vault.expiry_accounting.max_expiry_funding(expiry_market_id)
 }
 
-/// Rebalance live expiry cash toward the configured buffer around current backing needs.
+/// Maintain live expiry cash and unregister settled expiries from active valuation.
 ///
 /// PLP owns the allocation policy: it compares expiry cash against payout
 /// liability plus rebate reserve, preserves the fixed expiry cash floor, and
-/// records every cash movement in the pool money-out/money-in ledger. This
-/// remains callable while trading is paused because it manages existing pool
-/// cash rather than creating new risk.
+/// records every cash movement in the pool money-out/money-in ledger. Settled
+/// markets are deactivated and release all cash above settled backing needs.
+/// This remains callable while trading is paused because it manages existing
+/// pool cash rather than creating new risk.
 public fun rebalance_expiry_cash(
     vault: &mut PoolVault,
     market: &mut ExpiryMarket,
@@ -173,8 +174,13 @@ public fun rebalance_expiry_cash(
     market.assert_version_allowed();
     config.assert_not_valuation_in_progress();
     market.assert_market_oracle(market_oracle);
-    market_oracle.assert_active(clock);
 
+    if (market_oracle.is_settled()) {
+        vault.unregister_settled_expiry(market, config, market_oracle);
+        return
+    };
+
+    market_oracle.assert_active(clock);
     let expiry_market_id = market.id();
     assert!(vault.expiry_accounting.is_active_expiry(expiry_market_id), EExpiryMarketNotActive);
 
@@ -241,40 +247,28 @@ public fun add_expiry_valuation(valuation: &mut PoolValuation, expiry_valuation:
     valuation.active_expiry_value = valuation.active_expiry_value + expiry_value;
 }
 
-/// Sweep settled expiry surplus into the pool.
-///
-/// This no-ops before settlement. Once settled, it caches terminal payout
-/// liability if needed, deactivates the expiry from active valuation on the
-/// first sweep, and returns sweepable cash to idle pool liquidity.
-public fun sweep_settled_expiry_surplus(
+/// Resolve one manager's settled trading-loss rebate and return residual reserve to the pool.
+public fun claim_trading_loss_rebate(
     vault: &mut PoolVault,
     market: &mut ExpiryMarket,
+    manager: &mut PredictManager,
     config: &ProtocolConfig,
     market_oracle: &MarketOracle,
+    ctx: &mut TxContext,
 ) {
     vault.assert_version_allowed();
     config.assert_not_valuation_in_progress();
     market.assert_market_oracle(market_oracle);
-    if (!market_oracle.is_settled()) return;
 
-    let market_id = market.id();
-    let was_active = vault.expiry_accounting.is_active_expiry(market_id);
-    vault.expiry_accounting.deactivate_expiry_if_present(market_id);
-    let returned_cash = market.release_settled_surplus(market_oracle);
-    let returned_cash_amount = vault.receive_expiry_cash(config, market_id, returned_cash);
-    let (sent_to_expiry_after, received_from_expiry_after) = vault
-        .expiry_accounting
-        .expiry_flow_amounts(market_id);
-
-    if (was_active || returned_cash_amount > 0) {
-        vault_events::emit_expiry_surplus_swept(
-            vault.id(),
-            market_id,
-            pricing::settlement_price(market_oracle),
+    let expiry_market_id = market.id();
+    vault.expiry_accounting.assert_registered_expiry(expiry_market_id);
+    let residual_cash = market.claim_trading_loss_rebate(manager, config, market_oracle, ctx);
+    let returned_cash_amount = vault.receive_expiry_cash(config, expiry_market_id, residual_cash);
+    if (returned_cash_amount > 0) {
+        vault.emit_expiry_cash_received(
+            expiry_market_id,
+            market_oracle,
             returned_cash_amount,
-            vault.idle_balance.value(),
-            sent_to_expiry_after,
-            received_from_expiry_after,
         );
     };
 }
@@ -423,24 +417,9 @@ public(package) fun set_allowed_versions(vault: &mut PoolVault, allowed_versions
     vault.allowed_versions = allowed_versions;
 }
 
-/// Move initial idle DUSDC funding into a newly created expiry market.
-///
-/// This is intentionally unusable on a freshly published package until the LP
-/// funding path is implemented; the pool must already hold enough idle DUSDC.
-public(package) fun fund_new_expiry(vault: &mut PoolVault): Balance<DUSDC> {
-    let amount = constants::expiry_cash_floor!();
-    let idle_balance = vault.idle_balance.value();
-    assert!(idle_balance >= amount, EInsufficientIdleBalance);
-    vault.idle_balance.split(amount)
-}
-
 /// Register an expiry market for pool accounting and active valuation.
-public(package) fun register_expiry_market(
-    vault: &mut PoolVault,
-    expiry_market_id: ID,
-    initial_funding: u64,
-) {
-    vault.expiry_accounting.register_expiry(expiry_market_id, initial_funding);
+public(package) fun register_expiry_market(vault: &mut PoolVault, expiry_market_id: ID) {
+    vault.expiry_accounting.register_expiry(expiry_market_id);
 }
 
 /// Set the max net DUSDC the pool may have funded into one expiry.
@@ -487,7 +466,6 @@ fun assert_same_id_set(actual: &vector<ID>, expected: &vector<ID>, error: u64) {
     };
 }
 
-// Returns sampled branch terms and enforces the expiry backing invariant.
 fun expiry_rebalance_cash_terms(market: &ExpiryMarket): (u64, u64, u64) {
     let required_cash = market.payout_liability() + market.rebate_reserve();
     let target_buffer = math::mul(required_cash, constants::expiry_rebalance_pct!());
@@ -496,8 +474,27 @@ fun expiry_rebalance_cash_terms(market: &ExpiryMarket): (u64, u64, u64) {
         constants::expiry_cash_floor!(),
     );
     let cash_balance = market.cash_balance();
-    assert!(cash_balance >= required_cash, EInsufficientExpiryCashBacking);
     (cash_balance, target_cash, sweep_threshold_cash)
+}
+
+fun unregister_settled_expiry(
+    vault: &mut PoolVault,
+    market: &mut ExpiryMarket,
+    config: &ProtocolConfig,
+    market_oracle: &MarketOracle,
+) {
+    let expiry_market_id = market.id();
+    let deactivated = vault.expiry_accounting.deactivate_expiry_if_present(expiry_market_id);
+    let returned_cash = market.release_settled_pool_cash(market_oracle);
+    let returned_cash_amount = vault.receive_expiry_cash(config, expiry_market_id, returned_cash);
+
+    if (deactivated || returned_cash_amount > 0) {
+        vault.emit_expiry_cash_received(
+            expiry_market_id,
+            market_oracle,
+            returned_cash_amount,
+        );
+    };
 }
 
 fun send_expiry_cash(
@@ -519,10 +516,34 @@ fun receive_expiry_cash(
     cash: Balance<DUSDC>,
 ): u64 {
     let amount = cash.value();
+    if (amount == 0) {
+        cash.destroy_zero();
+        return 0
+    };
     vault.idle_balance.join(cash);
     vault.expiry_accounting.record_received_from_expiry(expiry_market_id, amount);
     vault.materialize_profit(config);
     amount
+}
+
+fun emit_expiry_cash_received(
+    vault: &PoolVault,
+    expiry_market_id: ID,
+    market_oracle: &MarketOracle,
+    amount: u64,
+) {
+    let (sent_to_expiry_after, received_from_expiry_after) = vault
+        .expiry_accounting
+        .expiry_flow_amounts(expiry_market_id);
+    vault_events::emit_expiry_cash_received(
+        vault.id(),
+        expiry_market_id,
+        pricing::settlement_price(market_oracle),
+        amount,
+        vault.idle_balance.value(),
+        sent_to_expiry_after,
+        received_from_expiry_after,
+    );
 }
 
 fun materialize_profit(vault: &mut PoolVault, config: &ProtocolConfig) {

--- a/packages/predict/sources/plp.move
+++ b/packages/predict/sources/plp.move
@@ -392,6 +392,7 @@ public(package) fun set_allowed_versions(vault: &mut PoolVault, allowed_versions
 
 /// Register an expiry market for pool accounting and active valuation.
 public(package) fun register_expiry_market(vault: &mut PoolVault, expiry_market_id: ID) {
+    vault.assert_version_allowed();
     vault.expiry_accounting.register_expiry(expiry_market_id);
 }
 
@@ -564,6 +565,7 @@ fun materialize_expiry_profit(
     let profit_basis_after = vault.expiry_accounting.profit_basis_debits();
     vault_events::emit_expiry_profit_materialized(
         vault.id(),
+        expiry_market_id,
         lp_profit,
         protocol_profit,
         vault.idle_balance.value(),

--- a/packages/predict/sources/plp.move
+++ b/packages/predict/sources/plp.move
@@ -32,19 +32,19 @@ use sui::{
 };
 use token::deep::DEEP;
 
-const EExpiryMarketNotActive: u64 = 1;
-const EInsufficientIdleBalance: u64 = 2;
-const EWrongPoolVault: u64 = 4;
-const EExpiryMarketAlreadyValued: u64 = 5;
-const EMissingExpiryValuation: u64 = 6;
-const EActiveExpirySetChanged: u64 = 7;
-const EZeroSupply: u64 = 12;
-const EZeroWithdraw: u64 = 13;
-const EInvalidInitialSupply: u64 = 14;
-const EZeroShares: u64 = 15;
-const EZeroPoolValue: u64 = 16;
-const EPackageVersionDisabled: u64 = 17;
-const EInsufficientExpiryCashBacking: u64 = 18;
+const EExpiryMarketNotActive: u64 = 0;
+const EInsufficientIdleBalance: u64 = 1;
+const EWrongPoolVault: u64 = 2;
+const EExpiryMarketAlreadyValued: u64 = 3;
+const EMissingExpiryValuation: u64 = 4;
+const EActiveExpirySetChanged: u64 = 5;
+const EZeroSupply: u64 = 6;
+const EZeroWithdraw: u64 = 7;
+const EInvalidInitialSupply: u64 = 8;
+const EZeroShares: u64 = 9;
+const EZeroPoolValue: u64 = 10;
+const EPackageVersionDisabled: u64 = 11;
+const EInsufficientExpiryCashBacking: u64 = 12;
 
 /// One-time witness type for Predict LP token registration.
 public struct PLP has drop {}
@@ -258,6 +258,7 @@ public fun sweep_settled_expiry_surplus(
     if (!market_oracle.is_settled()) return;
 
     let market_id = market.id();
+    let was_active = vault.expiry_accounting.is_active_expiry(market_id);
     vault.expiry_accounting.deactivate_expiry_if_present(market_id);
     let returned_cash = market.release_settled_surplus(market_oracle);
     let returned_cash_amount = vault.receive_expiry_cash(config, market_id, returned_cash);
@@ -265,7 +266,7 @@ public fun sweep_settled_expiry_surplus(
         .expiry_accounting
         .expiry_flow_amounts(market_id);
 
-    if (returned_cash_amount > 0) {
+    if (was_active || returned_cash_amount > 0) {
         vault_events::emit_expiry_surplus_swept(
             vault.id(),
             market_id,
@@ -530,24 +531,20 @@ fun materialize_profit(vault: &mut PoolVault, config: &ProtocolConfig) {
 
     // Materialized profit is cash-backed and irreversible: LP profit stays in
     // idle liquidity, while protocol profit leaves PLP NAV.
-    let protocol_profit = math::mul(profit, config.fee_config().protocol_reserve_fee_share());
+    let protocol_profit = math::mul(profit, config.fee_config().protocol_reserve_profit_share());
     let lp_profit = profit - protocol_profit;
     if (protocol_profit > 0) {
         let protocol_profit_balance = vault.idle_balance.split(protocol_profit);
         vault.protocol_reserve_balance.join(protocol_profit_balance);
     };
-    let (profit_basis_debits_after, profit_basis_credits_after) = vault
-        .expiry_accounting
-        .profit_basis_amounts();
+    let profit_basis_after = vault.expiry_accounting.profit_basis_debits();
     vault_events::emit_expiry_profit_materialized(
         vault.id(),
-        profit,
         lp_profit,
         protocol_profit,
         vault.idle_balance.value(),
         vault.protocol_reserve_balance.value(),
-        profit_basis_debits_after,
-        profit_basis_credits_after,
+        profit_basis_after,
     );
 }
 
@@ -580,7 +577,7 @@ fun pending_protocol_profit_exclusion(
     };
     math::mul(
         aggregate_credits - aggregate_debits,
-        config.fee_config().protocol_reserve_fee_share(),
+        config.fee_config().protocol_reserve_profit_share(),
     )
 }
 

--- a/packages/predict/sources/plp.move
+++ b/packages/predict/sources/plp.move
@@ -442,6 +442,29 @@ fun expiry_rebalance_cash_terms(market: &ExpiryMarket): (u64, u64, u64) {
     (market.cash_balance(), target_cash, sweep_threshold_cash)
 }
 
+fun synced_pool_value(vault: &PoolVault, config: &ProtocolConfig, active_expiry_value: u64): u64 {
+    let gross_pool_value = vault.idle_balance.value() + active_expiry_value;
+    gross_pool_value - vault.pending_protocol_profit_exclusion(config, active_expiry_value)
+}
+
+fun pending_protocol_profit_exclusion(
+    vault: &PoolVault,
+    config: &ProtocolConfig,
+    active_expiry_value: u64,
+): u64 {
+    // NAV prices pending protocol profit before it is terminally materialized.
+    // Live cash returns update credits, but reserve custody waits for terminal profit.
+    let aggregate_credits = vault.expiry_accounting.profit_basis_credits() + active_expiry_value;
+    let aggregate_debits = vault.expiry_accounting.profit_basis_debits();
+    if (aggregate_credits <= aggregate_debits) {
+        return 0
+    };
+    math::mul(
+        aggregate_credits - aggregate_debits,
+        config.fee_config().protocol_reserve_profit_share(),
+    )
+}
+
 fun assert_pool_vault(sync: &PoolSync, vault: &PoolVault) {
     assert!(sync.pool_vault_id == vault.id(), EWrongPoolVault);
 }
@@ -526,26 +549,6 @@ fun receive_expiry_cash(vault: &mut PoolVault, expiry_market_id: ID, cash: Balan
     amount
 }
 
-fun emit_expiry_cash_received(
-    vault: &PoolVault,
-    expiry_market_id: ID,
-    market_oracle: &MarketOracle,
-    amount: u64,
-) {
-    let (sent_to_expiry_after, received_from_expiry_after) = vault
-        .expiry_accounting
-        .expiry_flow_amounts(expiry_market_id);
-    vault_events::emit_expiry_cash_received(
-        vault.id(),
-        expiry_market_id,
-        pricing::settlement_price(market_oracle),
-        amount,
-        vault.idle_balance.value(),
-        sent_to_expiry_after,
-        received_from_expiry_after,
-    );
-}
-
 fun materialize_expiry_profit(
     vault: &mut PoolVault,
     config: &ProtocolConfig,
@@ -574,27 +577,24 @@ fun materialize_expiry_profit(
     );
 }
 
-fun synced_pool_value(vault: &PoolVault, config: &ProtocolConfig, active_expiry_value: u64): u64 {
-    let gross_pool_value = vault.idle_balance.value() + active_expiry_value;
-    gross_pool_value - vault.pending_protocol_profit_exclusion(config, active_expiry_value)
-}
-
-fun pending_protocol_profit_exclusion(
+fun emit_expiry_cash_received(
     vault: &PoolVault,
-    config: &ProtocolConfig,
-    active_expiry_value: u64,
-): u64 {
-    // NAV prices pending protocol profit before it is terminally materialized.
-    // Live cash returns update credits, but reserve custody waits for terminal profit.
-    let aggregate_credits = vault.expiry_accounting.profit_basis_credits() + active_expiry_value;
-    let aggregate_debits = vault.expiry_accounting.profit_basis_debits();
-    if (aggregate_credits <= aggregate_debits) {
-        return 0
-    };
-    math::mul(
-        aggregate_credits - aggregate_debits,
-        config.fee_config().protocol_reserve_profit_share(),
-    )
+    expiry_market_id: ID,
+    market_oracle: &MarketOracle,
+    amount: u64,
+) {
+    let (sent_to_expiry_after, received_from_expiry_after) = vault
+        .expiry_accounting
+        .expiry_flow_amounts(expiry_market_id);
+    vault_events::emit_expiry_cash_received(
+        vault.id(),
+        expiry_market_id,
+        pricing::settlement_price(market_oracle),
+        amount,
+        vault.idle_balance.value(),
+        sent_to_expiry_after,
+        received_from_expiry_after,
+    );
 }
 
 fun emit_expiry_cash_rebalanced(

--- a/packages/predict/sources/plp.move
+++ b/packages/predict/sources/plp.move
@@ -132,12 +132,12 @@ public fun total_supply(vault: &PoolVault): u64 {
     vault.treasury_cap.total_supply()
 }
 
-/// Return the money-out side of aggregate expiry profit basis.
+/// Return the pricing debit side of aggregate expiry profit basis.
 public fun profit_basis_debits(vault: &PoolVault): u64 {
     vault.expiry_accounting.profit_basis_debits()
 }
 
-/// Return the money-in side of aggregate expiry profit basis.
+/// Return the pricing credit side of aggregate expiry profit basis.
 public fun profit_basis_credits(vault: &PoolVault): u64 {
     vault.expiry_accounting.profit_basis_credits()
 }
@@ -203,7 +203,7 @@ public fun sync_expiry(
         config.risk_config().valuation_liquidation_budget(),
         clock,
     );
-    vault.rebalance_active_expiry_cash(market, config);
+    vault.rebalance_active_expiry_cash(market);
     let expiry_nav = market.pool_nav(config, market_oracle, pyth, clock);
     sync.record_expiry_synced(expiry_market_id, expiry_nav);
 }
@@ -241,7 +241,8 @@ public fun claim_trading_loss_rebate(
     let expiry_market_id = market.id();
     vault.expiry_accounting.assert_registered_expiry(expiry_market_id);
     let residual_cash = market.claim_trading_loss_rebate(manager, config, market_oracle, ctx);
-    let returned_cash_amount = vault.receive_expiry_cash(config, expiry_market_id, residual_cash);
+    let returned_cash_amount = vault.receive_expiry_cash(expiry_market_id, residual_cash);
+    vault.materialize_expiry_profit(config, expiry_market_id);
     if (returned_cash_amount > 0) {
         vault.emit_expiry_cash_received(
             expiry_market_id,
@@ -456,11 +457,7 @@ fun record_expiry_synced(sync: &mut PoolSync, expiry_market_id: ID, expiry_nav: 
     sync.synced_expiry_markets.push_back(expiry_market_id);
 }
 
-fun rebalance_active_expiry_cash(
-    vault: &mut PoolVault,
-    market: &mut ExpiryMarket,
-    config: &ProtocolConfig,
-) {
+fun rebalance_active_expiry_cash(vault: &mut PoolVault, market: &mut ExpiryMarket) {
     let expiry_market_id = market.id();
     let (cash_balance, target_cash, sweep_threshold_cash) = expiry_rebalance_cash_terms(market);
 
@@ -475,11 +472,7 @@ fun rebalance_active_expiry_cash(
     } else if (cash_balance > sweep_threshold_cash) {
         let cash_to_return = cash_balance - target_cash;
         let returned_cash = market.release_pool_cash(cash_to_return);
-        let returned_cash_amount = vault.receive_expiry_cash(
-            config,
-            expiry_market_id,
-            returned_cash,
-        );
+        let returned_cash_amount = vault.receive_expiry_cash(expiry_market_id, returned_cash);
         vault.emit_expiry_cash_rebalanced(
             market,
             expiry_market_id,
@@ -499,7 +492,8 @@ fun unregister_settled_expiry(
     let expiry_market_id = market.id();
     let deactivated = vault.expiry_accounting.deactivate_expiry_if_present(expiry_market_id);
     let returned_cash = market.release_settled_pool_cash(market_oracle);
-    let returned_cash_amount = vault.receive_expiry_cash(config, expiry_market_id, returned_cash);
+    let returned_cash_amount = vault.receive_expiry_cash(expiry_market_id, returned_cash);
+    vault.materialize_expiry_profit(config, expiry_market_id);
 
     if (deactivated || returned_cash_amount > 0) {
         vault.emit_expiry_cash_received(
@@ -522,12 +516,7 @@ fun send_expiry_cash(
     vault.expiry_accounting.record_sent_to_expiry(expiry_market_id, amount);
 }
 
-fun receive_expiry_cash(
-    vault: &mut PoolVault,
-    config: &ProtocolConfig,
-    expiry_market_id: ID,
-    cash: Balance<DUSDC>,
-): u64 {
+fun receive_expiry_cash(vault: &mut PoolVault, expiry_market_id: ID, cash: Balance<DUSDC>): u64 {
     let amount = cash.value();
     if (amount == 0) {
         cash.destroy_zero();
@@ -535,7 +524,6 @@ fun receive_expiry_cash(
     };
     vault.idle_balance.join(cash);
     vault.expiry_accounting.record_received_from_expiry(expiry_market_id, amount);
-    vault.materialize_profit(config);
     amount
 }
 
@@ -559,8 +547,12 @@ fun emit_expiry_cash_received(
     );
 }
 
-fun materialize_profit(vault: &mut PoolVault, config: &ProtocolConfig) {
-    let profit = vault.expiry_accounting.materialize_profit();
+fun materialize_expiry_profit(
+    vault: &mut PoolVault,
+    config: &ProtocolConfig,
+    expiry_market_id: ID,
+) {
+    let profit = vault.expiry_accounting.materialize_expiry_profit(expiry_market_id);
     if (profit == 0) return;
 
     // Materialized profit is cash-backed and irreversible: LP profit stays in
@@ -592,8 +584,8 @@ fun pending_protocol_profit_exclusion(
     config: &ProtocolConfig,
     active_expiry_value: u64,
 ): u64 {
-    // NAV prices pending protocol profit before it is cash-backed. Actual
-    // reserve custody only changes when expiry cash returns through materialization.
+    // NAV prices pending protocol profit before it is terminally materialized.
+    // Live cash returns update credits, but reserve custody waits for terminal profit.
     let aggregate_credits = vault.expiry_accounting.profit_basis_credits() + active_expiry_value;
     let aggregate_debits = vault.expiry_accounting.profit_basis_debits();
     if (aggregate_credits <= aggregate_debits) {

--- a/packages/predict/sources/plp.move
+++ b/packages/predict/sources/plp.move
@@ -4,23 +4,24 @@
 /// PLP token and pool vault accounting.
 ///
 /// PoolVault owns idle DUSDC and the PLP treasury cap. Expiry markets own
-/// active trading cash and risk state. This module coordinates full-pool
-/// valuation, PLP supply/withdrawal, expiry funding, live expiry cash
-/// rebalancing, rebate-reserve release, profit materialization, and
-/// settled-expiry cash receipt.
+/// active trading cash and risk state. This module coordinates full-pool sync,
+/// PLP supply/withdrawal, expiry funding, live expiry cash rebalancing,
+/// rebate-reserve release, profit materialization, and settled-expiry cash
+/// receipt.
 /// It does not own expiry-local strike, oracle, or position state.
 module deepbook_predict::plp;
 
 use deepbook::math;
 use deepbook_predict::{
     constants,
-    expiry_market::{ExpiryMarket, ExpiryValuation},
+    expiry_market::ExpiryMarket,
     market_oracle::MarketOracle,
     math as predict_math,
     pool_accounting::{Self, Ledger},
     predict_manager::PredictManager,
     pricing,
     protocol_config::ProtocolConfig,
+    pyth_source::PythSource,
     vault_events
 };
 use dusdc::dusdc::DUSDC;
@@ -36,15 +37,14 @@ use token::deep::DEEP;
 const EExpiryMarketNotActive: u64 = 0;
 const EInsufficientIdleBalance: u64 = 1;
 const EWrongPoolVault: u64 = 2;
-const EExpiryMarketAlreadyValued: u64 = 3;
-const EMissingExpiryValuation: u64 = 4;
-const EActiveExpirySetChanged: u64 = 5;
-const EZeroSupply: u64 = 6;
-const EZeroWithdraw: u64 = 7;
-const EInvalidInitialSupply: u64 = 8;
-const EZeroShares: u64 = 9;
-const EZeroPoolValue: u64 = 10;
-const EPackageVersionDisabled: u64 = 11;
+const EExpiryMarketAlreadySynced: u64 = 3;
+const EMissingExpirySync: u64 = 4;
+const EZeroSupply: u64 = 5;
+const EZeroWithdraw: u64 = 6;
+const EInvalidInitialSupply: u64 = 7;
+const EZeroShares: u64 = 8;
+const EZeroPoolValue: u64 = 9;
+const EPackageVersionDisabled: u64 = 10;
 
 /// One-time witness type for Predict LP token registration.
 public struct PLP has drop {}
@@ -66,17 +66,14 @@ public struct PoolVault has key {
     allowed_versions: VecSet<u64>,
 }
 
-/// Transaction-local pool valuation accumulator.
-public struct PoolValuation {
-    /// PoolVault ID this valuation is bound to.
+/// Transaction-local pool sync hot potato.
+///
+/// The sync flow snapshots active expiries, processes each one exactly once,
+/// coordinates cash movement, and accumulates active expiry NAV for share pricing.
+public struct PoolSync {
     pool_vault_id: ID,
-    /// Active expiry set snapshotted when valuation starts.
     expected_expiry_markets: vector<ID>,
-    /// Expiry IDs whose valuation witnesses have been consumed.
-    valued_expiry_markets: vector<ID>,
-    /// Running gross pool value, starting from idle DUSDC and adding each expiry NAV.
-    value: u64,
-    /// Running NAV of active expiries in this valuation.
+    synced_expiry_markets: vector<ID>,
     active_expiry_value: u64,
 }
 
@@ -155,96 +152,76 @@ public fun max_expiry_funding(vault: &PoolVault, expiry_market_id: ID): u64 {
     vault.expiry_accounting.max_expiry_funding(expiry_market_id)
 }
 
-/// Maintain live expiry cash and unregister settled expiries from active valuation.
-///
-/// PLP owns the allocation policy: it compares expiry cash against payout
-/// liability plus rebate reserve, preserves the fixed expiry cash floor, and
-/// records every cash movement in the pool money-out/money-in ledger. Settled
-/// markets are deactivated and release all cash above settled backing needs.
-/// This remains callable while trading is paused because it manages existing
-/// pool cash rather than creating new risk.
-public fun rebalance_expiry_cash(
-    vault: &mut PoolVault,
-    market: &mut ExpiryMarket,
-    config: &ProtocolConfig,
-    market_oracle: &MarketOracle,
-    clock: &Clock,
-) {
-    vault.assert_version_allowed();
-    market.assert_version_allowed();
-    config.assert_not_valuation_in_progress();
-    market.assert_market_oracle(market_oracle);
-
-    if (market_oracle.is_settled()) {
-        vault.unregister_settled_expiry(market, config, market_oracle);
-        return
-    };
-
-    market_oracle.assert_active(clock);
-    let expiry_market_id = market.id();
-    assert!(vault.expiry_accounting.is_active_expiry(expiry_market_id), EExpiryMarketNotActive);
-
-    let (cash_balance, target_cash, sweep_threshold_cash) = expiry_rebalance_cash_terms(
-        market,
-    );
-
-    if (cash_balance < target_cash) {
-        let requested_top_up = target_cash - cash_balance;
-        let funding_room = vault.expiry_accounting.available_expiry_funding(expiry_market_id);
-        let top_up = requested_top_up.min(vault.idle_balance.value()).min(funding_room);
-        if (top_up == 0) return;
-
-        vault.send_expiry_cash(market, expiry_market_id, top_up);
-        vault.emit_expiry_cash_rebalanced(market, expiry_market_id, top_up, true, target_cash);
-    } else if (cash_balance > sweep_threshold_cash) {
-        let cash_to_return = cash_balance - target_cash;
-        let returned_cash = market.release_pool_cash(cash_to_return);
-        let returned_cash_amount = vault.receive_expiry_cash(
-            config,
-            expiry_market_id,
-            returned_cash,
-        );
-        vault.emit_expiry_cash_rebalanced(
-            market,
-            expiry_market_id,
-            returned_cash_amount,
-            false,
-            target_cash,
-        );
-    };
-}
-
-/// Begin a full-pool valuation and lock protocol valuation-sensitive flows.
-///
-/// The accumulator snapshots the active expiry set and starts with idle DUSDC.
-/// Callers must add one valuation witness for each active expiry before
-/// supplying or withdrawing.
-public fun start_valuation(config: &mut ProtocolConfig, vault: &PoolVault): PoolValuation {
+/// Start a full-pool sync flow for this vault.
+public fun start_pool_sync(config: &mut ProtocolConfig, vault: &PoolVault): PoolSync {
     vault.assert_version_allowed();
     config.begin_valuation();
-    PoolValuation {
+    PoolSync {
         pool_vault_id: vault.id(),
         expected_expiry_markets: *vault.expiry_accounting.active_expiry_markets(),
-        valued_expiry_markets: vector[],
-        value: vault.idle_balance.value(),
+        synced_expiry_markets: vector[],
         active_expiry_value: 0,
     }
 }
 
-/// Add one active expiry valuation witness to the pool accumulator.
+/// Sync one snapshotted expiry's cash and active NAV.
 ///
-/// Aborts if the witness is not for the snapshotted active set or if the same
-/// expiry is added twice.
-public fun add_expiry_valuation(valuation: &mut PoolValuation, expiry_valuation: ExpiryValuation) {
-    let (expiry_market_id, expiry_value) = expiry_valuation.unpack();
-    assert!(valuation.expected_expiry_markets.contains(&expiry_market_id), EExpiryMarketNotActive);
-    assert!(
-        !valuation.valued_expiry_markets.contains(&expiry_market_id),
-        EExpiryMarketAlreadyValued,
+/// PLP owns the allocation policy: it compares expiry cash against payout
+/// liability plus rebate reserve, preserves the fixed expiry cash floor, and
+/// records every cash movement in the pool money-out/money-in ledger. Settled
+/// markets are deactivated and release all cash above settled backing needs;
+/// active markets are rebalanced before producing their current pool NAV.
+public fun sync_expiry(
+    sync: &mut PoolSync,
+    vault: &mut PoolVault,
+    market: &mut ExpiryMarket,
+    config: &ProtocolConfig,
+    market_oracle: &MarketOracle,
+    pyth: &PythSource,
+    clock: &Clock,
+) {
+    vault.assert_version_allowed();
+    market.assert_version_allowed();
+    sync.assert_pool_vault(vault);
+    config.assert_valuation_in_progress();
+    market.assert_market_oracle(market_oracle);
+    let expiry_market_id = market.id();
+    sync.assert_expiry_ready_to_sync(expiry_market_id);
+
+    if (market_oracle.is_settled()) {
+        vault.unregister_settled_expiry(market, config, market_oracle);
+        sync.record_expiry_synced(expiry_market_id, 0);
+        return
+    };
+
+    market_oracle.assert_active(clock);
+    assert!(vault.expiry_accounting.is_active_expiry(expiry_market_id), EExpiryMarketNotActive);
+
+    let expiry_nav = vault.sync_active_expiry_cash_and_nav(
+        market,
+        config,
+        market_oracle,
+        pyth,
+        clock,
     );
-    valuation.valued_expiry_markets.push_back(expiry_market_id);
-    valuation.value = valuation.value + expiry_value;
-    valuation.active_expiry_value = valuation.active_expiry_value + expiry_value;
+    sync.record_expiry_synced(expiry_market_id, expiry_nav);
+}
+
+/// Finish a full-pool sync flow and return current PLP-owned pool value.
+public fun finish_pool_sync(vault: &PoolVault, config: &mut ProtocolConfig, sync: PoolSync): u64 {
+    vault.assert_version_allowed();
+    config.assert_valuation_in_progress();
+    sync.assert_pool_vault(vault);
+    assert_all_expected_synced(&sync.expected_expiry_markets, &sync.synced_expiry_markets);
+    let pool_value = vault.synced_pool_value(config, sync.active_expiry_value);
+    let PoolSync {
+        pool_vault_id: _,
+        expected_expiry_markets: _,
+        synced_expiry_markets: _,
+        active_expiry_value: _,
+    } = sync;
+    config.end_valuation();
+    pool_value
 }
 
 /// Resolve one manager's settled trading-loss rebate and return residual reserve to the pool.
@@ -273,19 +250,18 @@ public fun claim_trading_loss_rebate(
     };
 }
 
-/// Supply DUSDC into the pool vault against a complete full-pool valuation.
+/// Supply DUSDC into the pool vault against a complete full-pool sync.
 ///
-/// Completes the valuation after flow preconditions pass and mints PLP shares
-/// at the computed pool value.
+/// Finishes pool sync to price shares, then mints PLP against the supplied DUSDC.
 public fun supply(
     vault: &mut PoolVault,
     config: &mut ProtocolConfig,
-    valuation: PoolValuation,
+    sync: PoolSync,
     payment: Coin<DUSDC>,
     ctx: &mut TxContext,
 ): Coin<PLP> {
     vault.assert_version_allowed();
-    let pool_value = vault.validated_pool_value(config, &valuation);
+    let pool_value = vault.finish_pool_sync(config, sync);
     let payment_amount = payment.value();
     assert!(payment_amount > 0, EZeroSupply);
 
@@ -300,7 +276,6 @@ public fun supply(
         shares
     };
 
-    finish_valuation(config, valuation);
     vault.idle_balance.join(payment.into_balance());
     let plp = coin::mint(&mut vault.treasury_cap, shares, ctx);
     vault_events::emit_supply_executed(
@@ -314,19 +289,18 @@ public fun supply(
     plp
 }
 
-/// Withdraw DUSDC from the pool vault against a complete full-pool valuation.
+/// Withdraw DUSDC from the pool vault against a complete full-pool sync.
 ///
-/// Completes the valuation after flow preconditions pass, burns PLP, and
-/// enforces enough idle liquidity for the withdrawal.
+/// Finishes pool sync to price shares, then burns PLP and withdraws idle DUSDC.
 public fun withdraw(
     vault: &mut PoolVault,
     config: &mut ProtocolConfig,
-    valuation: PoolValuation,
+    sync: PoolSync,
     lp_coin: Coin<PLP>,
     ctx: &mut TxContext,
 ): Coin<DUSDC> {
     vault.assert_version_allowed();
-    let pool_value = vault.validated_pool_value(config, &valuation);
+    let pool_value = vault.finish_pool_sync(config, sync);
     let lp_amount = lp_coin.value();
     assert!(lp_amount > 0, EZeroWithdraw);
 
@@ -336,7 +310,6 @@ public fun withdraw(
     let idle_balance = vault.idle_balance.value();
     assert!(idle_balance >= withdraw_amount, EInsufficientIdleBalance);
 
-    finish_valuation(config, valuation);
     vault.treasury_cap.burn(lp_coin);
     let payout = vault.idle_balance.split(withdraw_amount).into_coin(ctx);
     vault_events::emit_withdraw_executed(
@@ -442,19 +415,11 @@ public(package) fun set_max_expiry_funding(
 
 // === Private Functions ===
 
-fun assert_active_set_unchanged(vault: &PoolVault, expected_expiry_markets: &vector<ID>) {
-    assert_same_id_set(
-        vault.expiry_accounting.active_expiry_markets(),
-        expected_expiry_markets,
-        EActiveExpirySetChanged,
-    );
-}
-
-fun assert_all_expected_valued(
+fun assert_all_expected_synced(
     expected_expiry_markets: &vector<ID>,
-    valued_expiry_markets: &vector<ID>,
+    synced_expiry_markets: &vector<ID>,
 ) {
-    assert_same_id_set(valued_expiry_markets, expected_expiry_markets, EMissingExpiryValuation);
+    assert_same_id_set(synced_expiry_markets, expected_expiry_markets, EMissingExpirySync);
 }
 
 fun assert_same_id_set(actual: &vector<ID>, expected: &vector<ID>, error: u64) {
@@ -473,8 +438,68 @@ fun expiry_rebalance_cash_terms(market: &ExpiryMarket): (u64, u64, u64) {
     let sweep_threshold_cash = (required_cash + target_buffer + target_buffer).max(
         constants::expiry_cash_floor!(),
     );
-    let cash_balance = market.cash_balance();
-    (cash_balance, target_cash, sweep_threshold_cash)
+    (market.cash_balance(), target_cash, sweep_threshold_cash)
+}
+
+fun assert_pool_vault(sync: &PoolSync, vault: &PoolVault) {
+    assert!(sync.pool_vault_id == vault.id(), EWrongPoolVault);
+}
+
+fun assert_expiry_ready_to_sync(sync: &PoolSync, expiry_market_id: ID) {
+    assert!(sync.expected_expiry_markets.contains(&expiry_market_id), EExpiryMarketNotActive);
+    assert!(!sync.synced_expiry_markets.contains(&expiry_market_id), EExpiryMarketAlreadySynced);
+}
+
+fun record_expiry_synced(sync: &mut PoolSync, expiry_market_id: ID, expiry_nav: u64) {
+    sync.active_expiry_value = sync.active_expiry_value + expiry_nav;
+    sync.synced_expiry_markets.push_back(expiry_market_id);
+}
+
+fun sync_active_expiry_cash_and_nav(
+    vault: &mut PoolVault,
+    market: &mut ExpiryMarket,
+    config: &ProtocolConfig,
+    market_oracle: &MarketOracle,
+    pyth: &PythSource,
+    clock: &Clock,
+): u64 {
+    let prepared_nav = market.prepare_pool_sync(config, market_oracle, pyth, clock);
+    vault.rebalance_active_expiry_cash(market, config);
+    market.finish_pool_nav(prepared_nav)
+}
+
+fun rebalance_active_expiry_cash(
+    vault: &mut PoolVault,
+    market: &mut ExpiryMarket,
+    config: &ProtocolConfig,
+) {
+    let expiry_market_id = market.id();
+    let (cash_balance, target_cash, sweep_threshold_cash) = expiry_rebalance_cash_terms(market);
+
+    if (cash_balance < target_cash) {
+        let requested_top_up = target_cash - cash_balance;
+        let funding_room = vault.expiry_accounting.available_expiry_funding(expiry_market_id);
+        let top_up = requested_top_up.min(vault.idle_balance.value()).min(funding_room);
+        if (top_up > 0) {
+            vault.send_expiry_cash(market, expiry_market_id, top_up);
+            vault.emit_expiry_cash_rebalanced(market, expiry_market_id, top_up, true, target_cash);
+        };
+    } else if (cash_balance > sweep_threshold_cash) {
+        let cash_to_return = cash_balance - target_cash;
+        let returned_cash = market.release_pool_cash(cash_to_return);
+        let returned_cash_amount = vault.receive_expiry_cash(
+            config,
+            expiry_market_id,
+            returned_cash,
+        );
+        vault.emit_expiry_cash_rebalanced(
+            market,
+            expiry_market_id,
+            returned_cash_amount,
+            false,
+            target_cash,
+        );
+    };
 }
 
 fun unregister_settled_expiry(
@@ -569,19 +594,9 @@ fun materialize_profit(vault: &mut PoolVault, config: &ProtocolConfig) {
     );
 }
 
-fun validated_pool_value(
-    vault: &PoolVault,
-    config: &ProtocolConfig,
-    valuation: &PoolValuation,
-): u64 {
-    config.assert_valuation_in_progress();
-    assert!(valuation.pool_vault_id == vault.id(), EWrongPoolVault);
-    assert_active_set_unchanged(vault, &valuation.expected_expiry_markets);
-    assert_all_expected_valued(
-        &valuation.expected_expiry_markets,
-        &valuation.valued_expiry_markets,
-    );
-    valuation.value - vault.pending_protocol_profit_exclusion(config, valuation.active_expiry_value)
+fun synced_pool_value(vault: &PoolVault, config: &ProtocolConfig, active_expiry_value: u64): u64 {
+    let gross_pool_value = vault.idle_balance.value() + active_expiry_value;
+    gross_pool_value - vault.pending_protocol_profit_exclusion(config, active_expiry_value)
 }
 
 fun pending_protocol_profit_exclusion(
@@ -624,17 +639,6 @@ fun emit_expiry_cash_rebalanced(
         sent_to_expiry_after,
         received_from_expiry_after,
     );
-}
-
-fun finish_valuation(config: &mut ProtocolConfig, valuation: PoolValuation) {
-    let PoolValuation {
-        pool_vault_id: _,
-        expected_expiry_markets: _,
-        valued_expiry_markets: _,
-        value: _,
-        active_expiry_value: _,
-    } = valuation;
-    config.end_valuation();
 }
 
 // === Test-Only Functions ===

--- a/packages/predict/sources/pool_accounting.move
+++ b/packages/predict/sources/pool_accounting.move
@@ -39,15 +39,6 @@ public struct RegisteredExpiry has store {
     max_expiry_funding: u64,
 }
 
-public(package) fun new(ctx: &mut TxContext): Ledger {
-    Ledger {
-        active_expiry_markets: vector[],
-        registered_expiries: table::new(ctx),
-        profit_basis_debits: 0,
-        profit_basis_credits: 0,
-    }
-}
-
 public(package) fun active_expiry_markets(ledger: &Ledger): &vector<ID> {
     &ledger.active_expiry_markets
 }
@@ -64,28 +55,10 @@ public(package) fun profit_basis_credits(ledger: &Ledger): u64 {
     ledger.profit_basis_credits
 }
 
-public(package) fun profit_basis_amounts(ledger: &Ledger): (u64, u64) {
-    (ledger.profit_basis_debits, ledger.profit_basis_credits)
-}
-
-/// Abort unless this expiry is registered to the pool.
-public(package) fun assert_registered_expiry(ledger: &Ledger, expiry_market_id: ID) {
-    assert!(ledger.registered_expiries.contains(expiry_market_id), EUnknownRegisteredExpiry);
-}
-
 public(package) fun expiry_flow_amounts(ledger: &Ledger, expiry_market_id: ID): (u64, u64) {
     ledger.assert_registered_expiry(expiry_market_id);
     let flow = ledger.registered_expiries.borrow(expiry_market_id);
     (flow.sent_to_expiry, flow.received_from_expiry)
-}
-
-public(package) fun expiry_net_funding(ledger: &Ledger, expiry_market_id: ID): u64 {
-    let (sent, received) = ledger.expiry_flow_amounts(expiry_market_id);
-    if (sent > received) {
-        sent - received
-    } else {
-        0
-    }
 }
 
 public(package) fun max_expiry_funding(ledger: &Ledger, expiry_market_id: ID): u64 {
@@ -102,6 +75,15 @@ public(package) fun available_expiry_funding(ledger: &Ledger, expiry_market_id: 
         flow.max_expiry_funding - net_funding
     } else {
         0
+    }
+}
+
+public(package) fun new(ctx: &mut TxContext): Ledger {
+    Ledger {
+        active_expiry_markets: vector[],
+        registered_expiries: table::new(ctx),
+        profit_basis_debits: 0,
+        profit_basis_credits: 0,
     }
 }
 
@@ -144,14 +126,13 @@ public(package) fun set_max_expiry_funding(
     ledger: &mut Ledger,
     expiry_market_id: ID,
     max_expiry_funding: u64,
-) {
+): u64 {
     config_constants::assert_max_expiry_funding(max_expiry_funding);
     ledger.assert_registered_expiry(expiry_market_id);
-    assert!(
-        ledger.expiry_net_funding(expiry_market_id) <= max_expiry_funding,
-        EMaxExpiryFundingExceeded,
-    );
+    let net_funding = ledger.expiry_net_funding(expiry_market_id);
+    assert!(net_funding <= max_expiry_funding, EMaxExpiryFundingExceeded);
     ledger.registered_expiries.borrow_mut(expiry_market_id).max_expiry_funding = max_expiry_funding;
+    net_funding
 }
 
 public(package) fun record_sent_to_expiry(ledger: &mut Ledger, expiry_market_id: ID, amount: u64) {
@@ -184,6 +165,16 @@ public(package) fun materialize_profit(ledger: &mut Ledger): u64 {
     let profit = ledger.profit_basis_credits - ledger.profit_basis_debits;
     ledger.profit_basis_debits = ledger.profit_basis_credits;
     profit
+}
+
+fun assert_registered_expiry(ledger: &Ledger, expiry_market_id: ID) {
+    assert!(ledger.registered_expiries.contains(expiry_market_id), EUnknownRegisteredExpiry);
+}
+
+fun expiry_net_funding(ledger: &Ledger, expiry_market_id: ID): u64 {
+    ledger.assert_registered_expiry(expiry_market_id);
+    let flow = ledger.registered_expiries.borrow(expiry_market_id);
+    flow_net_funding(flow)
 }
 
 fun flow_net_funding(flow: &RegisteredExpiry): u64 {

--- a/packages/predict/sources/pool_accounting.move
+++ b/packages/predict/sources/pool_accounting.move
@@ -1,0 +1,195 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Pool-owned expiry registration and cash-flow accounting.
+///
+/// This module owns the durable set of expiries registered to a pool, the active
+/// expiry index used for valuation, DUSDC sent from the main pool into each
+/// expiry, DUSDC received back from each expiry, and per-expiry net funding
+/// caps. It does not custody funds or classify expiry-local liabilities;
+/// PoolVault uses the aggregate profit basis to materialize excess DUSDC.
+module deepbook_predict::pool_accounting;
+
+use deepbook_predict::config_constants;
+use sui::table::{Self, Table};
+
+const EUnknownRegisteredExpiry: u64 = 0;
+const ERegisteredExpiryAlreadyExists: u64 = 1;
+const EMaxExpiryFundingExceeded: u64 = 2;
+
+/// Aggregate and per-expiry DUSDC accounting ledger.
+public struct Ledger has store {
+    /// Expiry markets that still contribute active pool valuation/risk.
+    active_expiry_markets: vector<ID>,
+    /// Permanent per-expiry accounting rows. Presence means the expiry belongs to this pool.
+    registered_expiries: Table<ID, RegisteredExpiry>,
+    /// Money-out side of aggregate profit basis.
+    profit_basis_debits: u64,
+    /// Money-in side of aggregate profit basis.
+    profit_basis_credits: u64,
+}
+
+/// Durable accounting row for one registered expiry market.
+public struct RegisteredExpiry has store {
+    /// DUSDC sent from the main pool into this expiry.
+    sent_to_expiry: u64,
+    /// DUSDC returned from this expiry to the main pool.
+    received_from_expiry: u64,
+    /// Max net DUSDC the pool may have funded into this expiry.
+    max_expiry_funding: u64,
+}
+
+public(package) fun new(ctx: &mut TxContext): Ledger {
+    Ledger {
+        active_expiry_markets: vector[],
+        registered_expiries: table::new(ctx),
+        profit_basis_debits: 0,
+        profit_basis_credits: 0,
+    }
+}
+
+public(package) fun active_expiry_markets(ledger: &Ledger): &vector<ID> {
+    &ledger.active_expiry_markets
+}
+
+public(package) fun is_active_expiry(ledger: &Ledger, expiry_market_id: ID): bool {
+    ledger.active_expiry_markets.contains(&expiry_market_id)
+}
+
+public(package) fun profit_basis_debits(ledger: &Ledger): u64 {
+    ledger.profit_basis_debits
+}
+
+public(package) fun profit_basis_credits(ledger: &Ledger): u64 {
+    ledger.profit_basis_credits
+}
+
+public(package) fun profit_basis_amounts(ledger: &Ledger): (u64, u64) {
+    (ledger.profit_basis_debits, ledger.profit_basis_credits)
+}
+
+/// Abort unless this expiry is registered to the pool.
+public(package) fun assert_registered_expiry(ledger: &Ledger, expiry_market_id: ID) {
+    assert!(ledger.registered_expiries.contains(expiry_market_id), EUnknownRegisteredExpiry);
+}
+
+public(package) fun expiry_flow_amounts(ledger: &Ledger, expiry_market_id: ID): (u64, u64) {
+    ledger.assert_registered_expiry(expiry_market_id);
+    let flow = ledger.registered_expiries.borrow(expiry_market_id);
+    (flow.sent_to_expiry, flow.received_from_expiry)
+}
+
+public(package) fun expiry_net_funding(ledger: &Ledger, expiry_market_id: ID): u64 {
+    let (sent, received) = ledger.expiry_flow_amounts(expiry_market_id);
+    if (sent > received) {
+        sent - received
+    } else {
+        0
+    }
+}
+
+public(package) fun max_expiry_funding(ledger: &Ledger, expiry_market_id: ID): u64 {
+    ledger.assert_registered_expiry(expiry_market_id);
+    ledger.registered_expiries.borrow(expiry_market_id).max_expiry_funding
+}
+
+/// Return remaining net DUSDC the pool may fund into one expiry.
+public(package) fun available_expiry_funding(ledger: &Ledger, expiry_market_id: ID): u64 {
+    ledger.assert_registered_expiry(expiry_market_id);
+    let flow = ledger.registered_expiries.borrow(expiry_market_id);
+    let net_funding = flow_net_funding(flow);
+    if (net_funding < flow.max_expiry_funding) {
+        flow.max_expiry_funding - net_funding
+    } else {
+        0
+    }
+}
+
+public(package) fun register_expiry(
+    ledger: &mut Ledger,
+    expiry_market_id: ID,
+    initial_sent_to_expiry: u64,
+) {
+    assert!(!ledger.registered_expiries.contains(expiry_market_id), ERegisteredExpiryAlreadyExists);
+    let max_expiry_funding = config_constants::default_max_expiry_funding!();
+    assert!(initial_sent_to_expiry <= max_expiry_funding, EMaxExpiryFundingExceeded);
+    ledger.active_expiry_markets.push_back(expiry_market_id);
+    ledger
+        .registered_expiries
+        .add(
+            expiry_market_id,
+            RegisteredExpiry {
+                sent_to_expiry: initial_sent_to_expiry,
+                received_from_expiry: 0,
+                max_expiry_funding,
+            },
+        );
+    ledger.profit_basis_debits = ledger.profit_basis_debits + initial_sent_to_expiry;
+}
+
+public(package) fun deactivate_expiry_if_present(ledger: &mut Ledger, expiry_market_id: ID) {
+    ledger.assert_registered_expiry(expiry_market_id);
+    let mut i = 0;
+    let len = ledger.active_expiry_markets.length();
+    while (i < len && ledger.active_expiry_markets[i] != expiry_market_id) {
+        i = i + 1;
+    };
+    if (i == len) {
+        return
+    };
+    ledger.active_expiry_markets.swap_remove(i);
+}
+
+public(package) fun set_max_expiry_funding(
+    ledger: &mut Ledger,
+    expiry_market_id: ID,
+    max_expiry_funding: u64,
+) {
+    config_constants::assert_max_expiry_funding(max_expiry_funding);
+    ledger.assert_registered_expiry(expiry_market_id);
+    assert!(
+        ledger.expiry_net_funding(expiry_market_id) <= max_expiry_funding,
+        EMaxExpiryFundingExceeded,
+    );
+    ledger.registered_expiries.borrow_mut(expiry_market_id).max_expiry_funding = max_expiry_funding;
+}
+
+public(package) fun record_sent_to_expiry(ledger: &mut Ledger, expiry_market_id: ID, amount: u64) {
+    if (amount == 0) return;
+    ledger.assert_registered_expiry(expiry_market_id);
+    let flow = ledger.registered_expiries.borrow_mut(expiry_market_id);
+    let current_net_funding = flow_net_funding(flow);
+    assert!(current_net_funding + amount <= flow.max_expiry_funding, EMaxExpiryFundingExceeded);
+    flow.sent_to_expiry = flow.sent_to_expiry + amount;
+    ledger.profit_basis_debits = ledger.profit_basis_debits + amount;
+}
+
+public(package) fun record_received_from_expiry(
+    ledger: &mut Ledger,
+    expiry_market_id: ID,
+    amount: u64,
+) {
+    if (amount == 0) return;
+    ledger.assert_registered_expiry(expiry_market_id);
+    let flow = ledger.registered_expiries.borrow_mut(expiry_market_id);
+    flow.received_from_expiry = flow.received_from_expiry + amount;
+    ledger.profit_basis_credits = ledger.profit_basis_credits + amount;
+}
+
+/// Return newly materializable cash-backed DUSDC profit and mark it as realized.
+public(package) fun materialize_profit(ledger: &mut Ledger): u64 {
+    if (ledger.profit_basis_credits <= ledger.profit_basis_debits) {
+        return 0
+    };
+    let profit = ledger.profit_basis_credits - ledger.profit_basis_debits;
+    ledger.profit_basis_debits = ledger.profit_basis_credits;
+    profit
+}
+
+fun flow_net_funding(flow: &RegisteredExpiry): u64 {
+    if (flow.sent_to_expiry > flow.received_from_expiry) {
+        flow.sent_to_expiry - flow.received_from_expiry
+    } else {
+        0
+    }
+}

--- a/packages/predict/sources/pool_accounting.move
+++ b/packages/predict/sources/pool_accounting.move
@@ -78,6 +78,11 @@ public(package) fun available_expiry_funding(ledger: &Ledger, expiry_market_id: 
     }
 }
 
+/// Abort unless this expiry is registered to the pool.
+public(package) fun assert_registered_expiry(ledger: &Ledger, expiry_market_id: ID) {
+    assert!(ledger.registered_expiries.contains(expiry_market_id), EUnknownRegisteredExpiry);
+}
+
 public(package) fun new(ctx: &mut TxContext): Ledger {
     Ledger {
         active_expiry_markets: vector[],
@@ -87,29 +92,24 @@ public(package) fun new(ctx: &mut TxContext): Ledger {
     }
 }
 
-public(package) fun register_expiry(
-    ledger: &mut Ledger,
-    expiry_market_id: ID,
-    initial_sent_to_expiry: u64,
-) {
+public(package) fun register_expiry(ledger: &mut Ledger, expiry_market_id: ID) {
     assert!(!ledger.registered_expiries.contains(expiry_market_id), ERegisteredExpiryAlreadyExists);
     let max_expiry_funding = config_constants::default_max_expiry_funding!();
-    assert!(initial_sent_to_expiry <= max_expiry_funding, EMaxExpiryFundingExceeded);
     ledger.active_expiry_markets.push_back(expiry_market_id);
     ledger
         .registered_expiries
         .add(
             expiry_market_id,
             RegisteredExpiry {
-                sent_to_expiry: initial_sent_to_expiry,
+                sent_to_expiry: 0,
                 received_from_expiry: 0,
                 max_expiry_funding,
             },
         );
-    ledger.profit_basis_debits = ledger.profit_basis_debits + initial_sent_to_expiry;
 }
 
-public(package) fun deactivate_expiry_if_present(ledger: &mut Ledger, expiry_market_id: ID) {
+/// Remove an expiry from active valuation if present, returning whether it was active.
+public(package) fun deactivate_expiry_if_present(ledger: &mut Ledger, expiry_market_id: ID): bool {
     ledger.assert_registered_expiry(expiry_market_id);
     let mut i = 0;
     let len = ledger.active_expiry_markets.length();
@@ -117,9 +117,10 @@ public(package) fun deactivate_expiry_if_present(ledger: &mut Ledger, expiry_mar
         i = i + 1;
     };
     if (i == len) {
-        return
+        return false
     };
     ledger.active_expiry_markets.swap_remove(i);
+    true
 }
 
 public(package) fun set_max_expiry_funding(
@@ -165,10 +166,6 @@ public(package) fun materialize_profit(ledger: &mut Ledger): u64 {
     let profit = ledger.profit_basis_credits - ledger.profit_basis_debits;
     ledger.profit_basis_debits = ledger.profit_basis_credits;
     profit
-}
-
-fun assert_registered_expiry(ledger: &Ledger, expiry_market_id: ID) {
-    assert!(ledger.registered_expiries.contains(expiry_market_id), EUnknownRegisteredExpiry);
 }
 
 fun expiry_net_funding(ledger: &Ledger, expiry_market_id: ID): u64 {

--- a/packages/predict/sources/pool_accounting.move
+++ b/packages/predict/sources/pool_accounting.move
@@ -130,7 +130,10 @@ public(package) fun set_max_expiry_funding(
 ): u64 {
     config_constants::assert_max_expiry_funding(max_expiry_funding);
     ledger.assert_registered_expiry(expiry_market_id);
-    let net_funding = ledger.expiry_net_funding(expiry_market_id);
+    let net_funding = {
+        let flow = ledger.registered_expiries.borrow(expiry_market_id);
+        flow_net_funding(flow)
+    };
     assert!(net_funding <= max_expiry_funding, EMaxExpiryFundingExceeded);
     ledger.registered_expiries.borrow_mut(expiry_market_id).max_expiry_funding = max_expiry_funding;
     net_funding
@@ -166,12 +169,6 @@ public(package) fun materialize_profit(ledger: &mut Ledger): u64 {
     let profit = ledger.profit_basis_credits - ledger.profit_basis_debits;
     ledger.profit_basis_debits = ledger.profit_basis_credits;
     profit
-}
-
-fun expiry_net_funding(ledger: &Ledger, expiry_market_id: ID): u64 {
-    ledger.assert_registered_expiry(expiry_market_id);
-    let flow = ledger.registered_expiries.borrow(expiry_market_id);
-    flow_net_funding(flow)
 }
 
 fun flow_net_funding(flow: &RegisteredExpiry): u64 {

--- a/packages/predict/sources/pool_accounting.move
+++ b/packages/predict/sources/pool_accounting.move
@@ -52,10 +52,6 @@ public(package) fun active_expiry_markets(ledger: &Ledger): &vector<ID> {
     &ledger.active_expiry_markets
 }
 
-public(package) fun is_active_expiry(ledger: &Ledger, expiry_market_id: ID): bool {
-    ledger.active_expiry_markets.contains(&expiry_market_id)
-}
-
 public(package) fun profit_basis_debits(ledger: &Ledger): u64 {
     ledger.profit_basis_debits
 }
@@ -209,6 +205,14 @@ public(package) fun materialize_expiry_profit(ledger: &mut Ledger, expiry_market
     }
 }
 
+fun flow_net_funding(flow: &RegisteredExpiry): u64 {
+    if (flow.sent_to_expiry > flow.received_from_expiry) {
+        flow.sent_to_expiry - flow.received_from_expiry
+    } else {
+        0
+    }
+}
+
 fun start_terminal_accounting_if_needed(flow: &mut RegisteredExpiry): u64 {
     if (flow.terminal_accounting_started) {
         return 0
@@ -221,14 +225,6 @@ fun start_terminal_accounting_if_needed(flow: &mut RegisteredExpiry): u64 {
         // Start at sent cash so the normal received-delta path consumes any
         // initial terminal profit without special-case materialization logic.
         flow.terminal_received_watermark = flow.sent_to_expiry;
-        0
-    }
-}
-
-fun flow_net_funding(flow: &RegisteredExpiry): u64 {
-    if (flow.sent_to_expiry > flow.received_from_expiry) {
-        flow.sent_to_expiry - flow.received_from_expiry
-    } else {
         0
     }
 }

--- a/packages/predict/sources/pool_accounting.move
+++ b/packages/predict/sources/pool_accounting.move
@@ -5,17 +5,20 @@
 ///
 /// This module owns the durable set of expiries registered to a pool, the active
 /// expiry index used for valuation, DUSDC sent from the main pool into each
-/// expiry, DUSDC received back from each expiry, and per-expiry net funding
-/// caps. It does not custody funds or classify expiry-local liabilities;
-/// PoolVault uses the aggregate profit basis to materialize excess DUSDC.
+/// expiry, DUSDC received back from each expiry, terminal cash watermarks, and
+/// per-expiry net funding caps. It does not custody funds or classify
+/// expiry-local liabilities; PoolVault uses the aggregate profit basis to price
+/// PLP and materialize terminal excess DUSDC.
 module deepbook_predict::pool_accounting;
 
-use deepbook_predict::config_constants;
+use deepbook_predict::{config_constants, constants};
 use sui::table::{Self, Table};
 
 const EUnknownRegisteredExpiry: u64 = 0;
 const ERegisteredExpiryAlreadyExists: u64 = 1;
 const EMaxExpiryFundingExceeded: u64 = 2;
+const ETerminalAccountingStarted: u64 = 3;
+const EMaxActiveExpiryMarkets: u64 = 4;
 
 /// Aggregate and per-expiry DUSDC accounting ledger.
 public struct Ledger has store {
@@ -23,10 +26,12 @@ public struct Ledger has store {
     active_expiry_markets: vector<ID>,
     /// Permanent per-expiry accounting rows. Presence means the expiry belongs to this pool.
     registered_expiries: Table<ID, RegisteredExpiry>,
-    /// Money-out side of aggregate profit basis.
+    /// Pricing debit basis: DUSDC sent to expiries plus materialized terminal profit.
     profit_basis_debits: u64,
-    /// Money-in side of aggregate profit basis.
+    /// Pricing credit basis: all DUSDC received back from expiries.
     profit_basis_credits: u64,
+    /// Aggregate terminal losses that future terminal profits must recover first.
+    net_losses_to_fill: u64,
 }
 
 /// Durable accounting row for one registered expiry market.
@@ -35,6 +40,10 @@ public struct RegisteredExpiry has store {
     sent_to_expiry: u64,
     /// DUSDC returned from this expiry to the main pool.
     received_from_expiry: u64,
+    /// True once this expiry has started terminal profit/loss accounting.
+    terminal_accounting_started: bool,
+    /// Received amount already consumed by terminal accounting.
+    terminal_received_watermark: u64,
     /// Max net DUSDC the pool may have funded into this expiry.
     max_expiry_funding: u64,
 }
@@ -89,11 +98,16 @@ public(package) fun new(ctx: &mut TxContext): Ledger {
         registered_expiries: table::new(ctx),
         profit_basis_debits: 0,
         profit_basis_credits: 0,
+        net_losses_to_fill: 0,
     }
 }
 
 public(package) fun register_expiry(ledger: &mut Ledger, expiry_market_id: ID) {
     assert!(!ledger.registered_expiries.contains(expiry_market_id), ERegisteredExpiryAlreadyExists);
+    assert!(
+        ledger.active_expiry_markets.length() < constants::max_active_expiry_markets!(),
+        EMaxActiveExpiryMarkets,
+    );
     let max_expiry_funding = config_constants::default_max_expiry_funding!();
     ledger.active_expiry_markets.push_back(expiry_market_id);
     ledger
@@ -103,6 +117,8 @@ public(package) fun register_expiry(ledger: &mut Ledger, expiry_market_id: ID) {
             RegisteredExpiry {
                 sent_to_expiry: 0,
                 received_from_expiry: 0,
+                terminal_accounting_started: false,
+                terminal_received_watermark: 0,
                 max_expiry_funding,
             },
         );
@@ -143,6 +159,7 @@ public(package) fun record_sent_to_expiry(ledger: &mut Ledger, expiry_market_id:
     if (amount == 0) return;
     ledger.assert_registered_expiry(expiry_market_id);
     let flow = ledger.registered_expiries.borrow_mut(expiry_market_id);
+    assert!(!flow.terminal_accounting_started, ETerminalAccountingStarted);
     let current_net_funding = flow_net_funding(flow);
     assert!(current_net_funding + amount <= flow.max_expiry_funding, EMaxExpiryFundingExceeded);
     flow.sent_to_expiry = flow.sent_to_expiry + amount;
@@ -161,14 +178,51 @@ public(package) fun record_received_from_expiry(
     ledger.profit_basis_credits = ledger.profit_basis_credits + amount;
 }
 
-/// Return newly materializable cash-backed DUSDC profit and mark it as realized.
-public(package) fun materialize_profit(ledger: &mut Ledger): u64 {
-    if (ledger.profit_basis_credits <= ledger.profit_basis_debits) {
+/// Materialize one terminal expiry's unapplied profit against aggregate excess.
+public(package) fun materialize_expiry_profit(ledger: &mut Ledger, expiry_market_id: ID): u64 {
+    ledger.assert_registered_expiry(expiry_market_id);
+    let (initial_loss, profit) = {
+        let flow = ledger.registered_expiries.borrow_mut(expiry_market_id);
+        let initial_loss = start_terminal_accounting_if_needed(flow);
+        let received = flow.received_from_expiry;
+        let profit = if (received > flow.terminal_received_watermark) {
+            let profit = received - flow.terminal_received_watermark;
+            flow.terminal_received_watermark = received;
+            profit
+        } else {
+            0
+        };
+        (initial_loss, profit)
+    };
+    ledger.net_losses_to_fill = ledger.net_losses_to_fill + initial_loss;
+    if (profit == 0) {
         return 0
     };
-    let profit = ledger.profit_basis_credits - ledger.profit_basis_debits;
-    ledger.profit_basis_debits = ledger.profit_basis_credits;
-    profit
+    if (profit <= ledger.net_losses_to_fill) {
+        ledger.net_losses_to_fill = ledger.net_losses_to_fill - profit;
+        0
+    } else {
+        let materialized_profit = profit - ledger.net_losses_to_fill;
+        ledger.net_losses_to_fill = 0;
+        ledger.profit_basis_debits = ledger.profit_basis_debits + materialized_profit;
+        materialized_profit
+    }
+}
+
+fun start_terminal_accounting_if_needed(flow: &mut RegisteredExpiry): u64 {
+    if (flow.terminal_accounting_started) {
+        return 0
+    };
+    flow.terminal_accounting_started = true;
+    if (flow.sent_to_expiry > flow.received_from_expiry) {
+        flow.terminal_received_watermark = flow.received_from_expiry;
+        flow.sent_to_expiry - flow.received_from_expiry
+    } else {
+        // Start at sent cash so the normal received-delta path consumes any
+        // initial terminal profit without special-case materialization logic.
+        flow.terminal_received_watermark = flow.sent_to_expiry;
+        0
+    }
 }
 
 fun flow_net_funding(flow: &RegisteredExpiry): u64 {

--- a/packages/predict/sources/predict_manager.move
+++ b/packages/predict/sources/predict_manager.move
@@ -41,7 +41,7 @@ public struct PredictManager has key {
     /// Per-expiry aggregate trading cash flows and open position count.
     expiry_summaries: Table<ID, ExpiryTradingSummary>,
     /// DEEP staked and active for trading benefits, in raw units. Custody lives
-    /// in the Registry's pooled balance; this mirrors this manager's share.
+    /// in PoolVault; this mirrors this manager's share.
     active_stake: u64,
     /// DEEP staked this epoch, not yet active. Rolls into `active_stake` on the
     /// first interaction in a later epoch (`update_stake`).

--- a/packages/predict/sources/predict_manager.move
+++ b/packages/predict/sources/predict_manager.move
@@ -56,10 +56,10 @@ public struct ExpiryTradingSummary has store {
     open_position_count: u64,
     /// Trading fees paid to the pool, excluding builder fees.
     trading_fees_paid: u64,
-    /// DUSDC paid from this manager into the expiry market.
-    cash_paid_to_expiry: u64,
-    /// DUSDC received from the expiry market into this manager.
-    cash_received_from_expiry: u64,
+    /// DUSDC paid for positions, excluding trading and builder fees.
+    gross_paid_to_expiry: u64,
+    /// DUSDC payout before redeem trading and builder fees are deducted.
+    gross_received_from_expiry: u64,
 }
 
 // === Public Functions ===
@@ -107,24 +107,6 @@ public fun expiry_position_count(self: &PredictManager, expiry_market_id: ID): u
 public fun trading_fees_paid(self: &PredictManager, expiry_market_id: ID): u64 {
     if (self.expiry_summaries.contains(expiry_market_id)) {
         self.expiry_summaries[expiry_market_id].trading_fees_paid
-    } else {
-        0
-    }
-}
-
-/// Return aggregate DUSDC paid from this manager to one expiry market.
-public fun cash_paid_to_expiry(self: &PredictManager, expiry_market_id: ID): u64 {
-    if (self.expiry_summaries.contains(expiry_market_id)) {
-        self.expiry_summaries[expiry_market_id].cash_paid_to_expiry
-    } else {
-        0
-    }
-}
-
-/// Return aggregate DUSDC received from one expiry market into this manager.
-public fun cash_received_from_expiry(self: &PredictManager, expiry_market_id: ID): u64 {
-    if (self.expiry_summaries.contains(expiry_market_id)) {
-        self.expiry_summaries[expiry_market_id].cash_received_from_expiry
     } else {
         0
     }
@@ -230,8 +212,8 @@ public(package) fun remove_position(
     summary.open_position_count = summary.open_position_count - 1;
 }
 
-/// Record DUSDC paid from this manager into an expiry market.
-public(package) fun record_cash_paid_to_expiry(
+/// Record DUSDC paid for positions in an expiry market, excluding fees.
+public(package) fun record_gross_paid_to_expiry(
     self: &mut PredictManager,
     expiry_market_id: ID,
     amount: u64,
@@ -239,11 +221,11 @@ public(package) fun record_cash_paid_to_expiry(
     if (amount == 0) return;
     self.ensure_expiry_summary(expiry_market_id);
     let summary = &mut self.expiry_summaries[expiry_market_id];
-    summary.cash_paid_to_expiry = summary.cash_paid_to_expiry + amount;
+    summary.gross_paid_to_expiry = summary.gross_paid_to_expiry + amount;
 }
 
-/// Record DUSDC received from an expiry market into this manager.
-public(package) fun record_cash_received_from_expiry(
+/// Record gross DUSDC payout from an expiry market before fee deductions.
+public(package) fun record_gross_received_from_expiry(
     self: &mut PredictManager,
     expiry_market_id: ID,
     amount: u64,
@@ -251,7 +233,7 @@ public(package) fun record_cash_received_from_expiry(
     if (amount == 0) return;
     self.ensure_expiry_summary(expiry_market_id);
     let summary = &mut self.expiry_summaries[expiry_market_id];
-    summary.cash_received_from_expiry = summary.cash_received_from_expiry + amount;
+    summary.gross_received_from_expiry = summary.gross_received_from_expiry + amount;
 }
 
 /// Record pool trading fees paid by this manager for one expiry market.
@@ -266,7 +248,7 @@ public(package) fun record_trading_fee_paid(
     summary.trading_fees_paid = summary.trading_fees_paid + amount;
 }
 
-/// Remove and return aggregate fees and realized trading loss once all expiry positions are closed.
+/// Remove and return aggregate fees and gross profit once all expiry positions are closed.
 public(package) fun resolve_expiry_summary(
     self: &mut PredictManager,
     expiry_market_id: ID,
@@ -280,15 +262,15 @@ public(package) fun resolve_expiry_summary(
     let ExpiryTradingSummary {
         open_position_count: _,
         trading_fees_paid,
-        cash_paid_to_expiry,
-        cash_received_from_expiry,
+        gross_paid_to_expiry,
+        gross_received_from_expiry,
     } = self.expiry_summaries.remove(expiry_market_id);
-    let trading_loss = if (cash_paid_to_expiry > cash_received_from_expiry) {
-        cash_paid_to_expiry - cash_received_from_expiry
+    let gross_profit = if (gross_received_from_expiry > gross_paid_to_expiry) {
+        gross_received_from_expiry - gross_paid_to_expiry
     } else {
         0
     };
-    (trading_fees_paid, trading_loss)
+    (trading_fees_paid, gross_profit)
 }
 
 /// Roll inactive stake into active stake once a new epoch has begun. Idempotent
@@ -323,8 +305,8 @@ fun ensure_expiry_summary(self: &mut PredictManager, expiry_market_id: ID) {
         let summary = ExpiryTradingSummary {
             open_position_count: 0,
             trading_fees_paid: 0,
-            cash_paid_to_expiry: 0,
-            cash_received_from_expiry: 0,
+            gross_paid_to_expiry: 0,
+            gross_received_from_expiry: 0,
         };
         self.expiry_summaries.add(expiry_market_id, summary);
     }

--- a/packages/predict/sources/predict_manager.move
+++ b/packages/predict/sources/predict_manager.move
@@ -266,12 +266,12 @@ public(package) fun record_trading_fee_paid(
     summary.trading_fees_paid = summary.trading_fees_paid + amount;
 }
 
-/// Remove and return the aggregate trading summary once all expiry positions are closed.
+/// Remove and return aggregate fees and realized trading loss once all expiry positions are closed.
 public(package) fun resolve_expiry_summary(
     self: &mut PredictManager,
     expiry_market_id: ID,
-): (u64, u64, u64) {
-    if (!self.expiry_summaries.contains(expiry_market_id)) return (0, 0, 0);
+): (u64, u64) {
+    if (!self.expiry_summaries.contains(expiry_market_id)) return (0, 0);
 
     assert!(
         self.expiry_summaries[expiry_market_id].open_position_count == 0,
@@ -283,7 +283,12 @@ public(package) fun resolve_expiry_summary(
         cash_paid_to_expiry,
         cash_received_from_expiry,
     } = self.expiry_summaries.remove(expiry_market_id);
-    (trading_fees_paid, cash_paid_to_expiry, cash_received_from_expiry)
+    let trading_loss = if (cash_paid_to_expiry > cash_received_from_expiry) {
+        cash_paid_to_expiry - cash_received_from_expiry
+    } else {
+        0
+    };
+    (trading_fees_paid, trading_loss)
 }
 
 /// Roll inactive stake into active stake once a new epoch has begun. Idempotent

--- a/packages/predict/sources/pricing/pricing.move
+++ b/packages/predict/sources/pricing/pricing.move
@@ -55,47 +55,6 @@ public(package) fun up_price(point: &CurvePoint): u64 {
     point.up_price
 }
 
-/// Return a conservative directional probability from a prebuilt UP-price curve.
-///
-/// This is for valuation-time liquidation checks, so it returns an upper bound:
-/// UP orders use the higher UP price around the strike, and DOWN orders use the
-/// higher DOWN price implied by the lower UP price around the strike.
-public(package) fun directional_probability_upper_bound(
-    curve: &vector<CurvePoint>,
-    lower: u64,
-    higher: u64,
-): u64 {
-    assert!(lower < higher, EInvalidRange);
-    assert!((lower == constants::neg_inf!()) != (higher == constants::pos_inf!()), EInvalidRange);
-
-    let is_up = higher == constants::pos_inf!();
-    let strike = if (is_up) lower else higher;
-
-    let len = curve.length();
-    assert!(len > 0, EInvalidCurveRange);
-    assert!(strike >= curve[0].strike && strike <= curve[len - 1].strike, EInvalidCurveRange);
-
-    let mut lo = 0;
-    let mut hi = len;
-    while (lo < hi) {
-        let mid = (lo + hi) / 2;
-        if (curve[mid].strike < strike) {
-            lo = mid + 1;
-        } else {
-            hi = mid;
-        };
-    };
-
-    let point = &curve[lo];
-    if (point.strike == strike) {
-        return if (is_up) point.up_price else constants::float_scaling!() - point.up_price
-    };
-
-    let lo_point = &curve[lo - 1];
-    assert!(lo_point.up_price >= point.up_price, ERangePriceUnderflow);
-    if (is_up) lo_point.up_price else constants::float_scaling!() - point.up_price
-}
-
 /// Return the current raw probability for a live range.
 public(package) fun live_range_probability(
     config: &PricingConfig,

--- a/packages/predict/sources/protocol_config.move
+++ b/packages/predict/sources/protocol_config.move
@@ -162,12 +162,12 @@ public(package) fun set_block_scholes_svi_freshness_ms(config: &mut ProtocolConf
     config_events::emit_pricing_config_updated(config.id(), &config.pricing_config);
 }
 
-public(package) fun set_protocol_reserve_fee_share(
+public(package) fun set_protocol_reserve_profit_share(
     config: &mut ProtocolConfig,
-    protocol_reserve_fee_share: u64,
+    protocol_reserve_profit_share: u64,
 ) {
     config.assert_not_valuation_in_progress();
-    config.fee_config.set_protocol_reserve_fee_share(protocol_reserve_fee_share);
+    config.fee_config.set_protocol_reserve_profit_share(protocol_reserve_profit_share);
     config_events::emit_fee_config_updated(config.id(), &config.fee_config);
 }
 

--- a/packages/predict/sources/protocol_config.move
+++ b/packages/predict/sources/protocol_config.move
@@ -162,14 +162,12 @@ public(package) fun set_block_scholes_svi_freshness_ms(config: &mut ProtocolConf
     config_events::emit_pricing_config_updated(config.id(), &config.pricing_config);
 }
 
-public(package) fun set_fee_shares(
+public(package) fun set_protocol_reserve_fee_share(
     config: &mut ProtocolConfig,
-    lp_fee_share: u64,
-    protocol_fee_share: u64,
-    insurance_fee_share: u64,
+    protocol_reserve_fee_share: u64,
 ) {
     config.assert_not_valuation_in_progress();
-    config.fee_config.set_fee_shares(lp_fee_share, protocol_fee_share, insurance_fee_share);
+    config.fee_config.set_protocol_reserve_fee_share(protocol_reserve_fee_share);
     config_events::emit_fee_config_updated(config.id(), &config.fee_config);
 }
 
@@ -177,42 +175,6 @@ public(package) fun set_template_trading_loss_rebate_rate(config: &mut ProtocolC
     config.assert_not_valuation_in_progress();
     config.fee_config.set_trading_loss_rebate_rate(value);
     config_events::emit_fee_config_updated(config.id(), &config.fee_config);
-}
-
-public(package) fun set_max_total_exposure_pct(config: &mut ProtocolConfig, pct: u64) {
-    config.assert_not_valuation_in_progress();
-    config.risk_config.set_max_total_exposure_pct(pct);
-    config_events::emit_risk_config_updated(config.id(), &config.risk_config);
-}
-
-public(package) fun set_expiry_allocation(config: &mut ProtocolConfig, allocation: u64) {
-    config.assert_not_valuation_in_progress();
-    config.risk_config.set_expiry_allocation(allocation);
-    config_events::emit_risk_config_updated(config.id(), &config.risk_config);
-}
-
-public(package) fun set_grow_utilization_threshold(config: &mut ProtocolConfig, threshold: u64) {
-    config.assert_not_valuation_in_progress();
-    config.risk_config.set_grow_utilization_threshold(threshold);
-    config_events::emit_risk_config_updated(config.id(), &config.risk_config);
-}
-
-public(package) fun set_shrink_utilization_threshold(config: &mut ProtocolConfig, threshold: u64) {
-    config.assert_not_valuation_in_progress();
-    config.risk_config.set_shrink_utilization_threshold(threshold);
-    config_events::emit_risk_config_updated(config.id(), &config.risk_config);
-}
-
-public(package) fun set_grow_factor(config: &mut ProtocolConfig, factor: u64) {
-    config.assert_not_valuation_in_progress();
-    config.risk_config.set_grow_factor(factor);
-    config_events::emit_risk_config_updated(config.id(), &config.risk_config);
-}
-
-public(package) fun set_shrink_factor(config: &mut ProtocolConfig, factor: u64) {
-    config.assert_not_valuation_in_progress();
-    config.risk_config.set_shrink_factor(factor);
-    config_events::emit_risk_config_updated(config.id(), &config.risk_config);
 }
 
 public(package) fun set_valuation_liquidation_budget(config: &mut ProtocolConfig, budget: u64) {

--- a/packages/predict/sources/registry.move
+++ b/packages/predict/sources/registry.move
@@ -172,15 +172,13 @@ public fun set_block_scholes_svi_freshness_ms(
     config.set_block_scholes_svi_freshness_ms(value);
 }
 
-/// Set the current fee surplus distribution shares used during settled expiry surplus sweeps.
-public fun set_fee_shares(
+/// Set the current protocol reserve share used during settled expiry surplus sweeps.
+public fun set_protocol_reserve_fee_share(
     config: &mut ProtocolConfig,
     _admin_cap: &AdminCap,
-    lp_fee_share: u64,
-    protocol_fee_share: u64,
-    insurance_fee_share: u64,
+    protocol_reserve_fee_share: u64,
 ) {
-    config.set_fee_shares(lp_fee_share, protocol_fee_share, insurance_fee_share);
+    config.set_protocol_reserve_fee_share(protocol_reserve_fee_share);
 }
 
 /// Set the trading loss rebate rate template used by future expiry markets.
@@ -192,50 +190,15 @@ public fun set_template_trading_loss_rebate_rate(
     config.set_template_trading_loss_rebate_rate(value);
 }
 
-/// Set the maximum total exposure percentage.
-public fun set_max_total_exposure_pct(
-    config: &mut ProtocolConfig,
+/// Set the max net DUSDC the pool may fund into one expiry.
+public fun set_max_expiry_funding(
+    pool_vault: &mut PoolVault,
+    config: &ProtocolConfig,
     _admin_cap: &AdminCap,
-    pct: u64,
+    expiry_market_id: ID,
+    funding: u64,
 ) {
-    config.set_max_total_exposure_pct(pct);
-}
-
-/// Set the current DUSDC allocation for new expiry markets.
-public fun set_expiry_allocation(
-    config: &mut ProtocolConfig,
-    _admin_cap: &AdminCap,
-    allocation: u64,
-) {
-    config.set_expiry_allocation(allocation);
-}
-
-/// Set the utilization threshold that enables expiry allocation growth.
-public fun set_grow_utilization_threshold(
-    config: &mut ProtocolConfig,
-    _admin_cap: &AdminCap,
-    threshold: u64,
-) {
-    config.set_grow_utilization_threshold(threshold);
-}
-
-/// Set the utilization threshold that enables expiry allocation shrink.
-public fun set_shrink_utilization_threshold(
-    config: &mut ProtocolConfig,
-    _admin_cap: &AdminCap,
-    threshold: u64,
-) {
-    config.set_shrink_utilization_threshold(threshold);
-}
-
-/// Set the allocation growth target multiplier.
-public fun set_grow_factor(config: &mut ProtocolConfig, _admin_cap: &AdminCap, factor: u64) {
-    config.set_grow_factor(factor);
-}
-
-/// Set the allocation shrink target multiplier.
-public fun set_shrink_factor(config: &mut ProtocolConfig, _admin_cap: &AdminCap, factor: u64) {
-    config.set_shrink_factor(factor);
+    pool_vault.set_max_expiry_funding(config, expiry_market_id, funding);
 }
 
 /// Set the total liquidation candidate budget used before live valuations.
@@ -462,7 +425,7 @@ public fun destroy_market_oracle_cap(cap: MarketOracleCap) {
 /// Create the MarketOracle and ExpiryMarket objects for one future expiry.
 ///
 /// The registry enforces one market per expiry, validates the registered Pyth
-/// source, allocates initial pool capital, and registers the expiry as active.
+/// source, funds the expiry with initial pool cash, and registers it as active.
 public fun create_expiry_market(
     registry: &mut Registry,
     pool_vault: &mut PoolVault,
@@ -483,8 +446,8 @@ public fun create_expiry_market(
     assert!(registry.pyth_source_ids[pyth_lazer_feed_id] == pyth.id(), EFeedIdMismatch);
     assert!(!registry.expiry_market_ids.contains(expiry), EExpiryMarketAlreadyCreated);
     let allowed_versions = registry.allowed_versions;
-    let allocation = pool_vault.allocate_to_new_expiry(config.risk_config());
-    let allocation_amount = allocation.value();
+    let funding = pool_vault.fund_new_expiry();
+    let funding_amount = funding.value();
     let market_oracle_id = market_oracle::create_and_share(
         pyth,
         config.market_oracle_config(),
@@ -495,7 +458,7 @@ public fun create_expiry_market(
     );
     let expiry_market_id = expiry_market::create_and_share(
         config,
-        allocation,
+        funding,
         allowed_versions,
         market_oracle_id,
         pyth_lazer_feed_id,
@@ -504,8 +467,11 @@ public fun create_expiry_market(
         tick_size,
         ctx,
     );
-    pool_vault.register_expiry_market(expiry_market_id);
+    pool_vault.register_expiry_market(expiry_market_id, funding_amount);
     registry.expiry_market_ids.add(expiry, expiry_market_id);
+    let (sent_to_expiry_after, received_from_expiry_after) = pool_vault.expiry_flow_amounts(
+        expiry_market_id,
+    );
 
     config_events::emit_market_created(
         expiry_market_id,
@@ -515,13 +481,13 @@ public fun create_expiry_market(
         min_strike,
         tick_size,
     );
-    vault_events::emit_expiry_allocation_changed(
+    vault_events::emit_expiry_cash_funded(
         pool_vault.id(),
         expiry_market_id,
-        allocation_amount,
-        true,
-        allocation_amount,
+        funding_amount,
         pool_vault.idle_balance(),
+        sent_to_expiry_after,
+        received_from_expiry_after,
     );
 
     (expiry_market_id, market_oracle_id)

--- a/packages/predict/sources/registry.move
+++ b/packages/predict/sources/registry.move
@@ -192,8 +192,8 @@ public fun set_template_trading_loss_rebate_rate(
 /// Set the max net DUSDC the pool may fund into one expiry.
 public fun set_max_expiry_funding(
     pool_vault: &mut PoolVault,
-    config: &ProtocolConfig,
     _admin_cap: &AdminCap,
+    config: &ProtocolConfig,
     expiry_market_id: ID,
     funding: u64,
 ) {

--- a/packages/predict/sources/registry.move
+++ b/packages/predict/sources/registry.move
@@ -172,13 +172,13 @@ public fun set_block_scholes_svi_freshness_ms(
     config.set_block_scholes_svi_freshness_ms(value);
 }
 
-/// Set the current protocol reserve share used during settled expiry surplus sweeps.
-public fun set_protocol_reserve_fee_share(
+/// Set the current protocol reserve profit share used when materializing aggregate expiry profit.
+public fun set_protocol_reserve_profit_share(
     config: &mut ProtocolConfig,
     _admin_cap: &AdminCap,
-    protocol_reserve_fee_share: u64,
+    protocol_reserve_profit_share: u64,
 ) {
-    config.set_protocol_reserve_fee_share(protocol_reserve_fee_share);
+    config.set_protocol_reserve_profit_share(protocol_reserve_profit_share);
 }
 
 /// Set the trading loss rebate rate template used by future expiry markets.

--- a/packages/predict/sources/registry.move
+++ b/packages/predict/sources/registry.move
@@ -18,8 +18,7 @@ use deepbook_predict::{
     plp::PoolVault,
     predict_manager::{Self, PredictManager},
     protocol_config::{Self, ProtocolConfig},
-    pyth_source::{Self, PythSource},
-    vault_events
+    pyth_source::{Self, PythSource}
 };
 use sui::{clock::Clock, table::{Self, Table}, vec_set::{Self, VecSet}};
 
@@ -425,7 +424,8 @@ public fun destroy_market_oracle_cap(cap: MarketOracleCap) {
 /// Create the MarketOracle and ExpiryMarket objects for one future expiry.
 ///
 /// The registry enforces one market per expiry, validates the registered Pyth
-/// source, funds the expiry with initial pool cash, and registers it as active.
+/// source, and registers the expiry as active. Pool funding happens later through
+/// PLP rebalancing.
 public fun create_expiry_market(
     registry: &mut Registry,
     pool_vault: &mut PoolVault,
@@ -446,8 +446,6 @@ public fun create_expiry_market(
     assert!(registry.pyth_source_ids[pyth_lazer_feed_id] == pyth.id(), EFeedIdMismatch);
     assert!(!registry.expiry_market_ids.contains(expiry), EExpiryMarketAlreadyCreated);
     let allowed_versions = registry.allowed_versions;
-    let funding = pool_vault.fund_new_expiry();
-    let funding_amount = funding.value();
     let market_oracle_id = market_oracle::create_and_share(
         pyth,
         config.market_oracle_config(),
@@ -458,7 +456,6 @@ public fun create_expiry_market(
     );
     let expiry_market_id = expiry_market::create_and_share(
         config,
-        funding,
         allowed_versions,
         market_oracle_id,
         pyth_lazer_feed_id,
@@ -467,11 +464,8 @@ public fun create_expiry_market(
         tick_size,
         ctx,
     );
-    pool_vault.register_expiry_market(expiry_market_id, funding_amount);
+    pool_vault.register_expiry_market(expiry_market_id);
     registry.expiry_market_ids.add(expiry, expiry_market_id);
-    let (sent_to_expiry_after, received_from_expiry_after) = pool_vault.expiry_flow_amounts(
-        expiry_market_id,
-    );
 
     config_events::emit_market_created(
         expiry_market_id,
@@ -480,14 +474,6 @@ public fun create_expiry_market(
         expiry,
         min_strike,
         tick_size,
-    );
-    vault_events::emit_expiry_cash_funded(
-        pool_vault.id(),
-        expiry_market_id,
-        funding_amount,
-        pool_vault.idle_balance(),
-        sent_to_expiry_after,
-        received_from_expiry_after,
     );
 
     (expiry_market_id, market_oracle_id)

--- a/packages/predict/sources/strike_exposure/strike_exposure.move
+++ b/packages/predict/sources/strike_exposure/strike_exposure.move
@@ -20,7 +20,7 @@ use deepbook_predict::{
     math as predict_math,
     order::{Self, Order},
     order_events,
-    pricing::{Self, CurvePoint},
+    pricing,
     pricing_config::PricingConfig,
     pyth_source::PythSource,
     strike_nav_matrix::{Self, StrikeNavMatrix},
@@ -89,16 +89,12 @@ public(package) fun liquidation_ltv(exposure: &StrikeExposure): u64 {
     exposure.liquidation_ltv
 }
 
-/// Run valuation maintenance and evaluate live user-position liability.
-///
-/// Valuation uses one aggregate curve with conservative range upper bounds for
-/// bounded liquidations, then reuses that curve for NAV.
-public(package) fun prepare_valuation_liability(
-    exposure: &mut StrikeExposure,
+/// Evaluate live user-position liability over the current minted strike range.
+public(package) fun valuation_liability(
+    exposure: &StrikeExposure,
     config: &PricingConfig,
     market: &MarketOracle,
     pyth: &PythSource,
-    budget: u64,
     clock: &Clock,
 ): u64 {
     let live = exposure.live.borrow();
@@ -117,14 +113,6 @@ public(package) fun prepare_valuation_liability(
         minted_min_strike,
         minted_max_strike,
     );
-    if (budget > 0) {
-        let candidates = exposure.liquidation.select_liquidation_candidates(budget);
-        if (!candidates.is_empty()) {
-            exposure.liquidate_candidates_with_curve(&curve, candidates, clock);
-        };
-    };
-
-    let live = exposure.live.borrow();
     live
         .nav
         .live_value(
@@ -273,7 +261,7 @@ public(package) fun clear_liquidated_order(exposure: &mut StrikeExposure, order:
     exposure.liquidation.clear_liquidated(order);
 }
 
-/// Run one bounded liquidation pass and emit one event per removed order.
+/// Run one bounded liquidation pass using exact per-candidate pricing.
 public(package) fun liquidate_live_orders(
     exposure: &mut StrikeExposure,
     config: &PricingConfig,
@@ -286,7 +274,7 @@ public(package) fun liquidate_live_orders(
     if (candidates.is_empty()) return 0;
 
     let (forward, svi) = pricing::live_inputs(config, market, pyth, clock);
-    exposure.liquidate_candidates_with_inputs(&svi, forward, candidates, clock)
+    exposure.liquidate_candidates(&svi, forward, candidates, clock)
 }
 
 /// Cache terminal settled payout liability.
@@ -334,39 +322,7 @@ public(package) fun destroy_live_indexes(exposure: &mut StrikeExposure) {
     payout.destroy();
 }
 
-fun liquidate_candidates_with_curve(
-    exposure: &mut StrikeExposure,
-    curve: &vector<CurvePoint>,
-    candidates: vector<u256>,
-    clock: &Clock,
-): u64 {
-    let mut liquidated_count = 0;
-    let mut i = 0;
-    while (i < candidates.length()) {
-        let order = order::from_order_id(candidates[i]);
-        let (lower, higher) = exposure.order_strikes(&order);
-        let range_probability = pricing::directional_probability_upper_bound(
-            curve,
-            lower,
-            higher,
-        );
-        if (
-            exposure.liquidate_candidate_if_under_floor(
-                &order,
-                lower,
-                higher,
-                range_probability,
-                clock,
-            )
-        ) {
-            liquidated_count = liquidated_count + 1;
-        };
-        i = i + 1;
-    };
-    liquidated_count
-}
-
-fun liquidate_candidates_with_inputs(
+fun liquidate_candidates(
     exposure: &mut StrikeExposure,
     svi: &SVIParams,
     forward: u64,

--- a/packages/predict/sources/strike_exposure/strike_exposure.move
+++ b/packages/predict/sources/strike_exposure/strike_exposure.move
@@ -8,7 +8,7 @@
 /// payout liability for cash backing, and live position liability for LP
 /// valuation. It stores the parent market identity so market-scoped liquidation
 /// events can be emitted atomically with exposure removal. Expiry-market cash
-/// backing, fee custody, manager positions, and payout movement stay outside
+/// custody, rebate accounting, manager positions, and payout movement stay outside
 /// this module.
 module deepbook_predict::strike_exposure;
 

--- a/packages/predict/sources/strike_exposure/strike_exposure.move
+++ b/packages/predict/sources/strike_exposure/strike_exposure.move
@@ -89,13 +89,11 @@ public(package) fun liquidation_ltv(exposure: &StrikeExposure): u64 {
     exposure.liquidation_ltv
 }
 
-/// Run bounded liquidations and evaluate live user-position liability.
+/// Run valuation maintenance and evaluate live user-position liability.
 ///
-/// The bounded scan is the protocol's valuation-maintenance policy; it does not
-/// prove complete health of every active leveraged order. Valuation reuses one
-/// aggregate curve for both liquidation checks and NAV because valuation scans a
-/// larger batch than trade flows.
-public(package) fun liquidate_and_live_position_liability(
+/// Valuation uses one aggregate curve with conservative range upper bounds for
+/// bounded liquidations, then reuses that curve for NAV.
+public(package) fun prepare_valuation_liability(
     exposure: &mut StrikeExposure,
     config: &PricingConfig,
     market: &MarketOracle,

--- a/packages/predict/tests/config/fee_config_tests.move
+++ b/packages/predict/tests/config/fee_config_tests.move
@@ -17,55 +17,55 @@ fun defaults_match_config_constants() {
     let config = fee_config::new();
 
     assert_eq!(
-        config.protocol_reserve_fee_share(),
-        config_constants::default_protocol_reserve_fee_share!(),
+        config.protocol_reserve_profit_share(),
+        config_constants::default_protocol_reserve_profit_share!(),
     );
     assert_eq!(
         config.trading_loss_rebate_rate(),
         config_constants::default_trading_loss_rebate_rate!(),
     );
     assert_eq!(
-        float!() - config.protocol_reserve_fee_share(),
-        float!() - config_constants::default_protocol_reserve_fee_share!(),
+        float!() - config.protocol_reserve_profit_share(),
+        float!() - config_constants::default_protocol_reserve_profit_share!(),
     );
     destroy(config);
 }
 
-// === set_protocol_reserve_fee_share ===
+// === set_protocol_reserve_profit_share ===
 
 #[test]
-fun set_protocol_reserve_fee_share_updates_protocol_reserve_and_derived_lp() {
+fun set_protocol_reserve_profit_share_updates_protocol_reserve_and_derived_lp() {
     let mut config = fee_config::new();
 
-    config.set_protocol_reserve_fee_share(THIRTY_PERCENT);
+    config.set_protocol_reserve_profit_share(THIRTY_PERCENT);
 
-    assert_eq!(config.protocol_reserve_fee_share(), THIRTY_PERCENT);
-    assert_eq!(float!() - config.protocol_reserve_fee_share(), SEVENTY_PERCENT);
+    assert_eq!(config.protocol_reserve_profit_share(), THIRTY_PERCENT);
+    assert_eq!(float!() - config.protocol_reserve_profit_share(), SEVENTY_PERCENT);
     destroy(config);
 }
 
 #[test]
-fun set_protocol_reserve_fee_share_accepts_zero() {
+fun set_protocol_reserve_profit_share_accepts_zero() {
     let mut config = fee_config::new();
-    config.set_protocol_reserve_fee_share(0);
-    assert_eq!(config.protocol_reserve_fee_share(), 0);
-    assert_eq!(float!() - config.protocol_reserve_fee_share(), float!());
+    config.set_protocol_reserve_profit_share(0);
+    assert_eq!(config.protocol_reserve_profit_share(), 0);
+    assert_eq!(float!() - config.protocol_reserve_profit_share(), float!());
     destroy(config);
 }
 
 #[test]
-fun set_protocol_reserve_fee_share_accepts_full_protocol_reserve() {
+fun set_protocol_reserve_profit_share_accepts_full_protocol_reserve() {
     let mut config = fee_config::new();
-    config.set_protocol_reserve_fee_share(float!());
-    assert_eq!(config.protocol_reserve_fee_share(), float!());
-    assert_eq!(float!() - config.protocol_reserve_fee_share(), 0);
+    config.set_protocol_reserve_profit_share(float!());
+    assert_eq!(config.protocol_reserve_profit_share(), float!());
+    assert_eq!(float!() - config.protocol_reserve_profit_share(), 0);
     destroy(config);
 }
 
-#[test, expected_failure(abort_code = config_constants::EInvalidProtocolReserveFeeShare)]
-fun set_protocol_reserve_fee_share_above_float_aborts() {
+#[test, expected_failure(abort_code = config_constants::EInvalidProtocolReserveProfitShare)]
+fun set_protocol_reserve_profit_share_above_float_aborts() {
     let mut config = fee_config::new();
-    config.set_protocol_reserve_fee_share(float!() + 1);
+    config.set_protocol_reserve_profit_share(float!() + 1);
     abort 999
 }
 

--- a/packages/predict/tests/config/fee_config_tests.move
+++ b/packages/predict/tests/config/fee_config_tests.move
@@ -8,7 +8,6 @@ use deepbook_predict::{config_constants, constants::float_scaling as float, fee_
 use std::unit_test::{assert_eq, destroy};
 
 const THIRTY_PERCENT: u64 = 300_000_000;
-const SEVENTY_PERCENT: u64 = 700_000_000;
 
 // === Construction and getters ===
 
@@ -24,23 +23,18 @@ fun defaults_match_config_constants() {
         config.trading_loss_rebate_rate(),
         config_constants::default_trading_loss_rebate_rate!(),
     );
-    assert_eq!(
-        float!() - config.protocol_reserve_profit_share(),
-        float!() - config_constants::default_protocol_reserve_profit_share!(),
-    );
     destroy(config);
 }
 
 // === set_protocol_reserve_profit_share ===
 
 #[test]
-fun set_protocol_reserve_profit_share_updates_protocol_reserve_and_derived_lp() {
+fun set_protocol_reserve_profit_share_updates_value() {
     let mut config = fee_config::new();
 
     config.set_protocol_reserve_profit_share(THIRTY_PERCENT);
 
     assert_eq!(config.protocol_reserve_profit_share(), THIRTY_PERCENT);
-    assert_eq!(float!() - config.protocol_reserve_profit_share(), SEVENTY_PERCENT);
     destroy(config);
 }
 
@@ -49,7 +43,6 @@ fun set_protocol_reserve_profit_share_accepts_zero() {
     let mut config = fee_config::new();
     config.set_protocol_reserve_profit_share(0);
     assert_eq!(config.protocol_reserve_profit_share(), 0);
-    assert_eq!(float!() - config.protocol_reserve_profit_share(), float!());
     destroy(config);
 }
 
@@ -58,7 +51,6 @@ fun set_protocol_reserve_profit_share_accepts_full_protocol_reserve() {
     let mut config = fee_config::new();
     config.set_protocol_reserve_profit_share(float!());
     assert_eq!(config.protocol_reserve_profit_share(), float!());
-    assert_eq!(float!() - config.protocol_reserve_profit_share(), 0);
     destroy(config);
 }
 

--- a/packages/predict/tests/config/fee_config_tests.move
+++ b/packages/predict/tests/config/fee_config_tests.move
@@ -24,10 +24,8 @@ fun defaults_match_config_constants() {
         config.trading_loss_rebate_rate(),
         config_constants::default_trading_loss_rebate_rate!(),
     );
-    // Defaults must sum to 1.0 because LP share is derived as the complement.
-    assert_eq!(config.lp_fee_share() + config.protocol_reserve_fee_share(), float!());
     assert_eq!(
-        config.lp_fee_share(),
+        float!() - config.protocol_reserve_fee_share(),
         float!() - config_constants::default_protocol_reserve_fee_share!(),
     );
     destroy(config);
@@ -42,7 +40,7 @@ fun set_protocol_reserve_fee_share_updates_protocol_reserve_and_derived_lp() {
     config.set_protocol_reserve_fee_share(THIRTY_PERCENT);
 
     assert_eq!(config.protocol_reserve_fee_share(), THIRTY_PERCENT);
-    assert_eq!(config.lp_fee_share(), SEVENTY_PERCENT);
+    assert_eq!(float!() - config.protocol_reserve_fee_share(), SEVENTY_PERCENT);
     destroy(config);
 }
 
@@ -51,7 +49,7 @@ fun set_protocol_reserve_fee_share_accepts_zero() {
     let mut config = fee_config::new();
     config.set_protocol_reserve_fee_share(0);
     assert_eq!(config.protocol_reserve_fee_share(), 0);
-    assert_eq!(config.lp_fee_share(), float!());
+    assert_eq!(float!() - config.protocol_reserve_fee_share(), float!());
     destroy(config);
 }
 
@@ -60,7 +58,7 @@ fun set_protocol_reserve_fee_share_accepts_full_protocol_reserve() {
     let mut config = fee_config::new();
     config.set_protocol_reserve_fee_share(float!());
     assert_eq!(config.protocol_reserve_fee_share(), float!());
-    assert_eq!(config.lp_fee_share(), 0);
+    assert_eq!(float!() - config.protocol_reserve_fee_share(), 0);
     destroy(config);
 }
 

--- a/packages/predict/tests/config/fee_config_tests.move
+++ b/packages/predict/tests/config/fee_config_tests.move
@@ -7,92 +7,67 @@ module deepbook_predict::fee_config_tests;
 use deepbook_predict::{config_constants, constants::float_scaling as float, fee_config};
 use std::unit_test::{assert_eq, destroy};
 
+const THIRTY_PERCENT: u64 = 300_000_000;
+const SEVENTY_PERCENT: u64 = 700_000_000;
+
 // === Construction and getters ===
 
 #[test]
 fun defaults_match_config_constants() {
     let config = fee_config::new();
 
-    assert_eq!(config.lp_fee_share(), config_constants::default_lp_fee_share!());
-    assert_eq!(config.protocol_fee_share(), config_constants::default_protocol_fee_share!());
-    assert_eq!(config.insurance_fee_share(), config_constants::default_insurance_fee_share!());
+    assert_eq!(
+        config.protocol_reserve_fee_share(),
+        config_constants::default_protocol_reserve_fee_share!(),
+    );
     assert_eq!(
         config.trading_loss_rebate_rate(),
         config_constants::default_trading_loss_rebate_rate!(),
     );
-    // Defaults must sum to 1.0 — otherwise `set_fee_shares` would reject the
-    // default state itself.
+    // Defaults must sum to 1.0 because LP share is derived as the complement.
+    assert_eq!(config.lp_fee_share() + config.protocol_reserve_fee_share(), float!());
     assert_eq!(
-        config.lp_fee_share() + config.protocol_fee_share() + config.insurance_fee_share(),
-        float!(),
+        config.lp_fee_share(),
+        float!() - config_constants::default_protocol_reserve_fee_share!(),
     );
     destroy(config);
 }
 
-// === set_fee_shares ===
+// === set_protocol_reserve_fee_share ===
 
 #[test]
-fun set_fee_shares_updates_all_three_when_sum_is_one() {
+fun set_protocol_reserve_fee_share_updates_protocol_reserve_and_derived_lp() {
     let mut config = fee_config::new();
-    let lp = 700_000_000;
-    let proto = 200_000_000;
-    let insurance = 100_000_000;
 
-    config.set_fee_shares(lp, proto, insurance);
+    config.set_protocol_reserve_fee_share(THIRTY_PERCENT);
 
-    assert_eq!(config.lp_fee_share(), lp);
-    assert_eq!(config.protocol_fee_share(), proto);
-    assert_eq!(config.insurance_fee_share(), insurance);
+    assert_eq!(config.protocol_reserve_fee_share(), THIRTY_PERCENT);
+    assert_eq!(config.lp_fee_share(), SEVENTY_PERCENT);
     destroy(config);
 }
 
 #[test]
-fun set_fee_shares_accepts_full_lp_only() {
-    // Boundary: lp = 1.0, others = 0. Per-share max is `float!()`, so this is
-    // the maximum allowed lp value that still satisfies the sum check.
+fun set_protocol_reserve_fee_share_accepts_zero() {
     let mut config = fee_config::new();
-    config.set_fee_shares(float!(), 0, 0);
+    config.set_protocol_reserve_fee_share(0);
+    assert_eq!(config.protocol_reserve_fee_share(), 0);
     assert_eq!(config.lp_fee_share(), float!());
-    assert_eq!(config.protocol_fee_share(), 0);
-    assert_eq!(config.insurance_fee_share(), 0);
     destroy(config);
 }
 
-#[test, expected_failure(abort_code = fee_config::EInvalidFeeSplit)]
-fun set_fee_shares_sum_below_one_aborts() {
+#[test]
+fun set_protocol_reserve_fee_share_accepts_full_protocol_reserve() {
     let mut config = fee_config::new();
-    config.set_fee_shares(400_000_000, 200_000_000, 200_000_000); // sum = 0.8
-    abort 999
+    config.set_protocol_reserve_fee_share(float!());
+    assert_eq!(config.protocol_reserve_fee_share(), float!());
+    assert_eq!(config.lp_fee_share(), 0);
+    destroy(config);
 }
 
-#[test, expected_failure(abort_code = fee_config::EInvalidFeeSplit)]
-fun set_fee_shares_sum_above_one_aborts() {
+#[test, expected_failure(abort_code = config_constants::EInvalidProtocolReserveFeeShare)]
+fun set_protocol_reserve_fee_share_above_float_aborts() {
     let mut config = fee_config::new();
-    config.set_fee_shares(500_000_000, 300_000_000, 300_000_000); // sum = 1.1
-    abort 999
-}
-
-#[test, expected_failure(abort_code = config_constants::EInvalidLpFeeShare)]
-fun set_fee_shares_lp_above_float_aborts() {
-    // Per-share max is `float!()`. Caught by `assert_lp_fee_share` before the
-    // sum check, so the test fixes a code-specific abort even though the sum
-    // would also be wrong.
-    let mut config = fee_config::new();
-    config.set_fee_shares(float!() + 1, 0, 0);
-    abort 999
-}
-
-#[test, expected_failure(abort_code = config_constants::EInvalidProtocolFeeShare)]
-fun set_fee_shares_protocol_above_float_aborts() {
-    let mut config = fee_config::new();
-    config.set_fee_shares(0, float!() + 1, 0);
-    abort 999
-}
-
-#[test, expected_failure(abort_code = config_constants::EInvalidInsuranceFeeShare)]
-fun set_fee_shares_insurance_above_float_aborts() {
-    let mut config = fee_config::new();
-    config.set_fee_shares(0, 0, float!() + 1);
+    config.set_protocol_reserve_fee_share(float!() + 1);
     abort 999
 }
 

--- a/packages/predict/tests/config/risk_config_tests.move
+++ b/packages/predict/tests/config/risk_config_tests.move
@@ -4,17 +4,11 @@
 #[test_only]
 module deepbook_predict::risk_config_tests;
 
-use deepbook_predict::{config_constants, constants::float_scaling as float, risk_config};
+use deepbook_predict::{config_constants, risk_config};
 use std::unit_test::{assert_eq, destroy};
 
-// Allocation envelope is [50e9, 250e9] — well inside u64.
-const VALID_ALLOCATION: u64 = 100_000_000_000;
-const ALLOCATION_BELOW_MIN: u64 = 49_999_999_999;
-const ALLOCATION_ABOVE_MAX: u64 = 250_000_000_001;
-
-// Default grow / shrink utilization thresholds are 800e6 / 300e6.
-const DEFAULT_GROW_THRESHOLD: u64 = 800_000_000;
-const DEFAULT_SHRINK_THRESHOLD: u64 = 300_000_000;
+const VALID_VALUATION_BUDGET: u64 = 256;
+const VALID_TRADE_BUDGET: u64 = 48;
 
 // === Construction and getters ===
 
@@ -22,246 +16,96 @@ const DEFAULT_SHRINK_THRESHOLD: u64 = 300_000_000;
 fun defaults_match_config_constants() {
     let config = risk_config::new();
     assert_eq!(
-        config.max_total_exposure_pct(),
-        config_constants::default_max_total_exposure_pct!(),
-    );
-    assert_eq!(config.expiry_allocation(), config_constants::default_allocation!());
-    assert_eq!(
-        config.grow_utilization_threshold(),
-        config_constants::default_grow_utilization_threshold!(),
+        config.valuation_liquidation_budget(),
+        config_constants::default_valuation_liquidation_budget!(),
     );
     assert_eq!(
-        config.shrink_utilization_threshold(),
-        config_constants::default_shrink_utilization_threshold!(),
+        config.trade_liquidation_budget(),
+        config_constants::default_trade_liquidation_budget!(),
     );
-    assert_eq!(config.grow_factor(), config_constants::default_grow_factor!());
-    assert_eq!(config.shrink_factor(), config_constants::default_shrink_factor!());
     destroy(config);
 }
 
-// === set_max_total_exposure_pct ===
+// === set_valuation_liquidation_budget ===
 
 #[test]
-fun set_max_total_exposure_pct_updates() {
+fun set_valuation_liquidation_budget_updates() {
     let mut config = risk_config::new();
-    config.set_max_total_exposure_pct(500_000_000);
-    assert_eq!(config.max_total_exposure_pct(), 500_000_000);
+    config.set_valuation_liquidation_budget(VALID_VALUATION_BUDGET);
+    assert_eq!(config.valuation_liquidation_budget(), VALID_VALUATION_BUDGET);
     destroy(config);
 }
 
 #[test]
-fun set_max_total_exposure_pct_accepts_endpoints() {
-    // Envelope = [1, float!()].
+fun set_valuation_liquidation_budget_accepts_endpoints() {
     let mut config = risk_config::new();
-    config.set_max_total_exposure_pct(1);
-    assert_eq!(config.max_total_exposure_pct(), 1);
-    config.set_max_total_exposure_pct(float!());
-    assert_eq!(config.max_total_exposure_pct(), float!());
+    config.set_valuation_liquidation_budget(config_constants::min_valuation_liquidation_budget!());
+    assert_eq!(
+        config.valuation_liquidation_budget(),
+        config_constants::min_valuation_liquidation_budget!(),
+    );
+    config.set_valuation_liquidation_budget(config_constants::max_valuation_liquidation_budget!());
+    assert_eq!(
+        config.valuation_liquidation_budget(),
+        config_constants::max_valuation_liquidation_budget!(),
+    );
     destroy(config);
 }
 
-#[test, expected_failure(abort_code = config_constants::EInvalidMaxTotalExposurePct)]
-fun set_max_total_exposure_pct_zero_aborts() {
+#[test, expected_failure(abort_code = config_constants::EInvalidValuationLiquidationBudget)]
+fun set_valuation_liquidation_budget_below_min_aborts() {
     let mut config = risk_config::new();
-    config.set_max_total_exposure_pct(0);
+    config.set_valuation_liquidation_budget(
+        config_constants::min_valuation_liquidation_budget!() - 1,
+    );
     abort 999
 }
 
-#[test, expected_failure(abort_code = config_constants::EInvalidMaxTotalExposurePct)]
-fun set_max_total_exposure_pct_above_float_aborts() {
+#[test, expected_failure(abort_code = config_constants::EInvalidValuationLiquidationBudget)]
+fun set_valuation_liquidation_budget_above_max_aborts() {
     let mut config = risk_config::new();
-    config.set_max_total_exposure_pct(float!() + 1);
+    config.set_valuation_liquidation_budget(
+        config_constants::max_valuation_liquidation_budget!() + 1,
+    );
     abort 999
 }
 
-// === set_expiry_allocation ===
+// === set_trade_liquidation_budget ===
 
 #[test]
-fun set_expiry_allocation_updates() {
+fun set_trade_liquidation_budget_updates() {
     let mut config = risk_config::new();
-    config.set_expiry_allocation(VALID_ALLOCATION);
-    assert_eq!(config.expiry_allocation(), VALID_ALLOCATION);
+    config.set_trade_liquidation_budget(VALID_TRADE_BUDGET);
+    assert_eq!(config.trade_liquidation_budget(), VALID_TRADE_BUDGET);
     destroy(config);
 }
 
 #[test]
-fun set_expiry_allocation_accepts_endpoints() {
-    // Envelope = [50e9, 250e9]. Endpoints are exactly where off-by-one bounds
-    // bugs hide — assert both pass.
+fun set_trade_liquidation_budget_accepts_endpoints() {
     let mut config = risk_config::new();
-    config.set_expiry_allocation(50_000_000_000);
-    assert_eq!(config.expiry_allocation(), 50_000_000_000);
-    config.set_expiry_allocation(250_000_000_000);
-    assert_eq!(config.expiry_allocation(), 250_000_000_000);
+    config.set_trade_liquidation_budget(config_constants::min_trade_liquidation_budget!());
+    assert_eq!(
+        config.trade_liquidation_budget(),
+        config_constants::min_trade_liquidation_budget!(),
+    );
+    config.set_trade_liquidation_budget(config_constants::max_trade_liquidation_budget!());
+    assert_eq!(
+        config.trade_liquidation_budget(),
+        config_constants::max_trade_liquidation_budget!(),
+    );
     destroy(config);
 }
 
-#[test, expected_failure(abort_code = config_constants::EInvalidExpiryAllocation)]
-fun set_expiry_allocation_below_min_aborts() {
+#[test, expected_failure(abort_code = config_constants::EInvalidTradeLiquidationBudget)]
+fun set_trade_liquidation_budget_below_min_aborts() {
     let mut config = risk_config::new();
-    config.set_expiry_allocation(ALLOCATION_BELOW_MIN);
+    config.set_trade_liquidation_budget(config_constants::min_trade_liquidation_budget!() - 1);
     abort 999
 }
 
-#[test, expected_failure(abort_code = config_constants::EInvalidExpiryAllocation)]
-fun set_expiry_allocation_above_max_aborts() {
+#[test, expected_failure(abort_code = config_constants::EInvalidTradeLiquidationBudget)]
+fun set_trade_liquidation_budget_above_max_aborts() {
     let mut config = risk_config::new();
-    config.set_expiry_allocation(ALLOCATION_ABOVE_MAX);
-    abort 999
-}
-
-// === set_grow_utilization_threshold ===
-
-#[test]
-fun set_grow_utilization_threshold_updates() {
-    let mut config = risk_config::new();
-    config.set_grow_utilization_threshold(900_000_000);
-    assert_eq!(config.grow_utilization_threshold(), 900_000_000);
-    destroy(config);
-}
-
-#[test]
-fun set_grow_utilization_threshold_equal_to_shrink_is_allowed() {
-    // Cross-field invariant is `grow >= shrink`; equal is the boundary.
-    let mut config = risk_config::new();
-    config.set_grow_utilization_threshold(DEFAULT_SHRINK_THRESHOLD);
-    assert_eq!(config.grow_utilization_threshold(), DEFAULT_SHRINK_THRESHOLD);
-    destroy(config);
-}
-
-#[test]
-fun set_grow_utilization_threshold_zero_after_shrink_zeroed() {
-    // 0 is in the envelope but normally blocked by the cross-field check
-    // against the default shrink threshold (300e6). Drop shrink to 0 first
-    // and 0 becomes a valid grow value.
-    let mut config = risk_config::new();
-    config.set_shrink_utilization_threshold(0);
-    config.set_grow_utilization_threshold(0);
-    assert_eq!(config.grow_utilization_threshold(), 0);
-    destroy(config);
-}
-
-#[test, expected_failure(abort_code = config_constants::EInvalidGrowUtilizationThreshold)]
-fun set_grow_utilization_threshold_above_envelope_aborts() {
-    // Envelope max = float!().
-    let mut config = risk_config::new();
-    config.set_grow_utilization_threshold(float!() + 1);
-    abort 999
-}
-
-#[test, expected_failure(abort_code = risk_config::EInvalidResizeThresholds)]
-fun set_grow_utilization_threshold_below_shrink_aborts() {
-    // Default shrink = 300e6; a grow value strictly below that violates the
-    // cross-field invariant.
-    let mut config = risk_config::new();
-    config.set_grow_utilization_threshold(DEFAULT_SHRINK_THRESHOLD - 1);
-    abort 999
-}
-
-// === set_shrink_utilization_threshold ===
-
-#[test]
-fun set_shrink_utilization_threshold_updates() {
-    let mut config = risk_config::new();
-    config.set_shrink_utilization_threshold(200_000_000);
-    assert_eq!(config.shrink_utilization_threshold(), 200_000_000);
-    destroy(config);
-}
-
-#[test]
-fun set_shrink_utilization_threshold_equal_to_grow_is_allowed() {
-    let mut config = risk_config::new();
-    config.set_shrink_utilization_threshold(DEFAULT_GROW_THRESHOLD);
-    assert_eq!(config.shrink_utilization_threshold(), DEFAULT_GROW_THRESHOLD);
-    destroy(config);
-}
-
-#[test, expected_failure(abort_code = config_constants::EInvalidShrinkUtilizationThreshold)]
-fun set_shrink_utilization_threshold_above_envelope_aborts() {
-    let mut config = risk_config::new();
-    config.set_shrink_utilization_threshold(float!() + 1);
-    abort 999
-}
-
-#[test, expected_failure(abort_code = risk_config::EInvalidResizeThresholds)]
-fun set_shrink_utilization_threshold_above_grow_aborts() {
-    // Default grow = 800e6; a shrink value strictly above that violates the
-    // cross-field invariant.
-    let mut config = risk_config::new();
-    config.set_shrink_utilization_threshold(DEFAULT_GROW_THRESHOLD + 1);
-    abort 999
-}
-
-// === set_grow_factor ===
-
-#[test]
-fun set_grow_factor_updates() {
-    let mut config = risk_config::new();
-    config.set_grow_factor(3 * float!());
-    assert_eq!(config.grow_factor(), 3 * float!());
-    destroy(config);
-}
-
-#[test]
-fun set_grow_factor_accepts_endpoints() {
-    // Envelope = [float!()+1, 10*float!()].
-    let mut config = risk_config::new();
-    config.set_grow_factor(float!() + 1);
-    assert_eq!(config.grow_factor(), float!() + 1);
-    config.set_grow_factor(10 * float!());
-    assert_eq!(config.grow_factor(), 10 * float!());
-    destroy(config);
-}
-
-#[test, expected_failure(abort_code = config_constants::EInvalidGrowFactor)]
-fun set_grow_factor_zero_aborts() {
-    // Far below min (which is float!() + 1) — exercises the under-flow path
-    // distinctly from the float!() boundary.
-    let mut config = risk_config::new();
-    config.set_grow_factor(0);
-    abort 999
-}
-
-#[test, expected_failure(abort_code = config_constants::EInvalidGrowFactor)]
-fun set_grow_factor_equal_to_float_aborts() {
-    // Boundary: grow_factor must be strictly greater than 1.0.
-    let mut config = risk_config::new();
-    config.set_grow_factor(float!());
-    abort 999
-}
-
-#[test, expected_failure(abort_code = config_constants::EInvalidGrowFactor)]
-fun set_grow_factor_above_envelope_aborts() {
-    let mut config = risk_config::new();
-    config.set_grow_factor(10 * float!() + 1);
-    abort 999
-}
-
-// === set_shrink_factor ===
-
-#[test]
-fun set_shrink_factor_updates() {
-    let mut config = risk_config::new();
-    config.set_shrink_factor(400_000_000);
-    assert_eq!(config.shrink_factor(), 400_000_000);
-    destroy(config);
-}
-
-#[test]
-fun set_shrink_factor_accepts_endpoints() {
-    // Envelope = [0, float!()-1].
-    let mut config = risk_config::new();
-    config.set_shrink_factor(0);
-    assert_eq!(config.shrink_factor(), 0);
-    config.set_shrink_factor(float!() - 1);
-    assert_eq!(config.shrink_factor(), float!() - 1);
-    destroy(config);
-}
-
-#[test, expected_failure(abort_code = config_constants::EInvalidShrinkFactor)]
-fun set_shrink_factor_equal_to_float_aborts() {
-    // Boundary: shrink_factor must be strictly less than 1.0.
-    let mut config = risk_config::new();
-    config.set_shrink_factor(float!());
+    config.set_trade_liquidation_budget(config_constants::max_trade_liquidation_budget!() + 1);
     abort 999
 }

--- a/packages/predict/tests/config/stake_config_tests.move
+++ b/packages/predict/tests/config/stake_config_tests.move
@@ -13,6 +13,8 @@ const LOWER: u64 = 100_000_000_000; // default lower_benefit_power
 const THREE_HUNDRED_K: u64 = 300_000_000_000;
 const UPPER: u64 = 1_100_000_000_000; // default upper_benefit_power
 const TWO_MILLION: u64 = 2_000_000_000_000;
+const FEE_AMOUNT: u64 = 1_000_000_000;
+const ELIGIBLE_REBATE: u64 = 1_000_000_000;
 
 // === Construction and getter ===
 
@@ -87,26 +89,25 @@ fun set_benefit_powers_upper_below_min_aborts() {
 // === benefit curve (default config: lower 100k, upper 1.1M; fee cap 50%, rebate uncapped) ===
 
 #[test]
-fun fee_discount_follows_two_segment_curve() {
+fun fee_amount_after_discount_follows_two_segment_curve() {
     let config = stake_config::new();
-    assert_eq!(config.fee_discount_fraction(0), 0);
-    assert_eq!(config.fee_discount_fraction(TWENTY_K), 50_000_000); // ratio 0.1 -> 5%
-    assert_eq!(config.fee_discount_fraction(LOWER), 250_000_000); // kink, ratio 0.5 -> 25%
-    assert_eq!(config.fee_discount_fraction(THREE_HUNDRED_K), 300_000_000); // ratio 0.6 -> 30%
-    assert_eq!(config.fee_discount_fraction(UPPER), 500_000_000); // ratio 1.0 -> 50% (cap)
-    assert_eq!(config.fee_discount_fraction(TWO_MILLION), 500_000_000); // capped
+    assert_eq!(config.fee_amount_after_discount(FEE_AMOUNT, 0), 1_000_000_000);
+    assert_eq!(config.fee_amount_after_discount(FEE_AMOUNT, TWENTY_K), 950_000_000);
+    assert_eq!(config.fee_amount_after_discount(FEE_AMOUNT, LOWER), 750_000_000);
+    assert_eq!(config.fee_amount_after_discount(FEE_AMOUNT, THREE_HUNDRED_K), 700_000_000);
+    assert_eq!(config.fee_amount_after_discount(FEE_AMOUNT, UPPER), 500_000_000);
+    assert_eq!(config.fee_amount_after_discount(FEE_AMOUNT, TWO_MILLION), 500_000_000);
     destroy(config);
 }
 
 #[test]
-fun rebate_follows_two_segment_curve() {
-    // rebate_fraction is the benefit ratio directly (no staking cap).
+fun rebate_amount_follows_two_segment_curve() {
     let config = stake_config::new();
-    assert_eq!(config.rebate_fraction(0), 0);
-    assert_eq!(config.rebate_fraction(TWENTY_K), 100_000_000); // 10%
-    assert_eq!(config.rebate_fraction(LOWER), 500_000_000); // 50%
-    assert_eq!(config.rebate_fraction(THREE_HUNDRED_K), 600_000_000); // 60%
-    assert_eq!(config.rebate_fraction(UPPER), 1_000_000_000); // 100%
-    assert_eq!(config.rebate_fraction(TWO_MILLION), 1_000_000_000); // capped
+    assert_eq!(config.rebate_amount(ELIGIBLE_REBATE, 0), 0);
+    assert_eq!(config.rebate_amount(ELIGIBLE_REBATE, TWENTY_K), 100_000_000);
+    assert_eq!(config.rebate_amount(ELIGIBLE_REBATE, LOWER), 500_000_000);
+    assert_eq!(config.rebate_amount(ELIGIBLE_REBATE, THREE_HUNDRED_K), 600_000_000);
+    assert_eq!(config.rebate_amount(ELIGIBLE_REBATE, UPPER), 1_000_000_000);
+    assert_eq!(config.rebate_amount(ELIGIBLE_REBATE, TWO_MILLION), 1_000_000_000);
     destroy(config);
 }

--- a/packages/predict/tests/expiry_market_tests.move
+++ b/packages/predict/tests/expiry_market_tests.move
@@ -18,12 +18,7 @@ use deepbook_predict::{
 };
 use dusdc::dusdc::DUSDC;
 use std::unit_test::{assert_eq, destroy};
-use sui::{
-    clock::{Self, Clock},
-    coin,
-    test_scenario::{Self as test, return_shared},
-    vec_set
-};
+use sui::{clock::{Self, Clock}, coin, test_scenario::{Self as test, return_shared}, vec_set};
 
 const NOW_MS: u64 = 100_000;
 const EXPIRY_MS: u64 = 200_000;
@@ -72,10 +67,10 @@ fun rebate_eligibility_offsets_fee_reserve_by_gross_profit() {
     let mut market = scenario.take_shared_by_id<ExpiryMarket>(expiry_id);
 
     prepare_live_oracle_for_trading(&mut oracle, &mut pyth, &config, &cap, &clock);
-    market.receive_pool_cash(
-        coin::mint_for_testing<DUSDC>(constants::expiry_cash_floor!(), scenario.ctx())
-            .into_balance(),
-    );
+    market.receive_pool_cash(coin::mint_for_testing<DUSDC>(
+        constants::expiry_cash_floor!(),
+        scenario.ctx(),
+    ).into_balance());
     manager.deposit(
         coin::mint_for_testing<DUSDC>(MINT_DEPOSIT, scenario.ctx()),
         scenario.ctx(),
@@ -113,10 +108,7 @@ fun rebate_eligibility_offsets_fee_reserve_by_gross_profit() {
         scenario.ctx(),
     );
 
-    assert_eq!(
-        manager.balance(),
-        balance_before_claim + EXPECTED_REBATE_WITH_ONE_GROSS_PROFIT,
-    );
+    assert_eq!(manager.balance(), balance_before_claim + EXPECTED_REBATE_WITH_ONE_GROSS_PROFIT);
     assert_eq!(residual_cash.value(), GROSS_PROFIT_ONE);
     assert_eq!(market.rebate_reserve(), 0);
 
@@ -179,10 +171,12 @@ fun settle_oracle(
         settlement_source_timestamp_ms,
         settlement_update_timestamp_ms,
     );
-    assert!(oracle.settle_if_possible(
-        config,
-        pyth,
-        cap,
-        clock,
-    ));
+    assert!(
+        oracle.settle_if_possible(
+            config,
+            pyth,
+            cap,
+            clock,
+        ),
+    );
 }

--- a/packages/predict/tests/expiry_market_tests.move
+++ b/packages/predict/tests/expiry_market_tests.move
@@ -1,0 +1,188 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module deepbook_predict::expiry_market_tests;
+
+use deepbook_predict::{
+    constants,
+    expiry_market::{Self, ExpiryMarket},
+    i64,
+    market_oracle::{Self, MarketOracle, MarketOracleCap},
+    order,
+    predict_manager::PredictManager,
+    protocol_config::{Self, ProtocolConfig},
+    pyth_source::{Self, PythSource},
+    registry::{Self, AdminCap, Registry},
+    test_constants
+};
+use dusdc::dusdc::DUSDC;
+use std::unit_test::{assert_eq, destroy};
+use sui::{
+    clock::{Self, Clock},
+    coin,
+    test_scenario::{Self as test, return_shared},
+    vec_set
+};
+
+const NOW_MS: u64 = 100_000;
+const EXPIRY_MS: u64 = 200_000;
+const MIN_STRIKE: u64 = 100_000_000_000;
+const TICK_SIZE: u64 = 1_000_000_000;
+const SETTLEMENT_PRICE: u64 = 100_000_000_000;
+const LIVE_SOURCE_TIMESTAMP_MS: u64 = 99_000;
+const ZERO_TAIL_LOWER_STRIKE: u64 = 100_100_000_000_000;
+
+const MINT_QUANTITY: u64 = 1_000_000_000;
+const MINT_DEPOSIT: u64 = 1_000_000_000;
+const MINT_FEE: u64 = 5_000_000;
+const REBATE_RESERVE: u64 = 2_500_000;
+const GROSS_PROFIT_ONE: u64 = 1;
+const FULL_REBATE_STAKE: u64 = 1_100_000_000_000;
+const EXPECTED_REBATE_WITH_ONE_GROSS_PROFIT: u64 = 2_499_999;
+
+#[test]
+fun rebate_eligibility_offsets_fee_reserve_by_gross_profit() {
+    let mut scenario = test::begin(test_constants::alice());
+    let (mut registry, admin_cap) = registry::new_for_testing(scenario.ctx());
+    let mut config = protocol_config::new_for_testing(scenario.ctx());
+    config.set_min_ask_price(0);
+    let cap = registry::create_market_oracle_cap(&admin_cap, scenario.ctx());
+    let mut clock = clock::create_for_testing(scenario.ctx());
+    clock.set_for_testing(NOW_MS);
+    let mut pyth = pyth_source::new_for_testing(scenario.ctx());
+    let mut oracle = market_oracle::create_test_market_oracle_with_pyth(
+        &pyth,
+        EXPIRY_MS,
+        &cap,
+        scenario.ctx(),
+    );
+    let expiry_id = expiry_market::create_and_share(
+        &config,
+        vec_set::singleton(constants::current_version!()),
+        oracle.id(),
+        pyth.feed_id(),
+        EXPIRY_MS,
+        MIN_STRIKE,
+        TICK_SIZE,
+        scenario.ctx(),
+    );
+    let mut manager = registry::create_manager(&mut registry, scenario.ctx());
+    scenario.next_tx(test_constants::alice());
+    let mut market = scenario.take_shared_by_id<ExpiryMarket>(expiry_id);
+
+    prepare_live_oracle_for_trading(&mut oracle, &mut pyth, &config, &cap, &clock);
+    market.receive_pool_cash(
+        coin::mint_for_testing<DUSDC>(constants::expiry_cash_floor!(), scenario.ctx())
+            .into_balance(),
+    );
+    manager.deposit(
+        coin::mint_for_testing<DUSDC>(MINT_DEPOSIT, scenario.ctx()),
+        scenario.ctx(),
+    );
+
+    let order_id = market.mint(
+        &mut manager,
+        &config,
+        &oracle,
+        &pyth,
+        ZERO_TAIL_LOWER_STRIKE,
+        constants::pos_inf!(),
+        MINT_QUANTITY,
+        order::leverage_one_x(),
+        &clock,
+        scenario.ctx(),
+    );
+    assert_eq!(manager.trading_fees_paid(expiry_id), MINT_FEE);
+    assert_eq!(market.rebate_reserve(), REBATE_RESERVE);
+
+    manager.record_gross_received_from_expiry(expiry_id, GROSS_PROFIT_ONE);
+    manager.remove_position(expiry_id, order_id);
+    manager.add_inactive_stake(FULL_REBATE_STAKE);
+    return_shared(market);
+
+    scenario.next_epoch(test_constants::alice());
+    let mut market = scenario.take_shared_by_id<ExpiryMarket>(expiry_id);
+    settle_oracle(&mut oracle, &mut pyth, &config, &cap, &mut clock);
+
+    let balance_before_claim = manager.balance();
+    let residual_cash = market.claim_trading_loss_rebate(
+        &mut manager,
+        &config,
+        &oracle,
+        scenario.ctx(),
+    );
+
+    assert_eq!(
+        manager.balance(),
+        balance_before_claim + EXPECTED_REBATE_WITH_ONE_GROSS_PROFIT,
+    );
+    assert_eq!(residual_cash.value(), GROSS_PROFIT_ONE);
+    assert_eq!(market.rebate_reserve(), 0);
+
+    destroy(residual_cash);
+    return_shared(market);
+    destroy(manager);
+    destroy(oracle);
+    destroy(pyth);
+    registry::destroy_market_oracle_cap(cap);
+    destroy(config);
+    destroy(admin_cap);
+    registry::destroy_registry_drop_for_testing(registry);
+    clock.destroy_for_testing();
+    scenario.end();
+}
+
+fun prepare_live_oracle_for_trading(
+    oracle: &mut MarketOracle,
+    pyth: &mut PythSource,
+    config: &ProtocolConfig,
+    cap: &MarketOracleCap,
+    clock: &Clock,
+) {
+    pyth.set_state_for_testing(
+        SETTLEMENT_PRICE,
+        LIVE_SOURCE_TIMESTAMP_MS,
+        LIVE_SOURCE_TIMESTAMP_MS,
+    );
+    oracle.update_block_scholes_prices(
+        config,
+        pyth,
+        cap,
+        SETTLEMENT_PRICE,
+        SETTLEMENT_PRICE,
+        LIVE_SOURCE_TIMESTAMP_MS,
+        clock,
+    );
+    let svi = market_oracle::new_svi_params(1, 2, i64::zero(), i64::zero(), 3);
+    oracle.update_svi(
+        config,
+        cap,
+        svi,
+        LIVE_SOURCE_TIMESTAMP_MS,
+        clock,
+    );
+}
+
+fun settle_oracle(
+    oracle: &mut MarketOracle,
+    pyth: &mut PythSource,
+    config: &ProtocolConfig,
+    cap: &MarketOracleCap,
+    clock: &mut Clock,
+) {
+    let settlement_source_timestamp_ms = EXPIRY_MS + 1_000;
+    let settlement_update_timestamp_ms = EXPIRY_MS + 2_000;
+    clock.set_for_testing(settlement_update_timestamp_ms);
+    pyth.set_state_for_testing(
+        SETTLEMENT_PRICE,
+        settlement_source_timestamp_ms,
+        settlement_update_timestamp_ms,
+    );
+    assert!(oracle.settle_if_possible(
+        config,
+        pyth,
+        cap,
+        clock,
+    ));
+}

--- a/packages/predict/tests/flows/plp_rebate_flow_tests.move
+++ b/packages/predict/tests/flows/plp_rebate_flow_tests.move
@@ -1,0 +1,297 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module deepbook_predict::plp_rebate_flow_tests;
+
+use deepbook_predict::{
+    constants::{Self, float_scaling as float},
+    expiry_market::ExpiryMarket,
+    i64,
+    market_oracle::{Self, MarketOracle, MarketOracleCap},
+    order,
+    plp::{Self, PLP, PoolVault},
+    predict_manager::PredictManager,
+    protocol_config::{Self, ProtocolConfig},
+    pyth_source::PythSource,
+    registry::{Self, AdminCap, Registry},
+    test_constants
+};
+use dusdc::dusdc::DUSDC;
+use std::unit_test::{assert_eq, destroy};
+use sui::{
+    clock::{Self, Clock},
+    coin::{Self, Coin},
+    test_scenario::{Self as test, Scenario, return_shared}
+};
+
+const PYTH_FEED_ID: u32 = 1;
+const NOW_MS: u64 = 100_000;
+const EXPIRY_MS: u64 = 200_000;
+const MIN_STRIKE: u64 = 100_000_000_000;
+const TICK_SIZE: u64 = 1_000_000_000;
+const SETTLEMENT_PRICE: u64 = 100_000_000_000;
+const LIVE_SOURCE_TIMESTAMP_MS: u64 = 99_000;
+const ZERO_TAIL_LOWER_STRIKE: u64 = 100_100_000_000_000;
+
+const INITIAL_SUPPLY: u64 = 300_000_000_000;
+const PROTOCOL_RESERVE_SHARE: u64 = 400_000_000;
+const MIN_FEE_MINT_QUANTITY: u64 = 1_000_000_000;
+const MIN_FEE_MINT_DEPOSIT: u64 = 1_000_000_000;
+const MIN_FEE_MINT_FEE: u64 = 5_000_000;
+const MIN_FEE_REBATE_RESERVE: u64 = 2_500_000;
+const MIN_FEE_PROTOCOL_PROFIT: u64 = 1_000_000;
+
+/// Scenario-local objects shared by the PLP rebate flow tests.
+public struct Fixture {
+    scenario: Scenario,
+    registry: Registry,
+    admin_cap: AdminCap,
+    config: ProtocolConfig,
+    cap: MarketOracleCap,
+    clock: Clock,
+    vault_id: ID,
+    pyth_id: ID,
+    initial_plp: Coin<PLP>,
+}
+
+#[test]
+fun same_expiry_residual_rebate_cash_materializes_new_terminal_profit() {
+    let mut fixture = setup_pool_with_pyth();
+    fixture.config.set_min_ask_price(0);
+    let (expiry_id, oracle_id) = create_expiry(&mut fixture, EXPIRY_MS);
+    let mut manager = create_manager_for_testing(&mut fixture);
+
+    let mut pyth = fixture.scenario.take_shared_by_id<PythSource>(fixture.pyth_id);
+    let mut vault = fixture.scenario.take_shared_by_id<PoolVault>(fixture.vault_id);
+    let mut market = fixture.scenario.take_shared_by_id<ExpiryMarket>(expiry_id);
+    let mut oracle = fixture.scenario.take_shared_by_id<MarketOracle>(oracle_id);
+
+    prepare_live_oracle_for_trading(&fixture, &mut oracle, &mut pyth);
+    sync_expiry_for_testing(&mut fixture, &mut vault, &mut market, &oracle, &pyth);
+
+    manager.deposit(
+        coin::mint_for_testing<DUSDC>(MIN_FEE_MINT_DEPOSIT, fixture.scenario.ctx()),
+        fixture.scenario.ctx(),
+    );
+    let order_id = market.mint(
+        &mut manager,
+        &fixture.config,
+        &oracle,
+        &pyth,
+        ZERO_TAIL_LOWER_STRIKE,
+        constants::pos_inf!(),
+        MIN_FEE_MINT_QUANTITY,
+        order::leverage_one_x(),
+        &fixture.clock,
+        fixture.scenario.ctx(),
+    );
+    assert_eq!(manager.trading_fees_paid(expiry_id), MIN_FEE_MINT_FEE);
+
+    settle_oracle(&mut fixture, &mut oracle, &mut pyth);
+    sync_expiry_for_testing(&mut fixture, &mut vault, &mut market, &oracle, &pyth);
+
+    assert_eq!(vault.protocol_reserve_balance(), MIN_FEE_PROTOCOL_PROFIT);
+    assert_eq!(
+        vault.profit_basis_debits(),
+        constants::expiry_cash_floor!() + MIN_FEE_REBATE_RESERVE,
+    );
+    assert_eq!(
+        vault.profit_basis_credits(),
+        constants::expiry_cash_floor!() + MIN_FEE_REBATE_RESERVE,
+    );
+
+    let (closed_order_id, replacement_order_id) = market.redeem(
+        &mut manager,
+        &fixture.config,
+        &oracle,
+        &pyth,
+        order_id,
+        MIN_FEE_MINT_QUANTITY,
+        &fixture.clock,
+        fixture.scenario.ctx(),
+    );
+    assert_eq!(closed_order_id, order_id);
+    assert!(replacement_order_id.is_none());
+
+    plp::claim_trading_loss_rebate(
+        &mut vault,
+        &mut market,
+        &mut manager,
+        &fixture.config,
+        &oracle,
+        fixture.scenario.ctx(),
+    );
+
+    assert_eq!(vault.protocol_reserve_balance(), 2 * MIN_FEE_PROTOCOL_PROFIT);
+    assert_eq!(
+        vault.profit_basis_debits(),
+        constants::expiry_cash_floor!() + 2 * MIN_FEE_REBATE_RESERVE,
+    );
+    assert_eq!(
+        vault.profit_basis_credits(),
+        constants::expiry_cash_floor!() + 2 * MIN_FEE_REBATE_RESERVE,
+    );
+    assert_eq!(market.cash_balance(), 0);
+
+    return_shared(oracle);
+    return_shared(market);
+    return_shared(vault);
+    return_shared(pyth);
+    destroy(manager);
+    finish(fixture);
+}
+
+fun setup_pool_with_pyth(): Fixture {
+    let mut scenario = test::begin(test_constants::admin());
+    plp::init_for_testing(scenario.ctx());
+    let (mut registry, admin_cap) = registry::new_for_testing(scenario.ctx());
+    let mut config = protocol_config::new_for_testing(scenario.ctx());
+    config.set_protocol_reserve_profit_share(PROTOCOL_RESERVE_SHARE);
+    let cap = registry::create_market_oracle_cap(&admin_cap, scenario.ctx());
+    let mut clock = clock::create_for_testing(scenario.ctx());
+    clock.set_for_testing(NOW_MS);
+
+    scenario.next_tx(test_constants::admin());
+    let mut vault = scenario.take_shared<PoolVault>();
+    let vault_id = vault.id();
+    let sync = plp::start_pool_sync(&mut config, &vault);
+    let initial_plp = vault.supply(
+        &mut config,
+        sync,
+        coin::mint_for_testing<DUSDC>(INITIAL_SUPPLY, scenario.ctx()),
+        scenario.ctx(),
+    );
+    return_shared(vault);
+
+    scenario.next_tx(test_constants::admin());
+    let pyth_id = registry::create_pyth_source(
+        &mut registry,
+        &admin_cap,
+        PYTH_FEED_ID,
+        test_constants::default_expiry_fee_window_ms!(),
+        float!(),
+        scenario.ctx(),
+    );
+    scenario.next_tx(test_constants::admin());
+
+    Fixture {
+        scenario,
+        registry,
+        admin_cap,
+        config,
+        cap,
+        clock,
+        vault_id,
+        pyth_id,
+        initial_plp,
+    }
+}
+
+fun create_expiry(fixture: &mut Fixture, expiry: u64): (ID, ID) {
+    fixture.scenario.next_tx(test_constants::admin());
+    let pyth = fixture.scenario.take_shared_by_id<PythSource>(fixture.pyth_id);
+    let mut vault = fixture.scenario.take_shared_by_id<PoolVault>(fixture.vault_id);
+    let (expiry_id, oracle_id) = registry::create_expiry_market(
+        &mut fixture.registry,
+        &mut vault,
+        &fixture.config,
+        &pyth,
+        &fixture.cap,
+        expiry,
+        MIN_STRIKE,
+        TICK_SIZE,
+        &fixture.clock,
+        fixture.scenario.ctx(),
+    );
+    return_shared(vault);
+    return_shared(pyth);
+    fixture.scenario.next_tx(test_constants::admin());
+    (expiry_id, oracle_id)
+}
+
+fun create_manager_for_testing(fixture: &mut Fixture): PredictManager {
+    fixture.scenario.next_tx(test_constants::alice());
+    registry::create_manager(&mut fixture.registry, fixture.scenario.ctx())
+}
+
+fun prepare_live_oracle_for_trading(
+    fixture: &Fixture,
+    oracle: &mut MarketOracle,
+    pyth: &mut PythSource,
+) {
+    pyth.set_state_for_testing(
+        SETTLEMENT_PRICE,
+        LIVE_SOURCE_TIMESTAMP_MS,
+        LIVE_SOURCE_TIMESTAMP_MS,
+    );
+    oracle.update_block_scholes_prices(
+        &fixture.config,
+        pyth,
+        &fixture.cap,
+        SETTLEMENT_PRICE,
+        SETTLEMENT_PRICE,
+        LIVE_SOURCE_TIMESTAMP_MS,
+        &fixture.clock,
+    );
+    let svi = market_oracle::new_svi_params(1, 2, i64::zero(), i64::zero(), 3);
+    oracle.update_svi(
+        &fixture.config,
+        &fixture.cap,
+        svi,
+        LIVE_SOURCE_TIMESTAMP_MS,
+        &fixture.clock,
+    );
+}
+
+fun settle_oracle(fixture: &mut Fixture, oracle: &mut MarketOracle, pyth: &mut PythSource) {
+    let settlement_source_timestamp_ms = EXPIRY_MS + 1_000;
+    let settlement_update_timestamp_ms = EXPIRY_MS + 2_000;
+    fixture.clock.set_for_testing(settlement_update_timestamp_ms);
+    pyth.set_state_for_testing(
+        SETTLEMENT_PRICE,
+        settlement_source_timestamp_ms,
+        settlement_update_timestamp_ms,
+    );
+    assert!(oracle.settle_if_possible(&fixture.config, pyth, &fixture.cap, &fixture.clock));
+}
+
+fun sync_expiry_for_testing(
+    fixture: &mut Fixture,
+    vault: &mut PoolVault,
+    market: &mut ExpiryMarket,
+    oracle: &MarketOracle,
+    pyth: &PythSource,
+) {
+    let mut sync = plp::start_pool_sync(&mut fixture.config, vault);
+    sync.sync_expiry(
+        vault,
+        market,
+        &fixture.config,
+        oracle,
+        pyth,
+        &fixture.clock,
+    );
+    let _pool_value = vault.finish_pool_sync(&mut fixture.config, sync);
+}
+
+fun finish(fixture: Fixture) {
+    let Fixture {
+        scenario,
+        registry,
+        admin_cap,
+        config,
+        cap,
+        clock,
+        vault_id: _,
+        pyth_id: _,
+        initial_plp,
+    } = fixture;
+    destroy(initial_plp);
+    registry::destroy_market_oracle_cap(cap);
+    destroy(config);
+    destroy(admin_cap);
+    registry::destroy_registry_drop_for_testing(registry);
+    clock.destroy_for_testing();
+    scenario.end();
+}

--- a/packages/predict/tests/plp_accounting_tests.move
+++ b/packages/predict/tests/plp_accounting_tests.move
@@ -7,7 +7,7 @@ module deepbook_predict::plp_accounting_tests;
 use deepbook_predict::{
     config_constants,
     constants::{Self, float_scaling as float},
-    expiry_market::{Self, ExpiryMarket},
+    expiry_market::ExpiryMarket,
     market_oracle::{MarketOracle, MarketOracleCap},
     plp::{Self, PLP, PoolVault},
     protocol_config::{Self, ProtocolConfig},
@@ -92,8 +92,8 @@ fun set_max_expiry_funding_updates_registered_expiry() {
 
     registry::set_max_expiry_funding(
         &mut vault,
-        &fixture.config,
         &fixture.admin_cap,
+        &fixture.config,
         expiry_id,
         100_000_000_000,
     );
@@ -101,8 +101,8 @@ fun set_max_expiry_funding_updates_registered_expiry() {
 
     registry::set_max_expiry_funding(
         &mut vault,
-        &fixture.config,
         &fixture.admin_cap,
+        &fixture.config,
         expiry_id,
         constants::expiry_cash_floor!(),
     );
@@ -353,28 +353,6 @@ fun sync_same_expiry_twice_aborts() {
         &pyth,
         &fixture.clock,
     );
-    abort 999
-}
-
-#[test, expected_failure(abort_code = expiry_market::EWrongPreparedPoolNav)]
-fun finish_pool_nav_with_wrong_market_aborts() {
-    let mut fixture = setup_pool_with_pyth();
-    let (expiry_a_id, oracle_a_id) = create_expiry(&mut fixture, EXPIRY_MS);
-    let (expiry_b_id, _oracle_b_id) = create_expiry(&mut fixture, SECOND_EXPIRY_MS);
-
-    let mut market_a = fixture.scenario.take_shared_by_id<ExpiryMarket>(expiry_a_id);
-    let market_b = fixture.scenario.take_shared_by_id<ExpiryMarket>(expiry_b_id);
-    let oracle_a = fixture.scenario.take_shared_by_id<MarketOracle>(oracle_a_id);
-    let pyth = fixture.scenario.take_shared_by_id<PythSource>(fixture.pyth_id);
-
-    fixture.config.begin_valuation();
-    let prepared_nav = market_a.prepare_pool_sync(
-        &fixture.config,
-        &oracle_a,
-        &pyth,
-        &fixture.clock,
-    );
-    let _expiry_nav = market_b.finish_pool_nav(prepared_nav);
     abort 999
 }
 

--- a/packages/predict/tests/plp_accounting_tests.move
+++ b/packages/predict/tests/plp_accounting_tests.move
@@ -321,7 +321,7 @@ fun setup_pool_with_pyth(): Fixture {
     plp::init_for_testing(scenario.ctx());
     let (mut registry, admin_cap) = registry::new_for_testing(scenario.ctx());
     let mut config = protocol_config::new_for_testing(scenario.ctx());
-    config.set_protocol_reserve_fee_share(PROTOCOL_RESERVE_SHARE);
+    config.set_protocol_reserve_profit_share(PROTOCOL_RESERVE_SHARE);
     let cap = registry::create_market_oracle_cap(&admin_cap, scenario.ctx());
     let mut clock = clock::create_for_testing(scenario.ctx());
     clock.set_for_testing(NOW_MS);

--- a/packages/predict/tests/plp_accounting_tests.move
+++ b/packages/predict/tests/plp_accounting_tests.move
@@ -1,0 +1,431 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module deepbook_predict::plp_accounting_tests;
+
+use deepbook_predict::{
+    config_constants,
+    constants::{Self, float_scaling as float},
+    expiry_market::ExpiryMarket,
+    market_oracle::{MarketOracle, MarketOracleCap},
+    plp::{Self, PLP, PoolVault},
+    protocol_config::{Self, ProtocolConfig},
+    pyth_source::PythSource,
+    registry::{Self, AdminCap, Registry},
+    test_constants
+};
+use dusdc::dusdc::DUSDC;
+use std::unit_test::{assert_eq, destroy};
+use sui::{
+    clock::{Self, Clock},
+    coin::{Self, Coin},
+    test_scenario::{Self as test, Scenario, return_shared}
+};
+
+const PYTH_FEED_ID: u32 = 1;
+const NOW_MS: u64 = 100_000;
+const EXPIRY_MS: u64 = 200_000;
+const SECOND_EXPIRY_MS: u64 = 400_000;
+const MIN_STRIKE: u64 = 100_000_000_000;
+const TICK_SIZE: u64 = 1_000_000_000;
+const SETTLEMENT_PRICE: u64 = 100_000_000_000;
+
+const INITIAL_SUPPLY: u64 = 300_000_000_000;
+const PROTOCOL_RESERVE_SHARE: u64 = 400_000_000;
+const EXTRA_EXPIRY_CASH: u64 = 100_000_000_000;
+const TOP_UP_SHORTFALL: u64 = 10_000_000_000;
+const PARTIAL_LOSS: u64 = 20_000_000_000;
+const SECOND_EXPIRY_PROFIT: u64 = 90_000_000_000;
+const NAV_TEST_SUPPLY: u64 = 36_000_000_000;
+const NAV_TEST_EXPECTED_SHARES: u64 = 30_000_000_000;
+
+/// Scenario-local objects shared by the PLP accounting tests.
+public struct Fixture {
+    scenario: Scenario,
+    registry: Registry,
+    admin_cap: AdminCap,
+    config: ProtocolConfig,
+    cap: MarketOracleCap,
+    clock: Clock,
+    vault_id: ID,
+    pyth_id: ID,
+    initial_plp: Coin<PLP>,
+}
+
+// === Expiry Registration ===
+
+#[test]
+fun create_expiry_registers_active_flow_and_default_funding() {
+    let mut fixture = setup_pool_with_pyth();
+    let (expiry_id, _oracle_id) = create_expiry(&mut fixture, EXPIRY_MS);
+
+    let vault = fixture.scenario.take_shared_by_id<PoolVault>(fixture.vault_id);
+    let market = fixture.scenario.take_shared_by_id<ExpiryMarket>(expiry_id);
+
+    assert_eq!(market.cash_balance(), constants::expiry_cash_floor!());
+    assert_eq!(vault.idle_balance(), INITIAL_SUPPLY - constants::expiry_cash_floor!());
+    assert_eq!(vault.active_expiry_markets().length(), 1);
+    assert_eq!(vault.active_expiry_markets()[0], expiry_id);
+    let (sent_to_expiry, received_from_expiry) = vault.expiry_flow_amounts(expiry_id);
+    assert_eq!(sent_to_expiry, constants::expiry_cash_floor!());
+    assert_eq!(received_from_expiry, 0);
+    assert_eq!(
+        vault.max_expiry_funding(expiry_id),
+        config_constants::default_max_expiry_funding!(),
+    );
+    assert_eq!(vault.profit_basis_debits(), constants::expiry_cash_floor!());
+    assert_eq!(vault.profit_basis_credits(), 0);
+
+    return_shared(market);
+    return_shared(vault);
+    finish(fixture);
+}
+
+// === Max Expiry Funding ===
+
+#[test]
+fun set_max_expiry_funding_updates_registered_expiry() {
+    let mut fixture = setup_pool_with_pyth();
+    let (expiry_id, _oracle_id) = create_expiry(&mut fixture, EXPIRY_MS);
+
+    let mut vault = fixture.scenario.take_shared_by_id<PoolVault>(fixture.vault_id);
+
+    registry::set_max_expiry_funding(
+        &mut vault,
+        &fixture.config,
+        &fixture.admin_cap,
+        expiry_id,
+        100_000_000_000,
+    );
+    assert_eq!(vault.max_expiry_funding(expiry_id), 100_000_000_000);
+
+    registry::set_max_expiry_funding(
+        &mut vault,
+        &fixture.config,
+        &fixture.admin_cap,
+        expiry_id,
+        constants::expiry_cash_floor!(),
+    );
+    assert_eq!(vault.max_expiry_funding(expiry_id), constants::expiry_cash_floor!());
+
+    return_shared(vault);
+    finish(fixture);
+}
+
+// === Live Rebalancing ===
+
+#[test]
+fun rebalance_expiry_cash_tops_up_below_floor() {
+    let mut fixture = setup_pool_with_pyth();
+    let (expiry_id, oracle_id) = create_expiry(&mut fixture, EXPIRY_MS);
+
+    let mut vault = fixture.scenario.take_shared_by_id<PoolVault>(fixture.vault_id);
+    let mut market = fixture.scenario.take_shared_by_id<ExpiryMarket>(expiry_id);
+    let oracle = fixture.scenario.take_shared_by_id<MarketOracle>(oracle_id);
+
+    let cash_removed = market.release_pool_cash(TOP_UP_SHORTFALL);
+    destroy(cash_removed);
+
+    vault.rebalance_expiry_cash(&mut market, &fixture.config, &oracle, &fixture.clock);
+
+    assert_eq!(market.cash_balance(), constants::expiry_cash_floor!());
+    assert_eq!(
+        vault.idle_balance(),
+        INITIAL_SUPPLY - constants::expiry_cash_floor!() - TOP_UP_SHORTFALL,
+    );
+    let (sent_to_expiry, received_from_expiry) = vault.expiry_flow_amounts(expiry_id);
+    assert_eq!(sent_to_expiry, constants::expiry_cash_floor!() + TOP_UP_SHORTFALL);
+    assert_eq!(received_from_expiry, 0);
+    assert_eq!(vault.profit_basis_debits(), constants::expiry_cash_floor!() + TOP_UP_SHORTFALL);
+    assert_eq!(vault.profit_basis_credits(), 0);
+
+    return_shared(oracle);
+    return_shared(market);
+    return_shared(vault);
+    finish(fixture);
+}
+
+#[test]
+fun rebalance_expiry_cash_sweeps_excess_and_materializes_cash_backed_profit() {
+    let mut fixture = setup_pool_with_pyth();
+    let (expiry_id, oracle_id) = create_expiry(&mut fixture, EXPIRY_MS);
+
+    let mut vault = fixture.scenario.take_shared_by_id<PoolVault>(fixture.vault_id);
+    let mut market = fixture.scenario.take_shared_by_id<ExpiryMarket>(expiry_id);
+    let oracle = fixture.scenario.take_shared_by_id<MarketOracle>(oracle_id);
+
+    add_expiry_cash_for_accounting_test(&mut market, EXTRA_EXPIRY_CASH, fixture.scenario.ctx());
+
+    vault.rebalance_expiry_cash(&mut market, &fixture.config, &oracle, &fixture.clock);
+
+    assert_eq!(market.cash_balance(), constants::expiry_cash_floor!());
+    // Sweep returns 100b. The first 50b repays initial funding; the remaining
+    // 50b is materialized profit, split 30b LP / 20b protocol at 40%.
+    assert_eq!(vault.idle_balance(), 330_000_000_000);
+    assert_eq!(vault.protocol_reserve_balance(), 20_000_000_000);
+    let (sent_to_expiry, received_from_expiry) = vault.expiry_flow_amounts(expiry_id);
+    assert_eq!(sent_to_expiry, constants::expiry_cash_floor!());
+    assert_eq!(received_from_expiry, EXTRA_EXPIRY_CASH);
+    assert_eq!(vault.profit_basis_debits(), EXTRA_EXPIRY_CASH);
+    assert_eq!(vault.profit_basis_credits(), EXTRA_EXPIRY_CASH);
+
+    return_shared(oracle);
+    return_shared(market);
+    return_shared(vault);
+    finish(fixture);
+}
+
+// === Settled Sweeps and Profit Materialization ===
+
+#[test]
+fun sweep_settled_expiry_surplus_deactivates_and_materializes_profit() {
+    let mut fixture = setup_pool_with_pyth();
+    let (expiry_id, oracle_id) = create_expiry(&mut fixture, EXPIRY_MS);
+
+    let mut pyth = fixture.scenario.take_shared_by_id<PythSource>(fixture.pyth_id);
+    let mut vault = fixture.scenario.take_shared_by_id<PoolVault>(fixture.vault_id);
+    let mut market = fixture.scenario.take_shared_by_id<ExpiryMarket>(expiry_id);
+    let mut oracle = fixture.scenario.take_shared_by_id<MarketOracle>(oracle_id);
+
+    add_expiry_cash_for_accounting_test(&mut market, EXTRA_EXPIRY_CASH, fixture.scenario.ctx());
+    settle_oracle(&mut fixture, &mut oracle, &mut pyth, EXPIRY_MS);
+
+    vault.sweep_settled_expiry_surplus(&mut market, &fixture.config, &oracle);
+
+    assert_eq!(market.cash_balance(), 0);
+    assert_eq!(vault.active_expiry_markets().length(), 0);
+    // Settlement returns 150b. Against 50b initial funding, 100b profit is split
+    // 60b LP / 40b protocol at 40%.
+    assert_eq!(vault.idle_balance(), 360_000_000_000);
+    assert_eq!(vault.protocol_reserve_balance(), 40_000_000_000);
+    let (sent_to_expiry, received_from_expiry) = vault.expiry_flow_amounts(expiry_id);
+    assert_eq!(sent_to_expiry, constants::expiry_cash_floor!());
+    assert_eq!(received_from_expiry, constants::expiry_cash_floor!() + EXTRA_EXPIRY_CASH);
+    assert_eq!(vault.profit_basis_debits(), constants::expiry_cash_floor!() + EXTRA_EXPIRY_CASH);
+    assert_eq!(vault.profit_basis_credits(), constants::expiry_cash_floor!() + EXTRA_EXPIRY_CASH);
+
+    return_shared(oracle);
+    return_shared(market);
+    return_shared(vault);
+    return_shared(pyth);
+    finish(fixture);
+}
+
+#[test]
+fun aggregate_loss_carry_forward_blocks_protocol_profit_until_recovered() {
+    let mut fixture = setup_pool_with_pyth();
+    let (loss_expiry_id, loss_oracle_id) = create_expiry(&mut fixture, EXPIRY_MS);
+
+    let mut pyth = fixture.scenario.take_shared_by_id<PythSource>(fixture.pyth_id);
+    let mut vault = fixture.scenario.take_shared_by_id<PoolVault>(fixture.vault_id);
+    let mut loss_market = fixture.scenario.take_shared_by_id<ExpiryMarket>(loss_expiry_id);
+    let mut loss_oracle = fixture.scenario.take_shared_by_id<MarketOracle>(loss_oracle_id);
+
+    let lost_cash = loss_market.release_pool_cash(PARTIAL_LOSS);
+    destroy(lost_cash);
+    settle_oracle(&mut fixture, &mut loss_oracle, &mut pyth, EXPIRY_MS);
+    vault.sweep_settled_expiry_surplus(&mut loss_market, &fixture.config, &loss_oracle);
+
+    assert_eq!(vault.profit_basis_debits(), constants::expiry_cash_floor!());
+    assert_eq!(vault.profit_basis_credits(), constants::expiry_cash_floor!() - PARTIAL_LOSS);
+    assert_eq!(vault.protocol_reserve_balance(), 0);
+
+    return_shared(loss_oracle);
+    return_shared(loss_market);
+    return_shared(vault);
+    return_shared(pyth);
+
+    fixture.clock.set_for_testing(SECOND_EXPIRY_MS - 100_000);
+    let (profit_expiry_id, profit_oracle_id) = create_expiry(&mut fixture, SECOND_EXPIRY_MS);
+
+    let mut pyth = fixture.scenario.take_shared_by_id<PythSource>(fixture.pyth_id);
+    let mut vault = fixture.scenario.take_shared_by_id<PoolVault>(fixture.vault_id);
+    let mut profit_market = fixture.scenario.take_shared_by_id<ExpiryMarket>(profit_expiry_id);
+    let mut profit_oracle = fixture.scenario.take_shared_by_id<MarketOracle>(profit_oracle_id);
+
+    add_expiry_cash_for_accounting_test(
+        &mut profit_market,
+        SECOND_EXPIRY_PROFIT,
+        fixture.scenario.ctx(),
+    );
+    settle_oracle(
+        &mut fixture,
+        &mut profit_oracle,
+        &mut pyth,
+        SECOND_EXPIRY_MS,
+    );
+    vault.sweep_settled_expiry_surplus(&mut profit_market, &fixture.config, &profit_oracle);
+
+    // First expiry lost 20b; second expiry produced 90b. Only the net 70b is
+    // materialized, so protocol reserve receives 28b and LP idle keeps 42b.
+    assert_eq!(vault.protocol_reserve_balance(), 28_000_000_000);
+    assert_eq!(vault.idle_balance(), 342_000_000_000);
+    assert_eq!(vault.profit_basis_debits(), 170_000_000_000);
+    assert_eq!(vault.profit_basis_credits(), 170_000_000_000);
+
+    return_shared(profit_oracle);
+    return_shared(profit_market);
+    return_shared(vault);
+    return_shared(pyth);
+    finish(fixture);
+}
+
+// === Valuation Pricing ===
+
+#[test]
+fun supply_prices_active_unrealized_profit_net_of_protocol_share() {
+    let mut fixture = setup_pool_with_pyth();
+    let (expiry_id, oracle_id) = create_expiry(&mut fixture, EXPIRY_MS);
+
+    let mut vault = fixture.scenario.take_shared_by_id<PoolVault>(fixture.vault_id);
+    let mut market = fixture.scenario.take_shared_by_id<ExpiryMarket>(expiry_id);
+    let oracle = fixture.scenario.take_shared_by_id<MarketOracle>(oracle_id);
+    let pyth = fixture.scenario.take_shared_by_id<PythSource>(fixture.pyth_id);
+
+    add_expiry_cash_for_accounting_test(&mut market, EXTRA_EXPIRY_CASH, fixture.scenario.ctx());
+
+    let mut valuation = plp::start_valuation(&mut fixture.config, &vault);
+    let expiry_valuation = market.produce_valuation(
+        &fixture.config,
+        &oracle,
+        &pyth,
+        &fixture.clock,
+    );
+    valuation.add_expiry_valuation(expiry_valuation);
+    let new_plp = vault.supply(
+        &mut fixture.config,
+        valuation,
+        coin::mint_for_testing<DUSDC>(NAV_TEST_SUPPLY, fixture.scenario.ctx()),
+        fixture.scenario.ctx(),
+    );
+
+    // Pool value used for pricing is 360b:
+    // idle 250b + active expiry NAV 150b - pending protocol share 40b.
+    // 36b supply against 300b existing shares therefore mints 30b shares.
+    assert_eq!(new_plp.value(), NAV_TEST_EXPECTED_SHARES);
+    assert_eq!(vault.total_supply(), INITIAL_SUPPLY + NAV_TEST_EXPECTED_SHARES);
+
+    destroy(new_plp);
+    return_shared(pyth);
+    return_shared(oracle);
+    return_shared(market);
+    return_shared(vault);
+    finish(fixture);
+}
+
+// === Helpers ===
+
+fun setup_pool_with_pyth(): Fixture {
+    let mut scenario = test::begin(test_constants::admin());
+    plp::init_for_testing(scenario.ctx());
+    let (mut registry, admin_cap) = registry::new_for_testing(scenario.ctx());
+    let mut config = protocol_config::new_for_testing(scenario.ctx());
+    config.set_protocol_reserve_fee_share(PROTOCOL_RESERVE_SHARE);
+    let cap = registry::create_market_oracle_cap(&admin_cap, scenario.ctx());
+    let mut clock = clock::create_for_testing(scenario.ctx());
+    clock.set_for_testing(NOW_MS);
+
+    scenario.next_tx(test_constants::admin());
+    let mut vault = scenario.take_shared<PoolVault>();
+    let vault_id = vault.id();
+    let valuation = plp::start_valuation(&mut config, &vault);
+    let initial_plp = vault.supply(
+        &mut config,
+        valuation,
+        coin::mint_for_testing<DUSDC>(INITIAL_SUPPLY, scenario.ctx()),
+        scenario.ctx(),
+    );
+    return_shared(vault);
+
+    scenario.next_tx(test_constants::admin());
+    let pyth_id = registry::create_pyth_source(
+        &mut registry,
+        &admin_cap,
+        PYTH_FEED_ID,
+        test_constants::default_expiry_fee_window_ms!(),
+        float!(),
+        scenario.ctx(),
+    );
+    scenario.next_tx(test_constants::admin());
+
+    Fixture {
+        scenario,
+        registry,
+        admin_cap,
+        config,
+        cap,
+        clock,
+        vault_id,
+        pyth_id,
+        initial_plp,
+    }
+}
+
+fun create_expiry(fixture: &mut Fixture, expiry: u64): (ID, ID) {
+    fixture.scenario.next_tx(test_constants::admin());
+    let pyth = fixture.scenario.take_shared_by_id<PythSource>(fixture.pyth_id);
+    let mut vault = fixture.scenario.take_shared_by_id<PoolVault>(fixture.vault_id);
+    let (expiry_id, oracle_id) = registry::create_expiry_market(
+        &mut fixture.registry,
+        &mut vault,
+        &fixture.config,
+        &pyth,
+        &fixture.cap,
+        expiry,
+        MIN_STRIKE,
+        TICK_SIZE,
+        &fixture.clock,
+        fixture.scenario.ctx(),
+    );
+    return_shared(vault);
+    return_shared(pyth);
+    fixture.scenario.next_tx(test_constants::admin());
+    (expiry_id, oracle_id)
+}
+
+fun add_expiry_cash_for_accounting_test(
+    market: &mut ExpiryMarket,
+    amount: u64,
+    ctx: &mut TxContext,
+) {
+    market.receive_pool_cash(coin::mint_for_testing<DUSDC>(amount, ctx).into_balance());
+}
+
+fun settle_oracle(
+    fixture: &mut Fixture,
+    oracle: &mut MarketOracle,
+    pyth: &mut PythSource,
+    expiry: u64,
+) {
+    let settlement_source_timestamp_ms = expiry + 1_000;
+    let settlement_update_timestamp_ms = expiry + 2_000;
+    fixture.clock.set_for_testing(settlement_update_timestamp_ms);
+    pyth.set_state_for_testing(
+        SETTLEMENT_PRICE,
+        settlement_source_timestamp_ms,
+        settlement_update_timestamp_ms,
+    );
+    assert!(oracle.settle_if_possible(&fixture.config, pyth, &fixture.cap, &fixture.clock));
+}
+
+fun finish(fixture: Fixture) {
+    let Fixture {
+        scenario,
+        registry,
+        admin_cap,
+        config,
+        cap,
+        clock,
+        vault_id: _,
+        pyth_id: _,
+        initial_plp,
+    } = fixture;
+    destroy(initial_plp);
+    registry::destroy_market_oracle_cap(cap);
+    destroy(config);
+    destroy(admin_cap);
+    registry::destroy_registry_drop_for_testing(registry);
+    clock.destroy_for_testing();
+    scenario.end();
+}

--- a/packages/predict/tests/plp_accounting_tests.move
+++ b/packages/predict/tests/plp_accounting_tests.move
@@ -7,7 +7,7 @@ module deepbook_predict::plp_accounting_tests;
 use deepbook_predict::{
     config_constants,
     constants::{Self, float_scaling as float},
-    expiry_market::ExpiryMarket,
+    expiry_market::{Self, ExpiryMarket},
     market_oracle::{MarketOracle, MarketOracleCap},
     plp::{Self, PLP, PoolVault},
     protocol_config::{Self, ProtocolConfig},
@@ -34,7 +34,6 @@ const SETTLEMENT_PRICE: u64 = 100_000_000_000;
 const INITIAL_SUPPLY: u64 = 300_000_000_000;
 const PROTOCOL_RESERVE_SHARE: u64 = 400_000_000;
 const EXTRA_EXPIRY_CASH: u64 = 100_000_000_000;
-const TOP_UP_SHORTFALL: u64 = 10_000_000_000;
 const PARTIAL_LOSS: u64 = 20_000_000_000;
 const SECOND_EXPIRY_PROFIT: u64 = 90_000_000_000;
 const NAV_TEST_SUPPLY: u64 = 36_000_000_000;
@@ -56,25 +55,25 @@ public struct Fixture {
 // === Expiry Registration ===
 
 #[test]
-fun create_expiry_registers_active_flow_and_default_funding() {
+fun create_expiry_registers_zero_cash_active_flow_and_default_funding() {
     let mut fixture = setup_pool_with_pyth();
     let (expiry_id, _oracle_id) = create_expiry(&mut fixture, EXPIRY_MS);
 
     let vault = fixture.scenario.take_shared_by_id<PoolVault>(fixture.vault_id);
     let market = fixture.scenario.take_shared_by_id<ExpiryMarket>(expiry_id);
 
-    assert_eq!(market.cash_balance(), constants::expiry_cash_floor!());
-    assert_eq!(vault.idle_balance(), INITIAL_SUPPLY - constants::expiry_cash_floor!());
+    assert_eq!(market.cash_balance(), 0);
+    assert_eq!(vault.idle_balance(), INITIAL_SUPPLY);
     assert_eq!(vault.active_expiry_markets().length(), 1);
     assert_eq!(vault.active_expiry_markets()[0], expiry_id);
     let (sent_to_expiry, received_from_expiry) = vault.expiry_flow_amounts(expiry_id);
-    assert_eq!(sent_to_expiry, constants::expiry_cash_floor!());
+    assert_eq!(sent_to_expiry, 0);
     assert_eq!(received_from_expiry, 0);
     assert_eq!(
         vault.max_expiry_funding(expiry_id),
         config_constants::default_max_expiry_funding!(),
     );
-    assert_eq!(vault.profit_basis_debits(), constants::expiry_cash_floor!());
+    assert_eq!(vault.profit_basis_debits(), 0);
     assert_eq!(vault.profit_basis_credits(), 0);
 
     return_shared(market);
@@ -113,33 +112,29 @@ fun set_max_expiry_funding_updates_registered_expiry() {
     finish(fixture);
 }
 
-// === Live Rebalancing ===
+// === Pool Sync Rebalancing ===
 
 #[test]
-fun rebalance_expiry_cash_tops_up_below_floor() {
+fun pool_sync_tops_up_expiry_below_floor() {
     let mut fixture = setup_pool_with_pyth();
     let (expiry_id, oracle_id) = create_expiry(&mut fixture, EXPIRY_MS);
 
     let mut vault = fixture.scenario.take_shared_by_id<PoolVault>(fixture.vault_id);
     let mut market = fixture.scenario.take_shared_by_id<ExpiryMarket>(expiry_id);
     let oracle = fixture.scenario.take_shared_by_id<MarketOracle>(oracle_id);
+    let pyth = fixture.scenario.take_shared_by_id<PythSource>(fixture.pyth_id);
 
-    let cash_removed = market.release_pool_cash(TOP_UP_SHORTFALL);
-    destroy(cash_removed);
-
-    vault.rebalance_expiry_cash(&mut market, &fixture.config, &oracle, &fixture.clock);
+    sync_expiry_for_testing(&mut fixture, &mut vault, &mut market, &oracle, &pyth);
 
     assert_eq!(market.cash_balance(), constants::expiry_cash_floor!());
-    assert_eq!(
-        vault.idle_balance(),
-        INITIAL_SUPPLY - constants::expiry_cash_floor!() - TOP_UP_SHORTFALL,
-    );
+    assert_eq!(vault.idle_balance(), INITIAL_SUPPLY - constants::expiry_cash_floor!());
     let (sent_to_expiry, received_from_expiry) = vault.expiry_flow_amounts(expiry_id);
-    assert_eq!(sent_to_expiry, constants::expiry_cash_floor!() + TOP_UP_SHORTFALL);
+    assert_eq!(sent_to_expiry, constants::expiry_cash_floor!());
     assert_eq!(received_from_expiry, 0);
-    assert_eq!(vault.profit_basis_debits(), constants::expiry_cash_floor!() + TOP_UP_SHORTFALL);
+    assert_eq!(vault.profit_basis_debits(), constants::expiry_cash_floor!());
     assert_eq!(vault.profit_basis_credits(), 0);
 
+    return_shared(pyth);
     return_shared(oracle);
     return_shared(market);
     return_shared(vault);
@@ -147,39 +142,41 @@ fun rebalance_expiry_cash_tops_up_below_floor() {
 }
 
 #[test]
-fun rebalance_expiry_cash_sweeps_excess_and_materializes_cash_backed_profit() {
+fun pool_sync_sweeps_excess_and_materializes_cash_backed_profit() {
     let mut fixture = setup_pool_with_pyth();
     let (expiry_id, oracle_id) = create_expiry(&mut fixture, EXPIRY_MS);
 
     let mut vault = fixture.scenario.take_shared_by_id<PoolVault>(fixture.vault_id);
     let mut market = fixture.scenario.take_shared_by_id<ExpiryMarket>(expiry_id);
     let oracle = fixture.scenario.take_shared_by_id<MarketOracle>(oracle_id);
+    let pyth = fixture.scenario.take_shared_by_id<PythSource>(fixture.pyth_id);
 
     add_expiry_cash_for_accounting_test(&mut market, EXTRA_EXPIRY_CASH, fixture.scenario.ctx());
 
-    vault.rebalance_expiry_cash(&mut market, &fixture.config, &oracle, &fixture.clock);
+    sync_expiry_for_testing(&mut fixture, &mut vault, &mut market, &oracle, &pyth);
 
     assert_eq!(market.cash_balance(), constants::expiry_cash_floor!());
-    // Sweep returns 100b. The first 50b repays initial funding; the remaining
-    // 50b is materialized profit, split 30b LP / 20b protocol at 40%.
+    // Sweep returns 50b above the zero-liability floor; all 50b is materialized
+    // profit, split 30b LP / 20b protocol at 40%.
     assert_eq!(vault.idle_balance(), 330_000_000_000);
     assert_eq!(vault.protocol_reserve_balance(), 20_000_000_000);
     let (sent_to_expiry, received_from_expiry) = vault.expiry_flow_amounts(expiry_id);
-    assert_eq!(sent_to_expiry, constants::expiry_cash_floor!());
-    assert_eq!(received_from_expiry, EXTRA_EXPIRY_CASH);
-    assert_eq!(vault.profit_basis_debits(), EXTRA_EXPIRY_CASH);
-    assert_eq!(vault.profit_basis_credits(), EXTRA_EXPIRY_CASH);
+    assert_eq!(sent_to_expiry, 0);
+    assert_eq!(received_from_expiry, constants::expiry_cash_floor!());
+    assert_eq!(vault.profit_basis_debits(), constants::expiry_cash_floor!());
+    assert_eq!(vault.profit_basis_credits(), constants::expiry_cash_floor!());
 
+    return_shared(pyth);
     return_shared(oracle);
     return_shared(market);
     return_shared(vault);
     finish(fixture);
 }
 
-// === Settled Sweeps and Profit Materialization ===
+// === Settled Sync and Profit Materialization ===
 
 #[test]
-fun sweep_settled_expiry_surplus_deactivates_and_materializes_profit() {
+fun pool_sync_settled_expiry_deactivates_and_materializes_profit() {
     let mut fixture = setup_pool_with_pyth();
     let (expiry_id, oracle_id) = create_expiry(&mut fixture, EXPIRY_MS);
 
@@ -191,19 +188,19 @@ fun sweep_settled_expiry_surplus_deactivates_and_materializes_profit() {
     add_expiry_cash_for_accounting_test(&mut market, EXTRA_EXPIRY_CASH, fixture.scenario.ctx());
     settle_oracle(&mut fixture, &mut oracle, &mut pyth, EXPIRY_MS);
 
-    vault.sweep_settled_expiry_surplus(&mut market, &fixture.config, &oracle);
+    sync_expiry_for_testing(&mut fixture, &mut vault, &mut market, &oracle, &pyth);
 
     assert_eq!(market.cash_balance(), 0);
     assert_eq!(vault.active_expiry_markets().length(), 0);
-    // Settlement returns 150b. Against 50b initial funding, 100b profit is split
+    // Settlement returns 100b. With no prior funding, all 100b is profit split
     // 60b LP / 40b protocol at 40%.
     assert_eq!(vault.idle_balance(), 360_000_000_000);
     assert_eq!(vault.protocol_reserve_balance(), 40_000_000_000);
     let (sent_to_expiry, received_from_expiry) = vault.expiry_flow_amounts(expiry_id);
-    assert_eq!(sent_to_expiry, constants::expiry_cash_floor!());
-    assert_eq!(received_from_expiry, constants::expiry_cash_floor!() + EXTRA_EXPIRY_CASH);
-    assert_eq!(vault.profit_basis_debits(), constants::expiry_cash_floor!() + EXTRA_EXPIRY_CASH);
-    assert_eq!(vault.profit_basis_credits(), constants::expiry_cash_floor!() + EXTRA_EXPIRY_CASH);
+    assert_eq!(sent_to_expiry, 0);
+    assert_eq!(received_from_expiry, EXTRA_EXPIRY_CASH);
+    assert_eq!(vault.profit_basis_debits(), EXTRA_EXPIRY_CASH);
+    assert_eq!(vault.profit_basis_credits(), EXTRA_EXPIRY_CASH);
 
     return_shared(oracle);
     return_shared(market);
@@ -222,10 +219,11 @@ fun aggregate_loss_carry_forward_blocks_protocol_profit_until_recovered() {
     let mut loss_market = fixture.scenario.take_shared_by_id<ExpiryMarket>(loss_expiry_id);
     let mut loss_oracle = fixture.scenario.take_shared_by_id<MarketOracle>(loss_oracle_id);
 
+    sync_expiry_for_testing(&mut fixture, &mut vault, &mut loss_market, &loss_oracle, &pyth);
     let lost_cash = loss_market.release_pool_cash(PARTIAL_LOSS);
     destroy(lost_cash);
     settle_oracle(&mut fixture, &mut loss_oracle, &mut pyth, EXPIRY_MS);
-    vault.sweep_settled_expiry_surplus(&mut loss_market, &fixture.config, &loss_oracle);
+    sync_expiry_for_testing(&mut fixture, &mut vault, &mut loss_market, &loss_oracle, &pyth);
 
     assert_eq!(vault.profit_basis_debits(), constants::expiry_cash_floor!());
     assert_eq!(vault.profit_basis_credits(), constants::expiry_cash_floor!() - PARTIAL_LOSS);
@@ -255,14 +253,14 @@ fun aggregate_loss_carry_forward_blocks_protocol_profit_until_recovered() {
         &mut pyth,
         SECOND_EXPIRY_MS,
     );
-    vault.sweep_settled_expiry_surplus(&mut profit_market, &fixture.config, &profit_oracle);
+    sync_expiry_for_testing(&mut fixture, &mut vault, &mut profit_market, &profit_oracle, &pyth);
 
     // First expiry lost 20b; second expiry produced 90b. Only the net 70b is
     // materialized, so protocol reserve receives 28b and LP idle keeps 42b.
     assert_eq!(vault.protocol_reserve_balance(), 28_000_000_000);
     assert_eq!(vault.idle_balance(), 342_000_000_000);
-    assert_eq!(vault.profit_basis_debits(), 170_000_000_000);
-    assert_eq!(vault.profit_basis_credits(), 170_000_000_000);
+    assert_eq!(vault.profit_basis_debits(), 120_000_000_000);
+    assert_eq!(vault.profit_basis_credits(), 120_000_000_000);
 
     return_shared(profit_oracle);
     return_shared(profit_market);
@@ -285,23 +283,24 @@ fun supply_prices_active_unrealized_profit_net_of_protocol_share() {
 
     add_expiry_cash_for_accounting_test(&mut market, EXTRA_EXPIRY_CASH, fixture.scenario.ctx());
 
-    let mut valuation = plp::start_valuation(&mut fixture.config, &vault);
-    let expiry_valuation = market.produce_valuation(
+    let mut sync = plp::start_pool_sync(&mut fixture.config, &vault);
+    sync.sync_expiry(
+        &mut vault,
+        &mut market,
         &fixture.config,
         &oracle,
         &pyth,
         &fixture.clock,
     );
-    valuation.add_expiry_valuation(expiry_valuation);
     let new_plp = vault.supply(
         &mut fixture.config,
-        valuation,
+        sync,
         coin::mint_for_testing<DUSDC>(NAV_TEST_SUPPLY, fixture.scenario.ctx()),
         fixture.scenario.ctx(),
     );
 
     // Pool value used for pricing is 360b:
-    // idle 250b + active expiry NAV 150b - pending protocol share 40b.
+    // idle 330b + active expiry NAV 50b - pending protocol share 20b.
     // 36b supply against 300b existing shares therefore mints 30b shares.
     assert_eq!(new_plp.value(), NAV_TEST_EXPECTED_SHARES);
     assert_eq!(vault.total_supply(), INITIAL_SUPPLY + NAV_TEST_EXPECTED_SHARES);
@@ -312,6 +311,71 @@ fun supply_prices_active_unrealized_profit_net_of_protocol_share() {
     return_shared(market);
     return_shared(vault);
     finish(fixture);
+}
+
+// === Pool Sync Failures ===
+
+#[test, expected_failure(abort_code = plp::EMissingExpirySync)]
+fun finish_pool_sync_with_missing_expiry_aborts() {
+    let mut fixture = setup_pool_with_pyth();
+    let (_expiry_id, _oracle_id) = create_expiry(&mut fixture, EXPIRY_MS);
+
+    let vault = fixture.scenario.take_shared_by_id<PoolVault>(fixture.vault_id);
+    let sync = plp::start_pool_sync(&mut fixture.config, &vault);
+    let _pool_value = vault.finish_pool_sync(&mut fixture.config, sync);
+    abort 999
+}
+
+#[test, expected_failure(abort_code = plp::EExpiryMarketAlreadySynced)]
+fun sync_same_expiry_twice_aborts() {
+    let mut fixture = setup_pool_with_pyth();
+    let (expiry_id, oracle_id) = create_expiry(&mut fixture, EXPIRY_MS);
+
+    let mut vault = fixture.scenario.take_shared_by_id<PoolVault>(fixture.vault_id);
+    let mut market = fixture.scenario.take_shared_by_id<ExpiryMarket>(expiry_id);
+    let oracle = fixture.scenario.take_shared_by_id<MarketOracle>(oracle_id);
+    let pyth = fixture.scenario.take_shared_by_id<PythSource>(fixture.pyth_id);
+
+    let mut sync = plp::start_pool_sync(&mut fixture.config, &vault);
+    sync.sync_expiry(
+        &mut vault,
+        &mut market,
+        &fixture.config,
+        &oracle,
+        &pyth,
+        &fixture.clock,
+    );
+    sync.sync_expiry(
+        &mut vault,
+        &mut market,
+        &fixture.config,
+        &oracle,
+        &pyth,
+        &fixture.clock,
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = expiry_market::EWrongPreparedPoolNav)]
+fun finish_pool_nav_with_wrong_market_aborts() {
+    let mut fixture = setup_pool_with_pyth();
+    let (expiry_a_id, oracle_a_id) = create_expiry(&mut fixture, EXPIRY_MS);
+    let (expiry_b_id, _oracle_b_id) = create_expiry(&mut fixture, SECOND_EXPIRY_MS);
+
+    let mut market_a = fixture.scenario.take_shared_by_id<ExpiryMarket>(expiry_a_id);
+    let market_b = fixture.scenario.take_shared_by_id<ExpiryMarket>(expiry_b_id);
+    let oracle_a = fixture.scenario.take_shared_by_id<MarketOracle>(oracle_a_id);
+    let pyth = fixture.scenario.take_shared_by_id<PythSource>(fixture.pyth_id);
+
+    fixture.config.begin_valuation();
+    let prepared_nav = market_a.prepare_pool_sync(
+        &fixture.config,
+        &oracle_a,
+        &pyth,
+        &fixture.clock,
+    );
+    let _expiry_nav = market_b.finish_pool_nav(prepared_nav);
+    abort 999
 }
 
 // === Helpers ===
@@ -329,10 +393,10 @@ fun setup_pool_with_pyth(): Fixture {
     scenario.next_tx(test_constants::admin());
     let mut vault = scenario.take_shared<PoolVault>();
     let vault_id = vault.id();
-    let valuation = plp::start_valuation(&mut config, &vault);
+    let sync = plp::start_pool_sync(&mut config, &vault);
     let initial_plp = vault.supply(
         &mut config,
-        valuation,
+        sync,
         coin::mint_for_testing<DUSDC>(INITIAL_SUPPLY, scenario.ctx()),
         scenario.ctx(),
     );
@@ -407,6 +471,25 @@ fun settle_oracle(
         settlement_update_timestamp_ms,
     );
     assert!(oracle.settle_if_possible(&fixture.config, pyth, &fixture.cap, &fixture.clock));
+}
+
+fun sync_expiry_for_testing(
+    fixture: &mut Fixture,
+    vault: &mut PoolVault,
+    market: &mut ExpiryMarket,
+    oracle: &MarketOracle,
+    pyth: &PythSource,
+) {
+    let mut sync = plp::start_pool_sync(&mut fixture.config, vault);
+    sync.sync_expiry(
+        vault,
+        market,
+        &fixture.config,
+        oracle,
+        pyth,
+        &fixture.clock,
+    );
+    let _pool_value = vault.finish_pool_sync(&mut fixture.config, sync);
 }
 
 fun finish(fixture: Fixture) {

--- a/packages/predict/tests/plp_tests.move
+++ b/packages/predict/tests/plp_tests.move
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[test_only]
-module deepbook_predict::plp_accounting_tests;
+module deepbook_predict::plp_tests;
 
 use deepbook_predict::{
     config_constants,
@@ -38,8 +38,9 @@ const PARTIAL_LOSS: u64 = 20_000_000_000;
 const SECOND_EXPIRY_PROFIT: u64 = 90_000_000_000;
 const NAV_TEST_SUPPLY: u64 = 36_000_000_000;
 const NAV_TEST_EXPECTED_SHARES: u64 = 30_000_000_000;
+const REGISTERED_EXPIRY_ID: address = @0xA11C;
 
-/// Scenario-local objects shared by the PLP accounting tests.
+/// Scenario-local objects shared by the PLP tests.
 public struct Fixture {
     scenario: Scenario,
     registry: Registry,
@@ -55,14 +56,13 @@ public struct Fixture {
 // === Expiry Registration ===
 
 #[test]
-fun create_expiry_registers_zero_cash_active_flow_and_default_funding() {
-    let mut fixture = setup_pool_with_pyth();
-    let (expiry_id, _oracle_id) = create_expiry(&mut fixture, EXPIRY_MS);
+fun register_expiry_market_adds_zero_flow_with_default_funding() {
+    let fixture = setup_pool_with_pyth();
+    let expiry_id = REGISTERED_EXPIRY_ID.to_id();
 
-    let vault = fixture.scenario.take_shared_by_id<PoolVault>(fixture.vault_id);
-    let market = fixture.scenario.take_shared_by_id<ExpiryMarket>(expiry_id);
+    let mut vault = fixture.scenario.take_shared_by_id<PoolVault>(fixture.vault_id);
+    vault.register_expiry_market(expiry_id);
 
-    assert_eq!(market.cash_balance(), 0);
     assert_eq!(vault.idle_balance(), INITIAL_SUPPLY);
     assert_eq!(vault.active_expiry_markets().length(), 1);
     assert_eq!(vault.active_expiry_markets()[0], expiry_id);
@@ -76,7 +76,6 @@ fun create_expiry_registers_zero_cash_active_flow_and_default_funding() {
     assert_eq!(vault.profit_basis_debits(), 0);
     assert_eq!(vault.profit_basis_credits(), 0);
 
-    return_shared(market);
     return_shared(vault);
     finish(fixture);
 }
@@ -85,27 +84,16 @@ fun create_expiry_registers_zero_cash_active_flow_and_default_funding() {
 
 #[test]
 fun set_max_expiry_funding_updates_registered_expiry() {
-    let mut fixture = setup_pool_with_pyth();
-    let (expiry_id, _oracle_id) = create_expiry(&mut fixture, EXPIRY_MS);
+    let fixture = setup_pool_with_pyth();
+    let expiry_id = REGISTERED_EXPIRY_ID.to_id();
 
     let mut vault = fixture.scenario.take_shared_by_id<PoolVault>(fixture.vault_id);
+    vault.register_expiry_market(expiry_id);
 
-    registry::set_max_expiry_funding(
-        &mut vault,
-        &fixture.admin_cap,
-        &fixture.config,
-        expiry_id,
-        100_000_000_000,
-    );
+    vault.set_max_expiry_funding(&fixture.config, expiry_id, 100_000_000_000);
     assert_eq!(vault.max_expiry_funding(expiry_id), 100_000_000_000);
 
-    registry::set_max_expiry_funding(
-        &mut vault,
-        &fixture.admin_cap,
-        &fixture.config,
-        expiry_id,
-        constants::expiry_cash_floor!(),
-    );
+    vault.set_max_expiry_funding(&fixture.config, expiry_id, constants::expiry_cash_floor!());
     assert_eq!(vault.max_expiry_funding(expiry_id), constants::expiry_cash_floor!());
 
     return_shared(vault);
@@ -142,7 +130,7 @@ fun pool_sync_tops_up_expiry_below_floor() {
 }
 
 #[test]
-fun pool_sync_sweeps_excess_and_materializes_cash_backed_profit() {
+fun pool_sync_sweeps_live_excess_without_materializing_profit() {
     let mut fixture = setup_pool_with_pyth();
     let (expiry_id, oracle_id) = create_expiry(&mut fixture, EXPIRY_MS);
 
@@ -156,20 +144,104 @@ fun pool_sync_sweeps_excess_and_materializes_cash_backed_profit() {
     sync_expiry_for_testing(&mut fixture, &mut vault, &mut market, &oracle, &pyth);
 
     assert_eq!(market.cash_balance(), constants::expiry_cash_floor!());
-    // Sweep returns 50b above the zero-liability floor; all 50b is materialized
-    // profit, split 30b LP / 20b protocol at 40%.
-    assert_eq!(vault.idle_balance(), 330_000_000_000);
-    assert_eq!(vault.protocol_reserve_balance(), 20_000_000_000);
+    // Live sweep returns 50b above the zero-liability floor, but live cash is
+    // not terminal profit. It remains in pricing basis until the expiry settles.
+    assert_eq!(vault.idle_balance(), 350_000_000_000);
+    assert_eq!(vault.protocol_reserve_balance(), 0);
     let (sent_to_expiry, received_from_expiry) = vault.expiry_flow_amounts(expiry_id);
     assert_eq!(sent_to_expiry, 0);
     assert_eq!(received_from_expiry, constants::expiry_cash_floor!());
-    assert_eq!(vault.profit_basis_debits(), constants::expiry_cash_floor!());
+    assert_eq!(vault.profit_basis_debits(), 0);
     assert_eq!(vault.profit_basis_credits(), constants::expiry_cash_floor!());
 
     return_shared(pyth);
     return_shared(oracle);
     return_shared(market);
     return_shared(vault);
+    finish(fixture);
+}
+
+#[test]
+fun settled_break_even_expiry_does_not_materialize_prior_live_sweep_profit() {
+    let mut fixture = setup_pool_with_pyth();
+    let (live_expiry_id, live_oracle_id) = create_expiry(&mut fixture, SECOND_EXPIRY_MS);
+
+    let mut vault = fixture.scenario.take_shared_by_id<PoolVault>(fixture.vault_id);
+    let mut live_market = fixture.scenario.take_shared_by_id<ExpiryMarket>(live_expiry_id);
+    let live_oracle = fixture.scenario.take_shared_by_id<MarketOracle>(live_oracle_id);
+    let pyth = fixture.scenario.take_shared_by_id<PythSource>(fixture.pyth_id);
+
+    add_expiry_cash_for_accounting_test(
+        &mut live_market,
+        EXTRA_EXPIRY_CASH,
+        fixture.scenario.ctx(),
+    );
+    sync_expiry_for_testing(&mut fixture, &mut vault, &mut live_market, &live_oracle, &pyth);
+    assert_eq!(vault.protocol_reserve_balance(), 0);
+
+    return_shared(pyth);
+    return_shared(live_oracle);
+    return_shared(live_market);
+    return_shared(vault);
+
+    let (settled_expiry_id, settled_oracle_id) = create_expiry(&mut fixture, EXPIRY_MS);
+
+    let mut vault = fixture.scenario.take_shared_by_id<PoolVault>(fixture.vault_id);
+    let mut live_market = fixture.scenario.take_shared_by_id<ExpiryMarket>(live_expiry_id);
+    let live_oracle = fixture.scenario.take_shared_by_id<MarketOracle>(live_oracle_id);
+    let mut settled_market = fixture.scenario.take_shared_by_id<ExpiryMarket>(settled_expiry_id);
+    let mut settled_oracle = fixture.scenario.take_shared_by_id<MarketOracle>(settled_oracle_id);
+    let mut pyth = fixture.scenario.take_shared_by_id<PythSource>(fixture.pyth_id);
+
+    let mut sync = plp::start_pool_sync(&mut fixture.config, &vault);
+    sync.sync_expiry(
+        &mut vault,
+        &mut live_market,
+        &fixture.config,
+        &live_oracle,
+        &pyth,
+        &fixture.clock,
+    );
+    sync.sync_expiry(
+        &mut vault,
+        &mut settled_market,
+        &fixture.config,
+        &settled_oracle,
+        &pyth,
+        &fixture.clock,
+    );
+    let _pool_value = vault.finish_pool_sync(&mut fixture.config, sync);
+
+    settle_oracle(&mut fixture, &mut settled_oracle, &mut pyth, EXPIRY_MS);
+    let mut sync = plp::start_pool_sync(&mut fixture.config, &vault);
+    sync.sync_expiry(
+        &mut vault,
+        &mut live_market,
+        &fixture.config,
+        &live_oracle,
+        &pyth,
+        &fixture.clock,
+    );
+    sync.sync_expiry(
+        &mut vault,
+        &mut settled_market,
+        &fixture.config,
+        &settled_oracle,
+        &pyth,
+        &fixture.clock,
+    );
+    let _pool_value = vault.finish_pool_sync(&mut fixture.config, sync);
+
+    assert_eq!(vault.protocol_reserve_balance(), 0);
+    assert_eq!(vault.profit_basis_debits(), constants::expiry_cash_floor!());
+    assert_eq!(vault.profit_basis_credits(), 2 * constants::expiry_cash_floor!());
+
+    return_shared(settled_oracle);
+    return_shared(settled_market);
+    return_shared(live_oracle);
+    return_shared(live_market);
+    return_shared(vault);
+    return_shared(pyth);
     finish(fixture);
 }
 

--- a/packages/predict/tests/pool_accounting_tests.move
+++ b/packages/predict/tests/pool_accounting_tests.move
@@ -1,0 +1,96 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module deepbook_predict::pool_accounting_tests;
+
+use deepbook_predict::{constants, pool_accounting};
+use std::unit_test::assert_eq;
+
+const EXPIRY_ID: address = @0xACCC;
+const UNKNOWN_EXPIRY_ID: address = @0xBEEF;
+const EXPIRY_ID_0: address = @0xA000;
+const EXPIRY_ID_1: address = @0xA001;
+const EXPIRY_ID_2: address = @0xA002;
+const EXPIRY_ID_3: address = @0xA003;
+const EXPIRY_ID_4: address = @0xA004;
+const EXPIRY_ID_5: address = @0xA005;
+const EXPIRY_ID_6: address = @0xA006;
+const EXPIRY_ID_7: address = @0xA007;
+const EXPIRY_ID_8: address = @0xA008;
+const EXPIRY_ID_9: address = @0xA009;
+const EXPIRY_ID_10: address = @0xA010;
+
+#[test, expected_failure(abort_code = pool_accounting::ERegisteredExpiryAlreadyExists)]
+fun register_expiry_twice_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let expiry_id = EXPIRY_ID.to_id();
+    let mut ledger = pool_accounting::new(ctx);
+    ledger.register_expiry(expiry_id);
+    assert_eq!(ledger.active_expiry_markets().length(), 1);
+
+    ledger.register_expiry(expiry_id);
+    abort 999
+}
+
+#[test, expected_failure(abort_code = pool_accounting::EMaxActiveExpiryMarkets)]
+fun register_expiry_above_active_limit_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let mut ledger = pool_accounting::new(ctx);
+    register_ten_active_expiries(&mut ledger);
+    assert_eq!(ledger.active_expiry_markets().length(), 10);
+
+    ledger.register_expiry(EXPIRY_ID_10.to_id());
+    abort 999
+}
+
+#[test, expected_failure(abort_code = pool_accounting::EUnknownRegisteredExpiry)]
+fun unknown_expiry_flow_read_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let ledger = pool_accounting::new(ctx);
+    assert_eq!(ledger.active_expiry_markets().length(), 0);
+
+    let (_, _) = ledger.expiry_flow_amounts(UNKNOWN_EXPIRY_ID.to_id());
+    abort 999
+}
+
+#[test, expected_failure(abort_code = pool_accounting::EMaxExpiryFundingExceeded)]
+fun record_sent_above_max_expiry_funding_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let expiry_id = EXPIRY_ID.to_id();
+    let mut ledger = pool_accounting::new(ctx);
+    ledger.register_expiry(expiry_id);
+    ledger.set_max_expiry_funding(expiry_id, constants::expiry_cash_floor!());
+    assert_eq!(ledger.max_expiry_funding(expiry_id), constants::expiry_cash_floor!());
+
+    ledger.record_sent_to_expiry(expiry_id, constants::expiry_cash_floor!() + 1);
+    abort 999
+}
+
+#[test, expected_failure(abort_code = pool_accounting::ETerminalAccountingStarted)]
+fun record_sent_after_terminal_accounting_started_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let expiry_id = EXPIRY_ID.to_id();
+    let mut ledger = pool_accounting::new(ctx);
+    ledger.register_expiry(expiry_id);
+    ledger.record_sent_to_expiry(expiry_id, constants::expiry_cash_floor!());
+    ledger.record_received_from_expiry(expiry_id, constants::expiry_cash_floor!());
+    let materialized_profit = ledger.materialize_expiry_profit(expiry_id);
+    assert_eq!(materialized_profit, 0);
+
+    ledger.record_sent_to_expiry(expiry_id, 1);
+    abort 999
+}
+
+fun register_ten_active_expiries(ledger: &mut pool_accounting::Ledger) {
+    ledger.register_expiry(EXPIRY_ID_0.to_id());
+    ledger.register_expiry(EXPIRY_ID_1.to_id());
+    ledger.register_expiry(EXPIRY_ID_2.to_id());
+    ledger.register_expiry(EXPIRY_ID_3.to_id());
+    ledger.register_expiry(EXPIRY_ID_4.to_id());
+    ledger.register_expiry(EXPIRY_ID_5.to_id());
+    ledger.register_expiry(EXPIRY_ID_6.to_id());
+    ledger.register_expiry(EXPIRY_ID_7.to_id());
+    ledger.register_expiry(EXPIRY_ID_8.to_id());
+    ledger.register_expiry(EXPIRY_ID_9.to_id());
+}

--- a/packages/predict/tests/predict_manager_tests.move
+++ b/packages/predict/tests/predict_manager_tests.move
@@ -278,19 +278,21 @@ fun expiry_position_count_unknown_expiry_returns_zero() {
 // === Cash flow recording ===
 
 #[test]
-fun record_helpers_accumulate_per_expiry() {
+fun record_helpers_accumulate_into_resolved_summary() {
     let (mut scenario, registry_id) = setup();
     let mut manager = create_alice_manager(&mut scenario, registry_id);
     let expiry = FAKE_EXPIRY_ID.to_id();
 
     manager.record_trading_fee_paid(expiry, FEE_AMOUNT);
     manager.record_trading_fee_paid(expiry, FEE_AMOUNT);
-    manager.record_cash_paid_to_expiry(expiry, CASH_PAID);
-    manager.record_cash_received_from_expiry(expiry, CASH_RECEIVED);
+    manager.record_gross_paid_to_expiry(expiry, CASH_RECEIVED);
+    manager.record_gross_paid_to_expiry(expiry, CASH_RECEIVED);
+    manager.record_gross_received_from_expiry(expiry, CASH_PAID);
+    manager.record_gross_received_from_expiry(expiry, CASH_PAID);
 
-    assert_eq!(manager.trading_fees_paid(expiry), 2 * FEE_AMOUNT);
-    assert_eq!(manager.cash_paid_to_expiry(expiry), CASH_PAID);
-    assert_eq!(manager.cash_received_from_expiry(expiry), CASH_RECEIVED);
+    let (fees, gross_profit) = manager.resolve_expiry_summary(expiry);
+    assert_eq!(fees, 2 * FEE_AMOUNT);
+    assert_eq!(gross_profit, 80_000);
 
     destroy(manager);
     scenario.end();
@@ -299,19 +301,19 @@ fun record_helpers_accumulate_per_expiry() {
 #[test]
 fun record_helpers_zero_amount_is_no_op() {
     // The record_* helpers short-circuit on amount == 0 and do not even
-    // ensure the expiry summary exists. The getters then return 0 from
-    // the unknown-expiry fallback.
+    // ensure the expiry summary exists.
     let (mut scenario, registry_id) = setup();
     let mut manager = create_alice_manager(&mut scenario, registry_id);
     let expiry = FAKE_EXPIRY_ID.to_id();
 
     manager.record_trading_fee_paid(expiry, 0);
-    manager.record_cash_paid_to_expiry(expiry, 0);
-    manager.record_cash_received_from_expiry(expiry, 0);
+    manager.record_gross_paid_to_expiry(expiry, 0);
+    manager.record_gross_received_from_expiry(expiry, 0);
 
     assert_eq!(manager.trading_fees_paid(expiry), 0);
-    assert_eq!(manager.cash_paid_to_expiry(expiry), 0);
-    assert_eq!(manager.cash_received_from_expiry(expiry), 0);
+    let (fees, gross_profit) = manager.resolve_expiry_summary(expiry);
+    assert_eq!(fees, 0);
+    assert_eq!(gross_profit, 0);
 
     destroy(manager);
     scenario.end();
@@ -320,12 +322,13 @@ fun record_helpers_zero_amount_is_no_op() {
 #[test]
 fun getters_return_zero_for_unknown_expiry() {
     let (mut scenario, registry_id) = setup();
-    let manager = create_alice_manager(&mut scenario, registry_id);
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
     let expiry = FAKE_EXPIRY_ID.to_id();
 
     assert_eq!(manager.trading_fees_paid(expiry), 0);
-    assert_eq!(manager.cash_paid_to_expiry(expiry), 0);
-    assert_eq!(manager.cash_received_from_expiry(expiry), 0);
+    let (fees, gross_profit) = manager.resolve_expiry_summary(expiry);
+    assert_eq!(fees, 0);
+    assert_eq!(gross_profit, 0);
 
     destroy(manager);
     scenario.end();
@@ -339,32 +342,50 @@ fun resolve_expiry_summary_returns_zeros_for_untouched_expiry() {
     let mut manager = create_alice_manager(&mut scenario, registry_id);
     let expiry = FAKE_EXPIRY_ID.to_id();
 
-    let (fees, trading_loss) = manager.resolve_expiry_summary(expiry);
+    let (fees, gross_profit) = manager.resolve_expiry_summary(expiry);
     assert_eq!(fees, 0);
-    assert_eq!(trading_loss, 0);
+    assert_eq!(gross_profit, 0);
 
     destroy(manager);
     scenario.end();
 }
 
 #[test]
-fun resolve_expiry_summary_returns_fees_and_realized_trading_loss() {
+fun resolve_expiry_summary_returns_fees_and_zero_profit_after_loss() {
     let (mut scenario, registry_id) = setup();
     let mut manager = create_alice_manager(&mut scenario, registry_id);
     let expiry = FAKE_EXPIRY_ID.to_id();
 
     manager.record_trading_fee_paid(expiry, FEE_AMOUNT);
-    manager.record_cash_paid_to_expiry(expiry, CASH_PAID);
-    manager.record_cash_received_from_expiry(expiry, CASH_RECEIVED);
+    manager.record_gross_paid_to_expiry(expiry, CASH_PAID);
+    manager.record_gross_received_from_expiry(expiry, CASH_RECEIVED);
 
-    let (fees, trading_loss) = manager.resolve_expiry_summary(expiry);
+    let (fees, gross_profit) = manager.resolve_expiry_summary(expiry);
     assert_eq!(fees, FEE_AMOUNT);
-    assert_eq!(trading_loss, CASH_PAID - CASH_RECEIVED);
+    assert_eq!(gross_profit, 0);
 
     // Summary entry has been removed — second call returns zeros.
-    let (fees_again, trading_loss_again) = manager.resolve_expiry_summary(expiry);
+    let (fees_again, gross_profit_again) = manager.resolve_expiry_summary(expiry);
     assert_eq!(fees_again, 0);
-    assert_eq!(trading_loss_again, 0);
+    assert_eq!(gross_profit_again, 0);
+
+    destroy(manager);
+    scenario.end();
+}
+
+#[test]
+fun resolve_expiry_summary_returns_fees_and_gross_profit() {
+    let (mut scenario, registry_id) = setup();
+    let mut manager = create_alice_manager(&mut scenario, registry_id);
+    let expiry = FAKE_EXPIRY_ID.to_id();
+
+    manager.record_trading_fee_paid(expiry, FEE_AMOUNT);
+    manager.record_gross_paid_to_expiry(expiry, CASH_RECEIVED);
+    manager.record_gross_received_from_expiry(expiry, CASH_PAID);
+
+    let (fees, gross_profit) = manager.resolve_expiry_summary(expiry);
+    assert_eq!(fees, FEE_AMOUNT);
+    assert_eq!(gross_profit, 40_000);
 
     destroy(manager);
     scenario.end();

--- a/packages/predict/tests/predict_manager_tests.move
+++ b/packages/predict/tests/predict_manager_tests.move
@@ -339,17 +339,16 @@ fun resolve_expiry_summary_returns_zeros_for_untouched_expiry() {
     let mut manager = create_alice_manager(&mut scenario, registry_id);
     let expiry = FAKE_EXPIRY_ID.to_id();
 
-    let (fees, paid, received) = manager.resolve_expiry_summary(expiry);
+    let (fees, trading_loss) = manager.resolve_expiry_summary(expiry);
     assert_eq!(fees, 0);
-    assert_eq!(paid, 0);
-    assert_eq!(received, 0);
+    assert_eq!(trading_loss, 0);
 
     destroy(manager);
     scenario.end();
 }
 
 #[test]
-fun resolve_expiry_summary_returns_recorded_cash_flows_when_no_open_positions() {
+fun resolve_expiry_summary_returns_fees_and_realized_trading_loss() {
     let (mut scenario, registry_id) = setup();
     let mut manager = create_alice_manager(&mut scenario, registry_id);
     let expiry = FAKE_EXPIRY_ID.to_id();
@@ -358,16 +357,14 @@ fun resolve_expiry_summary_returns_recorded_cash_flows_when_no_open_positions() 
     manager.record_cash_paid_to_expiry(expiry, CASH_PAID);
     manager.record_cash_received_from_expiry(expiry, CASH_RECEIVED);
 
-    let (fees, paid, received) = manager.resolve_expiry_summary(expiry);
+    let (fees, trading_loss) = manager.resolve_expiry_summary(expiry);
     assert_eq!(fees, FEE_AMOUNT);
-    assert_eq!(paid, CASH_PAID);
-    assert_eq!(received, CASH_RECEIVED);
+    assert_eq!(trading_loss, CASH_PAID - CASH_RECEIVED);
 
     // Summary entry has been removed — second call returns zeros.
-    let (fees_again, paid_again, received_again) = manager.resolve_expiry_summary(expiry);
+    let (fees_again, trading_loss_again) = manager.resolve_expiry_summary(expiry);
     assert_eq!(fees_again, 0);
-    assert_eq!(paid_again, 0);
-    assert_eq!(received_again, 0);
+    assert_eq!(trading_loss_again, 0);
 
     destroy(manager);
     scenario.end();
@@ -380,7 +377,7 @@ fun resolve_expiry_summary_with_open_positions_aborts() {
     let expiry = FAKE_EXPIRY_ID.to_id();
 
     manager.add_position(expiry, ORDER_ID_A);
-    let (_, _, _) = manager.resolve_expiry_summary(expiry);
+    let (_, _) = manager.resolve_expiry_summary(expiry);
     abort 999
 }
 

--- a/packages/predict/tests/registry_setters_tests.move
+++ b/packages/predict/tests/registry_setters_tests.move
@@ -85,15 +85,14 @@ fun set_freshness_setters_forward_to_pricing_config() {
 // === Fee config setters ===
 
 #[test]
-fun set_fee_shares_forwards_all_three_to_fee_config() {
+fun set_protocol_reserve_fee_share_forwards_to_fee_config() {
     let ctx = &mut tx_context::dummy();
     let admin_cap = registry::create_admin_cap_for_testing(ctx);
     let mut config = protocol_config::new_for_testing(ctx);
 
-    registry::set_fee_shares(&mut config, &admin_cap, 700_000_000, 200_000_000, 100_000_000);
+    registry::set_protocol_reserve_fee_share(&mut config, &admin_cap, 300_000_000);
+    assert_eq!(fee_config::protocol_reserve_fee_share(config.fee_config()), 300_000_000);
     assert_eq!(fee_config::lp_fee_share(config.fee_config()), 700_000_000);
-    assert_eq!(fee_config::protocol_fee_share(config.fee_config()), 200_000_000);
-    assert_eq!(fee_config::insurance_fee_share(config.fee_config()), 100_000_000);
 
     destroy(config);
     destroy(admin_cap);

--- a/packages/predict/tests/registry_setters_tests.move
+++ b/packages/predict/tests/registry_setters_tests.move
@@ -92,7 +92,6 @@ fun set_protocol_reserve_fee_share_forwards_to_fee_config() {
 
     registry::set_protocol_reserve_fee_share(&mut config, &admin_cap, 300_000_000);
     assert_eq!(fee_config::protocol_reserve_fee_share(config.fee_config()), 300_000_000);
-    assert_eq!(fee_config::lp_fee_share(config.fee_config()), 700_000_000);
 
     destroy(config);
     destroy(admin_cap);
@@ -114,46 +113,26 @@ fun set_template_trading_loss_rebate_rate_forwards_to_fee_config() {
 // === Risk config setters ===
 
 #[test]
-fun set_max_total_exposure_pct_forwards_to_risk_config() {
+fun set_valuation_liquidation_budget_forwards_to_risk_config() {
     let ctx = &mut tx_context::dummy();
     let admin_cap = registry::create_admin_cap_for_testing(ctx);
     let mut config = protocol_config::new_for_testing(ctx);
 
-    registry::set_max_total_exposure_pct(&mut config, &admin_cap, 500_000_000);
-    assert_eq!(risk_config::max_total_exposure_pct(config.risk_config()), 500_000_000);
+    registry::set_valuation_liquidation_budget(&mut config, &admin_cap, 256);
+    assert_eq!(risk_config::valuation_liquidation_budget(config.risk_config()), 256);
 
     destroy(config);
     destroy(admin_cap);
 }
 
 #[test]
-fun set_expiry_allocation_forwards_to_risk_config() {
+fun set_trade_liquidation_budget_forwards_to_risk_config() {
     let ctx = &mut tx_context::dummy();
     let admin_cap = registry::create_admin_cap_for_testing(ctx);
     let mut config = protocol_config::new_for_testing(ctx);
 
-    registry::set_expiry_allocation(&mut config, &admin_cap, 100_000_000_000);
-    assert_eq!(risk_config::expiry_allocation(config.risk_config()), 100_000_000_000);
-
-    destroy(config);
-    destroy(admin_cap);
-}
-
-#[test]
-fun set_resize_setters_forward_to_risk_config() {
-    let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let mut config = protocol_config::new_for_testing(ctx);
-
-    registry::set_grow_utilization_threshold(&mut config, &admin_cap, 900_000_000);
-    registry::set_shrink_utilization_threshold(&mut config, &admin_cap, 200_000_000);
-    registry::set_grow_factor(&mut config, &admin_cap, 3 * float!());
-    registry::set_shrink_factor(&mut config, &admin_cap, 400_000_000);
-
-    assert_eq!(risk_config::grow_utilization_threshold(config.risk_config()), 900_000_000);
-    assert_eq!(risk_config::shrink_utilization_threshold(config.risk_config()), 200_000_000);
-    assert_eq!(risk_config::grow_factor(config.risk_config()), 3 * float!());
-    assert_eq!(risk_config::shrink_factor(config.risk_config()), 400_000_000);
+    registry::set_trade_liquidation_budget(&mut config, &admin_cap, 48);
+    assert_eq!(risk_config::trade_liquidation_budget(config.risk_config()), 48);
 
     destroy(config);
     destroy(admin_cap);

--- a/packages/predict/tests/registry_setters_tests.move
+++ b/packages/predict/tests/registry_setters_tests.move
@@ -85,13 +85,13 @@ fun set_freshness_setters_forward_to_pricing_config() {
 // === Fee config setters ===
 
 #[test]
-fun set_protocol_reserve_fee_share_forwards_to_fee_config() {
+fun set_protocol_reserve_profit_share_forwards_to_fee_config() {
     let ctx = &mut tx_context::dummy();
     let admin_cap = registry::create_admin_cap_for_testing(ctx);
     let mut config = protocol_config::new_for_testing(ctx);
 
-    registry::set_protocol_reserve_fee_share(&mut config, &admin_cap, 300_000_000);
-    assert_eq!(fee_config::protocol_reserve_fee_share(config.fee_config()), 300_000_000);
+    registry::set_protocol_reserve_profit_share(&mut config, &admin_cap, 300_000_000);
+    assert_eq!(fee_config::protocol_reserve_profit_share(config.fee_config()), 300_000_000);
 
     destroy(config);
     destroy(admin_cap);


### PR DESCRIPTION
## Summary
- Refactor Predict expiry/pool accounting so expiry markets own local cash and rebate reserves while pool accounting owns registered expiry flows, active expiry tracking, and aggregate profit basis.
- Add DUSDC profit materialization across expiry cash returns, splitting excess aggregate profit into LP idle balance and protocol reserves after loss carry-forward.
- Align configs, simulations, and tests with protocol reserve fee share, max expiry funding, rebalancing, and PLP NAV behavior.

## Line diff
Against `main...HEAD` on `at/predict-deep-buyback`:

| Area | Files | Insertions | Deletions | Net |
|---|---:|---:|---:|---:|
| `packages/predict/simulations` | 12 | 593 | 363 | +230 |
| `packages/predict/sources` | 16 | 964 | 1,216 | -252 |
| `packages/predict/tests` | 9 | 1,290 | 339 | +951 |
| **Total** | **37** | **2,847** | **1,918** | **+929** |

## Test Plan
- [x] sui move test --path packages/predict --gas-limit 100000000000