### PR TITLE
feat(predict): DEEP buyback funded from protocol reserve (Option B)

### DIFF
--- a/packages/predict/simulations/src/runtime.ts
+++ b/packages/predict/simulations/src/runtime.ts
@@ -506,6 +506,7 @@ export function supplyTx(
     poolVaultId: string,
     protocolConfigId: string,
     amount: bigint,
+    pythSourceId: string,
 ): Transaction {
     const tx = new Transaction();
     const dusdc = mintDusdc(tx, amount);
@@ -513,9 +514,19 @@ export function supplyTx(
         target: target("plp", "start_pool_sync"),
         arguments: [tx.object(protocolConfigId), tx.object(poolVaultId)],
     });
+    // The sim pool holds no SUI/DEEP incentives, so supply's incentive sources are
+    // ignored; pass the market PythSource as a placeholder for both slots.
     const [plpCoin] = tx.moveCall({
         target: target("plp", "supply"),
-        arguments: [tx.object(poolVaultId), tx.object(protocolConfigId), sync, dusdc],
+        arguments: [
+            tx.object(poolVaultId),
+            tx.object(protocolConfigId),
+            sync,
+            dusdc,
+            tx.object(pythSourceId),
+            tx.object(pythSourceId),
+            tx.object(CLOCK_ID),
+        ],
     });
     tx.transferObjects([plpCoin], tx.pure.address(address));
     return tx;
