### PR TITLE
Slim Predict admin registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ These are the most important rule files to consult based on the code you touch:
   - Defaults are applied in the module that creates the config/object.
   - Global template config can be snapshotted into per-object state at creation; existing objects should only change through an explicit admin path if one is intentionally added.
   - Name global-template setters with `template` when the value affects future objects but not existing objects.
-  - External admin entrypoints live in the admin/router module, currently `registry`; config struct setters stay `public(package)`.
+  - `AdminCap` lives in `admin`. Public admin entrypoints live on the module that owns the mutated state: `protocol_config` for global protocol config, object modules for per-object admin state, and `registry` only for registry-owned version, pause-cap, uniqueness, and multi-object creation flows. Embedded config struct setters stay `public(package)`.
   - Single-value bounds live in `config_constants::assert_*`; relational checks that depend on multiple fields live in the owning config setter.
   - Do not store generic `config_id` fields inside config structs or events; object identity is enough when identity matters.
   - Do not add singleton creation flags for objects created during package init.

--- a/packages/predict/simulations/run.sh
+++ b/packages/predict/simulations/run.sh
@@ -425,7 +425,7 @@ PY
 
   PACKAGE_ID=$(echo "$PREDICT_OUTPUT" | extract_published_package_id)
   REGISTRY_ID=$(echo "$PREDICT_OUTPUT" | extract_created_object_id "registry::Registry")
-  ADMIN_CAP_ID=$(echo "$PREDICT_OUTPUT" | extract_created_object_id "registry::AdminCap")
+  ADMIN_CAP_ID=$(echo "$PREDICT_OUTPUT" | extract_created_object_id "admin::AdminCap")
   PROTOCOL_CONFIG_ID=$(echo "$PREDICT_OUTPUT" | extract_created_object_id "protocol_config::ProtocolConfig")
   POOL_VAULT_ID=$(echo "$PREDICT_OUTPUT" | extract_created_object_id "plp::PoolVault")
 