@@ -528,9 +539,19 @@ export async function refreshOracleAndSupplyWithExpiryPoolSyncTx(
     await addOracleRefresh(tx, params);
     const dusdc = mintDusdc(tx, params.amount);
     const sync = startPoolSyncWithExpiry(tx, params);
+    // No incentives in the sim pool, so the incentive sources are ignored; reuse
+    // the market PythSource as a placeholder for both slots.
     const [plpCoin] = tx.moveCall({
         target: target("plp", "supply"),
-        arguments: [tx.object(params.poolVaultId), tx.object(params.protocolConfigId), sync, dusdc],
+        arguments: [
+            tx.object(params.poolVaultId),
+            tx.object(params.protocolConfigId),
+            sync,
+            dusdc,
+            tx.object(params.pythSourceId),
+            tx.object(params.pythSourceId),
+            tx.object(CLOCK_ID),
+        ],
     });
     tx.transferObjects([plpCoin], tx.pure.address(address));
     return tx;
@@ -542,16 +563,20 @@ export async function refreshOracleAndWithdrawWithExpiryPoolSyncTx(
     const tx = new Transaction();
     await addOracleRefresh(tx, params);
     const sync = startPoolSyncWithExpiry(tx, params);
-    const [dusdc] = tx.moveCall({
+    // withdraw returns (Coin<DUSDC>, Coin<SUI>, Coin<DEEP>): DUSDC pro-rata plus
+    // each incentive in-kind. The sim pool holds no incentives, so the SUI/DEEP
+    // coins are zero-value; transfer all three out.
+    const [dusdc, sui, deep] = tx.moveCall({
         target: target("plp", "withdraw"),
         arguments: [
             tx.object(params.poolVaultId),
             tx.object(params.protocolConfigId),
             sync,
             tx.object(params.lpCoinId),
+            tx.object(CLOCK_ID),
         ],
     });
-    tx.transferObjects([dusdc], tx.pure.address(address));
+    tx.transferObjects([dusdc, sui, deep], tx.pure.address(address));
     return tx;
 }
 

--- a/packages/predict/simulations/src/sim.ts
+++ b/packages/predict/simulations/src/sim.ts
@@ -790,7 +790,10 @@ async function setupSimulation(
     await executeAndWait(updatePythTrustedSignerTx(), "update_pyth_trusted_signer");
     console.log(`[${ts()}]   Pyth trusted signer configured`);
 
-    await executeAndWait(supplyTx(poolVaultId, protocolConfigId, capital.vaultSeed), "supply");
+    await executeAndWait(
+        supplyTx(poolVaultId, protocolConfigId, capital.vaultSeed, pythSourceId),
+        "supply",
+    );
     console.log(`[${ts()}]   Vault funded: ${capital.vaultSeed / DUSDC_DECIMALS} DUSDC`);
 
     result = await executeAndWait(

--- a/packages/predict/sources/config/config_constants.move
+++ b/packages/predict/sources/config/config_constants.move
@@ -35,6 +35,8 @@ const EInvalidOracleTickSize: u64 = 24;
 const EOracleTickSizeTooSmallForSpot: u64 = 25;
 const EInvalidOracleSpot: u64 = 26;
 const EOracleTickSizeTooLargeForSpot: u64 = 27;
+const EInvalidBuybackShare: u64 = 28;
+const EInvalidBuybackDiscount: u64 = 29;
 
 // === Expiry Funding and Liquidation ===
 
@@ -259,6 +261,33 @@ public(package) fun assert_trading_loss_rebate_rate(value: u64) {
         value >= min_trading_loss_rebate_rate!()
             && value <= max_trading_loss_rebate_rate!(),
         EInvalidTradingLossRebateRate,
+    );
+}
+
+// === Buyback ===
+
+/// Fraction of each expiry's LP profit authorized for DEEP buybacks. Default 50%.
+public(package) macro fun default_buyback_share(): u64 { 500_000_000 }
+public(package) macro fun min_buyback_share(): u64 { 0 }
+public(package) macro fun max_buyback_share(): u64 {
+    deepbook_predict::constants::float_scaling!()
+}
+
+public(package) fun assert_buyback_share(value: u64) {
+    assert!(value >= min_buyback_share!() && value <= max_buyback_share!(), EInvalidBuybackShare);
+}
+
+/// Discount applied to the oracle price when buying back DEEP. Default 0 (oracle mid).
+public(package) macro fun default_buyback_discount(): u64 { 0 }
+public(package) macro fun min_buyback_discount(): u64 { 0 }
+public(package) macro fun max_buyback_discount(): u64 {
+    deepbook_predict::constants::float_scaling!()
+}
+
+public(package) fun assert_buyback_discount(value: u64) {
+    assert!(
+        value >= min_buyback_discount!() && value <= max_buyback_discount!(),
+        EInvalidBuybackDiscount,
     );
 }
 

--- a/packages/predict/sources/config/fee_config.move
+++ b/packages/predict/sources/config/fee_config.move
@@ -9,12 +9,16 @@ module deepbook_predict::fee_config;
 
 use deepbook_predict::config_constants;
 
-/// Profit split and trading loss rebate policy.
+/// Profit split, trading loss rebate, and DEEP buyback policy.
 public struct FeeConfig has store {
     /// Merged protocol and insurance reserve share in FLOAT_SCALING.
     protocol_reserve_profit_share: u64,
     /// Fraction of aggregate expiry trading fees reserved for loss rebates.
     trading_loss_rebate_rate: u64,
+    /// Fraction of each expiry's LP profit authorized for DEEP buybacks, in FLOAT_SCALING.
+    buyback_share: u64,
+    /// Discount off the oracle price when buying back DEEP, in FLOAT_SCALING (0 = oracle mid).
+    buyback_discount: u64,
 }
 
 // === Public-Package Functions ===
@@ -27,10 +31,20 @@ public(package) fun trading_loss_rebate_rate(config: &FeeConfig): u64 {
     config.trading_loss_rebate_rate
 }
 
+public(package) fun buyback_share(config: &FeeConfig): u64 {
+    config.buyback_share
+}
+
+public(package) fun buyback_discount(config: &FeeConfig): u64 {
+    config.buyback_discount
+}
+
 public(package) fun new(): FeeConfig {
     FeeConfig {
         protocol_reserve_profit_share: config_constants::default_protocol_reserve_profit_share!(),
         trading_loss_rebate_rate: config_constants::default_trading_loss_rebate_rate!(),
+        buyback_share: config_constants::default_buyback_share!(),
+        buyback_discount: config_constants::default_buyback_discount!(),
     }
 }
 
@@ -45,4 +59,14 @@ public(package) fun set_protocol_reserve_profit_share(
 public(package) fun set_trading_loss_rebate_rate(config: &mut FeeConfig, value: u64) {
     config_constants::assert_trading_loss_rebate_rate(value);
     config.trading_loss_rebate_rate = value;
+}
+
+public(package) fun set_buyback_share(config: &mut FeeConfig, value: u64) {
+    config_constants::assert_buyback_share(value);
+    config.buyback_share = value;
+}
+
+public(package) fun set_buyback_discount(config: &mut FeeConfig, value: u64) {
+    config_constants::assert_buyback_discount(value);
+    config.buyback_discount = value;
 }

--- a/packages/predict/sources/config/protocol_config.move
+++ b/packages/predict/sources/config/protocol_config.move
@@ -167,6 +167,20 @@ public fun set_template_trading_loss_rebate_rate(
     config_events::emit_fee_config_updated(config.id(), &config.fee_config);
 }
 
+/// Set the fraction of each expiry's LP profit authorized for DEEP buybacks.
+public fun set_buyback_share(config: &mut ProtocolConfig, _admin_cap: &AdminCap, value: u64) {
+    config.assert_not_valuation_in_progress();
+    config.fee_config.set_buyback_share(value);
+    config_events::emit_fee_config_updated(config.id(), &config.fee_config);
+}
+
+/// Set the discount off the oracle price applied when buying back DEEP.
+public fun set_buyback_discount(config: &mut ProtocolConfig, _admin_cap: &AdminCap, value: u64) {
+    config.assert_not_valuation_in_progress();
+    config.fee_config.set_buyback_discount(value);
+    config_events::emit_fee_config_updated(config.id(), &config.fee_config);
+}
+
 /// Set the total liquidation candidate budget used before live valuations.
 public fun set_valuation_liquidation_budget(
     config: &mut ProtocolConfig,

--- a/packages/predict/sources/constants.move
+++ b/packages/predict/sources/constants.move
@@ -27,6 +27,11 @@ public macro fun float_scaling(): u64 { 1_000_000_000 }
 /// form into the package's 1e9-scaled `u64`.
 public macro fun float_scaling_decimals(): u64 { 9 }
 
+/// Decimals of the DUSDC settlement asset. `pyth_source::value_in_dusdc` converts
+/// the USD value of admin-deposited non-DUSDC incentive assets into this scale so
+/// it sums directly with the pool's DUSDC-denominated value.
+public macro fun dusdc_decimals(): u8 { 6 }
+
 // === Position Sizing ===
 
 /// Minimum position quantity increment.
@@ -45,6 +50,14 @@ public(package) macro fun max_active_expiry_markets(): u64 { 10 }
 
 /// Rebalancing band and target buffer fraction, in FLOAT_SCALING.
 public(package) macro fun expiry_rebalance_pct(): u64 { 100_000_000 }
+
+// === Incentive Streaming ===
+
+/// Maximum linear vesting window for an admin incentive deposit (365 days).
+/// A zero window is rejected separately (it would divide by zero in the release
+/// math); this ceiling stops an admin from locking a donation away from holders
+/// indefinitely.
+public(package) macro fun max_incentive_stream_ms(): u64 { 31_536_000_000 }
 
 // === Leverage ===
 

--- a/packages/predict/sources/events/config_events.move
+++ b/packages/predict/sources/events/config_events.move
@@ -30,6 +30,8 @@ public struct FeeConfigUpdated has copy, drop, store {
     protocol_config_id: ID,
     protocol_reserve_profit_share: u64,
     trading_loss_rebate_rate: u64,
+    buyback_share: u64,
+    buyback_discount: u64,
 }
 
 /// Emitted when liquidation-budget policy changes.
@@ -108,6 +110,8 @@ public(package) fun emit_fee_config_updated(protocol_config_id: ID, config: &Fee
         protocol_config_id,
         protocol_reserve_profit_share: config.protocol_reserve_profit_share(),
         trading_loss_rebate_rate: config.trading_loss_rebate_rate(),
+        buyback_share: config.buyback_share(),
+        buyback_discount: config.buyback_discount(),
     });
 }
 

--- a/packages/predict/sources/events/vault_events.move
+++ b/packages/predict/sources/events/vault_events.move
@@ -75,6 +75,21 @@ public struct ExpiryProfitMaterialized has copy, drop, store {
     idle_balance_after: u64,
     protocol_reserve_balance_after: u64,
     profit_basis_after: u64,
+    /// Cumulative LP-DUSDC authorized for DEEP buybacks after this materialization.
+    buyback_budget_after: u64,
+}
+
+/// Emitted when DEEP is bought back: the seller hands in DEEP and receives DUSDC
+/// from the buyback budget, and the DEEP is folded into LP-owned incentive holdings.
+public struct DeepBoughtBack has copy, drop, store {
+    pool_vault_id: ID,
+    deep_in: u64,
+    dusdc_out: u64,
+    /// Discount off the oracle price applied to this swap, in FLOAT_SCALING.
+    discount: u64,
+    buyback_budget_after: u64,
+    protocol_reserve_balance_after: u64,
+    incentive_deep_released_after: u64,
 }
 
 // === Public-Package Functions ===
@@ -181,6 +196,7 @@ public(package) fun emit_expiry_profit_materialized(
     idle_balance_after: u64,
     protocol_reserve_balance_after: u64,
     profit_basis_after: u64,
+    buyback_budget_after: u64,
 ) {
     event::emit(ExpiryProfitMaterialized {
         pool_vault_id,
@@ -190,5 +206,26 @@ public(package) fun emit_expiry_profit_materialized(
         idle_balance_after,
         protocol_reserve_balance_after,
         profit_basis_after,
+        buyback_budget_after,
+    });
+}
+
+public(package) fun emit_deep_bought_back(
+    pool_vault_id: ID,
+    deep_in: u64,
+    dusdc_out: u64,
+    discount: u64,
+    buyback_budget_after: u64,
+    protocol_reserve_balance_after: u64,
+    incentive_deep_released_after: u64,
+) {
+    event::emit(DeepBoughtBack {
+        pool_vault_id,
+        deep_in,
+        dusdc_out,
+        discount,
+        buyback_budget_after,
+        protocol_reserve_balance_after,
+        incentive_deep_released_after,
     });
 }

--- a/packages/predict/sources/oracle/pyth/pyth_source.move
+++ b/packages/predict/sources/oracle/pyth/pyth_source.move
@@ -3,9 +3,11 @@
 
 /// Raw Pyth Lazer spot source state.
 ///
-/// This module is intentionally limited to source ingestion and timestamp
-/// bookkeeping. It does not decide whether Pyth is authoritative, derive a
-/// forward, apply circuit breakers, or settle a market.
+/// This module is intentionally limited to source ingestion, timestamp
+/// bookkeeping, and reading its raw spot (including a plain units conversion of
+/// that spot via `value_in_dusdc`). It does not decide whether Pyth is
+/// authoritative, derive a forward, apply circuit breakers, or settle a market;
+/// callers own feed binding and freshness (see `pricing::assert_pyth_spot_fresh`).
 module deepbook_predict::pyth_source;
 
 use deepbook_predict::{constants, lazer_helper, oracle_events, protocol_config::ProtocolConfig};
@@ -106,6 +108,22 @@ public(package) fun freshness_timestamp_ms(source: &PythSource): u64 {
     source.source_timestamp_ms.min(source.update_timestamp_ms)
 }
 
+/// DUSDC-denominated value (DUSDC decimals) of `amount` raw units of an asset
+/// with `asset_decimals`, priced at this source's normalized 1e9-scaled spot,
+/// rounding up:
+///   ceil(amount * spot / 10^(asset_decimals + float_scaling_decimals - dusdc_decimals))
+/// Aborts on a zero spot (a zero oracle price cannot value the asset). Feed
+/// binding and freshness are the caller's responsibility (assert `feed_id()` and
+/// `pricing::assert_pyth_spot_fresh`), exactly as the market pricing path does.
+public(package) fun value_in_dusdc(source: &PythSource, amount: u64, asset_decimals: u8): u64 {
+    let spot = source.spot;
+    assert!(spot > 0, EZeroSpot);
+    // asset_decimals + 9 - 6 >= 3 for any decimals, so no underflow.
+    let exponent =
+        (asset_decimals as u64) + constants::float_scaling_decimals!() - (constants::dusdc_decimals!() as u64);
+    ceil_div((amount as u128) * (spot as u128), pow10(exponent)) as u64
+}
+
 /// Create and share a Pyth source bound to a Lazer feed id.
 public(package) fun create_and_share(
     feed_id: u32,
@@ -136,6 +154,14 @@ public(package) fun assert_version_allowed(source: &PythSource) {
 fun us_to_ms_ceil(timestamp_us: u64): u64 {
     let ms = timestamp_us / 1000;
     if (timestamp_us % 1000 == 0) ms else ms + 1
+}
+
+fun pow10(exponent: u64): u128 {
+    10u128.pow(exponent as u8)
+}
+
+fun ceil_div(numerator: u128, denominator: u128): u128 {
+    (numerator + denominator - 1) / denominator
 }
 
 // === Test-Only Functions ===

--- a/packages/predict/sources/oracle/pyth/pyth_source.move
+++ b/packages/predict/sources/oracle/pyth/pyth_source.move
@@ -124,6 +124,24 @@ public(package) fun value_in_dusdc(source: &PythSource, amount: u64, asset_decim
     ceil_div((amount as u128) * (spot as u128), pow10(exponent)) as u64
 }
 
+/// DUSDC-denominated value of `amount` raw units of an asset, like `value_in_dusdc`
+/// but rounding DOWN:
+///   floor(amount * spot / 10^(asset_decimals + float_scaling_decimals - dusdc_decimals))
+/// The round-up `value_in_dusdc` is conservative for valuing a holding *into* NAV;
+/// this floor variant is for paying an asset *out* (a buyback payout), so the pool
+/// never overpays. Same feed-binding/freshness contract as `value_in_dusdc`.
+public(package) fun value_in_dusdc_round_down(
+    source: &PythSource,
+    amount: u64,
+    asset_decimals: u8,
+): u64 {
+    let spot = source.spot;
+    assert!(spot > 0, EZeroSpot);
+    let exponent =
+        (asset_decimals as u64) + constants::float_scaling_decimals!() - (constants::dusdc_decimals!() as u64);
+    ((amount as u128) * (spot as u128) / pow10(exponent)) as u64
+}
+
 /// Create and share a Pyth source bound to a Lazer feed id.
 public(package) fun create_and_share(
     feed_id: u32,

--- a/packages/predict/sources/pool/plp.move
+++ b/packages/predict/sources/pool/plp.move
@@ -52,6 +52,11 @@ const ENoPlpHolders: u64 = 12;
 const EZeroStreamDuration: u64 = 13;
 const EStreamDurationTooLong: u64 = 14;
 const EIncentiveFeedMismatch: u64 = 15;
+const EInsufficientBuybackBudget: u64 = 16;
+const EZeroDusdcOut: u64 = 17;
+const EMinDusdcOutNotMet: u64 = 18;
+const EZeroDeepIn: u64 = 19;
+const EInsufficientProtocolReserve: u64 = 20;
 
 /// One-time witness type for Predict LP token registration.
 public struct PLP has drop {}
@@ -89,6 +94,11 @@ public struct PoolVault has key {
     idle_balance: Balance<DUSDC>,
     /// Protocol-owned DUSDC excluded from PLP redemption.
     protocol_reserve_balance: Balance<DUSDC>,
+    /// Cumulative protocol-reserve DUSDC authorized for DEEP buybacks and not yet
+    /// spent. A cap on buyback volume, not a segregated balance: the DUSDC stays in
+    /// `protocol_reserve_balance` (already excluded from LP NAV) and is spent down by
+    /// `execute_deep_buyback`. Holds `<= protocol_reserve_balance` by construction.
+    buyback_budget: u64,
     /// Pooled DEEP staked by all managers for trading benefits. Per-manager
     /// active/inactive amounts are mirrored on each `PredictManager`.
     staked_deep: Balance<DEEP>,
@@ -161,6 +171,11 @@ public fun staked_deep(vault: &PoolVault): u64 {
 /// Return protocol-owned DUSDC excluded from PLP redemption.
 public fun protocol_reserve_balance(vault: &PoolVault): u64 {
     vault.protocol_reserve_balance.value()
+}
+
+/// Return cumulative protocol-reserve DUSDC authorized for DEEP buybacks and not yet spent.
+public fun buyback_budget(vault: &PoolVault): u64 {
+    vault.buyback_budget
 }
 
 /// Return active expiry market IDs tracked by the pool.
@@ -456,6 +471,7 @@ public(package) fun new(treasury_cap: TreasuryCap<PLP>, ctx: &mut TxContext): Po
         id: object::new(ctx),
         idle_balance: balance::zero(),
         protocol_reserve_balance: balance::zero(),
+        buyback_budget: 0,
         staked_deep: balance::zero(),
         treasury_cap,
         expiry_accounting: pool_accounting::new(ctx),
@@ -525,6 +541,60 @@ public(package) fun receive_deep_incentive(
     vault.incentive_deep.fund(deposit, decimals, feed_id, duration_ms, clock);
 }
 
+/// Buy DEEP back from any seller, paying DUSDC out of the buyback budget.
+///
+/// Permissionless, funded by the protocol reserve: the seller's DEEP is priced off
+/// `deep_source` (rounded down, minus the configured discount) and folded into the
+/// LP-owned `incentive_deep` released balance — valued into NAV on `supply` and paid
+/// in-kind on `withdraw` — while the DUSDC payout comes from `protocol_reserve_balance`,
+/// capped by `buyback_budget`. The protocol reserve is excluded from LP NAV, so each
+/// swap moves value into LP-owned DEEP: the pool subsidizes LPs a DEEP position out of
+/// protocol revenue, and idle liquidity (hence withdrawals) is never touched.
+/// `(decimals, feed_id)` are the registry's DEEP binding, supplied by
+/// `registry::swap_deep_for_dusdc`, which owns the feed-config lookup (`registry`
+/// depends on `plp`, not the reverse).
+public(package) fun execute_deep_buyback(
+    vault: &mut PoolVault,
+    config: &ProtocolConfig,
+    deep_source: &PythSource,
+    deep: Coin<DEEP>,
+    decimals: u8,
+    feed_id: u32,
+    min_dusdc_out: u64,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): Coin<DUSDC> {
+    vault.assert_version_allowed();
+    config.assert_not_valuation_in_progress();
+    let deep_amount = deep.value();
+    assert!(deep_amount > 0, EZeroDeepIn);
+    assert!(deep_source.feed_id() == feed_id, EIncentiveFeedMismatch);
+    pricing::assert_pyth_spot_fresh(config.pricing_config(), deep_source, clock);
+
+    let oracle_out = deep_source.value_in_dusdc_round_down(deep_amount, decimals);
+    // dusdc_out = oracle_out * (1 - discount), rounded down.
+    let discount = config.fee_config().buyback_discount();
+    let dusdc_out = math::mul(oracle_out, constants::float_scaling!() - discount);
+    assert!(dusdc_out > 0, EZeroDusdcOut);
+    assert!(dusdc_out >= min_dusdc_out, EMinDusdcOutNotMet);
+    assert!(dusdc_out <= vault.buyback_budget, EInsufficientBuybackBudget);
+    assert!(vault.protocol_reserve_balance.value() >= dusdc_out, EInsufficientProtocolReserve);
+
+    vault.route_deep_into_incentive(deep, decimals, feed_id);
+    vault.buyback_budget = vault.buyback_budget - dusdc_out;
+    let payout = vault.protocol_reserve_balance.split(dusdc_out).into_coin(ctx);
+    vault_events::emit_deep_bought_back(
+        vault.id(),
+        deep_amount,
+        dusdc_out,
+        discount,
+        vault.buyback_budget,
+        vault.protocol_reserve_balance.value(),
+        vault.incentive_deep.released.value(),
+    );
+    payout
+}
+
 /// Set the max net DUSDC the pool may have funded into one expiry.
 public fun set_max_expiry_funding(
     vault: &mut PoolVault,
@@ -592,6 +662,18 @@ fun value_incentives(
         vault.incentive_deep.sync_value(config, deep_source, clock)
     } else 0;
     sui_value + deep_value
+}
+
+/// Fold bought-back DEEP into the LP-owned `incentive_deep` released balance — no
+/// vesting (it is bought at fair value, so it is immediately LP-owned and claimable).
+/// Caches the oracle binding when the incentive is empty so a later `sync_value` can
+/// price it; a non-empty incentive already carries the same registry-bound binding.
+fun route_deep_into_incentive(vault: &mut PoolVault, deep: Coin<DEEP>, decimals: u8, feed_id: u32) {
+    if (vault.incentive_deep.is_empty()) {
+        vault.incentive_deep.decimals = decimals;
+        vault.incentive_deep.feed_id = feed_id;
+    };
+    vault.incentive_deep.released.join(deep.into_balance());
 }
 
 fun synced_pool_value(vault: &PoolVault, config: &ProtocolConfig, active_expiry_value: u64): u64 {
@@ -813,6 +895,11 @@ fun materialize_expiry_profit(
         let protocol_profit_balance = vault.idle_balance.split(protocol_profit);
         vault.protocol_reserve_balance.join(protocol_profit_balance);
     };
+    // Authorize a slice of the protocol profit for DEEP buybacks. This moves no cash —
+    // the DUSDC stays in `protocol_reserve_balance` (already outside LP NAV); the budget
+    // only caps how much can later be swapped into DEEP via `execute_deep_buyback`.
+    vault.buyback_budget =
+        vault.buyback_budget + math::mul(protocol_profit, config.fee_config().buyback_share());
     let profit_basis_after = vault.expiry_accounting.profit_basis_debits();
     vault_events::emit_expiry_profit_materialized(
         vault.id(),
@@ -822,6 +909,7 @@ fun materialize_expiry_profit(
         vault.idle_balance.value(),
         vault.protocol_reserve_balance.value(),
         profit_basis_after,
+        vault.buyback_budget,
     );
 }
 
@@ -875,4 +963,29 @@ fun emit_expiry_cash_rebalanced(
 /// Register PLP in tests.
 public fun init_for_testing(ctx: &mut TxContext) {
     init(PLP {}, ctx);
+}
+
+#[test_only]
+/// Seed the buyback budget directly. Lets the swap flow be tested in isolation
+/// without driving a full expiry settlement; the funding carve is covered
+/// separately through the production materialization path.
+public fun set_buyback_budget_for_testing(vault: &mut PoolVault, amount: u64) {
+    vault.buyback_budget = amount;
+}
+
+#[test_only]
+/// Seed the protocol reserve balance directly (the source the buyback pays from).
+public fun set_protocol_reserve_for_testing(
+    vault: &mut PoolVault,
+    amount: u64,
+    ctx: &mut TxContext,
+) {
+    let current = vault.protocol_reserve_balance.value();
+    if (amount > current) {
+        vault
+            .protocol_reserve_balance
+            .join(coin::mint_for_testing<DUSDC>(amount - current, ctx).into_balance());
+    } else {
+        vault.protocol_reserve_balance.split(current - amount).into_coin(ctx).burn_for_testing();
+    };
 }

--- a/packages/predict/sources/pool/plp.move
+++ b/packages/predict/sources/pool/plp.move
@@ -31,6 +31,7 @@ use sui::{
     clock::Clock,
     coin::{Self, Coin, TreasuryCap},
     coin_registry,
+    sui::SUI,
     vec_set::{Self, VecSet}
 };
 use token::deep::DEEP;
@@ -46,9 +47,40 @@ const EInvalidInitialSupply: u64 = 7;
 const EZeroShares: u64 = 8;
 const EZeroPoolValue: u64 = 9;
 const EPackageVersionDisabled: u64 = 10;
+const EZeroIncentiveDeposit: u64 = 11;
+const ENoPlpHolders: u64 = 12;
+const EZeroStreamDuration: u64 = 13;
+const EStreamDurationTooLong: u64 = 14;
+const EIncentiveFeedMismatch: u64 = 15;
 
 /// One-time witness type for Predict LP token registration.
 public struct PLP has drop {}
+
+/// Per-incentive holdings on a linear vesting schedule, plus the oracle binding
+/// cached from the registry at deposit time (decimals + Lazer feed id) so the
+/// pool can value the asset during a sync without reading the registry (which
+/// depends on this module). The pool holds exactly two of these, one per fixed
+/// incentive asset (`SUI`, `DEEP`).
+///
+/// A deposit lands in `locked` and vests linearly into `released` over the
+/// window `[last_compound_ms, end_ms]`. Only `released` is folded into pool NAV
+/// and paid out in-kind on withdrawal, so a deposit accrues to holders gradually
+/// rather than instantly — and an instant supply+withdraw cannot capture the
+/// still-locked remainder (compounding advances on wall-clock time only).
+public struct IncentiveState<phantom T> has store {
+    /// Vested, claimable balance: priced into NAV and paid out in-kind.
+    released: Balance<T>,
+    /// Unvested balance still streaming into `released`.
+    locked: Balance<T>,
+    /// Start of the current release interval (last compound time), in ms.
+    last_compound_ms: u64,
+    /// End of the linear release window, in ms; 0 once fully vested (no schedule).
+    end_ms: u64,
+    /// Coin decimals and Lazer feed id, cached from the registry on deposit; 0
+    /// until the first deposit (the state is empty and unvalued until then).
+    decimals: u8,
+    feed_id: u32,
+}
 
 /// Pool-level capital and PLP accounting state.
 public struct PoolVault has key {
@@ -63,6 +95,14 @@ public struct PoolVault has key {
     treasury_cap: TreasuryCap<PLP>,
     /// Active expiry IDs, pool cash-flow rows, profit basis, and per-expiry funding caps.
     expiry_accounting: Ledger,
+    /// Admin-deposited LP-owned incentive in SUI: valued into pool NAV (released
+    /// portion, via `pyth_source::value_in_dusdc`) and paid out pro-rata in-kind
+    /// on withdrawal.
+    incentive_sui: IncentiveState<SUI>,
+    /// Admin-deposited LP-owned incentive in DEEP. Distinct from `staked_deep`
+    /// (manager custody, not redeemable): this balance is LP-owned and redeemed
+    /// in-kind on withdrawal.
+    incentive_deep: IncentiveState<DEEP>,
     /// Mirror of `ProtocolConfig.allowed_versions`; synced permissionlessly.
     allowed_versions: VecSet<u64>,
 }
@@ -131,6 +171,27 @@ public fun active_expiry_markets(vault: &PoolVault): &vector<ID> {
 /// Return total PLP supply.
 public fun total_supply(vault: &PoolVault): u64 {
     vault.treasury_cap.total_supply()
+}
+
+/// Return the vested (claimable) SUI incentive balance — the portion folded into
+/// NAV and paid out in-kind; the still-vesting remainder is `incentive_sui_locked`.
+public fun incentive_sui_balance(vault: &PoolVault): u64 {
+    vault.incentive_sui.released.value()
+}
+
+/// Return the unvested (still-streaming) SUI incentive balance.
+public fun incentive_sui_locked(vault: &PoolVault): u64 {
+    vault.incentive_sui.locked.value()
+}
+
+/// Return the vested (claimable) DEEP incentive balance.
+public fun incentive_deep_balance(vault: &PoolVault): u64 {
+    vault.incentive_deep.released.value()
+}
+
+/// Return the unvested (still-streaming) DEEP incentive balance.
+public fun incentive_deep_locked(vault: &PoolVault): u64 {
+    vault.incentive_deep.locked.value()
 }
 
 /// Return the pricing debit side of aggregate expiry profit basis.
@@ -207,21 +268,20 @@ public fun sync_expiry(
     sync.record_expiry_synced(expiry_market_id, expiry_nav);
 }
 
-/// Finish a full-pool sync flow and return current PLP-owned pool value.
+/// Finish a full-pool sync flow and return the PLP-owned DUSDC-denominated value
+/// (idle + active expiry NAV, net of pending protocol profit). Asserts every
+/// active expiry was synced. Incentives are valued separately by `supply` (priced
+/// into NAV) and paid in-kind by `withdraw`, so the sync flow itself is unaware
+/// of them.
 public fun finish_pool_sync(vault: &PoolVault, config: &mut ProtocolConfig, sync: PoolSync): u64 {
     vault.assert_version_allowed();
     config.assert_valuation_in_progress();
     sync.assert_pool_vault(vault);
     assert_all_expected_synced(&sync.expected_expiry_markets, &sync.synced_expiry_markets);
-    let pool_value = vault.synced_pool_value(config, sync.active_expiry_value);
-    let PoolSync {
-        pool_vault_id: _,
-        expected_expiry_markets: _,
-        synced_expiry_markets: _,
-        active_expiry_value: _,
-    } = sync;
+    let dusdc_value = vault.synced_pool_value(config, sync.active_expiry_value);
+    let PoolSync { .. } = sync;
     config.end_valuation();
-    pool_value
+    dusdc_value
 }
 
 /// Resolve one manager's settled trading-loss rebate and return residual reserve to the pool.
@@ -253,22 +313,36 @@ public fun claim_trading_loss_rebate(
 
 /// Supply DUSDC into the pool vault against a complete full-pool sync.
 ///
-/// Finishes pool sync to price shares, then mints PLP against the supplied DUSDC.
+/// Values both incentive assets from their fresh feeds, finishes the sync to get
+/// the DUSDC NAV, then prices shares against the total (DUSDC + incentive value)
+/// and mints PLP. Pricing against total NAV means a new depositor pays the
+/// incentives' fair value and cannot dilute existing holders' in-kind claim on
+/// them. `sui_source`/`deep_source` are the bound incentive feeds; an empty
+/// incentive ignores its source.
 public fun supply(
     vault: &mut PoolVault,
     config: &mut ProtocolConfig,
     sync: PoolSync,
     payment: Coin<DUSDC>,
+    sui_source: &PythSource,
+    deep_source: &PythSource,
+    clock: &Clock,
     ctx: &mut TxContext,
 ): Coin<PLP> {
     vault.assert_version_allowed();
-    let pool_value = vault.finish_pool_sync(config, sync);
+    // Value incentives while the valuation window is still open (before the
+    // finisher ends it), then finish for the DUSDC NAV.
+    let incentive_value = vault.value_incentives(config, sui_source, deep_source, clock);
+    let dusdc_value = vault.finish_pool_sync(config, sync);
+    let pool_value = dusdc_value + incentive_value;
     let payment_amount = payment.value();
     assert!(payment_amount > 0, EZeroSupply);
 
     let total_supply = vault.treasury_cap.total_supply();
     let shares = if (total_supply == 0) {
-        assert!(pool_value == 0, EInvalidInitialSupply);
+        // Bootstrap mints 1:1; only the DUSDC side must be empty (incentives
+        // can't exist before the first supply — see deposit guards).
+        assert!(dusdc_value == 0, EInvalidInitialSupply);
         payment_amount
     } else {
         assert!(pool_value > 0, EZeroPoolValue);
@@ -290,38 +364,51 @@ public fun supply(
     plp
 }
 
-/// Withdraw DUSDC from the pool vault against a complete full-pool sync.
+/// Withdraw from the pool vault against a complete full-pool sync.
 ///
-/// Finishes pool sync to price shares, then burns PLP and withdraws idle DUSDC.
+/// Pays the DUSDC-denominated pro-rata share plus the pro-rata in-kind share of
+/// each incentive asset (SUI, DEEP), all in one call. Each incentive is vested up
+/// to the withdrawal time, then `lp_amount * released / total_supply` (supply
+/// snapshotted before the burn) is split from its released balance, rounding
+/// down: the holder's slice covers every unit vested while they still held
+/// shares, and the locked remainder stays for those who remain. Incentives need
+/// no oracle here — an in-kind slice is fair by construction — so a stale feed
+/// can never block an exit.
 public fun withdraw(
     vault: &mut PoolVault,
     config: &mut ProtocolConfig,
     sync: PoolSync,
     lp_coin: Coin<PLP>,
+    clock: &Clock,
     ctx: &mut TxContext,
-): Coin<DUSDC> {
+): (Coin<DUSDC>, Coin<SUI>, Coin<DEEP>) {
     vault.assert_version_allowed();
-    let pool_value = vault.finish_pool_sync(config, sync);
+    // Only the DUSDC-denominated value backs the DUSDC payout; incentives are
+    // paid in-kind below from their live released balances (no oracle).
+    let dusdc_value = vault.finish_pool_sync(config, sync);
     let lp_amount = lp_coin.value();
     assert!(lp_amount > 0, EZeroWithdraw);
 
     let total_supply = vault.treasury_cap.total_supply();
-    let withdraw_amount = predict_math::mul_div_round_down(lp_amount, pool_value, total_supply);
+    let withdraw_amount = predict_math::mul_div_round_down(lp_amount, dusdc_value, total_supply);
     assert!(withdraw_amount > 0, EZeroWithdraw);
     let idle_balance = vault.idle_balance.value();
     assert!(idle_balance >= withdraw_amount, EInsufficientIdleBalance);
 
     vault.treasury_cap.burn(lp_coin);
     let payout = vault.idle_balance.split(withdraw_amount).into_coin(ctx);
+    let now_ms = clock.timestamp_ms();
+    let sui = vault.incentive_sui.claim(lp_amount, total_supply, now_ms, ctx);
+    let deep = vault.incentive_deep.claim(lp_amount, total_supply, now_ms, ctx);
     vault_events::emit_withdraw_executed(
         vault.id(),
         lp_amount,
         withdraw_amount,
-        pool_value,
+        dusdc_value,
         vault.treasury_cap.total_supply(),
         vault.idle_balance.value(),
     );
-    payout
+    (payout, sui, deep)
 }
 
 /// Stake DEEP for trading benefits. The DEEP is held in the pool vault; the
@@ -372,6 +459,8 @@ public(package) fun new(treasury_cap: TreasuryCap<PLP>, ctx: &mut TxContext): Po
         staked_deep: balance::zero(),
         treasury_cap,
         expiry_accounting: pool_accounting::new(ctx),
+        incentive_sui: empty_incentive_state(),
+        incentive_deep: empty_incentive_state(),
         allowed_versions: vec_set::singleton(constants::current_version!()),
     }
 }
@@ -395,6 +484,45 @@ public(package) fun set_allowed_versions(vault: &mut PoolVault, allowed_versions
 public(package) fun register_expiry_market(vault: &mut PoolVault, expiry_market_id: ID) {
     vault.assert_version_allowed();
     vault.expiry_accounting.register_expiry(expiry_market_id);
+}
+
+/// Take custody of an admin SUI incentive deposit, caching its oracle binding and
+/// arming a linear vesting schedule over `duration_ms`.
+///
+/// Mints no PLP. The deposit lands in the locked balance and vests into the
+/// released balance over `[now, now + duration_ms]`; released value accrues to
+/// existing holders via share price and is paid back in-kind on withdrawal.
+/// Requires existing PLP holders so the first future supplier can't capture the
+/// whole deposit. A deposit onto a still-vesting schedule first vests the prior
+/// schedule to now (locking in its released portion), then re-stretches the
+/// unvested remainder plus the new deposit over a fresh window. The authorizing
+/// `AdminCap` and feed-config checks live in `registry::deposit_sui_incentive`,
+/// which supplies the binding read from the registry.
+public(package) fun receive_sui_incentive(
+    vault: &mut PoolVault,
+    deposit: Coin<SUI>,
+    decimals: u8,
+    feed_id: u32,
+    duration_ms: u64,
+    clock: &Clock,
+) {
+    vault.assert_version_allowed();
+    assert!(vault.treasury_cap.total_supply() > 0, ENoPlpHolders);
+    vault.incentive_sui.fund(deposit, decimals, feed_id, duration_ms, clock);
+}
+
+/// Take custody of an admin DEEP incentive deposit. See `receive_sui_incentive`.
+public(package) fun receive_deep_incentive(
+    vault: &mut PoolVault,
+    deposit: Coin<DEEP>,
+    decimals: u8,
+    feed_id: u32,
+    duration_ms: u64,
+    clock: &Clock,
+) {
+    vault.assert_version_allowed();
+    assert!(vault.treasury_cap.total_supply() > 0, ENoPlpHolders);
+    vault.incentive_deep.fund(deposit, decimals, feed_id, duration_ms, clock);
 }
 
 /// Set the max net DUSDC the pool may have funded into one expiry.
@@ -444,6 +572,28 @@ fun expiry_rebalance_cash_terms(market: &ExpiryMarket): (u64, u64, u64) {
     (market.cash_balance(), target_cash, sweep_threshold_cash)
 }
 
+/// Total DUSDC-denominated value of both incentive assets for `supply` pricing.
+///
+/// Vests each non-empty incentive to now and prices its released balance from its
+/// bound, fresh feed; an empty incentive contributes 0 and ignores its source.
+/// Must be called inside the valuation window (before the finisher ends it) so
+/// the oracle reads are gated like the expiry path's.
+fun value_incentives(
+    vault: &mut PoolVault,
+    config: &ProtocolConfig,
+    sui_source: &PythSource,
+    deep_source: &PythSource,
+    clock: &Clock,
+): u64 {
+    let sui_value = if (!vault.incentive_sui.is_empty()) {
+        vault.incentive_sui.sync_value(config, sui_source, clock)
+    } else 0;
+    let deep_value = if (!vault.incentive_deep.is_empty()) {
+        vault.incentive_deep.sync_value(config, deep_source, clock)
+    } else 0;
+    sui_value + deep_value
+}
+
 fun synced_pool_value(vault: &PoolVault, config: &ProtocolConfig, active_expiry_value: u64): u64 {
     let gross_pool_value = vault.idle_balance.value() + active_expiry_value;
     gross_pool_value - vault.pending_protocol_profit_exclusion(config, active_expiry_value)
@@ -479,6 +629,102 @@ fun assert_expiry_ready_to_sync(sync: &PoolSync, expiry_market_id: ID) {
 fun record_expiry_synced(sync: &mut PoolSync, expiry_market_id: ID, expiry_nav: u64) {
     sync.active_expiry_value = sync.active_expiry_value + expiry_nav;
     sync.synced_expiry_markets.push_back(expiry_market_id);
+}
+
+fun empty_incentive_state<T>(): IncentiveState<T> {
+    IncentiveState<T> {
+        released: balance::zero<T>(),
+        locked: balance::zero<T>(),
+        last_compound_ms: 0,
+        end_ms: 0,
+        decimals: 0,
+        feed_id: 0,
+    }
+}
+
+/// Whether this incentive has no holdings (no released and no locked balance),
+/// so it need not be valued during a pool sync.
+fun is_empty<T>(state: &IncentiveState<T>): bool {
+    state.released.value() == 0 && state.locked.value() == 0
+}
+
+/// Add a deposit and (re)arm the linear vesting window. Vests any prior schedule
+/// to now first, so its already-vested portion stays in `released` and only the
+/// unvested remainder is re-stretched over the new window with the new deposit.
+fun fund<T>(
+    state: &mut IncentiveState<T>,
+    deposit: Coin<T>,
+    decimals: u8,
+    feed_id: u32,
+    duration_ms: u64,
+    clock: &Clock,
+) {
+    assert!(deposit.value() > 0, EZeroIncentiveDeposit);
+    assert!(duration_ms > 0, EZeroStreamDuration);
+    assert!(duration_ms <= constants::max_incentive_stream_ms!(), EStreamDurationTooLong);
+    let now_ms = clock.timestamp_ms();
+    state.compound(now_ms);
+    state.decimals = decimals;
+    state.feed_id = feed_id;
+    state.locked.join(deposit.into_balance());
+    state.last_compound_ms = now_ms;
+    state.end_ms = now_ms + duration_ms;
+}
+
+/// Verify the source binding + freshness, vest to now, and return the released
+/// balance's DUSDC value. Same freshness bound the market path applies.
+fun sync_value<T>(
+    state: &mut IncentiveState<T>,
+    config: &ProtocolConfig,
+    pyth_source: &PythSource,
+    clock: &Clock,
+): u64 {
+    assert!(pyth_source.feed_id() == state.feed_id, EIncentiveFeedMismatch);
+    pricing::assert_pyth_spot_fresh(config.pricing_config(), pyth_source, clock);
+    state.compound(clock.timestamp_ms());
+    pyth_source.value_in_dusdc(state.released.value(), state.decimals)
+}
+
+/// Vest to `now_ms`, then split the pro-rata `lp_amount / total_supply` share of
+/// the released balance, rounding down. `lp_amount <= total_supply`, so the share
+/// never exceeds the released balance.
+fun claim<T>(
+    state: &mut IncentiveState<T>,
+    lp_amount: u64,
+    total_supply: u64,
+    now_ms: u64,
+    ctx: &mut TxContext,
+): Coin<T> {
+    state.compound(now_ms);
+    let amount = predict_math::mul_div_round_down(lp_amount, state.released.value(), total_supply);
+    state.released.split(amount).into_coin(ctx)
+}
+
+/// Vest the linear schedule up to `now_ms`, moving the elapsed fraction of the
+/// locked balance into the released balance:
+///   release = locked * (now_ms - last_compound_ms) / (end_ms - last_compound_ms)
+/// No-op when there is no active schedule (`end_ms == 0`) or no time has passed.
+/// Once `now_ms` reaches `end_ms`, releases the entire locked remainder and
+/// clears the schedule (`end_ms = 0`), so later compounds are no-ops until the
+/// next deposit re-arms it.
+fun compound<T>(state: &mut IncentiveState<T>, now_ms: u64) {
+    if (state.end_ms == 0) return;
+    if (now_ms <= state.last_compound_ms) return;
+
+    let locked = state.locked.value();
+    let remaining = state.end_ms - state.last_compound_ms;
+    let amount = if (now_ms >= state.end_ms) {
+        state.last_compound_ms = 0;
+        state.end_ms = 0;
+        locked
+    } else {
+        let elapsed = now_ms - state.last_compound_ms;
+        state.last_compound_ms = now_ms;
+        predict_math::mul_div_round_down(locked, elapsed, remaining)
+    };
+    if (amount > 0) {
+        state.released.join(state.locked.split(amount));
+    };
 }
 
 fun rebalance_active_expiry_cash(vault: &mut PoolVault, market: &mut ExpiryMarket) {

--- a/packages/predict/sources/registry.move
+++ b/packages/predict/sources/registry.move
@@ -23,6 +23,7 @@ use deepbook_predict::{
     protocol_config::{Self, ProtocolConfig},
     pyth_source::{Self, PythSource}
 };
+use dusdc::dusdc::DUSDC;
 use std::type_name::{Self, TypeName};
 use sui::{
     clock::Clock,
@@ -387,6 +388,34 @@ public fun deposit_deep_incentive(
     registry.assert_version_allowed();
     let (decimals, feed_id) = registry.incentive_asset<DEEP>();
     vault.receive_deep_incentive(deposit, decimals, feed_id, duration_ms, clock);
+}
+
+/// Buy DEEP back from any seller for DUSDC, permissionlessly, funded by the LP
+/// buyback budget. Reads the registry's DEEP oracle binding and delegates pricing,
+/// NAV folding, and payout to `plp::execute_deep_buyback`. DEEP must be a configured
+/// incentive asset (it shares the registry binding); `min_dusdc_out` bounds slippage.
+public fun swap_deep_for_dusdc(
+    registry: &Registry,
+    vault: &mut PoolVault,
+    config: &ProtocolConfig,
+    deep_source: &PythSource,
+    deep: Coin<DEEP>,
+    min_dusdc_out: u64,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): Coin<DUSDC> {
+    registry.assert_version_allowed();
+    let (decimals, feed_id) = registry.incentive_asset<DEEP>();
+    vault.execute_deep_buyback(
+        config,
+        deep_source,
+        deep,
+        decimals,
+        feed_id,
+        min_dusdc_out,
+        clock,
+        ctx,
+    )
 }
 
 /// Read the configured `(decimals, feed_id)` binding for `T`. Aborts if `T` is

--- a/packages/predict/sources/registry.move
+++ b/packages/predict/sources/registry.move
@@ -23,7 +23,17 @@ use deepbook_predict::{
     protocol_config::{Self, ProtocolConfig},
     pyth_source::{Self, PythSource}
 };
-use sui::{clock::Clock, table::{Self, Table}, vec_set::{Self, VecSet}};
+use std::type_name::{Self, TypeName};
+use sui::{
+    clock::Clock,
+    coin::Coin,
+    coin_registry::Currency,
+    sui::SUI,
+    table::{Self, Table},
+    vec_map::{Self, VecMap},
+    vec_set::{Self, VecSet}
+};
+use token::deep::DEEP;
 
 const EFeedIdMismatch: u64 = 0;
 const EPythSourceAlreadyCreated: u64 = 1;
@@ -35,6 +45,7 @@ const EVersionAlreadyEnabled: u64 = 6;
 const EVersionNotEnabled: u64 = 7;
 const ECannotDisableLastVersion: u64 = 8;
 const EPythFeedNotRegistered: u64 = 9;
+const EIncentiveAssetNotConfigured: u64 = 10;
 
 /// Registry-owned config for one Pyth Lazer feed.
 public struct PythFeedConfig has copy, drop, store {
@@ -56,11 +67,22 @@ public struct PauseCap has key, store {
     id: UID,
 }
 
+/// Oracle binding for one admin-approved non-DUSDC incentive asset: the Lazer
+/// feed that prices it and its coin decimals (from `Currency<T>` metadata).
+public struct IncentiveAsset has copy, drop, store {
+    decimals: u8,
+    feed_id: u32,
+}
+
 /// Shared registry for source and expiry uniqueness.
 public struct Registry has key {
     id: UID,
     /// Pyth Lazer feed ID -> source object and creation-time market config.
     pyth_feed_configs: Table<u32, PythFeedConfig>,
+    /// Coin type -> Lazer feed binding for admin-deposited incentive assets.
+    /// The single home for oracle bindings: trading feeds (`pyth_feed_configs`)
+    /// and incentive assets live here together.
+    incentive_assets: VecMap<TypeName, IncentiveAsset>,
     /// Created expiry markets keyed by expiry timestamp.
     expiry_market_ids: Table<u64, ID>,
     /// IDs of `PauseCap` objects currently authorized to use pause-only entries.
@@ -309,6 +331,73 @@ public fun create_pyth_source(
     pyth_source_id
 }
 
+// === Incentive Assets (admin) ===
+
+/// Bind non-DUSDC incentive asset `T` to the Lazer `feed_id` that prices it.
+/// Decimals are read from `Currency<T>`. The feed must already have a
+/// registered Pyth config, so trading and incentive oracles share one registry.
+public fun set_incentive_asset<T>(
+    registry: &mut Registry,
+    _admin_cap: &AdminCap,
+    currency: &Currency<T>,
+    feed_id: u32,
+) {
+    registry.assert_version_allowed();
+    assert!(registry.pyth_feed_configs.contains(feed_id), EPythFeedNotRegistered);
+    let key = type_name::with_defining_ids<T>();
+    let asset = IncentiveAsset { decimals: currency.decimals(), feed_id };
+    if (registry.incentive_assets.contains(&key)) {
+        registry.incentive_assets.remove(&key);
+    };
+    registry.incentive_assets.insert(key, asset);
+}
+
+/// Whether `T` is a configured incentive asset.
+public fun has_incentive_asset<T>(registry: &Registry): bool {
+    registry.incentive_assets.contains(&type_name::with_defining_ids<T>())
+}
+
+/// Deposit SUI into the pool as an LP-owned incentive (a donation: no PLP minted).
+/// It vests linearly over `duration_ms`; the vested value accrues to existing
+/// holders pro-rata and the asset accrues to them in-kind on withdrawal. SUI must
+/// be a configured incentive asset; the pool must already have PLP holders
+/// (checked in `plp`).
+public fun deposit_sui_incentive(
+    registry: &Registry,
+    vault: &mut PoolVault,
+    _admin_cap: &AdminCap,
+    deposit: Coin<SUI>,
+    duration_ms: u64,
+    clock: &Clock,
+) {
+    registry.assert_version_allowed();
+    let (decimals, feed_id) = registry.incentive_asset<SUI>();
+    vault.receive_sui_incentive(deposit, decimals, feed_id, duration_ms, clock);
+}
+
+/// Deposit DEEP into the pool as an LP-owned incentive. See `deposit_sui_incentive`.
+public fun deposit_deep_incentive(
+    registry: &Registry,
+    vault: &mut PoolVault,
+    _admin_cap: &AdminCap,
+    deposit: Coin<DEEP>,
+    duration_ms: u64,
+    clock: &Clock,
+) {
+    registry.assert_version_allowed();
+    let (decimals, feed_id) = registry.incentive_asset<DEEP>();
+    vault.receive_deep_incentive(deposit, decimals, feed_id, duration_ms, clock);
+}
+
+/// Read the configured `(decimals, feed_id)` binding for `T`. Aborts if `T` is
+/// not a configured incentive asset.
+fun incentive_asset<T>(registry: &Registry): (u8, u32) {
+    let key = type_name::with_defining_ids<T>();
+    assert!(registry.incentive_assets.contains(&key), EIncentiveAssetNotConfigured);
+    let asset = &registry.incentive_assets[&key];
+    (asset.decimals, asset.feed_id)
+}
+
 /// Create the MarketOracle and ExpiryMarket objects for one future expiry.
 ///
 /// The registry enforces one market per expiry, validates the registered Pyth
@@ -420,6 +509,7 @@ fun new_registry_and_admin_cap(ctx: &mut TxContext): (Registry, AdminCap) {
         Registry {
             id: object::new(ctx),
             pyth_feed_configs: table::new(ctx),
+            incentive_assets: vec_map::empty(),
             expiry_market_ids: table::new(ctx),
             allowed_pause_caps: vec_set::empty(),
             allowed_versions: vec_set::singleton(constants::current_version!()),
@@ -482,10 +572,24 @@ public fun new_for_testing(ctx: &mut TxContext): (Registry, AdminCap) {
 }
 
 #[test_only]
+/// Configure an incentive binding without an on-chain `Currency<T>` or a
+/// registered feed source. Non-production fixture for tests that exercise pool
+/// valuation, not the admin registration path.
+public fun set_incentive_asset_for_testing<T>(registry: &mut Registry, decimals: u8, feed_id: u32) {
+    let key = type_name::with_defining_ids<T>();
+    let asset = IncentiveAsset { decimals, feed_id };
+    if (registry.incentive_assets.contains(&key)) {
+        registry.incentive_assets.remove(&key);
+    };
+    registry.incentive_assets.insert(key, asset);
+}
+
+#[test_only]
 public fun destroy_registry_for_testing(registry: Registry) {
     let Registry {
         id,
         pyth_feed_configs,
+        incentive_assets: _,
         expiry_market_ids,
         allowed_pause_caps: _,
         allowed_versions: _,
@@ -502,6 +606,7 @@ public fun destroy_registry_drop_for_testing(registry: Registry) {
     let Registry {
         id,
         pyth_feed_configs,
+        incentive_assets: _,
         expiry_market_ids,
         allowed_pause_caps: _,
         allowed_versions: _,

--- a/packages/predict/tests/flows/plp_rebate_flow_tests.move
+++ b/packages/predict/tests/flows/plp_rebate_flow_tests.move
@@ -15,7 +15,7 @@ use deepbook_predict::{
     plp::{Self, PLP, PoolVault},
     predict_manager::PredictManager,
     protocol_config::{Self, ProtocolConfig},
-    pyth_source::PythSource,
+    pyth_source::{Self, PythSource},
     registry::{Self, Registry},
     test_constants
 };
@@ -169,12 +169,18 @@ fun setup_pool_with_pyth(): Fixture {
     let mut vault = scenario.take_shared<PoolVault>();
     let vault_id = vault.id();
     let sync = plp::start_pool_sync(&mut config, &vault);
+    // Bootstrap supply: no incentives exist yet, so the sources are ignored.
+    let placeholder = pyth_source::new_for_testing(scenario.ctx());
     let initial_plp = vault.supply(
         &mut config,
         sync,
         coin::mint_for_testing<DUSDC>(INITIAL_SUPPLY, scenario.ctx()),
+        &placeholder,
+        &placeholder,
+        &clock,
         scenario.ctx(),
     );
+    destroy(placeholder);
     return_shared(vault);
 
     scenario.next_tx(test_constants::admin());

--- a/packages/predict/tests/flows/plp_rebate_flow_tests.move
+++ b/packages/predict/tests/flows/plp_rebate_flow_tests.move
@@ -46,6 +46,11 @@ const MIN_FEE_REBATE_RESERVE: u64 = 2_500_000;
 const MIN_FEE_PROTOCOL_PROFIT: u64 = 1_000_000;
 const MIN_FEE_TERMINAL_MATERIALIZED_PROFIT: u64 = 502_500_000;
 const MIN_FEE_TERMINAL_PROTOCOL_PROFIT: u64 = 201_000_000;
+// Protocol profit funds the buyback budget at the default 50% buyback share:
+// 50% of 201_000_000 = 100_500_000 at settlement, then 50% of 1_000_000 = 500_000
+// more after the rebate claim.
+const MIN_FEE_TERMINAL_BUYBACK_BUDGET: u64 = 100_500_000;
+const MIN_FEE_BUYBACK_BUDGET_AFTER_REBATE: u64 = 101_000_000;
 
 /// Scenario-local objects shared by the PLP rebate flow tests.
 public struct Fixture {
@@ -104,6 +109,7 @@ fun same_expiry_residual_rebate_cash_materializes_new_terminal_profit() {
         vault.profit_basis_credits(),
         constants::expiry_cash_floor!() + MIN_FEE_TERMINAL_MATERIALIZED_PROFIT,
     );
+    assert_eq!(vault.buyback_budget(), MIN_FEE_TERMINAL_BUYBACK_BUDGET);
 
     let (closed_order_id, replacement_order_id) = market.redeem(
         &mut manager,
@@ -143,6 +149,7 @@ fun same_expiry_residual_rebate_cash_materializes_new_terminal_profit() {
             + MIN_FEE_TERMINAL_MATERIALIZED_PROFIT
             + MIN_FEE_REBATE_RESERVE,
     );
+    assert_eq!(vault.buyback_budget(), MIN_FEE_BUYBACK_BUDGET_AFTER_REBATE);
     assert_eq!(market.cash_balance(), 0);
 
     return_shared(oracle);

--- a/packages/predict/tests/pool/plp_buyback_tests.move
+++ b/packages/predict/tests/pool/plp_buyback_tests.move
@@ -1,0 +1,444 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+/// Permissionless DEEP buyback funded from the protocol reserve: a configurable slice
+/// of each expiry's protocol profit is authorized as a DUSDC `buyback_budget`, and
+/// anyone may sell DEEP into the pool for DUSDC out of that budget. The DEEP is priced
+/// off the registry-bound DEEP `PythSource` (rounded down, minus the configured
+/// discount), paid from `protocol_reserve_balance` (excluded from LP NAV), and folded
+/// into the LP-owned `incentive_deep` released balance (so it enters PLP NAV and is
+/// paid in-kind on withdrawal). Each swap moves value from protocol revenue into an
+/// LP-owned DEEP position (NAV-accretive to LPs) and never touches idle liquidity, so
+/// withdrawals are unaffected.
+module deepbook_predict::plp_buyback_tests;
+
+use deepbook_predict::{
+    admin::AdminCap,
+    config_constants,
+    constants,
+    plp::{Self, PoolVault, PLP},
+    pricing,
+    protocol_config::{Self, ProtocolConfig},
+    pyth_source::{Self, PythSource},
+    registry::{Self, Registry},
+    test_constants
+};
+use dusdc::dusdc::DUSDC;
+use std::unit_test::{assert_eq, destroy};
+use sui::{clock::{Self, Clock}, coin, test_scenario as test};
+use token::deep::DEEP;
+
+const THOUSAND_DUSDC: u64 = 1_000_000_000;
+// DEEP has 6 decimals; at $1, raw DEEP units map 1:1 to raw DUSDC units.
+const FIFTY_DEEP: u64 = 50_000_000;
+const FIFTY_DUSDC: u64 = 50_000_000;
+const TWO_HUNDRED_DUSDC: u64 = 200_000_000;
+const DEEP_DECIMALS: u8 = 6;
+// `pyth_source::new_for_testing` reports feed id 0.
+const DEEP_FEED_ID: u32 = 0;
+const NOW_MS: u64 = 1_000_000;
+const TEN_PERCENT: u64 = 100_000_000;
+
+// === Helpers ===
+
+fun usd_spot(price_usd: u64): u64 {
+    price_usd * constants::float_scaling!()
+}
+
+fun fresh(): u64 {
+    config_constants::default_pyth_spot_freshness_ms!()
+}
+
+/// Pool set up with DEEP bound as the buyback oracle asset (feed id 0, 6 decimals).
+fun begin(): (test::Scenario, Registry, AdminCap, PoolVault, ProtocolConfig, Clock) {
+    let mut scenario = test::begin(test_constants::admin());
+    plp::init_for_testing(scenario.ctx());
+    let (mut registry, admin_cap) = registry::new_for_testing(scenario.ctx());
+    registry.set_incentive_asset_for_testing<DEEP>(DEEP_DECIMALS, DEEP_FEED_ID);
+    let config = protocol_config::new_for_testing(scenario.ctx());
+    let mut clk = clock::create_for_testing(scenario.ctx());
+    clk.set_for_testing(NOW_MS);
+    scenario.next_tx(test_constants::admin());
+    let vault = scenario.take_shared<PoolVault>();
+    (scenario, registry, admin_cap, vault, config, clk)
+}
+
+fun finish(
+    scenario: test::Scenario,
+    registry: Registry,
+    admin_cap: AdminCap,
+    vault: PoolVault,
+    config: ProtocolConfig,
+    clk: Clock,
+) {
+    destroy(admin_cap);
+    destroy(config);
+    destroy(clk);
+    test::return_shared(vault);
+    registry::destroy_registry_drop_for_testing(registry);
+    scenario.end();
+}
+
+/// A fresh DEEP `PythSource` (feed id 0) reporting `spot`, observed at `clk`.
+fun deep_source(scenario: &mut test::Scenario, clk: &Clock, spot: u64): PythSource {
+    let mut source = pyth_source::new_for_testing(scenario.ctx());
+    let now = clk.timestamp_ms();
+    source.set_state_for_testing(spot, now, now);
+    source
+}
+
+/// Bootstrap the pool with `amount` DUSDC of idle liquidity (mints PLP 1:1).
+fun bootstrap_supply(
+    vault: &mut PoolVault,
+    config: &mut ProtocolConfig,
+    scenario: &mut test::Scenario,
+    clk: &Clock,
+    amount: u64,
+): coin::Coin<PLP> {
+    let sync = plp::start_pool_sync(config, vault);
+    let placeholder = deep_source(scenario, clk, 0);
+    let lp = plp::supply(
+        vault,
+        config,
+        sync,
+        coin::mint_for_testing<DUSDC>(amount, scenario.ctx()),
+        &placeholder,
+        &placeholder,
+        clk,
+        scenario.ctx(),
+    );
+    destroy(placeholder);
+    lp
+}
+
+/// Seed the buyback budget and the protocol reserve it draws from.
+fun seed_buyback(vault: &mut PoolVault, scenario: &mut test::Scenario, budget: u64, reserve: u64) {
+    vault.set_buyback_budget_for_testing(budget);
+    vault.set_protocol_reserve_for_testing(reserve, scenario.ctx());
+}
+
+fun swap(
+    registry: &Registry,
+    vault: &mut PoolVault,
+    config: &ProtocolConfig,
+    scenario: &mut test::Scenario,
+    clk: &Clock,
+    spot: u64,
+    deep_amount: u64,
+    min_dusdc_out: u64,
+): coin::Coin<DUSDC> {
+    let source = deep_source(scenario, clk, spot);
+    let out = registry::swap_deep_for_dusdc(
+        registry,
+        vault,
+        config,
+        &source,
+        coin::mint_for_testing<DEEP>(deep_amount, scenario.ctx()),
+        min_dusdc_out,
+        clk,
+        scenario.ctx(),
+    );
+    destroy(source);
+    out
+}
+
+// === swap: success / pricing ===
+
+#[test]
+fun swap_pays_dusdc_from_reserve_and_folds_deep() {
+    let (mut scenario, registry, admin_cap, mut vault, mut config, clk) = begin();
+    let alice_lp = bootstrap_supply(&mut vault, &mut config, &mut scenario, &clk, THOUSAND_DUSDC);
+    seed_buyback(&mut vault, &mut scenario, TWO_HUNDRED_DUSDC, TWO_HUNDRED_DUSDC);
+
+    // 50 DEEP @ $1 = $50, paid from the protocol reserve; idle is never touched.
+    let out = swap(&registry, &mut vault, &config, &mut scenario, &clk, usd_spot(1), FIFTY_DEEP, 0);
+    assert_eq!(out.value(), FIFTY_DUSDC);
+    assert_eq!(vault.buyback_budget(), TWO_HUNDRED_DUSDC - FIFTY_DUSDC);
+    assert_eq!(vault.protocol_reserve_balance(), TWO_HUNDRED_DUSDC - FIFTY_DUSDC);
+    assert_eq!(vault.idle_balance(), THOUSAND_DUSDC);
+    assert_eq!(vault.incentive_deep_balance(), FIFTY_DEEP);
+
+    destroy(out);
+    destroy(alice_lp);
+    finish(scenario, registry, admin_cap, vault, config, clk);
+}
+
+#[test]
+fun swap_rounds_payout_down() {
+    let (mut scenario, registry, admin_cap, mut vault, mut config, clk) = begin();
+    let alice_lp = bootstrap_supply(&mut vault, &mut config, &mut scenario, &clk, THOUSAND_DUSDC);
+    seed_buyback(&mut vault, &mut scenario, TWO_HUNDRED_DUSDC, TWO_HUNDRED_DUSDC);
+
+    // 1 raw DEEP unit @ $1.50 = 1.5 DUSDC units, floored DOWN to 1 (the round-up
+    // valuation used for NAV would give 2 — the payout must never overpay).
+    let out = swap(
+        &registry,
+        &mut vault,
+        &config,
+        &mut scenario,
+        &clk,
+        usd_spot(1) + usd_spot(1) / 2,
+        1,
+        0,
+    );
+    assert_eq!(out.value(), 1);
+
+    destroy(out);
+    destroy(alice_lp);
+    finish(scenario, registry, admin_cap, vault, config, clk);
+}
+
+#[test]
+fun swap_applies_discount() {
+    let (mut scenario, registry, admin_cap, mut vault, mut config, clk) = begin();
+    let alice_lp = bootstrap_supply(&mut vault, &mut config, &mut scenario, &clk, THOUSAND_DUSDC);
+    seed_buyback(&mut vault, &mut scenario, TWO_HUNDRED_DUSDC, TWO_HUNDRED_DUSDC);
+    config.set_buyback_discount(&admin_cap, TEN_PERCENT);
+
+    // 50 DEEP @ $1 = $50, less 10% discount = $45 -> 45_000_000 DUSDC units.
+    let out = swap(&registry, &mut vault, &config, &mut scenario, &clk, usd_spot(1), FIFTY_DEEP, 0);
+    assert_eq!(out.value(), 45_000_000);
+    assert_eq!(vault.buyback_budget(), TWO_HUNDRED_DUSDC - 45_000_000);
+    assert_eq!(vault.protocol_reserve_balance(), TWO_HUNDRED_DUSDC - 45_000_000);
+    assert_eq!(vault.incentive_deep_balance(), FIFTY_DEEP);
+
+    destroy(out);
+    destroy(alice_lp);
+    finish(scenario, registry, admin_cap, vault, config, clk);
+}
+
+// === swap: NAV effect (protocol subsidizes LPs) ===
+
+#[test]
+fun nav_rises_when_protocol_funds_buyback() {
+    let (mut scenario, registry, admin_cap, mut vault, mut config, clk) = begin();
+    // Alice bootstraps 1000 DUSDC -> 1000 PLP at share price 1.0.
+    let alice_lp = bootstrap_supply(&mut vault, &mut config, &mut scenario, &clk, THOUSAND_DUSDC);
+    assert_eq!(alice_lp.value(), THOUSAND_DUSDC);
+    seed_buyback(&mut vault, &mut scenario, TWO_HUNDRED_DUSDC, TWO_HUNDRED_DUSDC);
+
+    // The protocol funds 50 DEEP into LP-owned holdings at no cost to idle: NAV rises
+    // from 1000 to 1050 (1000 idle + $50 DEEP), so share price becomes 1.05.
+    let out = swap(&registry, &mut vault, &config, &mut scenario, &clk, usd_spot(1), FIFTY_DEEP, 0);
+
+    let sync = plp::start_pool_sync(&mut config, &vault);
+    let src = deep_source(&mut scenario, &clk, usd_spot(1));
+    let bob_lp = plp::supply(
+        &mut vault,
+        &mut config,
+        sync,
+        coin::mint_for_testing<DUSDC>(THOUSAND_DUSDC + FIFTY_DUSDC, scenario.ctx()),
+        &src,
+        &src,
+        &clk,
+        scenario.ctx(),
+    );
+    // At share price 1.05, a 1050 DUSDC deposit mints exactly 1000 PLP.
+    assert_eq!(bob_lp.value(), THOUSAND_DUSDC);
+
+    destroy(src);
+    destroy(out);
+    destroy(alice_lp);
+    destroy(bob_lp);
+    finish(scenario, registry, admin_cap, vault, config, clk);
+}
+
+// === firewall: withdraw never touches the budget or the protocol reserve ===
+
+#[test]
+fun withdraw_does_not_spend_buyback_budget_or_reserve() {
+    let (mut scenario, registry, admin_cap, mut vault, mut config, clk) = begin();
+    let alice_lp = bootstrap_supply(&mut vault, &mut config, &mut scenario, &clk, THOUSAND_DUSDC);
+    seed_buyback(&mut vault, &mut scenario, TWO_HUNDRED_DUSDC, TWO_HUNDRED_DUSDC);
+
+    // A full withdrawal pays only from idle; budget and protocol reserve are untouched.
+    let sync = plp::start_pool_sync(&mut config, &vault);
+    let (dusdc, sui, deep) = plp::withdraw(
+        &mut vault,
+        &mut config,
+        sync,
+        alice_lp,
+        &clk,
+        scenario.ctx(),
+    );
+    assert_eq!(dusdc.value(), THOUSAND_DUSDC);
+    assert_eq!(deep.value(), 0);
+    assert_eq!(vault.buyback_budget(), TWO_HUNDRED_DUSDC);
+    assert_eq!(vault.protocol_reserve_balance(), TWO_HUNDRED_DUSDC);
+
+    destroy(dusdc);
+    destroy(sui);
+    destroy(deep);
+    finish(scenario, registry, admin_cap, vault, config, clk);
+}
+
+// === swap: abort coverage ===
+
+#[test, expected_failure(abort_code = plp::EZeroDeepIn)]
+fun swap_zero_deep_aborts() {
+    let (mut scenario, registry, _admin_cap, mut vault, mut config, clk) = begin();
+    let alice_lp = bootstrap_supply(&mut vault, &mut config, &mut scenario, &clk, THOUSAND_DUSDC);
+    seed_buyback(&mut vault, &mut scenario, TWO_HUNDRED_DUSDC, TWO_HUNDRED_DUSDC);
+    let out = swap(&registry, &mut vault, &config, &mut scenario, &clk, usd_spot(1), 0, 0);
+    destroy(out);
+    destroy(alice_lp);
+    abort
+}
+
+#[test, expected_failure(abort_code = plp::EMinDusdcOutNotMet)]
+fun swap_below_min_out_aborts() {
+    let (mut scenario, registry, _admin_cap, mut vault, mut config, clk) = begin();
+    let alice_lp = bootstrap_supply(&mut vault, &mut config, &mut scenario, &clk, THOUSAND_DUSDC);
+    seed_buyback(&mut vault, &mut scenario, TWO_HUNDRED_DUSDC, TWO_HUNDRED_DUSDC);
+    // 50 DEEP @ $1 yields 50_000_000; demand one unit more.
+    let out = swap(
+        &registry,
+        &mut vault,
+        &config,
+        &mut scenario,
+        &clk,
+        usd_spot(1),
+        FIFTY_DEEP,
+        FIFTY_DUSDC + 1,
+    );
+    destroy(out);
+    destroy(alice_lp);
+    abort
+}
+
+#[test, expected_failure(abort_code = plp::EInsufficientBuybackBudget)]
+fun swap_exceeds_budget_aborts() {
+    let (mut scenario, registry, _admin_cap, mut vault, mut config, clk) = begin();
+    let alice_lp = bootstrap_supply(&mut vault, &mut config, &mut scenario, &clk, THOUSAND_DUSDC);
+    // Budget below the 50_000_000 the swap would pay, though the reserve is ample.
+    seed_buyback(&mut vault, &mut scenario, FIFTY_DUSDC - 1, TWO_HUNDRED_DUSDC);
+    let out = swap(&registry, &mut vault, &config, &mut scenario, &clk, usd_spot(1), FIFTY_DEEP, 0);
+    destroy(out);
+    destroy(alice_lp);
+    abort
+}
+
+#[test, expected_failure(abort_code = plp::EInsufficientProtocolReserve)]
+fun swap_exceeds_protocol_reserve_aborts() {
+    let (mut scenario, registry, _admin_cap, mut vault, mut config, clk) = begin();
+    let alice_lp = bootstrap_supply(&mut vault, &mut config, &mut scenario, &clk, THOUSAND_DUSDC);
+    // Budget is ample but the protocol reserve is short: the reserve guard must bind.
+    seed_buyback(&mut vault, &mut scenario, TWO_HUNDRED_DUSDC, FIFTY_DUSDC - 1);
+    let out = swap(&registry, &mut vault, &config, &mut scenario, &clk, usd_spot(1), FIFTY_DEEP, 0);
+    destroy(out);
+    destroy(alice_lp);
+    abort
+}
+
+#[test, expected_failure(abort_code = plp::EZeroDusdcOut)]
+fun swap_full_discount_aborts_zero_out() {
+    let (mut scenario, registry, admin_cap, mut vault, mut config, clk) = begin();
+    let alice_lp = bootstrap_supply(&mut vault, &mut config, &mut scenario, &clk, THOUSAND_DUSDC);
+    seed_buyback(&mut vault, &mut scenario, TWO_HUNDRED_DUSDC, TWO_HUNDRED_DUSDC);
+    // A 100% discount floors every payout to zero.
+    config.set_buyback_discount(&admin_cap, constants::float_scaling!());
+    let out = swap(&registry, &mut vault, &config, &mut scenario, &clk, usd_spot(1), FIFTY_DEEP, 0);
+    destroy(out);
+    destroy(alice_lp);
+    destroy(admin_cap);
+    abort
+}
+
+#[test, expected_failure(abort_code = plp::EIncentiveFeedMismatch)]
+fun swap_wrong_feed_id_aborts() {
+    let (mut scenario, mut registry, _admin_cap, mut vault, mut config, clk) = begin();
+    // Re-bind DEEP to feed id 7; the test source reports feed id 0.
+    registry.set_incentive_asset_for_testing<DEEP>(DEEP_DECIMALS, 7);
+    let alice_lp = bootstrap_supply(&mut vault, &mut config, &mut scenario, &clk, THOUSAND_DUSDC);
+    seed_buyback(&mut vault, &mut scenario, TWO_HUNDRED_DUSDC, TWO_HUNDRED_DUSDC);
+    let out = swap(&registry, &mut vault, &config, &mut scenario, &clk, usd_spot(1), FIFTY_DEEP, 0);
+    destroy(out);
+    destroy(alice_lp);
+    abort
+}
+
+#[test, expected_failure(abort_code = pricing::EPythSpotStale)]
+fun swap_stale_spot_aborts() {
+    let (mut scenario, registry, _admin_cap, mut vault, mut config, clk) = begin();
+    let alice_lp = bootstrap_supply(&mut vault, &mut config, &mut scenario, &clk, THOUSAND_DUSDC);
+    seed_buyback(&mut vault, &mut scenario, TWO_HUNDRED_DUSDC, TWO_HUNDRED_DUSDC);
+    let stale_ms = NOW_MS - fresh() - 1;
+    let mut source = pyth_source::new_for_testing(scenario.ctx());
+    source.set_state_for_testing(usd_spot(1), stale_ms, stale_ms);
+    let out = registry::swap_deep_for_dusdc(
+        &registry,
+        &mut vault,
+        &config,
+        &source,
+        coin::mint_for_testing<DEEP>(FIFTY_DEEP, scenario.ctx()),
+        0,
+        &clk,
+        scenario.ctx(),
+    );
+    destroy(out);
+    destroy(source);
+    destroy(alice_lp);
+    abort
+}
+
+#[test, expected_failure(abort_code = registry::EIncentiveAssetNotConfigured)]
+fun swap_unconfigured_deep_aborts() {
+    let mut scenario = test::begin(test_constants::admin());
+    plp::init_for_testing(scenario.ctx());
+    // DEEP is never registered as an incentive asset.
+    let (registry, admin_cap) = registry::new_for_testing(scenario.ctx());
+    let mut config = protocol_config::new_for_testing(scenario.ctx());
+    let mut clk = clock::create_for_testing(scenario.ctx());
+    clk.set_for_testing(NOW_MS);
+    scenario.next_tx(test_constants::admin());
+    let mut vault = scenario.take_shared<PoolVault>();
+    let alice_lp = bootstrap_supply(&mut vault, &mut config, &mut scenario, &clk, THOUSAND_DUSDC);
+    seed_buyback(&mut vault, &mut scenario, TWO_HUNDRED_DUSDC, TWO_HUNDRED_DUSDC);
+    let out = swap(&registry, &mut vault, &config, &mut scenario, &clk, usd_spot(1), FIFTY_DEEP, 0);
+    destroy(out);
+    destroy(alice_lp);
+    destroy(admin_cap);
+    abort
+}
+
+#[test, expected_failure(abort_code = protocol_config::EValuationInProgress)]
+fun swap_during_valuation_aborts() {
+    let (mut scenario, registry, _admin_cap, mut vault, mut config, clk) = begin();
+    let alice_lp = bootstrap_supply(&mut vault, &mut config, &mut scenario, &clk, THOUSAND_DUSDC);
+    seed_buyback(&mut vault, &mut scenario, TWO_HUNDRED_DUSDC, TWO_HUNDRED_DUSDC);
+    config.begin_valuation();
+    let out = swap(&registry, &mut vault, &config, &mut scenario, &clk, usd_spot(1), FIFTY_DEEP, 0);
+    destroy(out);
+    destroy(alice_lp);
+    abort
+}
+
+// === admin config bounds ===
+
+#[test]
+fun default_buyback_config_matches_constants() {
+    let (scenario, registry, admin_cap, vault, config, clk) = begin();
+    assert_eq!(config.fee_config().buyback_share(), config_constants::default_buyback_share!());
+    assert_eq!(
+        config.fee_config().buyback_discount(),
+        config_constants::default_buyback_discount!(),
+    );
+    finish(scenario, registry, admin_cap, vault, config, clk);
+}
+
+#[test, expected_failure(abort_code = config_constants::EInvalidBuybackShare)]
+fun set_buyback_share_above_max_aborts() {
+    let (scenario, registry, admin_cap, vault, mut config, clk) = begin();
+    config.set_buyback_share(&admin_cap, constants::float_scaling!() + 1);
+    finish(scenario, registry, admin_cap, vault, config, clk);
+    abort
+}
+
+#[test, expected_failure(abort_code = config_constants::EInvalidBuybackDiscount)]
+fun set_buyback_discount_above_max_aborts() {
+    let (scenario, registry, admin_cap, vault, mut config, clk) = begin();
+    config.set_buyback_discount(&admin_cap, constants::float_scaling!() + 1);
+    finish(scenario, registry, admin_cap, vault, config, clk);
+    abort
+}

--- a/packages/predict/tests/pool/plp_incentive_tests.move
+++ b/packages/predict/tests/pool/plp_incentive_tests.move
@@ -1,0 +1,657 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+/// Admin-deposited incentive assets (SUI, DEEP): streamed donation accounting,
+/// fair share repricing on supply, and pro-rata in-kind payout on withdrawal.
+///
+/// A deposit vests linearly over a window: it lands in a locked balance and
+/// streams into a claimable (released) balance over time. Only the released
+/// portion is valued from its Lazer `PythSource` and folded into pool NAV on
+/// `supply`, so a new depositor pays the fair value of what has already vested
+/// and can't dilute existing holders — while an instant supply+withdraw cannot
+/// capture the still-locked remainder (compounding advances on wall-clock time
+/// only). `withdraw` returns the pro-rata DUSDC plus each incentive in-kind from
+/// its released balance directly (no oracle, so a stale feed can't block exits).
+/// The binding (coin -> feed + decimals) lives in the `Registry` alongside the
+/// trading feed index.
+module deepbook_predict::plp_incentive_tests;
+
+use deepbook_predict::{
+    admin::AdminCap,
+    config_constants,
+    constants,
+    plp::{Self, PoolVault, PLP},
+    pricing,
+    protocol_config::{Self, ProtocolConfig},
+    pyth_source::{Self, PythSource},
+    registry::{Self, Registry},
+    test_constants
+};
+use dusdc::dusdc::DUSDC;
+use std::unit_test::{assert_eq, destroy};
+use sui::{clock::{Self, Clock}, coin, sui::SUI, test_scenario as test};
+use token::deep::DEEP;
+
+const THOUSAND_DUSDC: u64 = 1_000_000_000;
+const ELEVEN_HUNDRED_DUSDC: u64 = 1_100_000_000;
+const TWELVE_HUNDRED_DUSDC: u64 = 1_200_000_000;
+const THIRTEEN_HUNDRED_DUSDC: u64 = 1_300_000_000;
+const HUNDRED_SUI: u64 = 100_000_000_000;
+const FIFTY_SUI: u64 = 50_000_000_000;
+const TWENTY_FIVE_SUI: u64 = 25_000_000_000;
+// DEEP has 6 decimals; 100 DEEP @ $1 = $100 in DUSDC units.
+const HUNDRED_DEEP: u64 = 100_000_000;
+const FIFTY_DEEP: u64 = 50_000_000;
+const DEEP_DECIMALS: u8 = 6;
+const SUI_DECIMALS: u8 = 9;
+// `pyth_source::new_for_testing` reports feed id 0.
+const SUI_FEED_ID: u32 = 0;
+// 100 SUI @ $2 in DUSDC units (6 decimals): $200 == 200_000_000.
+const SUI_INCENTIVE_VALUE: u64 = 200_000_000;
+const NOW_MS: u64 = 1_000_000;
+// Vesting window used across tests, and half of it.
+const STREAM_MS: u64 = 100_000;
+const HALF_MS: u64 = 50_000;
+
+// === Helpers ===
+
+fun usd_spot(price_usd: u64): u64 {
+    price_usd * constants::float_scaling!()
+}
+
+/// Spot freshness bound incentives share with the market path.
+fun fresh(): u64 {
+    config_constants::default_pyth_spot_freshness_ms!()
+}
+
+fun advance(clk: &mut Clock, ms: u64) {
+    let next = clk.timestamp_ms() + ms;
+    clk.set_for_testing(next);
+}
+
+fun begin(): (test::Scenario, Registry, AdminCap, PoolVault, ProtocolConfig, Clock) {
+    let mut scenario = test::begin(test_constants::admin());
+    plp::init_for_testing(scenario.ctx());
+    let (mut registry, admin_cap) = registry::new_for_testing(scenario.ctx());
+    registry.set_incentive_asset_for_testing<SUI>(SUI_DECIMALS, SUI_FEED_ID);
+    let config = protocol_config::new_for_testing(scenario.ctx());
+    let mut clk = clock::create_for_testing(scenario.ctx());
+    clk.set_for_testing(NOW_MS);
+    scenario.next_tx(test_constants::admin());
+    let vault = scenario.take_shared<PoolVault>();
+    (scenario, registry, admin_cap, vault, config, clk)
+}
+
+fun finish(
+    scenario: test::Scenario,
+    registry: Registry,
+    admin_cap: AdminCap,
+    vault: PoolVault,
+    config: ProtocolConfig,
+    clk: Clock,
+) {
+    destroy(admin_cap);
+    destroy(config);
+    destroy(clk);
+    test::return_shared(vault);
+    registry::destroy_registry_drop_for_testing(registry);
+    scenario.end();
+}
+
+/// A fresh SUI `PythSource` (feed id 0) reporting `spot`, observed at `clk`.
+fun sui_source(scenario: &mut test::Scenario, clk: &Clock, spot: u64): PythSource {
+    let mut source = pyth_source::new_for_testing(scenario.ctx());
+    let now = clk.timestamp_ms();
+    source.set_state_for_testing(spot, now, now);
+    source
+}
+
+fun bootstrap_supply(
+    vault: &mut PoolVault,
+    config: &mut ProtocolConfig,
+    scenario: &mut test::Scenario,
+    clk: &Clock,
+    amount: u64,
+): coin::Coin<PLP> {
+    let sync = plp::start_pool_sync(config, vault);
+    // No incentives exist at bootstrap, so the sources are ignored.
+    let placeholder = sui_source(scenario, clk, 0);
+    let lp = plp::supply(
+        vault,
+        config,
+        sync,
+        coin::mint_for_testing<DUSDC>(amount, scenario.ctx()),
+        &placeholder,
+        &placeholder,
+        clk,
+        scenario.ctx(),
+    );
+    destroy(placeholder);
+    lp
+}
+
+/// Supply while the pool holds a SUI incentive: `supply` itself values the
+/// released portion from a fresh spot observed at `clk`.
+fun supply_with_incentive(
+    vault: &mut PoolVault,
+    config: &mut ProtocolConfig,
+    scenario: &mut test::Scenario,
+    clk: &Clock,
+    spot: u64,
+    amount: u64,
+): coin::Coin<PLP> {
+    let sync = plp::start_pool_sync(config, vault);
+    let source = sui_source(scenario, clk, spot);
+    // No DEEP incentive in these tests, so its source slot is ignored; reuse the
+    // SUI source as the placeholder.
+    let lp = plp::supply(
+        vault,
+        config,
+        sync,
+        coin::mint_for_testing<DUSDC>(amount, scenario.ctx()),
+        &source,
+        &source,
+        clk,
+        scenario.ctx(),
+    );
+    destroy(source);
+    lp
+}
+
+fun donate_sui(
+    registry: &Registry,
+    vault: &mut PoolVault,
+    admin_cap: &AdminCap,
+    scenario: &mut test::Scenario,
+    clk: &Clock,
+    amount: u64,
+    duration_ms: u64,
+) {
+    registry::deposit_sui_incentive(
+        registry,
+        vault,
+        admin_cap,
+        coin::mint_for_testing<SUI>(amount, scenario.ctx()),
+        duration_ms,
+        clk,
+    );
+}
+
+fun donate_deep(
+    registry: &Registry,
+    vault: &mut PoolVault,
+    admin_cap: &AdminCap,
+    scenario: &mut test::Scenario,
+    clk: &Clock,
+    amount: u64,
+    duration_ms: u64,
+) {
+    registry::deposit_deep_incentive(
+        registry,
+        vault,
+        admin_cap,
+        coin::mint_for_testing<DEEP>(amount, scenario.ctx()),
+        duration_ms,
+        clk,
+    );
+}
+
+// === pyth_source::value_in_dusdc valuation math (independently hand-computed) ===
+
+#[test]
+fun incentive_value_matches_hand_calc() {
+    let mut scenario = test::begin(test_constants::admin());
+    let mut clk = clock::create_for_testing(scenario.ctx());
+    clk.set_for_testing(NOW_MS);
+
+    // 100 SUI @ $2 = $200 -> 200_000_000 DUSDC units (6 decimals).
+    let source = sui_source(&mut scenario, &clk, usd_spot(2));
+    assert_eq!(source.value_in_dusdc(HUNDRED_SUI, SUI_DECIMALS), SUI_INCENTIVE_VALUE);
+    // 100 SUI @ $5 = $500.
+    let source_five = sui_source(&mut scenario, &clk, usd_spot(5));
+    assert_eq!(source_five.value_in_dusdc(HUNDRED_SUI, SUI_DECIMALS), 500_000_000);
+    // 1 raw SUI unit @ $1 = $1e-9 -> 0.001 DUSDC units, rounds up to 1.
+    let source_one = sui_source(&mut scenario, &clk, usd_spot(1));
+    assert_eq!(source_one.value_in_dusdc(1, SUI_DECIMALS), 1);
+
+    destroy(source);
+    destroy(source_five);
+    destroy(source_one);
+    destroy(clk);
+    scenario.end();
+}
+
+// === deposit_incentive ===
+
+#[test]
+fun deposit_registers_and_mints_no_plp() {
+    let (mut scenario, registry, admin_cap, mut vault, mut config, clk) = begin();
+    let alice_lp = bootstrap_supply(&mut vault, &mut config, &mut scenario, &clk, THOUSAND_DUSDC);
+    let supply_before = vault.total_supply();
+
+    donate_sui(&registry, &mut vault, &admin_cap, &mut scenario, &clk, HUNDRED_SUI, STREAM_MS);
+
+    // The whole deposit is locked and vesting; nothing is claimable at the same
+    // instant, and no PLP is minted.
+    assert_eq!(vault.incentive_sui_locked(), HUNDRED_SUI);
+    assert_eq!(vault.incentive_sui_balance(), 0);
+    assert_eq!(vault.total_supply(), supply_before);
+
+    // A second deposit at the same instant just adds to locked (nothing vested).
+    donate_sui(&registry, &mut vault, &admin_cap, &mut scenario, &clk, HUNDRED_SUI, STREAM_MS);
+    assert_eq!(vault.incentive_sui_locked(), 2 * HUNDRED_SUI);
+    assert_eq!(vault.incentive_sui_balance(), 0);
+
+    destroy(alice_lp);
+    finish(scenario, registry, admin_cap, vault, config, clk);
+}
+
+// === linear vesting ===
+
+#[test]
+fun donation_vests_linearly_over_window() {
+    let (mut scenario, registry, admin_cap, mut vault, mut config, mut clk) = begin();
+    let alice_lp = bootstrap_supply(&mut vault, &mut config, &mut scenario, &clk, THOUSAND_DUSDC);
+    donate_sui(&registry, &mut vault, &admin_cap, &mut scenario, &clk, HUNDRED_SUI, STREAM_MS);
+
+    // A supply syncs (and thus vests) the incentive as of the current time. Half
+    // the window elapsed: half vests into the claimable balance.
+    advance(&mut clk, HALF_MS);
+    let lp1 = supply_with_incentive(
+        &mut vault,
+        &mut config,
+        &mut scenario,
+        &clk,
+        usd_spot(2),
+        THOUSAND_DUSDC,
+    );
+    assert_eq!(vault.incentive_sui_balance(), FIFTY_SUI);
+    assert_eq!(vault.incentive_sui_locked(), FIFTY_SUI);
+
+    // The window ends: the entire remainder vests and the schedule clears.
+    advance(&mut clk, HALF_MS);
+    let lp2 = supply_with_incentive(
+        &mut vault,
+        &mut config,
+        &mut scenario,
+        &clk,
+        usd_spot(2),
+        THOUSAND_DUSDC,
+    );
+    assert_eq!(vault.incentive_sui_balance(), HUNDRED_SUI);
+    assert_eq!(vault.incentive_sui_locked(), 0);
+
+    // Past the end, further vesting is a no-op (schedule already cleared).
+    advance(&mut clk, STREAM_MS);
+    let lp3 = supply_with_incentive(
+        &mut vault,
+        &mut config,
+        &mut scenario,
+        &clk,
+        usd_spot(2),
+        THOUSAND_DUSDC,
+    );
+    assert_eq!(vault.incentive_sui_balance(), HUNDRED_SUI);
+    assert_eq!(vault.incentive_sui_locked(), 0);
+
+    destroy(alice_lp);
+    destroy(lp1);
+    destroy(lp2);
+    destroy(lp3);
+    finish(scenario, registry, admin_cap, vault, config, clk);
+}
+
+#[test]
+fun second_deposit_vests_prior_then_rolls_remainder() {
+    let (mut scenario, registry, admin_cap, mut vault, mut config, mut clk) = begin();
+    let alice_lp = bootstrap_supply(&mut vault, &mut config, &mut scenario, &clk, THOUSAND_DUSDC);
+    donate_sui(&registry, &mut vault, &admin_cap, &mut scenario, &clk, HUNDRED_SUI, STREAM_MS);
+
+    // Halfway through, a second deposit lands. The deposit vests the prior
+    // schedule to now (50 SUI released), then its 50 SUI remainder plus the new
+    // 100 SUI re-stream over a fresh window.
+    advance(&mut clk, HALF_MS);
+    donate_sui(&registry, &mut vault, &admin_cap, &mut scenario, &clk, HUNDRED_SUI, STREAM_MS);
+    assert_eq!(vault.incentive_sui_balance(), FIFTY_SUI);
+    assert_eq!(vault.incentive_sui_locked(), FIFTY_SUI + HUNDRED_SUI);
+
+    // A supply after the fresh window vests the combined 150 SUI remainder.
+    advance(&mut clk, STREAM_MS);
+    let lp = supply_with_incentive(
+        &mut vault,
+        &mut config,
+        &mut scenario,
+        &clk,
+        usd_spot(2),
+        THOUSAND_DUSDC,
+    );
+    assert_eq!(vault.incentive_sui_balance(), 2 * HUNDRED_SUI);
+    assert_eq!(vault.incentive_sui_locked(), 0);
+
+    destroy(alice_lp);
+    destroy(lp);
+    finish(scenario, registry, admin_cap, vault, config, clk);
+}
+
+// === supply repricing (fairness / anti-dilution) ===
+
+#[test]
+fun supply_after_donation_reprices_shares() {
+    let (mut scenario, registry, admin_cap, mut vault, mut config, mut clk) = begin();
+    let alice_lp = bootstrap_supply(&mut vault, &mut config, &mut scenario, &clk, THOUSAND_DUSDC);
+    assert_eq!(alice_lp.value(), THOUSAND_DUSDC);
+
+    donate_sui(&registry, &mut vault, &admin_cap, &mut scenario, &clk, HUNDRED_SUI, STREAM_MS);
+    // Fully vest the donation so its value is priced into NAV.
+    advance(&mut clk, STREAM_MS);
+
+    // Bob supplies 1200 DUSDC at share price 1.2 (1000 DUSDC + 100 SUI @ $2) -> 1000 PLP.
+    let bob_lp = supply_with_incentive(
+        &mut vault,
+        &mut config,
+        &mut scenario,
+        &clk,
+        usd_spot(2),
+        TWELVE_HUNDRED_DUSDC,
+    );
+    assert_eq!(bob_lp.value(), 1_000_000_000);
+
+    destroy(alice_lp);
+    destroy(bob_lp);
+    finish(scenario, registry, admin_cap, vault, config, clk);
+}
+
+// === withdraw: pro-rata DUSDC + in-kind incentive ===
+
+#[test]
+fun withdraw_pays_pro_rata_dusdc_and_incentive_in_kind() {
+    let (mut scenario, registry, admin_cap, mut vault, mut config, mut clk) = begin();
+    let alice_lp = bootstrap_supply(&mut vault, &mut config, &mut scenario, &clk, THOUSAND_DUSDC);
+    donate_sui(&registry, &mut vault, &admin_cap, &mut scenario, &clk, HUNDRED_SUI, STREAM_MS);
+    // Fully vest so all 100 SUI is claimable.
+    advance(&mut clk, STREAM_MS);
+    let bob_lp = supply_with_incentive(
+        &mut vault,
+        &mut config,
+        &mut scenario,
+        &clk,
+        usd_spot(2),
+        TWELVE_HUNDRED_DUSDC,
+    );
+
+    assert_eq!(vault.idle_balance(), 2_200_000_000);
+    assert_eq!(vault.incentive_sui_balance(), HUNDRED_SUI);
+    assert_eq!(vault.incentive_sui_locked(), 0);
+    assert_eq!(vault.total_supply(), 2_000_000_000);
+
+    // Alice withdraws all 1e9 PLP (50%): 1100 DUSDC + 50 SUI in-kind, 0 DEEP.
+    let sync = plp::start_pool_sync(&mut config, &vault);
+    let (alice_dusdc, alice_sui, alice_deep) = plp::withdraw(
+        &mut vault,
+        &mut config,
+        sync,
+        alice_lp,
+        &clk,
+        scenario.ctx(),
+    );
+    assert_eq!(alice_dusdc.value(), 1_100_000_000);
+    assert_eq!(alice_sui.value(), FIFTY_SUI);
+    assert_eq!(alice_deep.value(), 0);
+
+    assert_eq!(vault.total_supply(), 1_000_000_000);
+    assert_eq!(vault.idle_balance(), 1_100_000_000);
+    assert_eq!(vault.incentive_sui_balance(), FIFTY_SUI);
+
+    // Bob withdraws all (100%): drains the pool, 1100 DUSDC + 50 SUI.
+    let sync2 = plp::start_pool_sync(&mut config, &vault);
+    let (bob_dusdc, bob_sui, bob_deep) = plp::withdraw(
+        &mut vault,
+        &mut config,
+        sync2,
+        bob_lp,
+        &clk,
+        scenario.ctx(),
+    );
+    assert_eq!(bob_dusdc.value(), 1_100_000_000);
+    assert_eq!(bob_sui.value(), FIFTY_SUI);
+    assert_eq!(bob_deep.value(), 0);
+
+    assert_eq!(vault.total_supply(), 0);
+    assert_eq!(vault.idle_balance(), 0);
+    assert_eq!(vault.incentive_sui_balance(), 0);
+
+    destroy(alice_dusdc);
+    destroy(alice_sui);
+    destroy(alice_deep);
+    destroy(bob_dusdc);
+    destroy(bob_sui);
+    destroy(bob_deep);
+    finish(scenario, registry, admin_cap, vault, config, clk);
+}
+
+#[test]
+fun instant_supply_withdraw_returns_less_dusdc_and_cannot_capture_locked() {
+    let (mut scenario, registry, admin_cap, mut vault, mut config, mut clk) = begin();
+    let alice_lp = bootstrap_supply(&mut vault, &mut config, &mut scenario, &clk, THOUSAND_DUSDC);
+    donate_sui(&registry, &mut vault, &admin_cap, &mut scenario, &clk, HUNDRED_SUI, STREAM_MS);
+
+    // Halfway through vesting: 50 SUI claimable, 50 SUI still locked.
+    advance(&mut clk, HALF_MS);
+
+    // Bob supplies 1100 DUSDC at NAV = 1000 DUSDC + 50 SUI ($100) = 1100 -> 1000 PLP.
+    let bob_lp = supply_with_incentive(
+        &mut vault,
+        &mut config,
+        &mut scenario,
+        &clk,
+        usd_spot(2),
+        ELEVEN_HUNDRED_DUSDC,
+    );
+    assert_eq!(bob_lp.value(), 1_000_000_000);
+    assert_eq!(vault.incentive_sui_balance(), FIFTY_SUI);
+    assert_eq!(vault.incentive_sui_locked(), FIFTY_SUI);
+
+    // Bob withdraws immediately (same instant, no further vesting): 50% of the
+    // pool. He gets back LESS DUSDC than the 1100 he deposited, plus an in-kind
+    // slice of only the *released* incentive — the locked 50 SUI is untouchable.
+    let sync = plp::start_pool_sync(&mut config, &vault);
+    let (bob_dusdc, bob_sui, bob_deep) = plp::withdraw(
+        &mut vault,
+        &mut config,
+        sync,
+        bob_lp,
+        &clk,
+        scenario.ctx(),
+    );
+
+    assert_eq!(bob_dusdc.value(), 1_050_000_000);
+    assert_eq!(bob_sui.value(), TWENTY_FIVE_SUI);
+    assert_eq!(bob_deep.value(), 0);
+    assert_eq!(vault.incentive_sui_locked(), FIFTY_SUI);
+    assert_eq!(vault.incentive_sui_balance(), TWENTY_FIVE_SUI);
+
+    destroy(alice_lp);
+    destroy(bob_dusdc);
+    destroy(bob_sui);
+    destroy(bob_deep);
+    finish(scenario, registry, admin_cap, vault, config, clk);
+}
+
+#[test]
+fun supply_and_withdraw_value_both_sui_and_deep() {
+    let (mut scenario, mut registry, admin_cap, mut vault, mut config, mut clk) = begin();
+    // Configure DEEP as a second incentive asset (test sources all report feed 0).
+    registry.set_incentive_asset_for_testing<DEEP>(DEEP_DECIMALS, SUI_FEED_ID);
+    let alice_lp = bootstrap_supply(&mut vault, &mut config, &mut scenario, &clk, THOUSAND_DUSDC);
+
+    // Donate both incentives; each lands fully locked, then fully vests.
+    donate_sui(&registry, &mut vault, &admin_cap, &mut scenario, &clk, HUNDRED_SUI, STREAM_MS);
+    donate_deep(&registry, &mut vault, &admin_cap, &mut scenario, &clk, HUNDRED_DEEP, STREAM_MS);
+    assert_eq!(vault.incentive_deep_locked(), HUNDRED_DEEP);
+    assert_eq!(vault.incentive_deep_balance(), 0);
+    advance(&mut clk, STREAM_MS);
+
+    // Bob supplies against NAV = 1000 DUSDC + $200 SUI + $100 DEEP = 1300 -> 1000 PLP.
+    // supply values BOTH incentives inline from their (distinct-spot) sources.
+    let sync = plp::start_pool_sync(&mut config, &vault);
+    let sui_src = sui_source(&mut scenario, &clk, usd_spot(2));
+    let deep_src = sui_source(&mut scenario, &clk, usd_spot(1));
+    let bob_lp = plp::supply(
+        &mut vault,
+        &mut config,
+        sync,
+        coin::mint_for_testing<DUSDC>(THIRTEEN_HUNDRED_DUSDC, scenario.ctx()),
+        &sui_src,
+        &deep_src,
+        &clk,
+        scenario.ctx(),
+    );
+    assert_eq!(bob_lp.value(), 1_000_000_000);
+    assert_eq!(vault.incentive_sui_balance(), HUNDRED_SUI);
+    assert_eq!(vault.incentive_deep_balance(), HUNDRED_DEEP);
+    destroy(sui_src);
+    destroy(deep_src);
+
+    // Bob withdraws 50%: 1150 DUSDC + 50 SUI + 50 DEEP, all in one call.
+    let sync2 = plp::start_pool_sync(&mut config, &vault);
+    let (bob_dusdc, bob_sui, bob_deep) = plp::withdraw(
+        &mut vault,
+        &mut config,
+        sync2,
+        bob_lp,
+        &clk,
+        scenario.ctx(),
+    );
+    assert_eq!(bob_dusdc.value(), 1_150_000_000);
+    assert_eq!(bob_sui.value(), FIFTY_SUI);
+    assert_eq!(bob_deep.value(), FIFTY_DEEP);
+    assert_eq!(vault.incentive_sui_balance(), FIFTY_SUI);
+    assert_eq!(vault.incentive_deep_balance(), FIFTY_DEEP);
+
+    destroy(alice_lp);
+    destroy(bob_dusdc);
+    destroy(bob_sui);
+    destroy(bob_deep);
+    finish(scenario, registry, admin_cap, vault, config, clk);
+}
+
+// === valuation abort coverage ===
+
+#[test, expected_failure(abort_code = pyth_source::EZeroSpot)]
+fun valuing_with_zero_spot_aborts() {
+    let mut scenario = test::begin(test_constants::admin());
+    let mut clk = clock::create_for_testing(scenario.ctx());
+    clk.set_for_testing(NOW_MS);
+    let source = sui_source(&mut scenario, &clk, 0);
+    source.value_in_dusdc(HUNDRED_SUI, SUI_DECIMALS);
+    abort
+}
+
+#[test, expected_failure(abort_code = plp::EIncentiveFeedMismatch)]
+fun supply_wrong_feed_id_aborts() {
+    let (mut scenario, mut registry, admin_cap, mut vault, mut config, clk) = begin();
+    // Re-bind SUI to feed id 7; the test PythSource reports feed id 0.
+    registry.set_incentive_asset_for_testing<SUI>(SUI_DECIMALS, 7);
+    let alice_lp = bootstrap_supply(&mut vault, &mut config, &mut scenario, &clk, THOUSAND_DUSDC);
+    donate_sui(&registry, &mut vault, &admin_cap, &mut scenario, &clk, HUNDRED_SUI, STREAM_MS);
+    // supply values the SUI incentive; the source reports feed id 0, not 7.
+    let bob_lp = supply_with_incentive(
+        &mut vault,
+        &mut config,
+        &mut scenario,
+        &clk,
+        usd_spot(2),
+        TWELVE_HUNDRED_DUSDC,
+    );
+    destroy(alice_lp);
+    destroy(bob_lp);
+    abort
+}
+
+#[test, expected_failure(abort_code = pricing::EPythSpotStale)]
+fun supply_stale_spot_aborts() {
+    let (mut scenario, registry, admin_cap, mut vault, mut config, clk) = begin();
+    let alice_lp = bootstrap_supply(&mut vault, &mut config, &mut scenario, &clk, THOUSAND_DUSDC);
+    donate_sui(&registry, &mut vault, &admin_cap, &mut scenario, &clk, HUNDRED_SUI, STREAM_MS);
+    let sync = plp::start_pool_sync(&mut config, &vault);
+    // Spot observed long enough ago to be stale at NOW_MS (feed id 0 matches SUI).
+    let stale_ms = NOW_MS - fresh() - 1;
+    let mut source = pyth_source::new_for_testing(scenario.ctx());
+    source.set_state_for_testing(usd_spot(2), stale_ms, stale_ms);
+    let bob_lp = plp::supply(
+        &mut vault,
+        &mut config,
+        sync,
+        coin::mint_for_testing<DUSDC>(THOUSAND_DUSDC, scenario.ctx()),
+        &source,
+        &source,
+        &clk,
+        scenario.ctx(),
+    );
+    destroy(alice_lp);
+    destroy(bob_lp);
+    destroy(source);
+    abort
+}
+
+// === deposit / sync abort coverage ===
+
+#[test, expected_failure(abort_code = plp::ENoPlpHolders)]
+fun deposit_before_any_plp_aborts() {
+    let (mut scenario, registry, admin_cap, mut vault, _config, clk) = begin();
+    donate_sui(&registry, &mut vault, &admin_cap, &mut scenario, &clk, HUNDRED_SUI, STREAM_MS);
+    abort
+}
+
+#[test, expected_failure(abort_code = plp::EZeroIncentiveDeposit)]
+fun deposit_zero_aborts() {
+    let (mut scenario, registry, admin_cap, mut vault, mut config, clk) = begin();
+    let alice_lp = bootstrap_supply(&mut vault, &mut config, &mut scenario, &clk, THOUSAND_DUSDC);
+    donate_sui(&registry, &mut vault, &admin_cap, &mut scenario, &clk, 0, STREAM_MS);
+    destroy(alice_lp);
+    abort
+}
+
+#[test, expected_failure(abort_code = plp::EZeroStreamDuration)]
+fun deposit_zero_duration_aborts() {
+    let (mut scenario, registry, admin_cap, mut vault, mut config, clk) = begin();
+    let alice_lp = bootstrap_supply(&mut vault, &mut config, &mut scenario, &clk, THOUSAND_DUSDC);
+    donate_sui(&registry, &mut vault, &admin_cap, &mut scenario, &clk, HUNDRED_SUI, 0);
+    destroy(alice_lp);
+    abort
+}
+
+#[test, expected_failure(abort_code = plp::EStreamDurationTooLong)]
+fun deposit_duration_too_long_aborts() {
+    let (mut scenario, registry, admin_cap, mut vault, mut config, clk) = begin();
+    let alice_lp = bootstrap_supply(&mut vault, &mut config, &mut scenario, &clk, THOUSAND_DUSDC);
+    donate_sui(
+        &registry,
+        &mut vault,
+        &admin_cap,
+        &mut scenario,
+        &clk,
+        HUNDRED_SUI,
+        constants::max_incentive_stream_ms!() + 1,
+    );
+    destroy(alice_lp);
+    abort
+}
+
+#[test, expected_failure(abort_code = registry::EIncentiveAssetNotConfigured)]
+fun deposit_unconfigured_asset_aborts() {
+    let (mut scenario, registry, admin_cap, mut vault, mut config, clk) = begin();
+    let alice_lp = bootstrap_supply(&mut vault, &mut config, &mut scenario, &clk, THOUSAND_DUSDC);
+    // DEEP is never configured as an incentive asset in `begin`.
+    registry::deposit_deep_incentive(
+        &registry,
+        &mut vault,
+        &admin_cap,
+        coin::mint_for_testing<DEEP>(1_000_000, scenario.ctx()),
+        STREAM_MS,
+        &clk,
+    );
+    destroy(alice_lp);
+    abort
+}

--- a/packages/predict/tests/pool/plp_tests.move
+++ b/packages/predict/tests/pool/plp_tests.move
@@ -12,7 +12,7 @@ use deepbook_predict::{
     market_oracle::{Self, MarketOracle, MarketOracleCap},
     plp::{Self, PLP, PoolVault},
     protocol_config::{Self, ProtocolConfig},
-    pyth_source::PythSource,
+    pyth_source::{Self, PythSource},
     registry::{Self, Registry},
     test_constants
 };
@@ -371,12 +371,20 @@ fun supply_prices_active_unrealized_profit_net_of_protocol_share() {
         &pyth,
         &fixture.clock,
     );
+    // No incentives in this pool, so supply's incentive sources/clock are unused;
+    // a local clock keeps the call from borrowing both config and clock off `fixture`.
+    let payment = coin::mint_for_testing<DUSDC>(NAV_TEST_SUPPLY, fixture.scenario.ctx());
+    let nav_clock = clock::create_for_testing(fixture.scenario.ctx());
     let new_plp = vault.supply(
         &mut fixture.config,
         sync,
-        coin::mint_for_testing<DUSDC>(NAV_TEST_SUPPLY, fixture.scenario.ctx()),
+        payment,
+        &pyth,
+        &pyth,
+        &nav_clock,
         fixture.scenario.ctx(),
     );
+    nav_clock.destroy_for_testing();
 
     // Pool value used for pricing is 360b:
     // idle 330b + active expiry NAV 50b - pending protocol share 20b.
@@ -451,12 +459,18 @@ fun setup_pool_with_pyth(): Fixture {
     let mut vault = scenario.take_shared<PoolVault>();
     let vault_id = vault.id();
     let sync = plp::start_pool_sync(&mut config, &vault);
+    // Bootstrap supply: no incentives exist yet, so the sources are ignored.
+    let placeholder = pyth_source::new_for_testing(scenario.ctx());
     let initial_plp = vault.supply(
         &mut config,
         sync,
         coin::mint_for_testing<DUSDC>(INITIAL_SUPPLY, scenario.ctx()),
+        &placeholder,
+        &placeholder,
+        &clock,
         scenario.ctx(),
     );
+    destroy(placeholder);
     return_shared(vault);
 
     scenario.next_tx(test_constants::admin());

--- a/packages/predict/tests/registry_create_tests.move
+++ b/packages/predict/tests/registry_create_tests.move
@@ -374,14 +374,22 @@ fun setup_ready_expiry_creation(expiry_tick_size: u64): (Scenario, ID, ID, Marke
     scenario.next_tx(test_constants::admin());
     let mut vault = scenario.take_shared<PoolVault>();
     let mut config = scenario.take_shared<ProtocolConfig>();
+    let pyth = scenario.take_shared_by_id<PythSource>(pyth_id);
+    let clock = clock::create_for_testing(scenario.ctx());
     let sync = plp::start_pool_sync(&mut config, &vault);
+    // Bootstrap supply: no incentives exist yet, so the sources are ignored.
     let lp = vault.supply(
         &mut config,
         sync,
         coin::mint_for_testing<DUSDC>(POOL_SUPPLY, scenario.ctx()),
+        &pyth,
+        &pyth,
+        &clock,
         scenario.ctx(),
     );
+    clock.destroy_for_testing();
     assert_eq!(coin::burn_for_testing(lp), POOL_SUPPLY);
+    return_shared(pyth);
     return_shared(config);
     return_shared(vault);
 


### PR DESCRIPTION
## Summary
- Sibling of #1058: the **same** permissionless DEEP buyback, but **funded from the protocol's reserve cut** instead of the LP share. A configurable `buyback_share` (default 50%) of each expiry's *protocol* profit is authorized as a DUSDC `buyback_budget`; the DUSDC stays in `protocol_reserve_balance` (already excluded from LP NAV).
- `registry::swap_deep_for_dusdc` pays DUSDC from `protocol_reserve_balance` (idle is **never** touched, so withdrawals are unaffected) and folds the DEEP into the LP-owned `incentive_deep` balance.
- Economics: every swap moves value **from protocol revenue into an LP-owned DEEP position** — the protocol subsidizes LPs a DEEP position, NAV-accretive to LPs on each swap.
- Same config knobs and round-down valuation helper; `DeepBoughtBack` reports `protocol_reserve_balance_after`.

## Key decisions
- **Only the funding/payout source differs from Option A (#1058)**: carve from `protocol_profit` (not `lp_profit`), pay from `protocol_reserve_balance` (not idle). DEEP still goes into PLP valuation, so the comparison is purely *who pays for the buyback — LPs (A) or the protocol (B)*.
- `buyback_budget <= protocol_reserve_balance` by construction, backed by an explicit `EInsufficientProtocolReserve` guard.
- Same module-dependency, rounding, and discount decisions as A.
- Based on `tlee/predict-plp-reserve-assets`. Compare against **Option A** (`tlee/predict-deep-buyback-lp`, #1058).

## Test plan
- [x] `sui move test --gas-limit 100000000000` — 479/479 pass
- [x] `plp_buyback_tests.move`: payout from reserve with idle untouched (firewall), NAV rises when the protocol funds the buyback, every abort incl. `EInsufficientProtocolReserve`, config bounds.
- [x] Funding carve asserted in the production rebate flow (budget = 50% of protocol profit at settlement + rebate).
- [x] `bunx prettier-move` clean; no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)