--- a/packages/predict/simulations/src/runtime.ts
+++ b/packages/predict/simulations/src/runtime.ts
@@ -294,7 +294,7 @@ export function finalizeDusdcCurrencyRegistrationTx(): Transaction {
 export function createMarketOracleCapTx(recipient: string): Transaction {
   const tx = new Transaction();
   const cap = tx.moveCall({
-    target: target("registry", "create_market_oracle_cap"),
+    target: target("market_oracle", "create_cap"),
     arguments: [tx.object(ADMIN_CAP_ID)],
   });
   tx.transferObjects([cap], tx.pure.address(recipient));

--- a/packages/predict/simulations/src/sim.ts
+++ b/packages/predict/simulations/src/sim.ts
@@ -643,7 +643,7 @@ async function setupSimulation(scenarioConfig: any, capital: SimulationCapital):
   console.log(`[${ts()}]   PoolVault: ${poolVaultId}`);
   console.log(`[${ts()}]   ProtocolConfig: ${protocolConfigId}`);
 
-  result = await executeAndWait(createMarketOracleCapTx(address), "create_market_oracle_cap");
+  result = await executeAndWait(createMarketOracleCapTx(address), "create_oracle_cap");
   const oracleCapChange = result.objectChanges.find(
     (change: any) => change.type === "created" && change.objectType.includes("MarketOracleCap"),
   );

--- a/packages/predict/sources/admin.move
+++ b/packages/predict/sources/admin.move
@@ -1,0 +1,34 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Administrative authority for Predict governance operations.
+///
+/// The package initializer creates one `AdminCap` and transfers it to the
+/// deployer. Modules that own admin-controlled state accept this capability
+/// directly instead of routing unrelated mutations through the registry.
+module deepbook_predict::admin;
+
+/// Capability for admin operations.
+/// Created during package init, transferred to deployer (multisig).
+public struct AdminCap has key, store {
+    id: UID,
+}
+
+/// Return the admin cap object ID.
+public fun id(cap: &AdminCap): ID {
+    cap.id.to_inner()
+}
+
+// === Public-Package Functions ===
+
+public(package) fun new(ctx: &mut TxContext): AdminCap {
+    AdminCap { id: object::new(ctx) }
+}
+
+// === Test-Only Functions ===
+
+#[test_only]
+/// Create an admin cap for tests.
+public fun create_admin_cap_for_testing(ctx: &mut TxContext): AdminCap {
+    new(ctx)
+}

--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -11,6 +11,7 @@ module deepbook_predict::expiry_market;
 
 use deepbook::math;
 use deepbook_predict::{
+    admin::AdminCap,
     claim_events,
     config_events,
     constants,
@@ -161,6 +162,12 @@ public fun mint_paused(market: &ExpiryMarket): bool {
 /// Return this market's mirrored set of allowed package versions.
 public fun allowed_versions(market: &ExpiryMarket): VecSet<u64> {
     market.allowed_versions
+}
+
+/// Set per-market mint pause. Admin can pause or unpause one expiry without
+/// changing global trading state.
+public fun set_mint_paused(market: &mut ExpiryMarket, _admin_cap: &AdminCap, paused: bool) {
+    market.set_mint_paused_internal(paused);
 }
 
 /// Produce this expiry's valuation witness for a full-pool valuation.
@@ -495,15 +502,9 @@ public(package) fun return_allocation(market: &mut ExpiryMarket, amount: u64): B
     market.lp_cash_balance.split(amount)
 }
 
-/// Set per-market mint pause and emit the pause-state event.
-public(package) fun set_mint_paused(market: &mut ExpiryMarket, paused: bool) {
-    market.mint_paused = paused;
-    config_events::emit_expiry_market_mint_paused_updated(market.id(), paused);
-}
-
 /// Force `mint_paused = true` (used by PauseCap path on registry; one-way).
 public(package) fun pause_mint(market: &mut ExpiryMarket) {
-    market.set_mint_paused(true);
+    market.set_mint_paused_internal(true);
 }
 
 /// Cache terminal payout liability in strike exposure if it has not already been cached.
@@ -540,6 +541,11 @@ public(package) fun release_settled_surplus(
 }
 
 // === Private Functions ===
+
+fun set_mint_paused_internal(market: &mut ExpiryMarket, paused: bool) {
+    market.mint_paused = paused;
+    config_events::emit_expiry_market_mint_paused_updated(market.id(), paused);
+}
 
 fun current_nav_terms(
     market: &mut ExpiryMarket,

--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -167,6 +167,7 @@ public fun allowed_versions(market: &ExpiryMarket): VecSet<u64> {
 /// Set per-market mint pause. Admin can pause or unpause one expiry without
 /// changing global trading state.
 public fun set_mint_paused(market: &mut ExpiryMarket, _admin_cap: &AdminCap, paused: bool) {
+    market.assert_version_allowed();
     market.set_mint_paused_internal(paused);
 }
 

--- a/packages/predict/sources/oracle/market_oracle.move
+++ b/packages/predict/sources/oracle/market_oracle.move
@@ -11,6 +11,7 @@ module deepbook_predict::market_oracle;
 
 use deepbook::math;
 use deepbook_predict::{
+    admin::AdminCap,
     config_constants,
     config_events,
     constants,
@@ -370,6 +371,32 @@ public fun set_basis_bounds(
     market.emit_bounds_updated();
 }
 
+/// Create a new oracle writer capability.
+public fun create_cap(_admin_cap: &AdminCap, ctx: &mut TxContext): MarketOracleCap {
+    MarketOracleCap { id: object::new(ctx) }
+}
+
+/// Destroy a MarketOracleCap the holder no longer needs.
+public fun destroy_cap(cap: MarketOracleCap) {
+    let MarketOracleCap { id } = cap;
+    id.delete();
+}
+
+/// Authorize an additional cap to write this market oracle.
+public fun register_cap(market: &mut MarketOracle, _admin_cap: &AdminCap, cap: &MarketOracleCap) {
+    market.register_cap_internal(cap);
+}
+
+/// Remove a cap from this market oracle's writer set.
+public fun unregister_cap(market: &mut MarketOracle, _admin_cap: &AdminCap, cap_id: ID) {
+    market.unregister_cap_internal(cap_id);
+}
+
+/// Let a cap holder remove its own cap from this market oracle.
+public fun self_unregister_cap(market: &mut MarketOracle, cap: &MarketOracleCap) {
+    market.unregister_cap_internal(cap.cap_id());
+}
+
 // === Public-Package Functions ===
 
 /// Overwrite this oracle's mirrored `allowed_versions`. The only authorized
@@ -403,15 +430,6 @@ public(package) fun settlement_price(market: &MarketOracle): u64 {
     assert!(market.is_settled(), EMarketNotSettled);
     assert!(market.settlement_source_timestamp_ms > market.expiry, EInvalidSettlementTimestamp);
     market.settlement_price.destroy_some()
-}
-
-public(package) fun create_cap(ctx: &mut TxContext): MarketOracleCap {
-    MarketOracleCap { id: object::new(ctx) }
-}
-
-public(package) fun destroy_cap(cap: MarketOracleCap) {
-    let MarketOracleCap { id } = cap;
-    id.delete();
 }
 
 /// Create and share a market oracle bound to a Pyth source and initial writer cap.
@@ -461,26 +479,6 @@ public(package) fun create_and_share(
     market_oracle_id
 }
 
-/// Authorize an additional cap to write this market oracle.
-public(package) fun register_cap(market: &mut MarketOracle, cap: &MarketOracleCap) {
-    market.assert_version_allowed();
-    let cap_id = cap.cap_id();
-    assert!(!market.authorized_cap_ids.contains(&cap_id), EInvalidMarketOracleCap);
-    market.authorized_cap_ids.insert(cap_id);
-}
-
-/// Remove a cap from this market oracle's writer set.
-public(package) fun unregister_cap(market: &mut MarketOracle, cap_id: ID) {
-    market.assert_version_allowed();
-    assert!(market.authorized_cap_ids.contains(&cap_id), EInvalidMarketOracleCap);
-    market.authorized_cap_ids.remove(&cap_id);
-}
-
-/// Let a cap holder remove its own cap from this market oracle.
-public(package) fun self_unregister_cap(market: &mut MarketOracle, cap: &MarketOracleCap) {
-    market.unregister_cap(cap.cap_id());
-}
-
 /// Abort if the running package version is not allowed for this oracle.
 public(package) fun assert_version_allowed(market: &MarketOracle) {
     assert!(
@@ -510,6 +508,19 @@ public(package) fun assert_authorized_cap(market: &MarketOracle, cap: &MarketOra
 }
 
 // === Private Functions ===
+
+fun register_cap_internal(market: &mut MarketOracle, cap: &MarketOracleCap) {
+    market.assert_version_allowed();
+    let cap_id = cap.cap_id();
+    assert!(!market.authorized_cap_ids.contains(&cap_id), EInvalidMarketOracleCap);
+    market.authorized_cap_ids.insert(cap_id);
+}
+
+fun unregister_cap_internal(market: &mut MarketOracle, cap_id: ID) {
+    market.assert_version_allowed();
+    assert!(market.authorized_cap_ids.contains(&cap_id), EInvalidMarketOracleCap);
+    market.authorized_cap_ids.remove(&cap_id);
+}
 
 fun apply_block_scholes_prices(
     market: &mut MarketOracle,

--- a/packages/predict/sources/oracle/pyth_source.move
+++ b/packages/predict/sources/oracle/pyth_source.move
@@ -9,6 +9,7 @@
 module deepbook_predict::pyth_source;
 
 use deepbook_predict::{
+    admin::AdminCap,
     config_constants,
     config_events,
     constants,
@@ -116,24 +117,11 @@ public fun expiry_fee_max_multiplier(source: &PythSource): u64 {
     source.expiry_fee_max_multiplier
 }
 
-// === Public-Package Functions ===
-
-/// Overwrite this source's mirrored `allowed_versions`. The only authorized
-/// caller is `registry::sync_pyth_source_allowed_versions`, which reads the
-/// source of truth from `Registry`.
-public(package) fun set_allowed_versions(source: &mut PythSource, allowed_versions: VecSet<u64>) {
-    source.allowed_versions = allowed_versions;
-}
-
-/// Return the timestamp that pricing can use for freshness checks.
-public(package) fun freshness_timestamp_ms(source: &PythSource): u64 {
-    source.source_timestamp_ms.min(source.update_timestamp_ms)
-}
-
 /// Set the trade-fee ramp parameters for this asset's markets. Window 0 or
 /// multiplier 1x disables the ramp.
-public(package) fun set_expiry_fee_params(
+public fun set_expiry_fee_params(
     source: &mut PythSource,
+    _admin_cap: &AdminCap,
     window_ms: u64,
     max_multiplier: u64,
 ) {
@@ -147,6 +135,20 @@ public(package) fun set_expiry_fee_params(
         window_ms,
         max_multiplier,
     );
+}
+
+// === Public-Package Functions ===
+
+/// Overwrite this source's mirrored `allowed_versions`. The only authorized
+/// caller is `registry::sync_pyth_source_allowed_versions`, which reads the
+/// source of truth from `Registry`.
+public(package) fun set_allowed_versions(source: &mut PythSource, allowed_versions: VecSet<u64>) {
+    source.allowed_versions = allowed_versions;
+}
+
+/// Return the timestamp that pricing can use for freshness checks.
+public(package) fun freshness_timestamp_ms(source: &PythSource): u64 {
+    source.source_timestamp_ms.min(source.update_timestamp_ms)
 }
 
 /// Create and share a Pyth source bound to a Lazer feed id with the per-asset

--- a/packages/predict/sources/protocol_config.move
+++ b/packages/predict/sources/protocol_config.move
@@ -9,6 +9,7 @@
 module deepbook_predict::protocol_config;
 
 use deepbook_predict::{
+    admin::AdminCap,
     config_events,
     fee_config::{Self, FeeConfig},
     leverage_config::{Self, LeverageConfig},
@@ -47,6 +48,248 @@ public fun id(config: &ProtocolConfig): ID {
 /// Return whether trading is currently paused.
 public fun trading_paused(config: &ProtocolConfig): bool {
     config.trading_paused
+}
+
+/// Set the base fee multiplier.
+public fun set_base_fee(config: &mut ProtocolConfig, _admin_cap: &AdminCap, fee: u64) {
+    config.assert_not_valuation_in_progress();
+    config.pricing_config.set_base_fee(fee);
+    config_events::emit_pricing_config_updated(config.id(), &config.pricing_config);
+}
+
+/// Set the minimum fee floor.
+public fun set_min_fee(config: &mut ProtocolConfig, _admin_cap: &AdminCap, fee: u64) {
+    config.assert_not_valuation_in_progress();
+    config.pricing_config.set_min_fee(fee);
+    config_events::emit_pricing_config_updated(config.id(), &config.pricing_config);
+}
+
+/// Set the maximum floor-index increase snapshotted by future expiry markets.
+public fun set_template_max_expiry_floor_premium(
+    config: &mut ProtocolConfig,
+    _admin_cap: &AdminCap,
+    value: u64,
+) {
+    config.assert_not_valuation_in_progress();
+    config.leverage_config.set_template_max_expiry_floor_premium(value);
+    config_events::emit_leverage_config_updated(config.id(), &config.leverage_config);
+}
+
+/// Set the liquidation LTV snapshotted by future expiry markets.
+public fun set_template_liquidation_ltv(
+    config: &mut ProtocolConfig,
+    _admin_cap: &AdminCap,
+    value: u64,
+) {
+    config.assert_not_valuation_in_progress();
+    config.leverage_config.set_template_liquidation_ltv(value);
+    config_events::emit_leverage_config_updated(config.id(), &config.leverage_config);
+}
+
+/// Set the staking benefit thresholds: `lower` (half of max benefits) and
+/// `upper` (full benefits). Validated as a pair (`upper > 2 * lower`).
+public fun set_benefit_powers(
+    config: &mut ProtocolConfig,
+    _admin_cap: &AdminCap,
+    lower: u64,
+    upper: u64,
+) {
+    config.assert_not_valuation_in_progress();
+    config.stake_config.set_benefit_powers(lower, upper);
+}
+
+/// Set the global minimum allowed mint price.
+public fun set_min_ask_price(config: &mut ProtocolConfig, _admin_cap: &AdminCap, value: u64) {
+    config.assert_not_valuation_in_progress();
+    config.pricing_config.set_min_ask_price(value);
+    config_events::emit_pricing_config_updated(config.id(), &config.pricing_config);
+}
+
+/// Set the global maximum allowed mint price.
+public fun set_max_ask_price(config: &mut ProtocolConfig, _admin_cap: &AdminCap, value: u64) {
+    config.assert_not_valuation_in_progress();
+    config.pricing_config.set_max_ask_price(value);
+    config_events::emit_pricing_config_updated(config.id(), &config.pricing_config);
+}
+
+/// Set the live Pyth spot freshness threshold.
+public fun set_pyth_spot_freshness_ms(
+    config: &mut ProtocolConfig,
+    _admin_cap: &AdminCap,
+    value: u64,
+) {
+    config.assert_not_valuation_in_progress();
+    config.pricing_config.set_pyth_spot_freshness_ms(value);
+    config_events::emit_pricing_config_updated(config.id(), &config.pricing_config);
+}
+
+/// Set the live Block Scholes spot/forward freshness threshold.
+public fun set_block_scholes_prices_freshness_ms(
+    config: &mut ProtocolConfig,
+    _admin_cap: &AdminCap,
+    value: u64,
+) {
+    config.assert_not_valuation_in_progress();
+    config.pricing_config.set_block_scholes_prices_freshness_ms(value);
+    config_events::emit_pricing_config_updated(config.id(), &config.pricing_config);
+}
+
+/// Set the live Block Scholes SVI freshness threshold.
+public fun set_block_scholes_svi_freshness_ms(
+    config: &mut ProtocolConfig,
+    _admin_cap: &AdminCap,
+    value: u64,
+) {
+    config.assert_not_valuation_in_progress();
+    config.pricing_config.set_block_scholes_svi_freshness_ms(value);
+    config_events::emit_pricing_config_updated(config.id(), &config.pricing_config);
+}
+
+/// Set the current fee surplus distribution shares used during settled expiry surplus sweeps.
+public fun set_fee_shares(
+    config: &mut ProtocolConfig,
+    _admin_cap: &AdminCap,
+    lp_fee_share: u64,
+    protocol_fee_share: u64,
+    insurance_fee_share: u64,
+) {
+    config.assert_not_valuation_in_progress();
+    config.fee_config.set_fee_shares(lp_fee_share, protocol_fee_share, insurance_fee_share);
+    config_events::emit_fee_config_updated(config.id(), &config.fee_config);
+}
+
+/// Set the trading loss rebate rate template used by future expiry markets.
+public fun set_template_trading_loss_rebate_rate(
+    config: &mut ProtocolConfig,
+    _admin_cap: &AdminCap,
+    value: u64,
+) {
+    config.assert_not_valuation_in_progress();
+    config.fee_config.set_trading_loss_rebate_rate(value);
+    config_events::emit_fee_config_updated(config.id(), &config.fee_config);
+}
+
+/// Set the maximum total exposure percentage.
+public fun set_max_total_exposure_pct(
+    config: &mut ProtocolConfig,
+    _admin_cap: &AdminCap,
+    pct: u64,
+) {
+    config.assert_not_valuation_in_progress();
+    config.risk_config.set_max_total_exposure_pct(pct);
+    config_events::emit_risk_config_updated(config.id(), &config.risk_config);
+}
+
+/// Set the current DUSDC allocation for new expiry markets.
+public fun set_expiry_allocation(
+    config: &mut ProtocolConfig,
+    _admin_cap: &AdminCap,
+    allocation: u64,
+) {
+    config.assert_not_valuation_in_progress();
+    config.risk_config.set_expiry_allocation(allocation);
+    config_events::emit_risk_config_updated(config.id(), &config.risk_config);
+}
+
+/// Set the utilization threshold that enables expiry allocation growth.
+public fun set_grow_utilization_threshold(
+    config: &mut ProtocolConfig,
+    _admin_cap: &AdminCap,
+    threshold: u64,
+) {
+    config.assert_not_valuation_in_progress();
+    config.risk_config.set_grow_utilization_threshold(threshold);
+    config_events::emit_risk_config_updated(config.id(), &config.risk_config);
+}
+
+/// Set the utilization threshold that enables expiry allocation shrink.
+public fun set_shrink_utilization_threshold(
+    config: &mut ProtocolConfig,
+    _admin_cap: &AdminCap,
+    threshold: u64,
+) {
+    config.assert_not_valuation_in_progress();
+    config.risk_config.set_shrink_utilization_threshold(threshold);
+    config_events::emit_risk_config_updated(config.id(), &config.risk_config);
+}
+
+/// Set the allocation growth target multiplier.
+public fun set_grow_factor(config: &mut ProtocolConfig, _admin_cap: &AdminCap, factor: u64) {
+    config.assert_not_valuation_in_progress();
+    config.risk_config.set_grow_factor(factor);
+    config_events::emit_risk_config_updated(config.id(), &config.risk_config);
+}
+
+/// Set the allocation shrink target multiplier.
+public fun set_shrink_factor(config: &mut ProtocolConfig, _admin_cap: &AdminCap, factor: u64) {
+    config.assert_not_valuation_in_progress();
+    config.risk_config.set_shrink_factor(factor);
+    config_events::emit_risk_config_updated(config.id(), &config.risk_config);
+}
+
+/// Set the total liquidation candidate budget used before live valuations.
+public fun set_valuation_liquidation_budget(
+    config: &mut ProtocolConfig,
+    _admin_cap: &AdminCap,
+    budget: u64,
+) {
+    config.assert_not_valuation_in_progress();
+    config.risk_config.set_valuation_liquidation_budget(budget);
+    config_events::emit_risk_config_updated(config.id(), &config.risk_config);
+}
+
+/// Set the total liquidation candidate budget used before mint and redeem flows.
+public fun set_trade_liquidation_budget(
+    config: &mut ProtocolConfig,
+    _admin_cap: &AdminCap,
+    budget: u64,
+) {
+    config.assert_not_valuation_in_progress();
+    config.risk_config.set_trade_liquidation_budget(budget);
+    config_events::emit_risk_config_updated(config.id(), &config.risk_config);
+}
+
+/// Set the settlement freshness threshold template for future market oracles.
+public fun set_market_oracle_template_settlement_freshness_ms(
+    config: &mut ProtocolConfig,
+    _admin_cap: &AdminCap,
+    value: u64,
+) {
+    config.assert_not_valuation_in_progress();
+    config.market_oracle_config.set_settlement_freshness_ms(value);
+    config_events::emit_market_oracle_template_config_updated(
+        config.id(),
+        &config.market_oracle_config,
+    );
+}
+
+/// Set basis guard bounds template for future market oracles.
+public fun set_market_oracle_template_basis_bounds(
+    config: &mut ProtocolConfig,
+    _admin_cap: &AdminCap,
+    max_spot_deviation: u64,
+    max_basis_deviation: u64,
+    min_basis: u64,
+    max_basis: u64,
+) {
+    config.assert_not_valuation_in_progress();
+    config
+        .market_oracle_config
+        .set_basis_bounds(
+            max_spot_deviation,
+            max_basis_deviation,
+            min_basis,
+            max_basis,
+        );
+    config_events::emit_market_oracle_template_config_updated(
+        config.id(),
+        &config.market_oracle_config,
+    );
+}
+
+/// Set whether trading is paused.
+public fun set_trading_paused(config: &mut ProtocolConfig, _admin_cap: &AdminCap, paused: bool) {
+    config.set_trading_paused_internal(paused);
 }
 
 // === Public-Package Functions ===
@@ -103,176 +346,10 @@ public(package) fun create_and_share(ctx: &mut TxContext): ID {
     id
 }
 
-public(package) fun set_base_fee(config: &mut ProtocolConfig, fee: u64) {
-    config.assert_not_valuation_in_progress();
-    config.pricing_config.set_base_fee(fee);
-    config_events::emit_pricing_config_updated(config.id(), &config.pricing_config);
-}
-
-public(package) fun set_min_fee(config: &mut ProtocolConfig, fee: u64) {
-    config.assert_not_valuation_in_progress();
-    config.pricing_config.set_min_fee(fee);
-    config_events::emit_pricing_config_updated(config.id(), &config.pricing_config);
-}
-
-public(package) fun set_template_max_expiry_floor_premium(config: &mut ProtocolConfig, value: u64) {
-    config.assert_not_valuation_in_progress();
-    config.leverage_config.set_template_max_expiry_floor_premium(value);
-    config_events::emit_leverage_config_updated(config.id(), &config.leverage_config);
-}
-
-public(package) fun set_template_liquidation_ltv(config: &mut ProtocolConfig, value: u64) {
-    config.assert_not_valuation_in_progress();
-    config.leverage_config.set_template_liquidation_ltv(value);
-    config_events::emit_leverage_config_updated(config.id(), &config.leverage_config);
-}
-
-public(package) fun set_benefit_powers(config: &mut ProtocolConfig, lower: u64, upper: u64) {
-    config.assert_not_valuation_in_progress();
-    config.stake_config.set_benefit_powers(lower, upper);
-}
-
-public(package) fun set_min_ask_price(config: &mut ProtocolConfig, value: u64) {
-    config.assert_not_valuation_in_progress();
-    config.pricing_config.set_min_ask_price(value);
-    config_events::emit_pricing_config_updated(config.id(), &config.pricing_config);
-}
-
-public(package) fun set_max_ask_price(config: &mut ProtocolConfig, value: u64) {
-    config.assert_not_valuation_in_progress();
-    config.pricing_config.set_max_ask_price(value);
-    config_events::emit_pricing_config_updated(config.id(), &config.pricing_config);
-}
-
-public(package) fun set_pyth_spot_freshness_ms(config: &mut ProtocolConfig, value: u64) {
-    config.assert_not_valuation_in_progress();
-    config.pricing_config.set_pyth_spot_freshness_ms(value);
-    config_events::emit_pricing_config_updated(config.id(), &config.pricing_config);
-}
-
-public(package) fun set_block_scholes_prices_freshness_ms(config: &mut ProtocolConfig, value: u64) {
-    config.assert_not_valuation_in_progress();
-    config.pricing_config.set_block_scholes_prices_freshness_ms(value);
-    config_events::emit_pricing_config_updated(config.id(), &config.pricing_config);
-}
-
-public(package) fun set_block_scholes_svi_freshness_ms(config: &mut ProtocolConfig, value: u64) {
-    config.assert_not_valuation_in_progress();
-    config.pricing_config.set_block_scholes_svi_freshness_ms(value);
-    config_events::emit_pricing_config_updated(config.id(), &config.pricing_config);
-}
-
-public(package) fun set_fee_shares(
-    config: &mut ProtocolConfig,
-    lp_fee_share: u64,
-    protocol_fee_share: u64,
-    insurance_fee_share: u64,
-) {
-    config.assert_not_valuation_in_progress();
-    config.fee_config.set_fee_shares(lp_fee_share, protocol_fee_share, insurance_fee_share);
-    config_events::emit_fee_config_updated(config.id(), &config.fee_config);
-}
-
-public(package) fun set_template_trading_loss_rebate_rate(config: &mut ProtocolConfig, value: u64) {
-    config.assert_not_valuation_in_progress();
-    config.fee_config.set_trading_loss_rebate_rate(value);
-    config_events::emit_fee_config_updated(config.id(), &config.fee_config);
-}
-
-public(package) fun set_max_total_exposure_pct(config: &mut ProtocolConfig, pct: u64) {
-    config.assert_not_valuation_in_progress();
-    config.risk_config.set_max_total_exposure_pct(pct);
-    config_events::emit_risk_config_updated(config.id(), &config.risk_config);
-}
-
-public(package) fun set_expiry_allocation(config: &mut ProtocolConfig, allocation: u64) {
-    config.assert_not_valuation_in_progress();
-    config.risk_config.set_expiry_allocation(allocation);
-    config_events::emit_risk_config_updated(config.id(), &config.risk_config);
-}
-
-public(package) fun set_grow_utilization_threshold(config: &mut ProtocolConfig, threshold: u64) {
-    config.assert_not_valuation_in_progress();
-    config.risk_config.set_grow_utilization_threshold(threshold);
-    config_events::emit_risk_config_updated(config.id(), &config.risk_config);
-}
-
-public(package) fun set_shrink_utilization_threshold(config: &mut ProtocolConfig, threshold: u64) {
-    config.assert_not_valuation_in_progress();
-    config.risk_config.set_shrink_utilization_threshold(threshold);
-    config_events::emit_risk_config_updated(config.id(), &config.risk_config);
-}
-
-public(package) fun set_grow_factor(config: &mut ProtocolConfig, factor: u64) {
-    config.assert_not_valuation_in_progress();
-    config.risk_config.set_grow_factor(factor);
-    config_events::emit_risk_config_updated(config.id(), &config.risk_config);
-}
-
-public(package) fun set_shrink_factor(config: &mut ProtocolConfig, factor: u64) {
-    config.assert_not_valuation_in_progress();
-    config.risk_config.set_shrink_factor(factor);
-    config_events::emit_risk_config_updated(config.id(), &config.risk_config);
-}
-
-public(package) fun set_valuation_liquidation_budget(config: &mut ProtocolConfig, budget: u64) {
-    config.assert_not_valuation_in_progress();
-    config.risk_config.set_valuation_liquidation_budget(budget);
-    config_events::emit_risk_config_updated(config.id(), &config.risk_config);
-}
-
-public(package) fun set_trade_liquidation_budget(config: &mut ProtocolConfig, budget: u64) {
-    config.assert_not_valuation_in_progress();
-    config.risk_config.set_trade_liquidation_budget(budget);
-    config_events::emit_risk_config_updated(config.id(), &config.risk_config);
-}
-
-/// Set the settlement freshness threshold template for future market oracles.
-public(package) fun set_market_oracle_template_settlement_freshness_ms(
-    config: &mut ProtocolConfig,
-    value: u64,
-) {
-    config.assert_not_valuation_in_progress();
-    config.market_oracle_config.set_settlement_freshness_ms(value);
-    config_events::emit_market_oracle_template_config_updated(
-        config.id(),
-        &config.market_oracle_config,
-    );
-}
-
-/// Set basis guard bounds template for future market oracles.
-public(package) fun set_market_oracle_template_basis_bounds(
-    config: &mut ProtocolConfig,
-    max_spot_deviation: u64,
-    max_basis_deviation: u64,
-    min_basis: u64,
-    max_basis: u64,
-) {
-    config.assert_not_valuation_in_progress();
-    config
-        .market_oracle_config
-        .set_basis_bounds(
-            max_spot_deviation,
-            max_basis_deviation,
-            min_basis,
-            max_basis,
-        );
-    config_events::emit_market_oracle_template_config_updated(
-        config.id(),
-        &config.market_oracle_config,
-    );
-}
-
-public(package) fun set_trading_paused(config: &mut ProtocolConfig, paused: bool) {
-    config.assert_not_valuation_in_progress();
-    config.trading_paused = paused;
-    config_events::emit_trading_paused_updated(config.id(), paused);
-}
-
 /// Force `trading_paused = true` without admin authority. Reserved for
 /// `PauseCap` holders going through the registry; cannot be used to unpause.
 public(package) fun pause_trading(config: &mut ProtocolConfig) {
-    config.set_trading_paused(true);
+    config.set_trading_paused_internal(true);
 }
 
 /// Begin a transaction-local full-pool valuation lock.
@@ -285,6 +362,12 @@ public(package) fun begin_valuation(config: &mut ProtocolConfig) {
 public(package) fun end_valuation(config: &mut ProtocolConfig) {
     config.assert_valuation_in_progress();
     config.valuation_in_progress = false;
+}
+
+fun set_trading_paused_internal(config: &mut ProtocolConfig, paused: bool) {
+    config.assert_not_valuation_in_progress();
+    config.trading_paused = paused;
+    config_events::emit_trading_paused_updated(config.id(), paused);
 }
 
 /// Abort unless trading is not paused.

--- a/packages/predict/sources/registry.move
+++ b/packages/predict/sources/registry.move
@@ -310,7 +310,7 @@ fun init(ctx: &mut TxContext) {
     let (registry, admin_cap) = new_registry_and_admin_cap(ctx);
     protocol_config::create_and_share(ctx);
     transfer::share_object(registry);
-    transfer::transfer(admin_cap, ctx.sender());
+    transfer::public_transfer(admin_cap, ctx.sender());
 }
 
 /// Construct registry and admin cap during package init or tests.
@@ -349,7 +349,7 @@ public fun init_for_testing(ctx: &mut TxContext): ID {
     let registry_id = registry.id();
     protocol_config::create_and_share(ctx);
     transfer::share_object(registry);
-    transfer::transfer(admin_cap, ctx.sender());
+    transfer::public_transfer(admin_cap, ctx.sender());
 
     registry_id
 }

--- a/packages/predict/sources/registry.move
+++ b/packages/predict/sources/registry.move
@@ -1,15 +1,16 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Registry and admin entrypoints for the Predict protocol.
+/// Registry, versioning, and creation entrypoints for the Predict protocol.
 ///
 /// This module creates shared setup objects, stores uniqueness indexes for
-/// Pyth sources and expiries, and exposes admin/governance entrypoints. Runtime
+/// Pyth sources and expiries, and exposes registry-owned governance entrypoints. Runtime
 /// pool accounting, expiry risk, oracle state, and user positions stay in their
 /// owning modules.
 module deepbook_predict::registry;
 
 use deepbook_predict::{
+    admin::{Self, AdminCap},
     builder_code,
     config_events,
     constants,
@@ -32,12 +33,6 @@ const EPackageVersionDisabled: u64 = 5;
 const EVersionAlreadyEnabled: u64 = 6;
 const EVersionNotEnabled: u64 = 7;
 const ECannotDisableLastVersion: u64 = 8;
-
-/// Capability for admin operations.
-/// Created during package init, transferred to deployer (multisig).
-public struct AdminCap has key, store {
-    id: UID,
-}
 
 /// Capability for emergency pause operations. Admin can mint these for
 /// trusted operators; holders can disable versions, pause global trading,
@@ -81,210 +76,6 @@ public fun pyth_source_id(registry: &Registry, pyth_lazer_feed_id: u32): Option<
     } else {
         option::none()
     }
-}
-
-/// Set the base fee multiplier.
-public fun set_base_fee(config: &mut ProtocolConfig, _admin_cap: &AdminCap, fee: u64) {
-    config.set_base_fee(fee);
-}
-
-/// Set the minimum fee floor.
-public fun set_min_fee(config: &mut ProtocolConfig, _admin_cap: &AdminCap, fee: u64) {
-    config.set_min_fee(fee);
-}
-
-/// Set the maximum floor-index increase snapshotted by future expiry markets.
-public fun set_template_max_expiry_floor_premium(
-    config: &mut ProtocolConfig,
-    _admin_cap: &AdminCap,
-    value: u64,
-) {
-    config.set_template_max_expiry_floor_premium(value);
-}
-
-/// Set the staking benefit thresholds: `lower` (half of max benefits) and
-/// `upper` (full benefits). Validated as a pair (`upper > 2 * lower`).
-public fun set_benefit_powers(
-    config: &mut ProtocolConfig,
-    _admin_cap: &AdminCap,
-    lower: u64,
-    upper: u64,
-) {
-    config.set_benefit_powers(lower, upper);
-}
-
-/// Set the per-asset time-to-expiry fee ramp for a Pyth source's markets.
-/// `window_ms` (0 disables) is the ms-before-expiry over which the fee ramps up;
-/// `max_multiplier` (FLOAT_SCALING, 1x disables) is the multiplier reached at
-/// expiry. Larger values suit more volatile assets.
-public fun set_pyth_source_expiry_fee_params(
-    pyth: &mut PythSource,
-    _admin_cap: &AdminCap,
-    window_ms: u64,
-    max_multiplier: u64,
-) {
-    pyth.set_expiry_fee_params(window_ms, max_multiplier);
-}
-
-/// Set the liquidation LTV snapshotted by future expiry markets.
-public fun set_template_liquidation_ltv(
-    config: &mut ProtocolConfig,
-    _admin_cap: &AdminCap,
-    value: u64,
-) {
-    config.set_template_liquidation_ltv(value);
-}
-
-/// Set the global minimum allowed mint price.
-public fun set_min_ask_price(config: &mut ProtocolConfig, _admin_cap: &AdminCap, value: u64) {
-    config.set_min_ask_price(value);
-}
-
-/// Set the global maximum allowed mint price.
-public fun set_max_ask_price(config: &mut ProtocolConfig, _admin_cap: &AdminCap, value: u64) {
-    config.set_max_ask_price(value);
-}
-
-/// Set the live Pyth spot freshness threshold.
-public fun set_pyth_spot_freshness_ms(
-    config: &mut ProtocolConfig,
-    _admin_cap: &AdminCap,
-    value: u64,
-) {
-    config.set_pyth_spot_freshness_ms(value);
-}
-
-/// Set the live Block Scholes spot/forward freshness threshold.
-public fun set_block_scholes_prices_freshness_ms(
-    config: &mut ProtocolConfig,
-    _admin_cap: &AdminCap,
-    value: u64,
-) {
-    config.set_block_scholes_prices_freshness_ms(value);
-}
-
-/// Set the live Block Scholes SVI freshness threshold.
-public fun set_block_scholes_svi_freshness_ms(
-    config: &mut ProtocolConfig,
-    _admin_cap: &AdminCap,
-    value: u64,
-) {
-    config.set_block_scholes_svi_freshness_ms(value);
-}
-
-/// Set the current fee surplus distribution shares used during settled expiry surplus sweeps.
-public fun set_fee_shares(
-    config: &mut ProtocolConfig,
-    _admin_cap: &AdminCap,
-    lp_fee_share: u64,
-    protocol_fee_share: u64,
-    insurance_fee_share: u64,
-) {
-    config.set_fee_shares(lp_fee_share, protocol_fee_share, insurance_fee_share);
-}
-
-/// Set the trading loss rebate rate template used by future expiry markets.
-public fun set_template_trading_loss_rebate_rate(
-    config: &mut ProtocolConfig,
-    _admin_cap: &AdminCap,
-    value: u64,
-) {
-    config.set_template_trading_loss_rebate_rate(value);
-}
-
-/// Set the maximum total exposure percentage.
-public fun set_max_total_exposure_pct(
-    config: &mut ProtocolConfig,
-    _admin_cap: &AdminCap,
-    pct: u64,
-) {
-    config.set_max_total_exposure_pct(pct);
-}
-
-/// Set the current DUSDC allocation for new expiry markets.
-public fun set_expiry_allocation(
-    config: &mut ProtocolConfig,
-    _admin_cap: &AdminCap,
-    allocation: u64,
-) {
-    config.set_expiry_allocation(allocation);
-}
-
-/// Set the utilization threshold that enables expiry allocation growth.
-public fun set_grow_utilization_threshold(
-    config: &mut ProtocolConfig,
-    _admin_cap: &AdminCap,
-    threshold: u64,
-) {
-    config.set_grow_utilization_threshold(threshold);
-}
-
-/// Set the utilization threshold that enables expiry allocation shrink.
-public fun set_shrink_utilization_threshold(
-    config: &mut ProtocolConfig,
-    _admin_cap: &AdminCap,
-    threshold: u64,
-) {
-    config.set_shrink_utilization_threshold(threshold);
-}
-
-/// Set the allocation growth target multiplier.
-public fun set_grow_factor(config: &mut ProtocolConfig, _admin_cap: &AdminCap, factor: u64) {
-    config.set_grow_factor(factor);
-}
-
-/// Set the allocation shrink target multiplier.
-public fun set_shrink_factor(config: &mut ProtocolConfig, _admin_cap: &AdminCap, factor: u64) {
-    config.set_shrink_factor(factor);
-}
-
-/// Set the total liquidation candidate budget used before live valuations.
-public fun set_valuation_liquidation_budget(
-    config: &mut ProtocolConfig,
-    _admin_cap: &AdminCap,
-    budget: u64,
-) {
-    config.set_valuation_liquidation_budget(budget);
-}
-
-/// Set the total liquidation candidate budget used before mint and redeem flows.
-public fun set_trade_liquidation_budget(
-    config: &mut ProtocolConfig,
-    _admin_cap: &AdminCap,
-    budget: u64,
-) {
-    config.set_trade_liquidation_budget(budget);
-}
-
-/// Set the settlement freshness threshold template used by future market oracles.
-public fun set_market_oracle_template_settlement_freshness_ms(
-    config: &mut ProtocolConfig,
-    _admin_cap: &AdminCap,
-    value: u64,
-) {
-    config.set_market_oracle_template_settlement_freshness_ms(value);
-}
-
-/// Set basis guard bounds template used by future market oracles.
-public fun set_market_oracle_template_basis_bounds(
-    config: &mut ProtocolConfig,
-    _admin_cap: &AdminCap,
-    max_spot_deviation: u64,
-    max_basis_deviation: u64,
-    min_basis: u64,
-    max_basis: u64,
-) {
-    config.set_market_oracle_template_basis_bounds(
-        max_spot_deviation,
-        max_basis_deviation,
-        min_basis,
-        max_basis,
-    );
-}
-
-/// Set whether trading is paused.
-public fun set_trading_paused(config: &mut ProtocolConfig, _admin_cap: &AdminCap, paused: bool) {
-    config.set_trading_paused(paused);
 }
 
 // === Version Management (admin) ===
@@ -380,7 +171,7 @@ public fun pause_trading_pause_cap(
 }
 
 /// Force `mint_paused = true` on a single expiry market via a valid `PauseCap`.
-/// One-way; admin's `set_expiry_market_mint_paused` is needed to unpause.
+/// One-way; admin's `expiry_market::set_mint_paused` is needed to unpause.
 public fun pause_expiry_market_mint_pause_cap(
     market: &mut ExpiryMarket,
     registry: &Registry,
@@ -388,17 +179,6 @@ public fun pause_expiry_market_mint_pause_cap(
 ) {
     registry.assert_valid_pause_cap(pause_cap);
     market.pause_mint();
-}
-
-// === Per-Market Mint Pause (admin) ===
-
-/// Set `mint_paused` on a single expiry market. Admin can pause or unpause.
-public fun set_expiry_market_mint_paused(
-    market: &mut ExpiryMarket,
-    _admin_cap: &AdminCap,
-    paused: bool,
-) {
-    market.set_mint_paused(paused);
 }
 
 /// Create a shared Pyth source for one admin-approved Lazer feed, configuring
@@ -424,39 +204,6 @@ public fun create_pyth_source(
     );
     registry.pyth_source_ids.add(pyth_lazer_feed_id, pyth_source_id);
     pyth_source_id
-}
-
-/// Admin-only creation of a new MarketOracleCap.
-public fun create_market_oracle_cap(_admin_cap: &AdminCap, ctx: &mut TxContext): MarketOracleCap {
-    market_oracle::create_cap(ctx)
-}
-
-/// Register an additional MarketOracleCap as authorized to update a market oracle.
-public fun register_market_oracle_cap(
-    market: &mut MarketOracle,
-    _admin_cap: &AdminCap,
-    cap: &MarketOracleCap,
-) {
-    market.register_cap(cap);
-}
-
-/// Revoke a MarketOracleCap's authorization on a market oracle.
-public fun unregister_market_oracle_cap(
-    market: &mut MarketOracle,
-    _admin_cap: &AdminCap,
-    cap_id: ID,
-) {
-    market.unregister_cap(cap_id);
-}
-
-/// Cap holder voluntarily removes its own cap from a market oracle.
-public fun self_unregister_market_oracle_cap(market: &mut MarketOracle, cap: &MarketOracleCap) {
-    market.self_unregister_cap(cap);
-}
-
-/// Destroy a MarketOracleCap the holder no longer needs.
-public fun destroy_market_oracle_cap(cap: MarketOracleCap) {
-    cap.destroy_cap();
 }
 
 /// Create the MarketOracle and ExpiryMarket objects for one future expiry.
@@ -576,9 +323,7 @@ fun new_registry_and_admin_cap(ctx: &mut TxContext): (Registry, AdminCap) {
             allowed_pause_caps: vec_set::empty(),
             allowed_versions: vec_set::singleton(constants::current_version!()),
         },
-        AdminCap {
-            id: object::new(ctx),
-        },
+        admin::new(ctx),
     )
 }
 
@@ -607,12 +352,6 @@ public fun init_for_testing(ctx: &mut TxContext): ID {
     transfer::transfer(admin_cap, ctx.sender());
 
     registry_id
-}
-
-#[test_only]
-/// Create an admin cap for tests.
-public fun create_admin_cap_for_testing(ctx: &mut TxContext): AdminCap {
-    AdminCap { id: object::new(ctx) }
 }
 
 #[test_only]

--- a/packages/predict/tests/admin_setters_tests.move
+++ b/packages/predict/tests/admin_setters_tests.move
@@ -5,7 +5,7 @@
 /// The tests verify each value reaches its destination and can be read back
 /// through the owning object's getter.
 #[test_only]
-module deepbook_predict::registry_setters_tests;
+module deepbook_predict::admin_setters_tests;
 
 use deepbook_predict::{
     admin,

--- a/packages/predict/tests/helper/oracle_cap_tests.move
+++ b/packages/predict/tests/helper/oracle_cap_tests.move
@@ -5,10 +5,10 @@
 module deepbook_predict::oracle_cap_tests;
 
 use deepbook_predict::{
+    admin,
     i64,
     market_oracle::{Self, MarketOracle, MarketOracleCap},
-    protocol_config::{Self, ProtocolConfig},
-    registry
+    protocol_config::{Self, ProtocolConfig}
 };
 use std::unit_test::destroy;
 use sui::clock;
@@ -21,13 +21,13 @@ const SECOND_SVI_SOURCE_TIMESTAMP_MS: u64 = 2_000;
 #[test]
 fun admin_can_create_multiple_market_oracle_caps() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap_1 = registry::create_market_oracle_cap(&admin_cap, ctx);
-    let cap_2 = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap_1 = market_oracle::create_cap(&admin_cap, ctx);
+    let cap_2 = market_oracle::create_cap(&admin_cap, ctx);
 
     assert!(cap_1.cap_id() != cap_2.cap_id());
-    registry::destroy_market_oracle_cap(cap_1);
-    registry::destroy_market_oracle_cap(cap_2);
+    market_oracle::destroy_cap(cap_1);
+    market_oracle::destroy_cap(cap_2);
     destroy(admin_cap);
 }
 
@@ -46,7 +46,7 @@ fun creator_cap_can_update_market_oracle() {
 fun unregistered_cap_cannot_update_market_oracle() {
     let ctx = &mut tx_context::dummy();
     let (mut market, config, _cap, admin_cap, clock) = setup(ctx);
-    let unregistered_cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let unregistered_cap = market_oracle::create_cap(&admin_cap, ctx);
 
     write_svi(
         &mut market,
@@ -62,9 +62,9 @@ fun unregistered_cap_cannot_update_market_oracle() {
 fun registered_cap_can_update_market_oracle() {
     let ctx = &mut tx_context::dummy();
     let (mut market, config, cap_1, admin_cap, clock) = setup(ctx);
-    let cap_2 = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let cap_2 = market_oracle::create_cap(&admin_cap, ctx);
 
-    registry::register_market_oracle_cap(&mut market, &admin_cap, &cap_2);
+    market_oracle::register_cap(&mut market, &admin_cap, &cap_2);
     write_svi(&mut market, &config, &cap_2, FIRST_SVI_SOURCE_TIMESTAMP_MS, &clock);
     assert!(market.block_scholes_svi_source_timestamp_ms() == FIRST_SVI_SOURCE_TIMESTAMP_MS);
 
@@ -75,11 +75,11 @@ fun registered_cap_can_update_market_oracle() {
 fun unregistered_cap_loses_market_oracle_access() {
     let ctx = &mut tx_context::dummy();
     let (mut market, config, _cap_1, admin_cap, clock) = setup(ctx);
-    let cap_2 = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let cap_2 = market_oracle::create_cap(&admin_cap, ctx);
 
-    registry::register_market_oracle_cap(&mut market, &admin_cap, &cap_2);
+    market_oracle::register_cap(&mut market, &admin_cap, &cap_2);
     write_svi(&mut market, &config, &cap_2, FIRST_SVI_SOURCE_TIMESTAMP_MS, &clock);
-    registry::unregister_market_oracle_cap(&mut market, &admin_cap, cap_2.cap_id());
+    market_oracle::unregister_cap(&mut market, &admin_cap, cap_2.cap_id());
     write_svi(&mut market, &config, &cap_2, SECOND_SVI_SOURCE_TIMESTAMP_MS, &clock);
     abort 999
 }
@@ -89,16 +89,16 @@ fun self_unregistered_cap_loses_market_oracle_access() {
     let ctx = &mut tx_context::dummy();
     let (mut market, config, cap, _admin_cap, clock) = setup(ctx);
 
-    registry::self_unregister_market_oracle_cap(&mut market, &cap);
+    market_oracle::self_unregister_cap(&mut market, &cap);
     write_svi(&mut market, &config, &cap, FIRST_SVI_SOURCE_TIMESTAMP_MS, &clock);
     abort 999
 }
 
 fun setup(
     ctx: &mut TxContext,
-): (MarketOracle, ProtocolConfig, MarketOracleCap, registry::AdminCap, clock::Clock) {
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+): (MarketOracle, ProtocolConfig, MarketOracleCap, admin::AdminCap, clock::Clock) {
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let config = protocol_config::new_for_testing(ctx);
     let market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
     let mut clock = clock::create_for_testing(ctx);
@@ -110,11 +110,11 @@ fun cleanup(
     market: MarketOracle,
     config: ProtocolConfig,
     mut caps: vector<MarketOracleCap>,
-    admin_cap: registry::AdminCap,
+    admin_cap: admin::AdminCap,
     clock: clock::Clock,
 ) {
     while (!caps.is_empty()) {
-        registry::destroy_market_oracle_cap(caps.pop_back());
+        market_oracle::destroy_cap(caps.pop_back());
     };
     caps.destroy_empty();
     destroy(market);

--- a/packages/predict/tests/helper/test_helpers.move
+++ b/packages/predict/tests/helper/test_helpers.move
@@ -11,7 +11,7 @@
 #[test_only]
 module deepbook_predict::test_helpers;
 
-use deepbook_predict::{registry::{AdminCap, Registry}, test_constants};
+use deepbook_predict::{admin::AdminCap, registry::Registry, test_constants};
 use std::unit_test::destroy;
 use sui::test_scenario::{Self as test, Scenario};
 

--- a/packages/predict/tests/oracle/market_oracle_basis_tests.move
+++ b/packages/predict/tests/oracle/market_oracle_basis_tests.move
@@ -4,7 +4,7 @@
 #[test_only]
 module deepbook_predict::market_oracle_basis_tests;
 
-use deepbook_predict::{market_oracle, registry};
+use deepbook_predict::{admin, market_oracle};
 
 const EXPIRY_MS: u64 = 100_000;
 
@@ -13,8 +13,8 @@ fun basis_aborts_when_spot_zero() {
     // Fresh market has block_scholes_spot = 0; basis() guards against
     // division-by-zero before forward is even read.
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
 
     let _ = market.block_scholes_basis();

--- a/packages/predict/tests/oracle/market_oracle_getters_tests.move
+++ b/packages/predict/tests/oracle/market_oracle_getters_tests.move
@@ -4,7 +4,7 @@
 #[test_only]
 module deepbook_predict::market_oracle_getters_tests;
 
-use deepbook_predict::{constants, i64, market_oracle, registry};
+use deepbook_predict::{admin, constants, i64, market_oracle};
 use std::unit_test::{assert_eq, destroy};
 use sui::clock;
 
@@ -18,8 +18,8 @@ const AFTER_EXPIRY: u64 = 200_000;
 #[test]
 fun id_round_trips_through_object() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
 
     let id = market.id();
@@ -33,8 +33,8 @@ fun id_round_trips_through_object() {
 #[test]
 fun cap_id_round_trips() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
 
     let cap_id_first = cap.cap_id();
     assert_eq!(cap.cap_id(), cap_id_first);
@@ -46,8 +46,8 @@ fun cap_id_round_trips() {
 #[test]
 fun expiry_returns_constructor_value() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
 
     assert_eq!(market.expiry(), EXPIRY_MS);
@@ -60,8 +60,8 @@ fun expiry_returns_constructor_value() {
 #[test]
 fun allowed_versions_seeded_with_current() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
 
     let versions = market.allowed_versions();
@@ -76,8 +76,8 @@ fun allowed_versions_seeded_with_current() {
 #[test]
 fun pyth_source_id_is_persisted() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
 
     // Stable binding identity (same value across reads).
@@ -93,8 +93,8 @@ fun pyth_source_id_is_persisted() {
 #[test]
 fun is_settled_false_on_fresh_market() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
 
     assert!(!market.is_settled());
@@ -110,8 +110,8 @@ fun is_settled_false_on_fresh_market() {
 #[test]
 fun status_is_active_before_expiry() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
     let mut clock = clock::create_for_testing(ctx);
     clock.set_for_testing(BEFORE_EXPIRY);
@@ -127,8 +127,8 @@ fun status_is_active_before_expiry() {
 #[test]
 fun status_pending_at_and_after_expiry() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
     let mut clock = clock::create_for_testing(ctx);
 
@@ -166,8 +166,8 @@ fun source_constants_are_distinct() {
 #[test]
 fun default_block_scholes_state_is_zero() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
 
     assert_eq!(market.block_scholes_spot(), 0);

--- a/packages/predict/tests/oracle/market_oracle_set_bounds_tests.move
+++ b/packages/predict/tests/oracle/market_oracle_set_bounds_tests.move
@@ -4,7 +4,7 @@
 #[test_only]
 module deepbook_predict::market_oracle_set_bounds_tests;
 
-use deepbook_predict::{config_constants, market_oracle, protocol_config, registry};
+use deepbook_predict::{admin, config_constants, market_oracle, protocol_config};
 use std::unit_test::destroy;
 
 const EXPIRY_MS: u64 = 100_000;
@@ -19,8 +19,8 @@ const VALID_MAX_BASIS: u64 = 1_050_000_000;
 #[test]
 fun set_settlement_freshness_ms_round_trip_succeeds() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let config = protocol_config::new_for_testing(ctx);
     let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
 
@@ -34,8 +34,8 @@ fun set_settlement_freshness_ms_round_trip_succeeds() {
 fun set_settlement_freshness_ms_below_min_aborts() {
     // Envelope min = 1; 0 must be rejected by the config_constants guard.
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let config = protocol_config::new_for_testing(ctx);
     let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
     market.set_settlement_freshness_ms(&config, &cap, 0);
@@ -45,8 +45,8 @@ fun set_settlement_freshness_ms_below_min_aborts() {
 #[test, expected_failure(abort_code = config_constants::EInvalidSettlementFreshnessMs)]
 fun set_settlement_freshness_ms_above_max_aborts() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let config = protocol_config::new_for_testing(ctx);
     let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
     market.set_settlement_freshness_ms(&config, &cap, 60_001);
@@ -56,9 +56,9 @@ fun set_settlement_freshness_ms_above_max_aborts() {
 #[test, expected_failure(abort_code = market_oracle::EInvalidMarketOracleCap)]
 fun set_settlement_freshness_ms_with_unregistered_cap_aborts() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
-    let unregistered_cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
+    let unregistered_cap = market_oracle::create_cap(&admin_cap, ctx);
     let config = protocol_config::new_for_testing(ctx);
     let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
     market.set_settlement_freshness_ms(&config, &unregistered_cap, VALID_FRESHNESS_MS);
@@ -68,8 +68,8 @@ fun set_settlement_freshness_ms_with_unregistered_cap_aborts() {
 #[test, expected_failure(abort_code = protocol_config::EValuationInProgress)]
 fun set_settlement_freshness_ms_during_valuation_aborts() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let mut config = protocol_config::new_for_testing(ctx);
     let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
     config.begin_valuation();
@@ -83,8 +83,8 @@ fun set_settlement_freshness_ms_during_valuation_aborts() {
 #[test]
 fun set_basis_bounds_round_trip_succeeds() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let config = protocol_config::new_for_testing(ctx);
     let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
 
@@ -104,8 +104,8 @@ fun set_basis_bounds_round_trip_succeeds() {
 fun set_basis_bounds_min_equal_to_max_aborts() {
     // Module-level invariant: min_basis < max_basis strictly.
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let config = protocol_config::new_for_testing(ctx);
     let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
 
@@ -123,8 +123,8 @@ fun set_basis_bounds_min_equal_to_max_aborts() {
 #[test, expected_failure(abort_code = market_oracle::EInvalidBasisBounds)]
 fun set_basis_bounds_min_above_max_aborts() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let config = protocol_config::new_for_testing(ctx);
     let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
 
@@ -144,8 +144,8 @@ fun set_basis_bounds_min_above_max_aborts() {
 #[test, expected_failure(abort_code = config_constants::EInvalidMaxSpotDeviation)]
 fun set_basis_bounds_max_spot_deviation_zero_aborts() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let config = protocol_config::new_for_testing(ctx);
     let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
 
@@ -163,8 +163,8 @@ fun set_basis_bounds_max_spot_deviation_zero_aborts() {
 #[test, expected_failure(abort_code = config_constants::EInvalidMaxBasisDeviation)]
 fun set_basis_bounds_max_basis_deviation_zero_aborts() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let config = protocol_config::new_for_testing(ctx);
     let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
 
@@ -182,8 +182,8 @@ fun set_basis_bounds_max_basis_deviation_zero_aborts() {
 #[test, expected_failure(abort_code = config_constants::EInvalidMinBasis)]
 fun set_basis_bounds_min_basis_below_envelope_aborts() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let config = protocol_config::new_for_testing(ctx);
     let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
 
@@ -201,8 +201,8 @@ fun set_basis_bounds_min_basis_below_envelope_aborts() {
 #[test, expected_failure(abort_code = config_constants::EInvalidMaxBasis)]
 fun set_basis_bounds_max_basis_above_envelope_aborts() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let config = protocol_config::new_for_testing(ctx);
     let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
 
@@ -220,9 +220,9 @@ fun set_basis_bounds_max_basis_above_envelope_aborts() {
 #[test, expected_failure(abort_code = market_oracle::EInvalidMarketOracleCap)]
 fun set_basis_bounds_with_unregistered_cap_aborts() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
-    let unregistered_cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
+    let unregistered_cap = market_oracle::create_cap(&admin_cap, ctx);
     let config = protocol_config::new_for_testing(ctx);
     let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
 
@@ -240,8 +240,8 @@ fun set_basis_bounds_with_unregistered_cap_aborts() {
 #[test, expected_failure(abort_code = protocol_config::EValuationInProgress)]
 fun set_basis_bounds_during_valuation_aborts() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let mut config = protocol_config::new_for_testing(ctx);
     let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
     config.begin_valuation();
@@ -261,7 +261,7 @@ fun cleanup(
     market: market_oracle::MarketOracle,
     config: protocol_config::ProtocolConfig,
     cap: market_oracle::MarketOracleCap,
-    admin_cap: registry::AdminCap,
+    admin_cap: admin::AdminCap,
 ) {
     destroy(market);
     destroy(config);

--- a/packages/predict/tests/oracle/market_oracle_settlement_tests.move
+++ b/packages/predict/tests/oracle/market_oracle_settlement_tests.move
@@ -5,7 +5,7 @@
 #[allow(unused_variable)]
 module deepbook_predict::market_oracle_settlement_tests;
 
-use deepbook_predict::{market_oracle, protocol_config, pyth_source, registry};
+use deepbook_predict::{admin, market_oracle, protocol_config, pyth_source};
 use std::unit_test::{assert_eq, destroy};
 use sui::clock;
 
@@ -211,13 +211,13 @@ fun setup(
     market_oracle::MarketOracle,
     protocol_config::ProtocolConfig,
     market_oracle::MarketOracleCap,
-    registry::AdminCap,
+    admin::AdminCap,
     pyth_source::PythSource,
     clock::Clock,
 ) {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let config = protocol_config::new_for_testing(ctx);
     let pyth = pyth_source::new_for_testing(ctx);
     let market = market_oracle::create_test_market_oracle_with_pyth(&pyth, EXPIRY_MS, &cap, ctx);
@@ -230,7 +230,7 @@ fun cleanup(
     market: market_oracle::MarketOracle,
     config: protocol_config::ProtocolConfig,
     cap: market_oracle::MarketOracleCap,
-    admin_cap: registry::AdminCap,
+    admin_cap: admin::AdminCap,
     pyth: pyth_source::PythSource,
     clock: clock::Clock,
 ) {

--- a/packages/predict/tests/oracle/market_oracle_update_prices_tests.move
+++ b/packages/predict/tests/oracle/market_oracle_update_prices_tests.move
@@ -9,11 +9,11 @@
 module deepbook_predict::market_oracle_update_prices_tests;
 
 use deepbook_predict::{
+    admin,
     constants::float_scaling as float,
     market_oracle,
     protocol_config,
-    pyth_source,
-    registry
+    pyth_source
 };
 use std::unit_test::{assert_eq, destroy};
 use sui::clock;
@@ -264,7 +264,7 @@ fun update_prices_second_push_basis_deviation_too_large_aborts() {
 #[test, expected_failure(abort_code = market_oracle::EInvalidMarketOracleCap)]
 fun update_prices_with_unregistered_cap_aborts() {
     let (mut market, config, cap, admin_cap, pyth, clock) = setup_active(NOW_MS);
-    let unregistered_cap = registry::create_market_oracle_cap(&admin_cap, &mut tx_context::dummy());
+    let unregistered_cap = market_oracle::create_cap(&admin_cap, &mut tx_context::dummy());
     market.update_block_scholes_prices(
         &config,
         &pyth,
@@ -298,8 +298,8 @@ fun update_prices_with_wrong_pyth_source_aborts() {
 #[test, expected_failure(abort_code = protocol_config::EValuationInProgress)]
 fun update_prices_during_valuation_aborts() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let mut config = protocol_config::new_for_testing(ctx);
     let pyth = pyth_source::new_for_testing(ctx);
     let mut market = market_oracle::create_test_market_oracle_with_pyth(
@@ -332,13 +332,13 @@ fun setup_active(
     market_oracle::MarketOracle,
     protocol_config::ProtocolConfig,
     market_oracle::MarketOracleCap,
-    registry::AdminCap,
+    admin::AdminCap,
     pyth_source::PythSource,
     clock::Clock,
 ) {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let config = protocol_config::new_for_testing(ctx);
     let pyth = pyth_source::new_for_testing(ctx);
     let market = market_oracle::create_test_market_oracle_with_pyth(&pyth, EXPIRY_MS, &cap, ctx);
@@ -351,7 +351,7 @@ fun cleanup(
     market: market_oracle::MarketOracle,
     config: protocol_config::ProtocolConfig,
     cap: market_oracle::MarketOracleCap,
-    admin_cap: registry::AdminCap,
+    admin_cap: admin::AdminCap,
     pyth: pyth_source::PythSource,
     clock: clock::Clock,
 ) {

--- a/packages/predict/tests/oracle/market_oracle_update_svi_tests.move
+++ b/packages/predict/tests/oracle/market_oracle_update_svi_tests.move
@@ -4,7 +4,7 @@
 #[test_only]
 module deepbook_predict::market_oracle_update_svi_tests;
 
-use deepbook_predict::{i64, market_oracle, protocol_config, registry};
+use deepbook_predict::{admin, i64, market_oracle, protocol_config};
 use std::unit_test::{assert_eq, destroy};
 use sui::clock;
 
@@ -22,8 +22,8 @@ const AFTER_EXPIRY_MS: u64 = 200_000;
 #[test]
 fun update_svi_stores_values_and_advances_timestamps() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let config = protocol_config::new_for_testing(ctx);
     let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
     let mut clock = clock::create_for_testing(ctx);
@@ -49,8 +49,8 @@ fun update_svi_strictly_advances_source_timestamp() {
     // After a first update at FIRST_SVI_SOURCE_TIMESTAMP_MS, a second update
     // with a strictly greater source timestamp must succeed.
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let config = protocol_config::new_for_testing(ctx);
     let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
     let mut clock = clock::create_for_testing(ctx);
@@ -69,8 +69,8 @@ fun update_svi_strictly_advances_source_timestamp() {
 fun update_svi_equal_source_timestamp_aborts() {
     // The check is `source_timestamp_ms > previous`; equal is rejected.
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let config = protocol_config::new_for_testing(ctx);
     let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
     let mut clock = clock::create_for_testing(ctx);
@@ -85,8 +85,8 @@ fun update_svi_equal_source_timestamp_aborts() {
 #[test, expected_failure(abort_code = market_oracle::EStaleSVISourceUpdate)]
 fun update_svi_earlier_source_timestamp_aborts() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let config = protocol_config::new_for_testing(ctx);
     let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
     let mut clock = clock::create_for_testing(ctx);
@@ -102,8 +102,8 @@ fun update_svi_earlier_source_timestamp_aborts() {
 fun update_svi_source_timestamp_after_now_aborts() {
     // Source timestamp from the publisher must not be ahead of the on-chain clock.
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let config = protocol_config::new_for_testing(ctx);
     let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
     let mut clock = clock::create_for_testing(ctx);
@@ -118,8 +118,8 @@ fun update_svi_source_timestamp_after_now_aborts() {
 fun update_svi_source_equal_to_now_is_allowed() {
     // The future-timestamp guard is `<=`, so source_ts == now is permitted.
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let config = protocol_config::new_for_testing(ctx);
     let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
     let mut clock = clock::create_for_testing(ctx);
@@ -137,8 +137,8 @@ fun update_svi_after_expiry_aborts() {
     // Status switches to pending_settlement at expiry; update_svi is
     // active-market-only.
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let config = protocol_config::new_for_testing(ctx);
     let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
     let mut clock = clock::create_for_testing(ctx);
@@ -153,8 +153,8 @@ fun update_svi_after_expiry_aborts() {
 fun update_svi_during_valuation_aborts() {
     // protocol_config gates this via assert_not_valuation_in_progress.
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let mut config = protocol_config::new_for_testing(ctx);
     let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
     let mut clock = clock::create_for_testing(ctx);
@@ -170,7 +170,7 @@ fun cleanup(
     market: market_oracle::MarketOracle,
     config: protocol_config::ProtocolConfig,
     cap: market_oracle::MarketOracleCap,
-    admin_cap: registry::AdminCap,
+    admin_cap: admin::AdminCap,
     clock: clock::Clock,
 ) {
     destroy(market);

--- a/packages/predict/tests/oracle/pyth_source_tests.move
+++ b/packages/predict/tests/oracle/pyth_source_tests.move
@@ -4,7 +4,7 @@
 #[test_only]
 module deepbook_predict::pyth_source_tests;
 
-use deepbook_predict::{config_constants, pyth_source, test_constants};
+use deepbook_predict::{admin, config_constants, pyth_source, test_constants};
 use std::unit_test::{assert_eq, destroy};
 
 const HOUR_MS: u64 = 3_600_000;
@@ -26,20 +26,27 @@ fun defaults_disable_the_ramp() {
 #[test]
 fun setter_updates_expiry_fee_params() {
     let ctx = &mut tx_context::dummy();
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
     let mut source = pyth_source::new_for_testing(ctx);
 
-    source.set_expiry_fee_params(HOUR_MS, TWO_X);
+    source.set_expiry_fee_params(&admin_cap, HOUR_MS, TWO_X);
 
     assert_eq!(source.expiry_fee_window_ms(), HOUR_MS);
     assert_eq!(source.expiry_fee_max_multiplier(), TWO_X);
     destroy(source);
+    destroy(admin_cap);
 }
 
 #[test, expected_failure(abort_code = config_constants::EInvalidExpiryFeeWindowMs)]
 fun window_above_max_aborts() {
     let ctx = &mut tx_context::dummy();
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
     let mut source = pyth_source::new_for_testing(ctx);
-    source.set_expiry_fee_params(config_constants::max_expiry_fee_window_ms!() + 1, TWO_X);
+    source.set_expiry_fee_params(
+        &admin_cap,
+        config_constants::max_expiry_fee_window_ms!() + 1,
+        TWO_X,
+    );
 
     abort
 }
@@ -47,8 +54,13 @@ fun window_above_max_aborts() {
 #[test, expected_failure(abort_code = config_constants::EInvalidExpiryFeeMaxMultiplier)]
 fun multiplier_below_min_aborts() {
     let ctx = &mut tx_context::dummy();
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
     let mut source = pyth_source::new_for_testing(ctx);
-    source.set_expiry_fee_params(HOUR_MS, config_constants::min_expiry_fee_max_multiplier!() - 1);
+    source.set_expiry_fee_params(
+        &admin_cap,
+        HOUR_MS,
+        config_constants::min_expiry_fee_max_multiplier!() - 1,
+    );
 
     abort
 }

--- a/packages/predict/tests/pause_tests.move
+++ b/packages/predict/tests/pause_tests.move
@@ -119,7 +119,7 @@ fun revoked_pause_cap_cannot_act() {
 fun sync_market_oracle_copies_registry_allowed_versions() {
     let ctx = &mut tx_context::dummy();
     let (mut registry, admin_cap) = registry::new_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
     let current = constants::current_version!();
     let next = NEXT_VERSION;
@@ -149,7 +149,7 @@ fun synced_market_oracle_blocks_disabled_version() {
     let ctx = &mut tx_context::dummy();
     let (mut registry, admin_cap) = registry::new_for_testing(ctx);
     let config = protocol_config::new_for_testing(ctx);
-    let cap = registry::create_market_oracle_cap(&admin_cap, ctx);
+    let cap = market_oracle::create_cap(&admin_cap, ctx);
     let mut market = market_oracle::create_test_market_oracle(EXPIRY_MS, &cap, ctx);
     let mut clock = clock::create_for_testing(ctx);
     clock.set_for_testing(NOW_MS);

--- a/packages/predict/tests/plp_stake_tests.move
+++ b/packages/predict/tests/plp_stake_tests.move
@@ -5,6 +5,7 @@
 module deepbook_predict::plp_stake_tests;
 
 use deepbook_predict::{
+    admin,
     plp::{Self, PoolVault},
     predict_manager::{Self, PredictManager},
     registry,
@@ -19,7 +20,7 @@ const THIRTY_K_DEEP: u64 = 30_000_000_000;
 
 // === Helpers ===
 
-fun begin(): (test::Scenario, registry::Registry, registry::AdminCap, PoolVault, PredictManager) {
+fun begin(): (test::Scenario, registry::Registry, admin::AdminCap, PoolVault, PredictManager) {
     let mut scenario = test::begin(test_constants::alice());
     plp::init_for_testing(scenario.ctx()); // shares a PoolVault
     let (mut reg, admin_cap) = registry::new_for_testing(scenario.ctx());
@@ -32,7 +33,7 @@ fun begin(): (test::Scenario, registry::Registry, registry::AdminCap, PoolVault,
 fun finish(
     scenario: test::Scenario,
     reg: registry::Registry,
-    admin_cap: registry::AdminCap,
+    admin_cap: admin::AdminCap,
     vault: PoolVault,
     manager: PredictManager,
 ) {

--- a/packages/predict/tests/protocol_config_tests.move
+++ b/packages/predict/tests/protocol_config_tests.move
@@ -4,7 +4,7 @@
 #[test_only]
 module deepbook_predict::protocol_config_tests;
 
-use deepbook_predict::protocol_config;
+use deepbook_predict::{admin, protocol_config};
 use std::unit_test::destroy;
 
 // === trading_paused / pause_trading ===
@@ -37,17 +37,17 @@ fun pause_trading_is_one_way_from_package() {
 
 #[test]
 fun set_trading_paused_round_trips_both_directions() {
-    // The package-internal set_trading_paused is the admin path; it can flip
-    // either direction.
     let ctx = &mut tx_context::dummy();
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
     let mut config = protocol_config::new_for_testing(ctx);
 
-    config.set_trading_paused(true);
+    config.set_trading_paused(&admin_cap, true);
     assert!(config.trading_paused());
-    config.set_trading_paused(false);
+    config.set_trading_paused(&admin_cap, false);
     assert!(!config.trading_paused());
 
     destroy(config);
+    destroy(admin_cap);
 }
 
 // === assert_trading_allowed ===
@@ -65,8 +65,9 @@ fun assert_trading_allowed_passes_when_not_paused_and_no_valuation() {
 #[test, expected_failure(abort_code = protocol_config::ETradingPaused)]
 fun assert_trading_allowed_aborts_when_paused() {
     let ctx = &mut tx_context::dummy();
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
     let mut config = protocol_config::new_for_testing(ctx);
-    config.set_trading_paused(true);
+    config.set_trading_paused(&admin_cap, true);
 
     config.assert_trading_allowed();
     abort 999
@@ -173,9 +174,10 @@ fun pause_trading_during_valuation_aborts() {
 #[test, expected_failure(abort_code = protocol_config::EValuationInProgress)]
 fun set_trading_paused_during_valuation_aborts() {
     let ctx = &mut tx_context::dummy();
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
     let mut config = protocol_config::new_for_testing(ctx);
     config.begin_valuation();
 
-    config.set_trading_paused(true);
+    config.set_trading_paused(&admin_cap, true);
     abort 999
 }

--- a/packages/predict/tests/registry_setters_tests.move
+++ b/packages/predict/tests/registry_setters_tests.move
@@ -1,14 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Cover the registry's admin setter surface. Each setter is a thin wrapper
-/// around the corresponding ProtocolConfig (or PythSource) write — so the
-/// tests just verify the value reaches the destination, then read it back
-/// through the sub-config getter.
+/// Cover admin-gated setters on the modules that own the mutated state.
+/// The tests verify each value reaches its destination and can be read back
+/// through the owning object's getter.
 #[test_only]
 module deepbook_predict::registry_setters_tests;
 
 use deepbook_predict::{
+    admin,
     constants::float_scaling as float,
     fee_config,
     leverage_config,
@@ -16,7 +16,6 @@ use deepbook_predict::{
     pricing_config,
     protocol_config,
     pyth_source,
-    registry,
     risk_config,
     stake_config
 };
@@ -27,10 +26,10 @@ use std::unit_test::{assert_eq, destroy};
 #[test]
 fun set_base_fee_forwards_to_pricing_config() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
     let mut config = protocol_config::new_for_testing(ctx);
 
-    registry::set_base_fee(&mut config, &admin_cap, 30_000_000);
+    protocol_config::set_base_fee(&mut config, &admin_cap, 30_000_000);
     assert_eq!(pricing_config::base_fee(config.pricing_config()), 30_000_000);
 
     destroy(config);
@@ -40,10 +39,10 @@ fun set_base_fee_forwards_to_pricing_config() {
 #[test]
 fun set_min_fee_forwards_to_pricing_config() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
     let mut config = protocol_config::new_for_testing(ctx);
 
-    registry::set_min_fee(&mut config, &admin_cap, 4_000_000);
+    protocol_config::set_min_fee(&mut config, &admin_cap, 4_000_000);
     assert_eq!(pricing_config::min_fee(config.pricing_config()), 4_000_000);
 
     destroy(config);
@@ -53,11 +52,11 @@ fun set_min_fee_forwards_to_pricing_config() {
 #[test]
 fun set_min_and_max_ask_price_forward_to_pricing_config() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
     let mut config = protocol_config::new_for_testing(ctx);
 
-    registry::set_min_ask_price(&mut config, &admin_cap, 20_000_000);
-    registry::set_max_ask_price(&mut config, &admin_cap, 980_000_000);
+    protocol_config::set_min_ask_price(&mut config, &admin_cap, 20_000_000);
+    protocol_config::set_max_ask_price(&mut config, &admin_cap, 980_000_000);
     assert_eq!(pricing_config::min_ask_price(config.pricing_config()), 20_000_000);
     assert_eq!(pricing_config::max_ask_price(config.pricing_config()), 980_000_000);
 
@@ -68,12 +67,12 @@ fun set_min_and_max_ask_price_forward_to_pricing_config() {
 #[test]
 fun set_freshness_setters_forward_to_pricing_config() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
     let mut config = protocol_config::new_for_testing(ctx);
 
-    registry::set_pyth_spot_freshness_ms(&mut config, &admin_cap, 5_000);
-    registry::set_block_scholes_prices_freshness_ms(&mut config, &admin_cap, 4_000);
-    registry::set_block_scholes_svi_freshness_ms(&mut config, &admin_cap, 30_000);
+    protocol_config::set_pyth_spot_freshness_ms(&mut config, &admin_cap, 5_000);
+    protocol_config::set_block_scholes_prices_freshness_ms(&mut config, &admin_cap, 4_000);
+    protocol_config::set_block_scholes_svi_freshness_ms(&mut config, &admin_cap, 30_000);
     assert_eq!(pricing_config::pyth_spot_freshness_ms(config.pricing_config()), 5_000);
     assert_eq!(pricing_config::block_scholes_prices_freshness_ms(config.pricing_config()), 4_000);
     assert_eq!(pricing_config::block_scholes_svi_freshness_ms(config.pricing_config()), 30_000);
@@ -87,10 +86,10 @@ fun set_freshness_setters_forward_to_pricing_config() {
 #[test]
 fun set_fee_shares_forwards_all_three_to_fee_config() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
     let mut config = protocol_config::new_for_testing(ctx);
 
-    registry::set_fee_shares(&mut config, &admin_cap, 700_000_000, 200_000_000, 100_000_000);
+    protocol_config::set_fee_shares(&mut config, &admin_cap, 700_000_000, 200_000_000, 100_000_000);
     assert_eq!(fee_config::lp_fee_share(config.fee_config()), 700_000_000);
     assert_eq!(fee_config::protocol_fee_share(config.fee_config()), 200_000_000);
     assert_eq!(fee_config::insurance_fee_share(config.fee_config()), 100_000_000);
@@ -102,10 +101,10 @@ fun set_fee_shares_forwards_all_three_to_fee_config() {
 #[test]
 fun set_template_trading_loss_rebate_rate_forwards_to_fee_config() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
     let mut config = protocol_config::new_for_testing(ctx);
 
-    registry::set_template_trading_loss_rebate_rate(&mut config, &admin_cap, 250_000_000);
+    protocol_config::set_template_trading_loss_rebate_rate(&mut config, &admin_cap, 250_000_000);
     assert_eq!(fee_config::trading_loss_rebate_rate(config.fee_config()), 250_000_000);
 
     destroy(config);
@@ -117,10 +116,10 @@ fun set_template_trading_loss_rebate_rate_forwards_to_fee_config() {
 #[test]
 fun set_max_total_exposure_pct_forwards_to_risk_config() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
     let mut config = protocol_config::new_for_testing(ctx);
 
-    registry::set_max_total_exposure_pct(&mut config, &admin_cap, 500_000_000);
+    protocol_config::set_max_total_exposure_pct(&mut config, &admin_cap, 500_000_000);
     assert_eq!(risk_config::max_total_exposure_pct(config.risk_config()), 500_000_000);
 
     destroy(config);
@@ -130,10 +129,10 @@ fun set_max_total_exposure_pct_forwards_to_risk_config() {
 #[test]
 fun set_expiry_allocation_forwards_to_risk_config() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
     let mut config = protocol_config::new_for_testing(ctx);
 
-    registry::set_expiry_allocation(&mut config, &admin_cap, 100_000_000_000);
+    protocol_config::set_expiry_allocation(&mut config, &admin_cap, 100_000_000_000);
     assert_eq!(risk_config::expiry_allocation(config.risk_config()), 100_000_000_000);
 
     destroy(config);
@@ -143,13 +142,13 @@ fun set_expiry_allocation_forwards_to_risk_config() {
 #[test]
 fun set_resize_setters_forward_to_risk_config() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
     let mut config = protocol_config::new_for_testing(ctx);
 
-    registry::set_grow_utilization_threshold(&mut config, &admin_cap, 900_000_000);
-    registry::set_shrink_utilization_threshold(&mut config, &admin_cap, 200_000_000);
-    registry::set_grow_factor(&mut config, &admin_cap, 3 * float!());
-    registry::set_shrink_factor(&mut config, &admin_cap, 400_000_000);
+    protocol_config::set_grow_utilization_threshold(&mut config, &admin_cap, 900_000_000);
+    protocol_config::set_shrink_utilization_threshold(&mut config, &admin_cap, 200_000_000);
+    protocol_config::set_grow_factor(&mut config, &admin_cap, 3 * float!());
+    protocol_config::set_shrink_factor(&mut config, &admin_cap, 400_000_000);
 
     assert_eq!(risk_config::grow_utilization_threshold(config.risk_config()), 900_000_000);
     assert_eq!(risk_config::shrink_utilization_threshold(config.risk_config()), 200_000_000);
@@ -165,10 +164,10 @@ fun set_resize_setters_forward_to_risk_config() {
 #[test]
 fun set_template_max_expiry_floor_premium_forwards_to_leverage_config() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
     let mut config = protocol_config::new_for_testing(ctx);
 
-    registry::set_template_max_expiry_floor_premium(&mut config, &admin_cap, 300_000_000);
+    protocol_config::set_template_max_expiry_floor_premium(&mut config, &admin_cap, 300_000_000);
     assert_eq!(leverage_config::max_expiry_floor_premium(config.leverage_config()), 300_000_000);
 
     destroy(config);
@@ -180,10 +179,15 @@ fun set_template_max_expiry_floor_premium_forwards_to_leverage_config() {
 #[test]
 fun set_benefit_powers_forwards_to_stake_config() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
     let mut config = protocol_config::new_for_testing(ctx);
 
-    registry::set_benefit_powers(&mut config, &admin_cap, 200_000_000_000, 1_000_000_000_000);
+    protocol_config::set_benefit_powers(
+        &mut config,
+        &admin_cap,
+        200_000_000_000,
+        1_000_000_000_000,
+    );
     assert_eq!(stake_config::lower_benefit_power(config.stake_config()), 200_000_000_000);
     assert_eq!(stake_config::upper_benefit_power(config.stake_config()), 1_000_000_000_000);
 
@@ -196,10 +200,14 @@ fun set_benefit_powers_forwards_to_stake_config() {
 #[test]
 fun set_market_oracle_template_settlement_freshness_forwards() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
     let mut config = protocol_config::new_for_testing(ctx);
 
-    registry::set_market_oracle_template_settlement_freshness_ms(&mut config, &admin_cap, 5_000);
+    protocol_config::set_market_oracle_template_settlement_freshness_ms(
+        &mut config,
+        &admin_cap,
+        5_000,
+    );
     assert_eq!(market_oracle_config::settlement_freshness_ms(config.market_oracle_config()), 5_000);
 
     destroy(config);
@@ -209,10 +217,10 @@ fun set_market_oracle_template_settlement_freshness_forwards() {
 #[test]
 fun set_market_oracle_template_basis_bounds_forwards_all_four() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
     let mut config = protocol_config::new_for_testing(ctx);
 
-    registry::set_market_oracle_template_basis_bounds(
+    protocol_config::set_market_oracle_template_basis_bounds(
         &mut config,
         &admin_cap,
         50_000_000,
@@ -237,14 +245,14 @@ fun set_market_oracle_template_basis_bounds_forwards_all_four() {
 #[test]
 fun set_trading_paused_round_trips_through_config_getter() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
     let mut config = protocol_config::new_for_testing(ctx);
 
     assert!(!config.trading_paused());
-    registry::set_trading_paused(&mut config, &admin_cap, true);
+    protocol_config::set_trading_paused(&mut config, &admin_cap, true);
     assert!(config.trading_paused());
     // Admin can also unpause (unlike PauseCap which is one-way).
-    registry::set_trading_paused(&mut config, &admin_cap, false);
+    protocol_config::set_trading_paused(&mut config, &admin_cap, false);
     assert!(!config.trading_paused());
 
     destroy(config);
@@ -254,12 +262,12 @@ fun set_trading_paused_round_trips_through_config_getter() {
 // === Pyth source expiry-fee setter ===
 
 #[test]
-fun set_pyth_source_expiry_fee_params_forwards_to_pyth() {
+fun set_expiry_fee_params_updates_pyth() {
     let ctx = &mut tx_context::dummy();
-    let admin_cap = registry::create_admin_cap_for_testing(ctx);
+    let admin_cap = admin::create_admin_cap_for_testing(ctx);
     let mut pyth = pyth_source::new_for_testing(ctx);
 
-    registry::set_pyth_source_expiry_fee_params(&mut pyth, &admin_cap, 3_600_000, 2 * float!());
+    pyth_source::set_expiry_fee_params(&mut pyth, &admin_cap, 3_600_000, 2 * float!());
     assert_eq!(pyth.expiry_fee_window_ms(), 3_600_000);
     assert_eq!(pyth.expiry_fee_max_multiplier(), 2 * float!());
 


### PR DESCRIPTION
## Summary
- move `AdminCap` into a dedicated `admin` module and remove registry-owned admin pass-through setters
- expose admin-gated setters on the modules that own the mutated state: `protocol_config`, `pyth_source`, `expiry_market`, and `market_oracle`
- rewire tests, simulation setup, and repo guidance to the direct owner-module admin APIs

## Test Plan
- [x] `/Users/aslantashtanov/Desktop/Projects/deepbookv3/node_modules/.bin/prettier --plugin /Users/aslantashtanov/Desktop/Projects/deepbookv3/node_modules/@mysten/prettier-plugin-move/out/index.js --check ...` for touched Move/Markdown files
- [x] `git diff --check`
- [x] stale registry-admin API search returned no matches
- [ ] `sui move test --path packages/predict --gas-limit 100000000000` blocked before compilation: local `sui 1.28.3-homebrew` rejects dependency manifest `edition = "2024"` and only supports `legacy`, `2024.alpha`, `2024.beta`
