### PR TITLE
Centralize Predict config ownership

### DIFF
--- a/packages/predict/simulations/src/runtime.ts
+++ b/packages/predict/simulations/src/runtime.ts
@@ -408,6 +408,7 @@ export function createMarketOracleCapTx(recipient: string): Transaction {
 }
 
 export function createPythSourceTx(
+    protocolConfigId: string,
     feedId: number,
     tickSize: bigint,
     expiryFeeWindowMs: bigint,
@@ -418,6 +419,7 @@ export function createPythSourceTx(
         target: target("registry", "create_pyth_source"),
         arguments: [
             tx.object(REGISTRY_ID),
+            tx.object(protocolConfigId),
             tx.object(ADMIN_CAP_ID),
             tx.pure.u32(feedId),
             tx.pure.u64(tickSize),

--- a/packages/predict/simulations/src/sim.ts
+++ b/packages/predict/simulations/src/sim.ts
@@ -777,7 +777,13 @@ async function setupSimulation(
     console.log(`[${ts()}]   OracleCap: ${oracleCapId}`);
 
     result = await executeAndWait(
-        createPythSourceTx(1, ORACLE_TICK_SIZE, expiryFeeWindowMs, expiryFeeMaxMultiplier),
+        createPythSourceTx(
+            protocolConfigId,
+            1,
+            ORACLE_TICK_SIZE,
+            expiryFeeWindowMs,
+            expiryFeeMaxMultiplier,
+        ),
         "create_pyth_source",
     );
     const pythSourceChange = result.objectChanges.find(

--- a/packages/predict/sources/config/feed_template.move
+++ b/packages/predict/sources/config/feed_template.move
@@ -1,0 +1,64 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Per-feed template policy used when creating future expiry markets.
+///
+/// ProtocolConfig stores one template per Pyth Lazer feed and exposes the
+/// admin entrypoints that mutate these values. Expiry markets snapshot the
+/// values at creation.
+module deepbook_predict::feed_template;
+
+use deepbook_predict::config_constants;
+
+/// Admin-selected template values for future expiry markets of one feed.
+public struct FeedTemplate has copy, drop, store {
+    /// Strike tick size for the feed's future expiry markets.
+    tick_size: u64,
+    /// Window before expiry over which trade fees ramp up.
+    expiry_fee_window_ms: u64,
+    /// Fee multiplier reached at expiry, in FLOAT_SCALING; 1x disables.
+    expiry_fee_max_multiplier: u64,
+}
+
+// === Public-Package Functions ===
+
+public(package) fun tick_size(template: &FeedTemplate): u64 {
+    template.tick_size
+}
+
+public(package) fun expiry_fee_window_ms(template: &FeedTemplate): u64 {
+    template.expiry_fee_window_ms
+}
+
+public(package) fun expiry_fee_max_multiplier(template: &FeedTemplate): u64 {
+    template.expiry_fee_max_multiplier
+}
+
+public(package) fun new(
+    tick_size: u64,
+    expiry_fee_window_ms: u64,
+    expiry_fee_max_multiplier: u64,
+): FeedTemplate {
+    config_constants::assert_oracle_tick_size(tick_size);
+    config_constants::assert_expiry_fee_window_ms(expiry_fee_window_ms);
+    config_constants::assert_expiry_fee_max_multiplier(expiry_fee_max_multiplier);
+    FeedTemplate { tick_size, expiry_fee_window_ms, expiry_fee_max_multiplier }
+}
+
+public(package) fun set_tick_size(template: &mut FeedTemplate, tick_size: u64) {
+    config_constants::assert_oracle_tick_size(tick_size);
+    template.tick_size = tick_size;
+}
+
+public(package) fun set_expiry_fee_window_ms(template: &mut FeedTemplate, window_ms: u64) {
+    config_constants::assert_expiry_fee_window_ms(window_ms);
+    template.expiry_fee_window_ms = window_ms;
+}
+
+public(package) fun set_expiry_fee_max_multiplier(
+    template: &mut FeedTemplate,
+    max_multiplier: u64,
+) {
+    config_constants::assert_expiry_fee_max_multiplier(max_multiplier);
+    template.expiry_fee_max_multiplier = max_multiplier;
+}

--- a/packages/predict/sources/config/market_oracle_config.move
+++ b/packages/predict/sources/config/market_oracle_config.move
@@ -1,18 +1,19 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Stored oracle template config for newly created market oracles.
+/// Stored oracle policy values for market oracle settlement and push guards.
 ///
-/// ProtocolConfig owns the current template. Each MarketOracle snapshots these
-/// bounds at creation and can later be tuned through its cap-authorized path.
+/// `ProtocolConfig` owns a global template for future expiries and stamps a
+/// mutable per-expiry copy when an expiry market is created. `MarketOracle`
+/// cap-authorized setters mutate that stamped copy through `ProtocolConfig`.
 module deepbook_predict::market_oracle_config;
 
 use deepbook_predict::config_constants;
 
 const EInvalidBasisBounds: u64 = 0;
 
-/// Oracle bounds template snapshotted into each MarketOracle at creation.
-public struct MarketOracleConfig has store {
+/// Oracle bounds/freshness policy used as both template and per-expiry copy.
+public struct MarketOracleConfig has copy, drop, store {
     /// Maximum age for a source update to be usable for settlement.
     settlement_freshness_ms: u64,
     /// Maximum spot deviation allowed between consecutive Block Scholes pushes.
@@ -57,13 +58,13 @@ public(package) fun new(): MarketOracleConfig {
     }
 }
 
-/// Set the settlement freshness threshold for future market oracles.
+/// Set the settlement freshness threshold.
 public(package) fun set_settlement_freshness_ms(config: &mut MarketOracleConfig, value: u64) {
     config_constants::assert_settlement_freshness_ms(value);
     config.settlement_freshness_ms = value;
 }
 
-/// Set basis guard bounds for future market oracles.
+/// Set basis guard bounds.
 public(package) fun set_basis_bounds(
     config: &mut MarketOracleConfig,
     max_spot_deviation: u64,

--- a/packages/predict/sources/config/protocol_config.move
+++ b/packages/predict/sources/config/protocol_config.move
@@ -1,17 +1,19 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Protocol-wide configuration and flow gates for Predict.
+/// Protocol-wide configuration, templates, per-expiry rows, and flow gates for Predict.
 ///
-/// This shared object owns the admin-tunable config structs, trading pause,
-/// and full-pool valuation lock. Flow modules decide which gates apply before
-/// they mutate expiry, oracle, pool, or manager state.
+/// This shared object owns the admin-tunable config structs, feed templates,
+/// per-expiry config rows, trading pause, and full-pool valuation lock. Flow
+/// modules decide which gates apply before they mutate expiry, oracle, pool, or
+/// manager state.
 module deepbook_predict::protocol_config;
 
 use deepbook_predict::{
     admin::AdminCap,
     config_constants,
     config_events,
+    constants,
     fee_config::{Self, FeeConfig},
     feed_template::FeedTemplate,
     leverage_config::{Self, LeverageConfig},
@@ -30,11 +32,10 @@ const EFeedTemplateNotFound: u64 = 4;
 const EExpiryEntryAlreadyExists: u64 = 5;
 const EExpiryEntryNotFound: u64 = 6;
 const EWrongMarketOracle: u64 = 7;
-const EInvalidExpirySnapshot: u64 = 8;
-const EInvalidOraclePolicy: u64 = 9;
+const EWrongExpiryMarket: u64 = 8;
 
 /// Frozen contract terms stamped for one expiry.
-public struct ExpiryConfigSnapshot has copy, drop, store {
+public struct ExpiryConfigSnapshot has copy, drop {
     /// 1e9-scaled floor-to-live-value threshold for liquidation.
     liquidation_ltv: u64,
     /// Maximum terminal increase in the contract floor index over one expiry.
@@ -45,36 +46,20 @@ public struct ExpiryConfigSnapshot has copy, drop, store {
     min_strike: u64,
     /// Strike tick size for this expiry's oracle grid.
     tick_size: u64,
-    /// Pyth Lazer feed ID bound to this expiry.
-    pyth_lazer_feed_id: u32,
     /// Window before expiry over which trade fees ramp up.
     expiry_fee_window_ms: u64,
     /// Fee multiplier reached at expiry, in FLOAT_SCALING; 1x disables.
     expiry_fee_max_multiplier: u64,
 }
 
-/// Mutable per-expiry oracle policy controlled by authorized oracle operators.
-public struct ExpiryOraclePolicy has copy, drop, store {
-    /// Maximum age for a source to be used for settlement.
-    settlement_freshness_ms: u64,
-    /// Maximum allowed spot move between Block Scholes pushes.
-    max_spot_deviation: u64,
-    /// Maximum allowed basis move between Block Scholes pushes.
-    max_basis_deviation: u64,
-    /// Minimum allowed forward / spot basis.
-    min_basis: u64,
-    /// Maximum allowed forward / spot basis.
-    max_basis: u64,
-}
-
 /// Central per-expiry config row.
 public struct ExpiryEntry has copy, drop, store {
+    /// Expiry market object bound to this expiry.
+    expiry_market_id: ID,
     /// Market oracle object bound to this expiry.
     market_oracle_id: ID,
-    /// Frozen contract terms for this expiry.
-    snapshot: ExpiryConfigSnapshot,
     /// Mutable oracle bounds/freshness policy for this expiry.
-    oracle_policy: ExpiryOraclePolicy,
+    oracle_policy: MarketOracleConfig,
     /// Blocks new mints for this expiry while true.
     mint_paused: bool,
 }
@@ -94,7 +79,7 @@ public struct ProtocolConfig has key {
     valuation_in_progress: bool,
     /// Pyth Lazer feed ID -> future-expiry template policy.
     per_feed: Table<u32, FeedTemplate>,
-    /// Expiry timestamp -> frozen snapshot and mutable per-expiry controls.
+    /// Expiry timestamp -> object bindings and mutable per-expiry controls.
     per_expiry: Table<u64, ExpiryEntry>,
 }
 
@@ -108,6 +93,11 @@ public fun id(config: &ProtocolConfig): ID {
 /// Return whether trading is currently paused.
 public fun trading_paused(config: &ProtocolConfig): bool {
     config.trading_paused
+}
+
+/// Return whether new mints are paused for one expiry.
+public fun expiry_mint_paused(config: &ProtocolConfig, expiry: u64): bool {
+    config.expiry_entry(expiry).entry_mint_paused()
 }
 
 /// Return the configured strike tick size for a Pyth Lazer feed, if registered.
@@ -367,6 +357,16 @@ public fun set_trading_paused(config: &mut ProtocolConfig, _admin_cap: &AdminCap
     config.set_trading_paused_internal(paused);
 }
 
+/// Set whether new mints are paused for one expiry.
+public fun set_expiry_mint_paused(
+    config: &mut ProtocolConfig,
+    _admin_cap: &AdminCap,
+    expiry: u64,
+    paused: bool,
+) {
+    config.set_expiry_mint_paused_internal(expiry, paused);
+}
+
 // === Public-Package Functions ===
 
 public(package) fun pricing_config(config: &ProtocolConfig): &PricingConfig {
@@ -379,10 +379,6 @@ public(package) fun fee_config(config: &ProtocolConfig): &FeeConfig {
 
 public(package) fun risk_config(config: &ProtocolConfig): &RiskConfig {
     &config.risk_config
-}
-
-public(package) fun market_oracle_config(config: &ProtocolConfig): &MarketOracleConfig {
-    &config.market_oracle_config
 }
 
 public(package) fun leverage_config(config: &ProtocolConfig): &LeverageConfig {
@@ -409,89 +405,34 @@ public(package) fun min_strike(snapshot: &ExpiryConfigSnapshot): u64 {
     snapshot.min_strike
 }
 
-public(package) fun snapshot_tick_size(snapshot: &ExpiryConfigSnapshot): u64 {
+public(package) fun tick_size(snapshot: &ExpiryConfigSnapshot): u64 {
     snapshot.tick_size
 }
 
-public(package) fun pyth_lazer_feed_id(snapshot: &ExpiryConfigSnapshot): u32 {
-    snapshot.pyth_lazer_feed_id
-}
-
-public(package) fun snapshot_expiry_fee_window_ms(snapshot: &ExpiryConfigSnapshot): u64 {
+public(package) fun expiry_fee_window_ms(snapshot: &ExpiryConfigSnapshot): u64 {
     snapshot.expiry_fee_window_ms
 }
 
-public(package) fun snapshot_expiry_fee_max_multiplier(snapshot: &ExpiryConfigSnapshot): u64 {
+public(package) fun expiry_fee_max_multiplier(snapshot: &ExpiryConfigSnapshot): u64 {
     snapshot.expiry_fee_max_multiplier
-}
-
-public(package) fun settlement_freshness_ms(policy: &ExpiryOraclePolicy): u64 {
-    policy.settlement_freshness_ms
-}
-
-public(package) fun max_spot_deviation(policy: &ExpiryOraclePolicy): u64 {
-    policy.max_spot_deviation
-}
-
-public(package) fun max_basis_deviation(policy: &ExpiryOraclePolicy): u64 {
-    policy.max_basis_deviation
-}
-
-public(package) fun min_basis(policy: &ExpiryOraclePolicy): u64 {
-    policy.min_basis
-}
-
-public(package) fun max_basis(policy: &ExpiryOraclePolicy): u64 {
-    policy.max_basis
-}
-
-public(package) fun entry_market_oracle_id(entry: &ExpiryEntry): ID {
-    entry.market_oracle_id
-}
-
-public(package) fun entry_snapshot(entry: &ExpiryEntry): &ExpiryConfigSnapshot {
-    &entry.snapshot
-}
-
-public(package) fun entry_oracle_policy(entry: &ExpiryEntry): &ExpiryOraclePolicy {
-    &entry.oracle_policy
-}
-
-public(package) fun entry_mint_paused(entry: &ExpiryEntry): bool {
-    entry.mint_paused
-}
-
-public(package) fun has_feed_template(config: &ProtocolConfig, pyth_lazer_feed_id: u32): bool {
-    config.per_feed.contains(pyth_lazer_feed_id)
-}
-
-public(package) fun feed_template(config: &ProtocolConfig, pyth_lazer_feed_id: u32): &FeedTemplate {
-    config.assert_feed_template_exists(pyth_lazer_feed_id);
-    config.per_feed.borrow(pyth_lazer_feed_id)
-}
-
-public(package) fun has_expiry_entry(config: &ProtocolConfig, expiry: u64): bool {
-    config.per_expiry.contains(expiry)
-}
-
-public(package) fun expiry_entry(config: &ProtocolConfig, expiry: u64): &ExpiryEntry {
-    assert!(config.has_expiry_entry(expiry), EExpiryEntryNotFound);
-    config.per_expiry.borrow(expiry)
-}
-
-public(package) fun expiry_snapshot(config: &ProtocolConfig, expiry: u64): &ExpiryConfigSnapshot {
-    config.expiry_entry(expiry).entry_snapshot()
 }
 
 public(package) fun expiry_oracle_policy(
     config: &ProtocolConfig,
     expiry: u64,
-): &ExpiryOraclePolicy {
+): &MarketOracleConfig {
     config.expiry_entry(expiry).entry_oracle_policy()
 }
 
-public(package) fun expiry_mint_paused(config: &ProtocolConfig, expiry: u64): bool {
-    config.expiry_entry(expiry).entry_mint_paused()
+public(package) fun assert_expiry_market_binding(
+    config: &ProtocolConfig,
+    expiry: u64,
+    expiry_market_id: ID,
+) {
+    assert!(
+        config.expiry_entry(expiry).entry_expiry_market_id() == expiry_market_id,
+        EWrongExpiryMarket,
+    );
 }
 
 public(package) fun assert_expiry_oracle_binding(
@@ -505,55 +446,46 @@ public(package) fun assert_expiry_oracle_binding(
     );
 }
 
-public(package) fun new_expiry_config_snapshot(
-    liquidation_ltv: u64,
-    max_expiry_floor_premium: u64,
-    trading_loss_rebate_rate: u64,
-    min_strike: u64,
-    tick_size: u64,
-    pyth_lazer_feed_id: u32,
-    expiry_fee_window_ms: u64,
-    expiry_fee_max_multiplier: u64,
-): ExpiryConfigSnapshot {
-    config_constants::assert_liquidation_ltv(liquidation_ltv);
-    config_constants::assert_max_expiry_floor_premium(max_expiry_floor_premium);
-    config_constants::assert_trading_loss_rebate_rate(trading_loss_rebate_rate);
-    config_constants::assert_oracle_tick_size(tick_size);
-    assert!(min_strike > 0 && min_strike % tick_size == 0, EInvalidExpirySnapshot);
-    config_constants::assert_expiry_fee_window_ms(expiry_fee_window_ms);
-    config_constants::assert_expiry_fee_max_multiplier(expiry_fee_max_multiplier);
-    ExpiryConfigSnapshot {
-        liquidation_ltv,
-        max_expiry_floor_premium,
-        trading_loss_rebate_rate,
-        min_strike,
-        tick_size,
-        pyth_lazer_feed_id,
-        expiry_fee_window_ms,
-        expiry_fee_max_multiplier,
-    }
+public(package) fun set_expiry_oracle_settlement_freshness_ms(
+    config: &mut ProtocolConfig,
+    expiry: u64,
+    market_oracle_id: ID,
+    value: u64,
+) {
+    config.assert_not_valuation_in_progress();
+    let policy = {
+        let entry = config.expiry_entry_mut(expiry);
+        assert!(entry.market_oracle_id == market_oracle_id, EWrongMarketOracle);
+        entry.oracle_policy.set_settlement_freshness_ms(value);
+        entry.oracle_policy
+    };
+    emit_expiry_oracle_policy_updated(market_oracle_id, &policy);
 }
 
-public(package) fun new_expiry_oracle_policy(
-    settlement_freshness_ms: u64,
+public(package) fun set_expiry_oracle_basis_bounds(
+    config: &mut ProtocolConfig,
+    expiry: u64,
+    market_oracle_id: ID,
     max_spot_deviation: u64,
     max_basis_deviation: u64,
     min_basis: u64,
     max_basis: u64,
-): ExpiryOraclePolicy {
-    config_constants::assert_settlement_freshness_ms(settlement_freshness_ms);
-    config_constants::assert_max_spot_deviation(max_spot_deviation);
-    config_constants::assert_max_basis_deviation(max_basis_deviation);
-    config_constants::assert_min_basis(min_basis);
-    config_constants::assert_max_basis(max_basis);
-    assert!(min_basis < max_basis, EInvalidOraclePolicy);
-    ExpiryOraclePolicy {
-        settlement_freshness_ms,
-        max_spot_deviation,
-        max_basis_deviation,
-        min_basis,
-        max_basis,
-    }
+) {
+    config.assert_not_valuation_in_progress();
+    let policy = {
+        let entry = config.expiry_entry_mut(expiry);
+        assert!(entry.market_oracle_id == market_oracle_id, EWrongMarketOracle);
+        entry
+            .oracle_policy
+            .set_basis_bounds(
+                max_spot_deviation,
+                max_basis_deviation,
+                min_basis,
+                max_basis,
+            );
+        entry.oracle_policy
+    };
+    emit_expiry_oracle_policy_updated(market_oracle_id, &policy);
 }
 
 public(package) fun add_feed_template(
@@ -570,22 +502,37 @@ public(package) fun add_feed_template(
 public(package) fun stamp_expiry_entry(
     config: &mut ProtocolConfig,
     expiry: u64,
+    expiry_market_id: ID,
     market_oracle_id: ID,
-    snapshot: ExpiryConfigSnapshot,
-    oracle_policy: ExpiryOraclePolicy,
-) {
+    pyth_lazer_feed_id: u32,
+    spot: u64,
+): ExpiryConfigSnapshot {
     assert!(!config.has_expiry_entry(expiry), EExpiryEntryAlreadyExists);
+    let feed_template = *config.feed_template(pyth_lazer_feed_id);
+    let tick_size = feed_template.tick_size();
+    let min_strike = centered_min_strike(spot, tick_size);
+    let snapshot = ExpiryConfigSnapshot {
+        liquidation_ltv: config.leverage_config.liquidation_ltv(),
+        max_expiry_floor_premium: config.leverage_config.max_expiry_floor_premium(),
+        trading_loss_rebate_rate: config.fee_config.trading_loss_rebate_rate(),
+        min_strike,
+        tick_size,
+        expiry_fee_window_ms: feed_template.expiry_fee_window_ms(),
+        expiry_fee_max_multiplier: feed_template.expiry_fee_max_multiplier(),
+    };
+    let oracle_policy = config.market_oracle_config;
     config
         .per_expiry
         .add(
             expiry,
             ExpiryEntry {
+                expiry_market_id,
                 market_oracle_id,
-                snapshot,
                 oracle_policy,
                 mint_paused: false,
             },
         );
+    snapshot
 }
 
 /// Abort unless trading mutations are currently allowed.
@@ -622,6 +569,12 @@ public(package) fun pause_trading(config: &mut ProtocolConfig) {
     config.set_trading_paused_internal(true);
 }
 
+/// Force `mint_paused = true` for one expiry. Reserved for `PauseCap` holders
+/// going through the registry; cannot be used to unpause.
+public(package) fun pause_expiry_mint(config: &mut ProtocolConfig, expiry: u64) {
+    config.set_expiry_mint_paused_internal(expiry, true);
+}
+
 /// Begin a transaction-local full-pool valuation lock.
 public(package) fun begin_valuation(config: &mut ProtocolConfig) {
     config.assert_not_valuation_in_progress();
@@ -640,13 +593,69 @@ fun set_trading_paused_internal(config: &mut ProtocolConfig, paused: bool) {
     config_events::emit_trading_paused_updated(config.id(), paused);
 }
 
+fun set_expiry_mint_paused_internal(config: &mut ProtocolConfig, expiry: u64, paused: bool) {
+    config.assert_not_valuation_in_progress();
+    let expiry_market_id = {
+        let entry = config.expiry_entry_mut(expiry);
+        entry.mint_paused = paused;
+        entry.entry_expiry_market_id()
+    };
+    config_events::emit_expiry_market_mint_paused_updated(expiry_market_id, paused);
+}
+
 /// Abort unless trading is not paused.
 fun assert_not_trading_paused(config: &ProtocolConfig) {
     assert!(!config.trading_paused, ETradingPaused);
 }
 
+fun has_feed_template(config: &ProtocolConfig, pyth_lazer_feed_id: u32): bool {
+    config.per_feed.contains(pyth_lazer_feed_id)
+}
+
+fun has_expiry_entry(config: &ProtocolConfig, expiry: u64): bool {
+    config.per_expiry.contains(expiry)
+}
+
 fun assert_feed_template_exists(config: &ProtocolConfig, pyth_lazer_feed_id: u32) {
     assert!(config.has_feed_template(pyth_lazer_feed_id), EFeedTemplateNotFound);
+}
+
+fun expiry_entry_mut(config: &mut ProtocolConfig, expiry: u64): &mut ExpiryEntry {
+    assert!(config.has_expiry_entry(expiry), EExpiryEntryNotFound);
+    config.per_expiry.borrow_mut(expiry)
+}
+
+fun entry_expiry_market_id(entry: &ExpiryEntry): ID {
+    entry.expiry_market_id
+}
+
+fun entry_market_oracle_id(entry: &ExpiryEntry): ID {
+    entry.market_oracle_id
+}
+
+fun entry_oracle_policy(entry: &ExpiryEntry): &MarketOracleConfig {
+    &entry.oracle_policy
+}
+
+fun entry_mint_paused(entry: &ExpiryEntry): bool {
+    entry.mint_paused
+}
+
+fun feed_template(config: &ProtocolConfig, pyth_lazer_feed_id: u32): &FeedTemplate {
+    config.assert_feed_template_exists(pyth_lazer_feed_id);
+    config.per_feed.borrow(pyth_lazer_feed_id)
+}
+
+fun expiry_entry(config: &ProtocolConfig, expiry: u64): &ExpiryEntry {
+    assert!(config.has_expiry_entry(expiry), EExpiryEntryNotFound);
+    config.per_expiry.borrow(expiry)
+}
+
+fun centered_min_strike(spot: u64, tick_size: u64): u64 {
+    config_constants::assert_oracle_tick_size_covers_spot(tick_size, spot);
+    let center_ticks = constants::oracle_strike_grid_ticks!() / 2;
+
+    (spot / tick_size - center_ticks) * tick_size
 }
 
 fun emit_feed_template_updated(config: &ProtocolConfig, pyth_lazer_feed_id: u32) {
@@ -654,6 +663,17 @@ fun emit_feed_template_updated(config: &ProtocolConfig, pyth_lazer_feed_id: u32)
         config.id(),
         pyth_lazer_feed_id,
         config.feed_template(pyth_lazer_feed_id),
+    );
+}
+
+fun emit_expiry_oracle_policy_updated(market_oracle_id: ID, policy: &MarketOracleConfig) {
+    config_events::emit_market_oracle_bounds_updated(
+        market_oracle_id,
+        policy.settlement_freshness_ms(),
+        policy.max_spot_deviation(),
+        policy.max_basis_deviation(),
+        policy.min_basis(),
+        policy.max_basis(),
     );
 }
 

--- a/packages/predict/sources/config/protocol_config.move
+++ b/packages/predict/sources/config/protocol_config.move
@@ -10,18 +10,74 @@ module deepbook_predict::protocol_config;
 
 use deepbook_predict::{
     admin::AdminCap,
+    config_constants,
     config_events,
     fee_config::{Self, FeeConfig},
+    feed_template::FeedTemplate,
     leverage_config::{Self, LeverageConfig},
     market_oracle_config::{Self, MarketOracleConfig},
     pricing_config::{Self, PricingConfig},
     risk_config::{Self, RiskConfig},
     stake_config::{Self, StakeConfig}
 };
+use sui::table::{Self, Table};
 
 const ETradingPaused: u64 = 0;
 const EValuationInProgress: u64 = 1;
 const EValuationNotInProgress: u64 = 2;
+const EFeedTemplateAlreadyExists: u64 = 3;
+const EFeedTemplateNotFound: u64 = 4;
+const EExpiryEntryAlreadyExists: u64 = 5;
+const EExpiryEntryNotFound: u64 = 6;
+const EWrongMarketOracle: u64 = 7;
+const EInvalidExpirySnapshot: u64 = 8;
+const EInvalidOraclePolicy: u64 = 9;
+
+/// Frozen contract terms stamped for one expiry.
+public struct ExpiryConfigSnapshot has copy, drop, store {
+    /// 1e9-scaled floor-to-live-value threshold for liquidation.
+    liquidation_ltv: u64,
+    /// Maximum terminal increase in the contract floor index over one expiry.
+    max_expiry_floor_premium: u64,
+    /// Fraction of aggregate expiry trading fees reserved for loss rebates.
+    trading_loss_rebate_rate: u64,
+    /// Minimum finite strike in this expiry's oracle grid.
+    min_strike: u64,
+    /// Strike tick size for this expiry's oracle grid.
+    tick_size: u64,
+    /// Pyth Lazer feed ID bound to this expiry.
+    pyth_lazer_feed_id: u32,
+    /// Window before expiry over which trade fees ramp up.
+    expiry_fee_window_ms: u64,
+    /// Fee multiplier reached at expiry, in FLOAT_SCALING; 1x disables.
+    expiry_fee_max_multiplier: u64,
+}
+
+/// Mutable per-expiry oracle policy controlled by authorized oracle operators.
+public struct ExpiryOraclePolicy has copy, drop, store {
+    /// Maximum age for a source to be used for settlement.
+    settlement_freshness_ms: u64,
+    /// Maximum allowed spot move between Block Scholes pushes.
+    max_spot_deviation: u64,
+    /// Maximum allowed basis move between Block Scholes pushes.
+    max_basis_deviation: u64,
+    /// Minimum allowed forward / spot basis.
+    min_basis: u64,
+    /// Maximum allowed forward / spot basis.
+    max_basis: u64,
+}
+
+/// Central per-expiry config row.
+public struct ExpiryEntry has copy, drop, store {
+    /// Market oracle object bound to this expiry.
+    market_oracle_id: ID,
+    /// Frozen contract terms for this expiry.
+    snapshot: ExpiryConfigSnapshot,
+    /// Mutable oracle bounds/freshness policy for this expiry.
+    oracle_policy: ExpiryOraclePolicy,
+    /// Blocks new mints for this expiry while true.
+    mint_paused: bool,
+}
 
 /// Shared protocol policy and config state.
 public struct ProtocolConfig has key {
@@ -36,6 +92,10 @@ public struct ProtocolConfig has key {
     trading_paused: bool,
     /// Transaction-local lock held while a full-pool valuation is assembled.
     valuation_in_progress: bool,
+    /// Pyth Lazer feed ID -> future-expiry template policy.
+    per_feed: Table<u32, FeedTemplate>,
+    /// Expiry timestamp -> frozen snapshot and mutable per-expiry controls.
+    per_expiry: Table<u64, ExpiryEntry>,
 }
 
 // === Public Functions ===
@@ -48,6 +108,39 @@ public fun id(config: &ProtocolConfig): ID {
 /// Return whether trading is currently paused.
 public fun trading_paused(config: &ProtocolConfig): bool {
     config.trading_paused
+}
+
+/// Return the configured strike tick size for a Pyth Lazer feed, if registered.
+public fun pyth_feed_tick_size(config: &ProtocolConfig, pyth_lazer_feed_id: u32): Option<u64> {
+    if (config.has_feed_template(pyth_lazer_feed_id)) {
+        option::some(config.feed_template(pyth_lazer_feed_id).tick_size())
+    } else {
+        option::none()
+    }
+}
+
+/// Return the configured expiry-fee ramp window for a Pyth Lazer feed, if registered.
+public fun pyth_feed_expiry_fee_window_ms(
+    config: &ProtocolConfig,
+    pyth_lazer_feed_id: u32,
+): Option<u64> {
+    if (config.has_feed_template(pyth_lazer_feed_id)) {
+        option::some(config.feed_template(pyth_lazer_feed_id).expiry_fee_window_ms())
+    } else {
+        option::none()
+    }
+}
+
+/// Return the configured expiry-fee max multiplier for a Pyth Lazer feed, if registered.
+public fun pyth_feed_expiry_fee_max_multiplier(
+    config: &ProtocolConfig,
+    pyth_lazer_feed_id: u32,
+): Option<u64> {
+    if (config.has_feed_template(pyth_lazer_feed_id)) {
+        option::some(config.feed_template(pyth_lazer_feed_id).expiry_fee_max_multiplier())
+    } else {
+        option::none()
+    }
 }
 
 /// Set the base fee multiplier.
@@ -227,6 +320,48 @@ public fun set_market_oracle_template_basis_bounds(
     );
 }
 
+/// Set the strike tick size used by future expiry markets for one Pyth feed.
+public fun set_pyth_feed_tick_size(
+    config: &mut ProtocolConfig,
+    _admin_cap: &AdminCap,
+    pyth_lazer_feed_id: u32,
+    tick_size: u64,
+) {
+    config.assert_not_valuation_in_progress();
+    config.assert_feed_template_exists(pyth_lazer_feed_id);
+    config.per_feed.borrow_mut(pyth_lazer_feed_id).set_tick_size(tick_size);
+    config.emit_feed_template_updated(pyth_lazer_feed_id);
+}
+
+/// Set the per-asset expiry-fee ramp window snapshotted by future expiry markets
+/// for one Pyth feed.
+public fun set_pyth_feed_expiry_fee_window_ms(
+    config: &mut ProtocolConfig,
+    _admin_cap: &AdminCap,
+    pyth_lazer_feed_id: u32,
+    window_ms: u64,
+) {
+    config.assert_not_valuation_in_progress();
+    config.assert_feed_template_exists(pyth_lazer_feed_id);
+    config.per_feed.borrow_mut(pyth_lazer_feed_id).set_expiry_fee_window_ms(window_ms);
+    config.emit_feed_template_updated(pyth_lazer_feed_id);
+}
+
+/// Set the per-asset expiry-fee max multiplier snapshotted by future expiry markets
+/// for one Pyth feed. `max_multiplier` (FLOAT_SCALING, 1x disables) is the multiplier
+/// reached at expiry over the configured ramp window. Larger values suit more volatile assets.
+public fun set_pyth_feed_expiry_fee_max_multiplier(
+    config: &mut ProtocolConfig,
+    _admin_cap: &AdminCap,
+    pyth_lazer_feed_id: u32,
+    max_multiplier: u64,
+) {
+    config.assert_not_valuation_in_progress();
+    config.assert_feed_template_exists(pyth_lazer_feed_id);
+    config.per_feed.borrow_mut(pyth_lazer_feed_id).set_expiry_fee_max_multiplier(max_multiplier);
+    config.emit_feed_template_updated(pyth_lazer_feed_id);
+}
+
 /// Set whether trading is paused.
 public fun set_trading_paused(config: &mut ProtocolConfig, _admin_cap: &AdminCap, paused: bool) {
     config.set_trading_paused_internal(paused);
@@ -256,6 +391,201 @@ public(package) fun leverage_config(config: &ProtocolConfig): &LeverageConfig {
 
 public(package) fun stake_config(config: &ProtocolConfig): &StakeConfig {
     &config.stake_config
+}
+
+public(package) fun liquidation_ltv(snapshot: &ExpiryConfigSnapshot): u64 {
+    snapshot.liquidation_ltv
+}
+
+public(package) fun max_expiry_floor_premium(snapshot: &ExpiryConfigSnapshot): u64 {
+    snapshot.max_expiry_floor_premium
+}
+
+public(package) fun trading_loss_rebate_rate(snapshot: &ExpiryConfigSnapshot): u64 {
+    snapshot.trading_loss_rebate_rate
+}
+
+public(package) fun min_strike(snapshot: &ExpiryConfigSnapshot): u64 {
+    snapshot.min_strike
+}
+
+public(package) fun snapshot_tick_size(snapshot: &ExpiryConfigSnapshot): u64 {
+    snapshot.tick_size
+}
+
+public(package) fun pyth_lazer_feed_id(snapshot: &ExpiryConfigSnapshot): u32 {
+    snapshot.pyth_lazer_feed_id
+}
+
+public(package) fun snapshot_expiry_fee_window_ms(snapshot: &ExpiryConfigSnapshot): u64 {
+    snapshot.expiry_fee_window_ms
+}
+
+public(package) fun snapshot_expiry_fee_max_multiplier(snapshot: &ExpiryConfigSnapshot): u64 {
+    snapshot.expiry_fee_max_multiplier
+}
+
+public(package) fun settlement_freshness_ms(policy: &ExpiryOraclePolicy): u64 {
+    policy.settlement_freshness_ms
+}
+
+public(package) fun max_spot_deviation(policy: &ExpiryOraclePolicy): u64 {
+    policy.max_spot_deviation
+}
+
+public(package) fun max_basis_deviation(policy: &ExpiryOraclePolicy): u64 {
+    policy.max_basis_deviation
+}
+
+public(package) fun min_basis(policy: &ExpiryOraclePolicy): u64 {
+    policy.min_basis
+}
+
+public(package) fun max_basis(policy: &ExpiryOraclePolicy): u64 {
+    policy.max_basis
+}
+
+public(package) fun entry_market_oracle_id(entry: &ExpiryEntry): ID {
+    entry.market_oracle_id
+}
+
+public(package) fun entry_snapshot(entry: &ExpiryEntry): &ExpiryConfigSnapshot {
+    &entry.snapshot
+}
+
+public(package) fun entry_oracle_policy(entry: &ExpiryEntry): &ExpiryOraclePolicy {
+    &entry.oracle_policy
+}
+
+public(package) fun entry_mint_paused(entry: &ExpiryEntry): bool {
+    entry.mint_paused
+}
+
+public(package) fun has_feed_template(config: &ProtocolConfig, pyth_lazer_feed_id: u32): bool {
+    config.per_feed.contains(pyth_lazer_feed_id)
+}
+
+public(package) fun feed_template(config: &ProtocolConfig, pyth_lazer_feed_id: u32): &FeedTemplate {
+    config.assert_feed_template_exists(pyth_lazer_feed_id);
+    config.per_feed.borrow(pyth_lazer_feed_id)
+}
+
+public(package) fun has_expiry_entry(config: &ProtocolConfig, expiry: u64): bool {
+    config.per_expiry.contains(expiry)
+}
+
+public(package) fun expiry_entry(config: &ProtocolConfig, expiry: u64): &ExpiryEntry {
+    assert!(config.has_expiry_entry(expiry), EExpiryEntryNotFound);
+    config.per_expiry.borrow(expiry)
+}
+
+public(package) fun expiry_snapshot(config: &ProtocolConfig, expiry: u64): &ExpiryConfigSnapshot {
+    config.expiry_entry(expiry).entry_snapshot()
+}
+
+public(package) fun expiry_oracle_policy(
+    config: &ProtocolConfig,
+    expiry: u64,
+): &ExpiryOraclePolicy {
+    config.expiry_entry(expiry).entry_oracle_policy()
+}
+
+public(package) fun expiry_mint_paused(config: &ProtocolConfig, expiry: u64): bool {
+    config.expiry_entry(expiry).entry_mint_paused()
+}
+
+public(package) fun assert_expiry_oracle_binding(
+    config: &ProtocolConfig,
+    expiry: u64,
+    market_oracle_id: ID,
+) {
+    assert!(
+        config.expiry_entry(expiry).entry_market_oracle_id() == market_oracle_id,
+        EWrongMarketOracle,
+    );
+}
+
+public(package) fun new_expiry_config_snapshot(
+    liquidation_ltv: u64,
+    max_expiry_floor_premium: u64,
+    trading_loss_rebate_rate: u64,
+    min_strike: u64,
+    tick_size: u64,
+    pyth_lazer_feed_id: u32,
+    expiry_fee_window_ms: u64,
+    expiry_fee_max_multiplier: u64,
+): ExpiryConfigSnapshot {
+    config_constants::assert_liquidation_ltv(liquidation_ltv);
+    config_constants::assert_max_expiry_floor_premium(max_expiry_floor_premium);
+    config_constants::assert_trading_loss_rebate_rate(trading_loss_rebate_rate);
+    config_constants::assert_oracle_tick_size(tick_size);
+    assert!(min_strike > 0 && min_strike % tick_size == 0, EInvalidExpirySnapshot);
+    config_constants::assert_expiry_fee_window_ms(expiry_fee_window_ms);
+    config_constants::assert_expiry_fee_max_multiplier(expiry_fee_max_multiplier);
+    ExpiryConfigSnapshot {
+        liquidation_ltv,
+        max_expiry_floor_premium,
+        trading_loss_rebate_rate,
+        min_strike,
+        tick_size,
+        pyth_lazer_feed_id,
+        expiry_fee_window_ms,
+        expiry_fee_max_multiplier,
+    }
+}
+
+public(package) fun new_expiry_oracle_policy(
+    settlement_freshness_ms: u64,
+    max_spot_deviation: u64,
+    max_basis_deviation: u64,
+    min_basis: u64,
+    max_basis: u64,
+): ExpiryOraclePolicy {
+    config_constants::assert_settlement_freshness_ms(settlement_freshness_ms);
+    config_constants::assert_max_spot_deviation(max_spot_deviation);
+    config_constants::assert_max_basis_deviation(max_basis_deviation);
+    config_constants::assert_min_basis(min_basis);
+    config_constants::assert_max_basis(max_basis);
+    assert!(min_basis < max_basis, EInvalidOraclePolicy);
+    ExpiryOraclePolicy {
+        settlement_freshness_ms,
+        max_spot_deviation,
+        max_basis_deviation,
+        min_basis,
+        max_basis,
+    }
+}
+
+public(package) fun add_feed_template(
+    config: &mut ProtocolConfig,
+    pyth_lazer_feed_id: u32,
+    template: FeedTemplate,
+) {
+    config.assert_not_valuation_in_progress();
+    assert!(!config.has_feed_template(pyth_lazer_feed_id), EFeedTemplateAlreadyExists);
+    config.per_feed.add(pyth_lazer_feed_id, template);
+    config.emit_feed_template_updated(pyth_lazer_feed_id);
+}
+
+public(package) fun stamp_expiry_entry(
+    config: &mut ProtocolConfig,
+    expiry: u64,
+    market_oracle_id: ID,
+    snapshot: ExpiryConfigSnapshot,
+    oracle_policy: ExpiryOraclePolicy,
+) {
+    assert!(!config.has_expiry_entry(expiry), EExpiryEntryAlreadyExists);
+    config
+        .per_expiry
+        .add(
+            expiry,
+            ExpiryEntry {
+                market_oracle_id,
+                snapshot,
+                oracle_policy,
+                mint_paused: false,
+            },
+        );
 }
 
 /// Abort unless trading mutations are currently allowed.
@@ -315,6 +645,18 @@ fun assert_not_trading_paused(config: &ProtocolConfig) {
     assert!(!config.trading_paused, ETradingPaused);
 }
 
+fun assert_feed_template_exists(config: &ProtocolConfig, pyth_lazer_feed_id: u32) {
+    assert!(config.has_feed_template(pyth_lazer_feed_id), EFeedTemplateNotFound);
+}
+
+fun emit_feed_template_updated(config: &ProtocolConfig, pyth_lazer_feed_id: u32) {
+    config_events::emit_feed_template_updated(
+        config.id(),
+        pyth_lazer_feed_id,
+        config.feed_template(pyth_lazer_feed_id),
+    );
+}
+
 fun new(ctx: &mut TxContext): ProtocolConfig {
     ProtocolConfig {
         id: object::new(ctx),
@@ -326,6 +668,8 @@ fun new(ctx: &mut TxContext): ProtocolConfig {
         stake_config: stake_config::new(),
         trading_paused: false,
         valuation_in_progress: false,
+        per_feed: table::new(ctx),
+        per_expiry: table::new(ctx),
     }
 }
 

--- a/packages/predict/sources/events/config_events.move
+++ b/packages/predict/sources/events/config_events.move
@@ -6,6 +6,7 @@ module deepbook_predict::config_events;
 
 use deepbook_predict::{
     fee_config::FeeConfig,
+    feed_template::FeedTemplate,
     leverage_config::LeverageConfig,
     market_oracle_config::MarketOracleConfig,
     pricing_config::PricingConfig,
@@ -54,6 +55,15 @@ public struct MarketOracleTemplateConfigUpdated has copy, drop, store {
     max_basis_deviation: u64,
     min_basis: u64,
     max_basis: u64,
+}
+
+/// Emitted when per-feed future-expiry template policy changes.
+public struct FeedTemplateUpdated has copy, drop, store {
+    protocol_config_id: ID,
+    pyth_lazer_feed_id: u32,
+    tick_size: u64,
+    expiry_fee_window_ms: u64,
+    expiry_fee_max_multiplier: u64,
 }
 
 /// Emitted when global trading pause state changes.
@@ -138,6 +148,20 @@ public(package) fun emit_market_oracle_template_config_updated(
         max_basis_deviation: config.max_basis_deviation(),
         min_basis: config.min_basis(),
         max_basis: config.max_basis(),
+    });
+}
+
+public(package) fun emit_feed_template_updated(
+    protocol_config_id: ID,
+    pyth_lazer_feed_id: u32,
+    template: &FeedTemplate,
+) {
+    event::emit(FeedTemplateUpdated {
+        protocol_config_id,
+        pyth_lazer_feed_id,
+        tick_size: template.tick_size(),
+        expiry_fee_window_ms: template.expiry_fee_window_ms(),
+        expiry_fee_max_multiplier: template.expiry_fee_max_multiplier(),
     });
 }
 

--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -11,9 +11,7 @@ module deepbook_predict::expiry_market;
 
 use deepbook::math;
 use deepbook_predict::{
-    admin::AdminCap,
     claim_events,
-    config_events,
     constants,
     market_oracle::{MarketOracle, MarketOracleCap},
     order::{Self, Order},
@@ -43,18 +41,20 @@ public struct ExpiryMarket has key {
     market_oracle_id: ID,
     pyth_lazer_feed_id: u32,
     expiry: u64,
-    /// Trading loss rebate rate snapshotted from fee config at creation.
-    trading_loss_rebate_rate: u64,
     /// DUSDC backing payout liability, rebate reserve, and residual expiry NAV.
     cash_balance: Balance<DUSDC>,
     /// Trading-fee basis whose rebate eligibility has not been resolved.
     unresolved_trading_fees_paid: u64,
+    /// Fraction of aggregate expiry trading fees reserved for loss rebates.
+    trading_loss_rebate_rate: u64,
+    /// Frozen per-expiry trade-fee ramp window.
+    expiry_fee_window_ms: u64,
+    /// Frozen per-expiry trade-fee ramp max multiplier.
+    expiry_fee_max_multiplier: u64,
     /// Exposure lifecycle state for this expiry's oracle grid.
     strike_exposure: StrikeExposure,
     /// Mirror of `ProtocolConfig.allowed_versions`; synced permissionlessly.
     allowed_versions: VecSet<u64>,
-    /// When true, `mint` aborts. Other flows (redeem, settle, cleanup) unaffected.
-    mint_paused: bool,
 }
 
 // === Public Functions ===
@@ -106,12 +106,12 @@ public fun liquidation_ltv(market: &ExpiryMarket): u64 {
 
 /// Return the trade-fee ramp window snapshotted for this expiry.
 public fun expiry_fee_window_ms(market: &ExpiryMarket): u64 {
-    market.strike_exposure.expiry_fee_window_ms()
+    market.expiry_fee_window_ms
 }
 
 /// Return the trade-fee ramp max multiplier snapshotted for this expiry.
 public fun expiry_fee_max_multiplier(market: &ExpiryMarket): u64 {
-    market.strike_exposure.expiry_fee_max_multiplier()
+    market.expiry_fee_max_multiplier
 }
 
 /// Return the minimum strike snapshotted for this expiry's oracle grid.
@@ -134,26 +134,14 @@ public fun payout_liability(market: &ExpiryMarket): u64 {
     market.strike_exposure.payout_liability()
 }
 
-/// Return whether minting is currently paused on this expiry market.
-public fun mint_paused(market: &ExpiryMarket): bool {
-    market.mint_paused
-}
-
 /// Return this market's mirrored set of allowed package versions.
 public fun allowed_versions(market: &ExpiryMarket): VecSet<u64> {
     market.allowed_versions
 }
 
-/// Set per-market mint pause. Admin can pause or unpause one expiry without
-/// changing global trading state.
-public fun set_mint_paused(market: &mut ExpiryMarket, _admin_cap: &AdminCap, paused: bool) {
-    market.assert_version_allowed();
-    market.set_mint_paused_internal(paused);
-}
-
 /// Mint a live position interval against this expiry market.
 ///
-/// Requires the package version to be allowed for this market, per-market mint
+/// Requires the package version to be allowed for this market, expiry mint
 /// pause to be off, trading globally enabled, manager ownership, a live fresh
 /// oracle, enough expiry cash to back the post-mint max payout and rebate reserve,
 /// and leveraged floor terms below this expiry's liquidation LTV at terminal.
@@ -174,7 +162,7 @@ public fun mint(
     ctx: &mut TxContext,
 ): u256 {
     market.assert_version_allowed();
-    assert!(!market.mint_paused, EMintPaused);
+    assert!(!market.expiry_mint_paused(config), EMintPaused);
     config.assert_trading_allowed();
     market.mint_internal(
         manager,
@@ -306,53 +294,54 @@ public(package) fun assert_version_allowed(market: &ExpiryMarket) {
 
 /// Create and share a zero-cash expiry market for one market oracle.
 ///
-/// The market snapshots the Pyth feed ID, initializes strike exposure state, and
-/// starts with zero expiry cash. Pool funding only enters through PLP rebalancing.
+/// `ProtocolConfig` stamps the per-expiry config row. The market snapshots the
+/// Pyth feed ID into its own binding state and initializes structural strike
+/// exposure state with zero expiry cash. Pool funding only enters through PLP
+/// rebalancing.
 public(package) fun create_and_share(
-    config: &ProtocolConfig,
+    config: &mut ProtocolConfig,
     allowed_versions: VecSet<u64>,
     market_oracle_id: ID,
-    pyth_lazer_feed_id: u32,
+    pyth: &PythSource,
     expiry: u64,
-    min_strike: u64,
-    tick_size: u64,
     preallocated_ticks: u64,
-    expiry_fee_window_ms: u64,
-    expiry_fee_max_multiplier: u64,
     ctx: &mut TxContext,
-): ID {
+): (ID, u64, u64) {
     let id = object::new(ctx);
     let expiry_market_id = id.to_inner();
+    let snapshot = config.stamp_expiry_entry(
+        expiry,
+        expiry_market_id,
+        market_oracle_id,
+        pyth.feed_id(),
+        pyth.spot(),
+    );
+    let min_strike = snapshot.min_strike();
+    let tick_size = snapshot.tick_size();
     let market = ExpiryMarket {
         id,
         market_oracle_id,
-        pyth_lazer_feed_id,
+        pyth_lazer_feed_id: pyth.feed_id(),
         expiry,
-        trading_loss_rebate_rate: config.fee_config().trading_loss_rebate_rate(),
         cash_balance: balance::zero(),
         unresolved_trading_fees_paid: 0,
+        trading_loss_rebate_rate: snapshot.trading_loss_rebate_rate(),
+        expiry_fee_window_ms: snapshot.expiry_fee_window_ms(),
+        expiry_fee_max_multiplier: snapshot.expiry_fee_max_multiplier(),
         strike_exposure: strike_exposure::new(
             expiry_market_id,
             expiry,
             min_strike,
             tick_size,
+            snapshot.max_expiry_floor_premium(),
+            snapshot.liquidation_ltv(),
             preallocated_ticks,
-            config.leverage_config().max_expiry_floor_premium(),
-            config.leverage_config().liquidation_ltv(),
-            expiry_fee_window_ms,
-            expiry_fee_max_multiplier,
             ctx,
         ),
         allowed_versions,
-        mint_paused: false,
     };
     transfer::share_object(market);
-    expiry_market_id
-}
-
-/// Force `mint_paused = true` (used by PauseCap path on registry; one-way).
-public(package) fun pause_mint(market: &mut ExpiryMarket) {
-    market.set_mint_paused_internal(true);
+    (expiry_market_id, min_strike, tick_size)
 }
 
 /// Cache terminal payout liability in strike exposure if it has not already been cached.
@@ -435,7 +424,7 @@ public(package) fun claim_trading_loss_rebate(
     market.resolve_trading_fee_basis(trading_fees_paid);
     let resolved_rebate_reserve = math::mul(
         trading_fees_paid,
-        market.trading_loss_rebate_rate,
+        market.trading_loss_rebate_rate(),
     );
     let eligible_rebate = if (resolved_rebate_reserve > gross_profit) {
         resolved_rebate_reserve - gross_profit
@@ -505,13 +494,13 @@ public(package) fun release_pool_cash(market: &mut ExpiryMarket, amount: u64): B
 
 // === Private Functions ===
 
-fun set_mint_paused_internal(market: &mut ExpiryMarket, paused: bool) {
-    market.mint_paused = paused;
-    config_events::emit_expiry_market_mint_paused_updated(market.id(), paused);
-}
-
 fun assert_pyth_feed(market: &ExpiryMarket, pyth: &PythSource) {
     assert!(market.pyth_lazer_feed_id == pyth.feed_id(), EWrongPythSource);
+}
+
+fun expiry_mint_paused(market: &ExpiryMarket, config: &ProtocolConfig): bool {
+    config.assert_expiry_market_binding(market.expiry, market.id());
+    config.expiry_mint_paused(market.expiry)
 }
 
 fun builder_fee_amount(builder_code_id: &Option<ID>, fee_amount: u64, quantity: u64): u64 {
@@ -565,29 +554,40 @@ fun mint_internal(
         config.risk_config().trade_liquidation_budget(),
         clock,
     );
+    let entry_probability = pricing::live_range_probability(
+        config.pricing_config(),
+        market_oracle,
+        pyth,
+        lower_strike,
+        higher_strike,
+        clock,
+    );
+    order::assert_mint_leverage_tier(entry_probability, leverage);
+    let fee_rate = pricing::assert_mint_fee_rate(
+        config.pricing_config(),
+        market_oracle,
+        market.expiry_fee_window_ms,
+        market.expiry_fee_max_multiplier,
+        entry_probability,
+        clock,
+    );
+    let fee_amount = math::mul(fee_rate, quantity);
 
-    let (minted_order, fee_amount) = market
+    let minted_order = market
         .strike_exposure
         .allocate_mint_order(
-            config.pricing_config(),
-            market_oracle,
-            pyth,
             lower_strike,
             higher_strike,
             quantity,
             leverage,
+            entry_probability,
             clock,
         );
     let fee_amount = config
         .stake_config()
         .fee_amount_after_discount(fee_amount, manager.active_stake());
 
-    let builder_fee_amount = market.settle_mint_payment(
-        manager,
-        &minted_order,
-        fee_amount,
-        ctx,
-    );
+    let builder_fee_amount = market.settle_mint_payment(manager, &minted_order, fee_amount, ctx);
     order_events::emit_order_minted(
         market.id(),
         manager,
@@ -614,19 +614,29 @@ fun redeem_live_internal(
     manager.assert_owner(ctx);
     manager.update_stake(ctx);
     market.assert_pyth_feed(pyth);
-    pricing::assert_live_quote_available(config.pricing_config(), market_oracle, pyth, clock);
-    manager.remove_position(market.id(), order.id());
+    let strikes = market.strike_exposure.order_strikes(order);
+    let range_probability = pricing::live_range_probability(
+        config.pricing_config(),
+        market_oracle,
+        pyth,
+        strikes.lower(),
+        strikes.higher(),
+        clock,
+    );
+    let fee_rate = pricing::fee_rate(
+        config.pricing_config(),
+        market_oracle,
+        market.expiry_fee_window_ms,
+        market.expiry_fee_max_multiplier,
+        range_probability,
+        clock,
+    );
 
-    let (resulting_order, redeem_amount, fee_amount) = market
+    manager.remove_position(market.id(), order.id());
+    let (resulting_order, redeem_amount) = market
         .strike_exposure
-        .close_and_quote_live_order(
-            config.pricing_config(),
-            market_oracle,
-            pyth,
-            order,
-            close_quantity,
-            clock,
-        );
+        .close_live_order(order, close_quantity, range_probability, clock);
+    let fee_amount = math::mul(fee_rate, close_quantity).min(redeem_amount);
     let fee_amount = config
         .stake_config()
         .fee_amount_after_discount(fee_amount, manager.active_stake());

--- a/packages/predict/sources/oracle/market_oracle.move
+++ b/packages/predict/sources/oracle/market_oracle.move
@@ -4,16 +4,14 @@
 /// Per-expiry Predict market oracle state and write API.
 ///
 /// This module owns market-specific state: expiry, settlement, operator
-/// authorization, Pyth source binding, bounds, and inline Block Scholes data.
-/// It stores oracle updates and terminal settlement state. Live oracle reads
-/// are resolved by `pricing.move`.
+/// authorization, Pyth source binding, and inline Block Scholes data. Config
+/// owns per-expiry oracle policy. This module stores oracle updates and terminal
+/// settlement state. Live oracle reads are resolved by `pricing.move`.
 module deepbook_predict::market_oracle;
 
 use deepbook::math;
 use deepbook_predict::{
     admin::AdminCap,
-    config_constants,
-    config_events,
     constants,
     i64,
     market_oracle_config::MarketOracleConfig,
@@ -26,7 +24,6 @@ use sui::{clock::Clock, vec_set::{Self, VecSet}};
 const EInvalidMarketOracleCap: u64 = 0;
 const EMarketNotActive: u64 = 1;
 const EMarketSettled: u64 = 2;
-const EInvalidBasisBounds: u64 = 3;
 const ESpotDeviationTooLarge: u64 = 4;
 const EBasisDeviationTooLarge: u64 = 5;
 const EBasisOutOfRange: u64 = 6;
@@ -74,11 +71,6 @@ public struct MarketOracle has key {
     block_scholes_svi: SVIParams,
     block_scholes_svi_source_timestamp_ms: u64,
     block_scholes_svi_update_timestamp_ms: u64,
-    settlement_freshness_ms: u64,
-    max_spot_deviation: u64,
-    max_basis_deviation: u64,
-    min_basis: u64,
-    max_basis: u64,
     /// None until terminal settlement records a source price.
     settlement_price: Option<u64>,
     /// Settlement source code; zero before settlement.
@@ -256,14 +248,17 @@ public fun update_block_scholes_prices(
 
     let status = market.status(clock);
     assert!(status != STATUS_SETTLED, EMarketSettled);
+    config.assert_expiry_oracle_binding(market.expiry, market.id());
+    let policy = config.expiry_oracle_policy(market.expiry);
 
     let basis = market.validate_block_scholes_price_update(
+        policy,
         block_scholes_spot,
         block_scholes_forward,
         block_scholes_source_timestamp_ms,
         clock,
     );
-    market.validate_basis_push(block_scholes_spot, basis);
+    market.validate_basis_push(policy, block_scholes_spot, basis);
     market.apply_block_scholes_prices(
         block_scholes_spot,
         block_scholes_forward,
@@ -271,7 +266,7 @@ public fun update_block_scholes_prices(
         block_scholes_source_timestamp_ms,
         clock,
     );
-    market.settle_if_possible_internal(pyth, clock);
+    market.settle_if_possible_internal(policy, pyth, clock);
 }
 
 /// Settle from the earliest valid stored source, if one is available.
@@ -291,7 +286,9 @@ public fun settle_if_possible(
     config.assert_not_valuation_in_progress();
     if (market.status(clock) != STATUS_PENDING_SETTLEMENT) return false;
     market.assert_pyth_source(pyth);
-    market.settle_if_possible_internal(pyth, clock)
+    config.assert_expiry_oracle_binding(market.expiry, market.id());
+    let policy = config.expiry_oracle_policy(market.expiry);
+    market.settle_if_possible_internal(policy, pyth, clock)
 }
 
 /// Update live SVI data from an authorized Block Scholes writer.
@@ -333,27 +330,24 @@ public fun update_svi(
 
 /// Set the settlement freshness threshold for this oracle.
 ///
-/// This is per-oracle cap-authorized config and affects this oracle directly.
+/// This is per-oracle cap-authorized config stored in `ProtocolConfig`.
 public fun set_settlement_freshness_ms(
-    market: &mut MarketOracle,
-    config: &ProtocolConfig,
+    config: &mut ProtocolConfig,
+    market: &MarketOracle,
     cap: &MarketOracleCap,
     value: u64,
 ) {
     market.assert_version_allowed();
     market.assert_authorized_cap(cap);
-    config.assert_not_valuation_in_progress();
-    config_constants::assert_settlement_freshness_ms(value);
-    market.settlement_freshness_ms = value;
-    market.emit_bounds_updated();
+    config.set_expiry_oracle_settlement_freshness_ms(market.expiry, market.id(), value);
 }
 
 /// Set basis and deviation bounds for this oracle.
 ///
-/// This is per-oracle cap-authorized config and affects this oracle directly.
+/// This is per-oracle cap-authorized config stored in `ProtocolConfig`.
 public fun set_basis_bounds(
-    market: &mut MarketOracle,
-    config: &ProtocolConfig,
+    config: &mut ProtocolConfig,
+    market: &MarketOracle,
     cap: &MarketOracleCap,
     max_spot_deviation: u64,
     max_basis_deviation: u64,
@@ -362,13 +356,14 @@ public fun set_basis_bounds(
 ) {
     market.assert_version_allowed();
     market.assert_authorized_cap(cap);
-    config.assert_not_valuation_in_progress();
-    validate_basis_bounds_inputs(max_spot_deviation, max_basis_deviation, min_basis, max_basis);
-    market.max_spot_deviation = max_spot_deviation;
-    market.max_basis_deviation = max_basis_deviation;
-    market.min_basis = min_basis;
-    market.max_basis = max_basis;
-    market.emit_bounds_updated();
+    config.set_expiry_oracle_basis_bounds(
+        market.expiry,
+        market.id(),
+        max_spot_deviation,
+        max_basis_deviation,
+        min_basis,
+        max_basis,
+    );
 }
 
 /// Create a new oracle writer capability.
@@ -435,7 +430,6 @@ public(package) fun settlement_price(market: &MarketOracle): u64 {
 /// Create and share a market oracle bound to a Pyth source and initial writer cap.
 public(package) fun create_and_share(
     pyth: &PythSource,
-    config: &MarketOracleConfig,
     cap: &MarketOracleCap,
     expiry: u64,
     allowed_versions: VecSet<u64>,
@@ -463,11 +457,6 @@ public(package) fun create_and_share(
         },
         block_scholes_svi_source_timestamp_ms: 0,
         block_scholes_svi_update_timestamp_ms: 0,
-        settlement_freshness_ms: config.settlement_freshness_ms(),
-        max_spot_deviation: config.max_spot_deviation(),
-        max_basis_deviation: config.max_basis_deviation(),
-        min_basis: config.min_basis(),
-        max_basis: config.max_basis(),
         settlement_price: option::none(),
         settlement_source: 0,
         settlement_source_timestamp_ms: 0,
@@ -548,6 +537,7 @@ fun apply_block_scholes_prices(
 
 fun validate_block_scholes_price_update(
     market: &MarketOracle,
+    policy: &MarketOracleConfig,
     spot: u64,
     forward: u64,
     source_timestamp_ms: u64,
@@ -561,13 +551,18 @@ fun validate_block_scholes_price_update(
     );
     assert!(source_timestamp_ms <= clock.timestamp_ms(), EFuturePriceSourceUpdate);
 
-    compute_bounded_basis(market, spot, forward)
+    compute_bounded_basis(policy, spot, forward)
 }
 
-fun settle_if_possible_internal(market: &mut MarketOracle, pyth: &PythSource, clock: &Clock): bool {
+fun settle_if_possible_internal(
+    market: &mut MarketOracle,
+    policy: &MarketOracleConfig,
+    pyth: &PythSource,
+    clock: &Clock,
+): bool {
     if (market.status(clock) != STATUS_PENDING_SETTLEMENT) return false;
 
-    let spot_source = market.valid_settlement_spot_source(pyth, clock);
+    let spot_source = market.valid_settlement_spot_source(policy, pyth, clock);
     if (spot_source.is_none()) return false;
 
     market.settle_from_spot_source(pyth, spot_source.destroy_some());
@@ -576,6 +571,7 @@ fun settle_if_possible_internal(market: &mut MarketOracle, pyth: &PythSource, cl
 
 fun valid_settlement_spot_source(
     market: &MarketOracle,
+    policy: &MarketOracleConfig,
     pyth: &PythSource,
     clock: &Clock,
 ): Option<u8> {
@@ -591,12 +587,12 @@ fun valid_settlement_spot_source(
     let pyth_valid =
         pyth_timestamp > 0
         && pyth_timestamp <= now
-        && now - pyth_timestamp <= market.settlement_freshness_ms
+        && now - pyth_timestamp <= policy.settlement_freshness_ms()
         && pyth_source_timestamp_ms > market.expiry;
     let block_scholes_valid =
         block_scholes_timestamp > 0
         && block_scholes_timestamp <= now
-        && now - block_scholes_timestamp <= market.settlement_freshness_ms
+        && now - block_scholes_timestamp <= policy.settlement_freshness_ms()
         && block_scholes_source_timestamp_ms > market.expiry;
     if (pyth_valid) {
         option::some(SOURCE_PYTH)
@@ -645,18 +641,23 @@ fun settle(
     );
 }
 
-fun compute_bounded_basis(market: &MarketOracle, spot: u64, forward: u64): u64 {
+fun compute_bounded_basis(policy: &MarketOracleConfig, spot: u64, forward: u64): u64 {
     let basis = math::div(forward, spot);
-    assert!(basis >= market.min_basis, EBasisOutOfRange);
-    assert!(basis <= market.max_basis, EBasisOutOfRange);
+    assert!(basis >= policy.min_basis(), EBasisOutOfRange);
+    assert!(basis <= policy.max_basis(), EBasisOutOfRange);
     basis
 }
 
-fun validate_basis_push(market: &MarketOracle, new_spot: u64, new_basis: u64) {
+fun validate_basis_push(
+    market: &MarketOracle,
+    policy: &MarketOracleConfig,
+    new_spot: u64,
+    new_basis: u64,
+) {
     let prev_spot = market.block_scholes_spot;
     if (prev_spot > 0) {
         assert!(
-            within_deviation(prev_spot, new_spot, market.max_spot_deviation),
+            within_deviation(prev_spot, new_spot, policy.max_spot_deviation()),
             ESpotDeviationTooLarge,
         );
     };
@@ -665,40 +666,16 @@ fun validate_basis_push(market: &MarketOracle, new_spot: u64, new_basis: u64) {
     if (prev_spot > 0 && prev_forward > 0) {
         let prev_basis = market.block_scholes_basis();
         assert!(
-            within_deviation(prev_basis, new_basis, market.max_basis_deviation),
+            within_deviation(prev_basis, new_basis, policy.max_basis_deviation()),
             EBasisDeviationTooLarge,
         );
     };
-}
-
-fun validate_basis_bounds_inputs(
-    max_spot_deviation: u64,
-    max_basis_deviation: u64,
-    min_basis: u64,
-    max_basis: u64,
-) {
-    config_constants::assert_max_spot_deviation(max_spot_deviation);
-    config_constants::assert_max_basis_deviation(max_basis_deviation);
-    config_constants::assert_min_basis(min_basis);
-    config_constants::assert_max_basis(max_basis);
-    assert!(min_basis < max_basis, EInvalidBasisBounds);
 }
 
 fun within_deviation(prev: u64, next: u64, max_deviation: u64): bool {
     let diff = if (next >= prev) { next - prev } else { prev - next };
     let max_allowed = math::mul(prev, max_deviation);
     diff <= max_allowed
-}
-
-fun emit_bounds_updated(market: &MarketOracle) {
-    config_events::emit_market_oracle_bounds_updated(
-        market.id(),
-        market.settlement_freshness_ms,
-        market.max_spot_deviation,
-        market.max_basis_deviation,
-        market.min_basis,
-        market.max_basis,
-    );
 }
 
 // === Test-Only Functions ===
@@ -757,11 +734,6 @@ fun create_test_market_oracle_with_pyth_id(
         },
         block_scholes_svi_source_timestamp_ms: 0,
         block_scholes_svi_update_timestamp_ms: 0,
-        settlement_freshness_ms: config_constants::default_settlement_freshness_ms!(),
-        max_spot_deviation: config_constants::default_max_spot_deviation!(),
-        max_basis_deviation: config_constants::default_max_basis_deviation!(),
-        min_basis: config_constants::default_min_basis!(),
-        max_basis: config_constants::default_max_basis!(),
         settlement_price: option::none(),
         settlement_source: 0,
         settlement_source_timestamp_ms: 0,

--- a/packages/predict/sources/registry.move
+++ b/packages/predict/sources/registry.move
@@ -4,9 +4,9 @@
 /// Registry, versioning, and creation entrypoints for the Predict protocol.
 ///
 /// This module creates shared setup objects, stores uniqueness indexes for
-/// Pyth sources and expiries, and exposes registry-owned governance entrypoints. Runtime
-/// pool accounting, expiry risk, oracle state, and user positions stay in their
-/// owning modules.
+/// Pyth sources and expiries, and exposes registry-owned governance entrypoints.
+/// Runtime pool accounting, config policy, expiry risk, oracle state, and user
+/// positions stay in their owning modules.
 module deepbook_predict::registry;
 
 use deepbook_predict::{
@@ -16,6 +16,7 @@ use deepbook_predict::{
     config_events,
     constants,
     expiry_market::{Self, ExpiryMarket},
+    feed_template,
     market_oracle::{Self, MarketOracle, MarketOracleCap},
     plp::PoolVault,
     predict_manager::{Self, PredictManager},
@@ -34,20 +35,6 @@ const EPackageVersionDisabled: u64 = 5;
 const EVersionAlreadyEnabled: u64 = 6;
 const EVersionNotEnabled: u64 = 7;
 const ECannotDisableLastVersion: u64 = 8;
-const EPythFeedNotRegistered: u64 = 9;
-
-/// Registry-owned config for one Pyth Lazer feed.
-public struct PythFeedConfig has copy, drop, store {
-    /// Shared PythSource object bound to the feed.
-    pyth_source_id: ID,
-    /// Admin-selected strike tick size for future expiries.
-    tick_size: u64,
-    /// Window before expiry over which trade fees ramp up for future expiries.
-    expiry_fee_window_ms: u64,
-    /// Fee multiplier reached at expiry, in FLOAT_SCALING; 1x disables. Snapshotted into
-    /// each market at creation.
-    expiry_fee_max_multiplier: u64,
-}
 
 /// Capability for emergency pause operations. Admin can mint these for
 /// trusted operators; holders can disable versions, pause global trading,
@@ -59,8 +46,8 @@ public struct PauseCap has key, store {
 /// Shared registry for source and expiry uniqueness.
 public struct Registry has key {
     id: UID,
-    /// Pyth Lazer feed ID -> source object and creation-time market config.
-    pyth_feed_configs: Table<u32, PythFeedConfig>,
+    /// Pyth Lazer feed ID -> canonical shared PythSource object.
+    pyth_source_ids: Table<u32, ID>,
     /// Created expiry markets keyed by expiry timestamp.
     expiry_market_ids: Table<u64, ID>,
     /// IDs of `PauseCap` objects currently authorized to use pause-only entries.
@@ -86,87 +73,11 @@ public fun allowed_versions(registry: &Registry): VecSet<u64> {
 
 /// Return the shared PythSource ID for a feed, if it has been created.
 public fun pyth_source_id(registry: &Registry, pyth_lazer_feed_id: u32): Option<ID> {
-    if (registry.pyth_feed_configs.contains(pyth_lazer_feed_id)) {
-        option::some(registry.pyth_feed_configs.borrow(pyth_lazer_feed_id).pyth_source_id)
+    if (registry.pyth_source_ids.contains(pyth_lazer_feed_id)) {
+        option::some(*registry.pyth_source_ids.borrow(pyth_lazer_feed_id))
     } else {
         option::none()
     }
-}
-
-/// Return the configured strike tick size for a Pyth Lazer feed, if registered.
-public fun pyth_feed_tick_size(registry: &Registry, pyth_lazer_feed_id: u32): Option<u64> {
-    if (registry.pyth_feed_configs.contains(pyth_lazer_feed_id)) {
-        option::some(registry.pyth_feed_configs.borrow(pyth_lazer_feed_id).tick_size)
-    } else {
-        option::none()
-    }
-}
-
-/// Return the configured expiry-fee ramp window for a Pyth Lazer feed, if registered.
-public fun pyth_feed_expiry_fee_window_ms(
-    registry: &Registry,
-    pyth_lazer_feed_id: u32,
-): Option<u64> {
-    if (registry.pyth_feed_configs.contains(pyth_lazer_feed_id)) {
-        option::some(registry.pyth_feed_configs.borrow(pyth_lazer_feed_id).expiry_fee_window_ms)
-    } else {
-        option::none()
-    }
-}
-
-/// Return the configured expiry-fee max multiplier for a Pyth Lazer feed, if registered.
-public fun pyth_feed_expiry_fee_max_multiplier(
-    registry: &Registry,
-    pyth_lazer_feed_id: u32,
-): Option<u64> {
-    if (registry.pyth_feed_configs.contains(pyth_lazer_feed_id)) {
-        option::some(registry
-            .pyth_feed_configs
-            .borrow(pyth_lazer_feed_id)
-            .expiry_fee_max_multiplier)
-    } else {
-        option::none()
-    }
-}
-
-/// Set the per-asset expiry-fee ramp window snapshotted by future expiry markets
-/// for one Pyth feed.
-public fun set_pyth_feed_expiry_fee_window_ms(
-    registry: &mut Registry,
-    _admin_cap: &AdminCap,
-    pyth_lazer_feed_id: u32,
-    window_ms: u64,
-) {
-    assert!(registry.pyth_feed_configs.contains(pyth_lazer_feed_id), EPythFeedNotRegistered);
-    config_constants::assert_expiry_fee_window_ms(window_ms);
-    registry.pyth_feed_configs.borrow_mut(pyth_lazer_feed_id).expiry_fee_window_ms = window_ms;
-}
-
-/// Set the per-asset expiry-fee max multiplier snapshotted by future expiry markets
-/// for one Pyth feed. `max_multiplier` (FLOAT_SCALING, 1x disables) is the multiplier
-/// reached at expiry over the configured ramp window. Larger values suit more volatile assets.
-public fun set_pyth_feed_expiry_fee_max_multiplier(
-    registry: &mut Registry,
-    _admin_cap: &AdminCap,
-    pyth_lazer_feed_id: u32,
-    max_multiplier: u64,
-) {
-    assert!(registry.pyth_feed_configs.contains(pyth_lazer_feed_id), EPythFeedNotRegistered);
-    config_constants::assert_expiry_fee_max_multiplier(max_multiplier);
-    registry.pyth_feed_configs.borrow_mut(pyth_lazer_feed_id).expiry_fee_max_multiplier =
-        max_multiplier;
-}
-
-/// Set the strike tick size used by future expiry markets for one Pyth feed.
-public fun set_pyth_feed_tick_size(
-    registry: &mut Registry,
-    _admin_cap: &AdminCap,
-    pyth_lazer_feed_id: u32,
-    tick_size: u64,
-) {
-    assert!(registry.pyth_feed_configs.contains(pyth_lazer_feed_id), EPythFeedNotRegistered);
-    config_constants::assert_oracle_tick_size(tick_size);
-    registry.pyth_feed_configs.borrow_mut(pyth_lazer_feed_id).tick_size = tick_size;
 }
 
 // === Version Management (admin) ===
@@ -273,11 +184,12 @@ public fun pause_expiry_market_mint_pause_cap(
 }
 
 /// Create a shared Pyth source for one admin-approved Lazer feed, configuring
-/// the per-asset expiry-fee ramp policy up front.
+/// the per-feed template policy in `ProtocolConfig` up front.
 ///
 /// The registry enforces one source object per feed ID.
 public fun create_pyth_source(
     registry: &mut Registry,
+    config: &mut ProtocolConfig,
     _admin_cap: &AdminCap,
     pyth_lazer_feed_id: u32,
     tick_size: u64,
@@ -286,26 +198,19 @@ public fun create_pyth_source(
     ctx: &mut TxContext,
 ): ID {
     registry.assert_version_allowed();
-    assert!(!registry.pyth_feed_configs.contains(pyth_lazer_feed_id), EPythSourceAlreadyCreated);
-    config_constants::assert_oracle_tick_size(tick_size);
-    config_constants::assert_expiry_fee_window_ms(expiry_fee_window_ms);
-    config_constants::assert_expiry_fee_max_multiplier(expiry_fee_max_multiplier);
+    assert!(!registry.pyth_source_ids.contains(pyth_lazer_feed_id), EPythSourceAlreadyCreated);
+    let template = feed_template::new(
+        tick_size,
+        expiry_fee_window_ms,
+        expiry_fee_max_multiplier,
+    );
+    config.add_feed_template(pyth_lazer_feed_id, template);
     let pyth_source_id = pyth_source::create_and_share(
         pyth_lazer_feed_id,
         registry.allowed_versions,
         ctx,
     );
-    registry
-        .pyth_feed_configs
-        .add(
-            pyth_lazer_feed_id,
-            PythFeedConfig {
-                pyth_source_id,
-                tick_size,
-                expiry_fee_window_ms,
-                expiry_fee_max_multiplier,
-            },
-        );
+    registry.pyth_source_ids.add(pyth_lazer_feed_id, pyth_source_id);
     pyth_source_id
 }
 
@@ -328,12 +233,12 @@ public fun create_expiry_market(
     config.assert_trading_allowed();
     assert!(expiry > clock.timestamp_ms(), EInvalidExpiry);
     let pyth_lazer_feed_id = pyth.feed_id();
-    assert!(registry.pyth_feed_configs.contains(pyth_lazer_feed_id), EFeedIdMismatch);
-    let pyth_config = registry.pyth_feed_configs.borrow(pyth_lazer_feed_id);
-    assert!(pyth_config.pyth_source_id == pyth.id(), EFeedIdMismatch);
-    let tick_size = pyth_config.tick_size;
-    let expiry_fee_window_ms = pyth_config.expiry_fee_window_ms;
-    let expiry_fee_max_multiplier = pyth_config.expiry_fee_max_multiplier;
+    assert!(registry.pyth_source_ids.contains(pyth_lazer_feed_id), EFeedIdMismatch);
+    assert!(*registry.pyth_source_ids.borrow(pyth_lazer_feed_id) == pyth.id(), EFeedIdMismatch);
+    let feed_template = config.feed_template(pyth_lazer_feed_id);
+    let tick_size = feed_template.tick_size();
+    let expiry_fee_window_ms = feed_template.expiry_fee_window_ms();
+    let expiry_fee_max_multiplier = feed_template.expiry_fee_max_multiplier();
     pricing::assert_pyth_spot_fresh(config.pricing_config(), pyth, clock);
     let min_strike = centered_min_strike(pyth.spot(), tick_size);
     let preallocated_ticks = expiry_preallocated_ticks(expiry, clock.timestamp_ms());
@@ -419,7 +324,7 @@ fun new_registry_and_admin_cap(ctx: &mut TxContext): (Registry, AdminCap) {
     (
         Registry {
             id: object::new(ctx),
-            pyth_feed_configs: table::new(ctx),
+            pyth_source_ids: table::new(ctx),
             expiry_market_ids: table::new(ctx),
             allowed_pause_caps: vec_set::empty(),
             allowed_versions: vec_set::singleton(constants::current_version!()),
@@ -485,13 +390,13 @@ public fun new_for_testing(ctx: &mut TxContext): (Registry, AdminCap) {
 public fun destroy_registry_for_testing(registry: Registry) {
     let Registry {
         id,
-        pyth_feed_configs,
+        pyth_source_ids,
         expiry_market_ids,
         allowed_pause_caps: _,
         allowed_versions: _,
     } = registry;
     id.delete();
-    pyth_feed_configs.destroy_empty();
+    pyth_source_ids.destroy_empty();
     expiry_market_ids.destroy_empty();
 }
 
@@ -501,12 +406,12 @@ public fun destroy_registry_for_testing(registry: Registry) {
 public fun destroy_registry_drop_for_testing(registry: Registry) {
     let Registry {
         id,
-        pyth_feed_configs,
+        pyth_source_ids,
         expiry_market_ids,
         allowed_pause_caps: _,
         allowed_versions: _,
     } = registry;
     id.delete();
-    pyth_feed_configs.drop();
+    pyth_source_ids.drop();
     expiry_market_ids.drop();
 }

--- a/packages/predict/sources/registry.move
+++ b/packages/predict/sources/registry.move
@@ -3,8 +3,8 @@
 
 /// Registry, versioning, and creation entrypoints for the Predict protocol.
 ///
-/// This module creates shared setup objects, stores uniqueness indexes for
-/// Pyth sources and expiries, and exposes registry-owned governance entrypoints.
+/// This module creates shared setup objects, stores Pyth source uniqueness,
+/// and exposes registry-owned governance entrypoints.
 /// Runtime pool accounting, config policy, expiry risk, oracle state, and user
 /// positions stay in their owning modules.
 module deepbook_predict::registry;
@@ -12,7 +12,6 @@ module deepbook_predict::registry;
 use deepbook_predict::{
     admin::{Self, AdminCap},
     builder_code,
-    config_constants,
     config_events,
     constants,
     expiry_market::{Self, ExpiryMarket},
@@ -29,7 +28,6 @@ use sui::{clock::Clock, table::{Self, Table}, vec_set::{Self, VecSet}};
 const EFeedIdMismatch: u64 = 0;
 const EPythSourceAlreadyCreated: u64 = 1;
 const EInvalidExpiry: u64 = 2;
-const EExpiryMarketAlreadyCreated: u64 = 3;
 const EPauseCapNotValid: u64 = 4;
 const EPackageVersionDisabled: u64 = 5;
 const EVersionAlreadyEnabled: u64 = 6;
@@ -43,13 +41,11 @@ public struct PauseCap has key, store {
     id: UID,
 }
 
-/// Shared registry for source and expiry uniqueness.
+/// Shared registry for Pyth source uniqueness and governance state.
 public struct Registry has key {
     id: UID,
     /// Pyth Lazer feed ID -> canonical shared PythSource object.
     pyth_source_ids: Table<u32, ID>,
-    /// Created expiry markets keyed by expiry timestamp.
-    expiry_market_ids: Table<u64, ID>,
     /// IDs of `PauseCap` objects currently authorized to use pause-only entries.
     /// Admin mints into this set and revokes from it.
     allowed_pause_caps: VecSet<ID>,
@@ -173,14 +169,15 @@ public fun pause_trading_pause_cap(
 }
 
 /// Force `mint_paused = true` on a single expiry market via a valid `PauseCap`.
-/// One-way; admin's `expiry_market::set_mint_paused` is needed to unpause.
+/// One-way; admin's `protocol_config::set_expiry_mint_paused` is needed to unpause.
 public fun pause_expiry_market_mint_pause_cap(
-    market: &mut ExpiryMarket,
+    config: &mut ProtocolConfig,
     registry: &Registry,
     pause_cap: &PauseCap,
+    expiry: u64,
 ) {
     registry.assert_valid_pause_cap(pause_cap);
-    market.pause_mint();
+    config.pause_expiry_mint(expiry);
 }
 
 /// Create a shared Pyth source for one admin-approved Lazer feed, configuring
@@ -216,13 +213,13 @@ public fun create_pyth_source(
 
 /// Create the MarketOracle and ExpiryMarket objects for one future expiry.
 ///
-/// The registry enforces one market per expiry, validates the registered Pyth
-/// source, and registers the expiry as active. Pool funding happens later through
-/// PLP rebalancing.
+/// The registry validates the registered Pyth source, asks `ProtocolConfig` to
+/// enforce one row per expiry, and registers the expiry as active. Pool funding
+/// happens later through PLP rebalancing.
 public fun create_expiry_market(
     registry: &mut Registry,
     pool_vault: &mut PoolVault,
-    config: &ProtocolConfig,
+    config: &mut ProtocolConfig,
     pyth: &PythSource,
     cap: &MarketOracleCap,
     expiry: u64,
@@ -235,38 +232,26 @@ public fun create_expiry_market(
     let pyth_lazer_feed_id = pyth.feed_id();
     assert!(registry.pyth_source_ids.contains(pyth_lazer_feed_id), EFeedIdMismatch);
     assert!(*registry.pyth_source_ids.borrow(pyth_lazer_feed_id) == pyth.id(), EFeedIdMismatch);
-    let feed_template = config.feed_template(pyth_lazer_feed_id);
-    let tick_size = feed_template.tick_size();
-    let expiry_fee_window_ms = feed_template.expiry_fee_window_ms();
-    let expiry_fee_max_multiplier = feed_template.expiry_fee_max_multiplier();
     pricing::assert_pyth_spot_fresh(config.pricing_config(), pyth, clock);
-    let min_strike = centered_min_strike(pyth.spot(), tick_size);
     let preallocated_ticks = expiry_preallocated_ticks(expiry, clock.timestamp_ms());
-    assert!(!registry.expiry_market_ids.contains(expiry), EExpiryMarketAlreadyCreated);
     let allowed_versions = registry.allowed_versions;
     let market_oracle_id = market_oracle::create_and_share(
         pyth,
-        config.market_oracle_config(),
         cap,
         expiry,
         allowed_versions,
         ctx,
     );
-    let expiry_market_id = expiry_market::create_and_share(
+    let (expiry_market_id, min_strike, tick_size) = expiry_market::create_and_share(
         config,
         allowed_versions,
         market_oracle_id,
-        pyth_lazer_feed_id,
+        pyth,
         expiry,
-        min_strike,
-        tick_size,
         preallocated_ticks,
-        expiry_fee_window_ms,
-        expiry_fee_max_multiplier,
         ctx,
     );
     pool_vault.register_expiry_market(expiry_market_id);
-    registry.expiry_market_ids.add(expiry, expiry_market_id);
 
     config_events::emit_market_created(
         expiry_market_id,
@@ -325,7 +310,6 @@ fun new_registry_and_admin_cap(ctx: &mut TxContext): (Registry, AdminCap) {
         Registry {
             id: object::new(ctx),
             pyth_source_ids: table::new(ctx),
-            expiry_market_ids: table::new(ctx),
             allowed_pause_caps: vec_set::empty(),
             allowed_versions: vec_set::singleton(constants::current_version!()),
         },
@@ -336,14 +320,6 @@ fun new_registry_and_admin_cap(ctx: &mut TxContext): (Registry, AdminCap) {
 /// Abort unless the supplied `PauseCap` was minted by admin and not revoked.
 fun assert_valid_pause_cap(registry: &Registry, pause_cap: &PauseCap) {
     assert!(registry.allowed_pause_caps.contains(&pause_cap.id.to_inner()), EPauseCapNotValid);
-}
-
-/// Floor spot to the configured tick and center the fixed oracle grid around it.
-fun centered_min_strike(spot: u64, tick_size: u64): u64 {
-    config_constants::assert_oracle_tick_size_covers_spot(tick_size, spot);
-    let center_ticks = constants::oracle_strike_grid_ticks!() / 2;
-
-    (spot / tick_size - center_ticks) * tick_size
 }
 
 fun expiry_preallocated_ticks(expiry: u64, now_ms: u64): u64 {
@@ -391,27 +367,23 @@ public fun destroy_registry_for_testing(registry: Registry) {
     let Registry {
         id,
         pyth_source_ids,
-        expiry_market_ids,
         allowed_pause_caps: _,
         allowed_versions: _,
     } = registry;
     id.delete();
     pyth_source_ids.destroy_empty();
-    expiry_market_ids.destroy_empty();
 }
 
 /// Variant for tests that exercise registration paths: drops the uniqueness
-/// tables without requiring them to be empty.
+/// table without requiring it to be empty.
 #[test_only]
 public fun destroy_registry_drop_for_testing(registry: Registry) {
     let Registry {
         id,
         pyth_source_ids,
-        expiry_market_ids,
         allowed_pause_caps: _,
         allowed_versions: _,
     } = registry;
     id.delete();
     pyth_source_ids.drop();
-    expiry_market_ids.drop();
 }

--- a/packages/predict/sources/strike_exposure/index/strike_nav_matrix.move
+++ b/packages/predict/sources/strike_exposure/index/strike_nav_matrix.move
@@ -12,18 +12,19 @@
 module deepbook_predict::strike_nav_matrix;
 
 use deepbook::math;
-use deepbook_predict::{constants, math as predict_math, pricing::CurvePoint};
+use deepbook_predict::{
+    constants,
+    math as predict_math,
+    pricing::CurvePoint,
+    strike_grid::StrikeGrid
+};
 use sui::table::{Self, Table};
 
 const PAGE_SLOTS: u64 = 128;
 
-const EInvalidTickSize: u64 = 0;
-const EInvalidStrikeRange: u64 = 1;
 const EInsufficientQuantity: u64 = 2;
 const EInvalidCurveRange: u64 = 3;
-const EUnalignedStrike: u64 = 4;
 const EZeroQuantity: u64 = 5;
-const ETooManyStrikes: u64 = 6;
 const EFloorExceedsLiveValue: u64 = 7;
 const EInvalidPreallocatedTicks: u64 = 8;
 
@@ -31,10 +32,6 @@ const EInvalidPreallocatedTicks: u64 = 8;
 public struct StrikeNavMatrix has store {
     pages: Table<u64, vector<NavTotals>>,
     page_totals: vector<NavTotals>,
-    tick_size: u64,
-    min_strike: u64,
-    max_strike: u64,
-    total_strikes: u64,
     base_qty: u64,
     /// Floor-index-normalized aggregate contract floor, realized with round-down math.
     floor_shares: u64,
@@ -54,15 +51,11 @@ public struct NavTotals has copy, drop, store {
 
 /// Create a NAV matrix with a centered preallocated span for the oracle strike grid.
 public(package) fun new(
-    min_strike: u64,
-    tick_size: u64,
-    max_strike: u64,
+    grid: &StrikeGrid,
     preallocated_ticks: u64,
     ctx: &mut TxContext,
 ): StrikeNavMatrix {
-    assert_valid_grid(min_strike, tick_size, max_strike);
-
-    let total_strikes = (max_strike - min_strike) / tick_size + 1;
+    let total_strikes = grid.total_strikes();
     assert_valid_preallocated_ticks(total_strikes, preallocated_ticks);
     let page_count = page_count(total_strikes);
     let mut pages = table::new(ctx);
@@ -82,10 +75,6 @@ public(package) fun new(
     StrikeNavMatrix {
         pages,
         page_totals,
-        tick_size,
-        min_strike,
-        max_strike,
-        total_strikes,
         base_qty: 0,
         floor_shares: 0,
     }
@@ -94,23 +83,25 @@ public(package) fun new(
 /// Insert interval quantity for `(lower, higher]`.
 public(package) fun insert_range(
     nav: &mut StrikeNavMatrix,
+    grid: &StrikeGrid,
     lower: u64,
     higher: u64,
     qty: u64,
     floor_shares: u64,
 ) {
-    nav.apply_range(lower, higher, qty, floor_shares, true);
+    nav.apply_range(grid, lower, higher, qty, floor_shares, true);
 }
 
 /// Remove interval quantity for `(lower, higher]`.
 public(package) fun remove_range(
     nav: &mut StrikeNavMatrix,
+    grid: &StrikeGrid,
     lower: u64,
     higher: u64,
     qty: u64,
     floor_shares: u64,
 ) {
-    nav.apply_range(lower, higher, qty, floor_shares, false);
+    nav.apply_range(grid, lower, higher, qty, floor_shares, false);
 }
 
 /// Evaluate live contract value against a sampled pricing curve.
@@ -120,6 +111,7 @@ public(package) fun remove_range(
 /// policy, not an exact per-order recoverability proof.
 public(package) fun live_value(
     nav: &StrikeNavMatrix,
+    grid: &StrikeGrid,
     curve: &vector<CurvePoint>,
     minted_min_strike: u64,
     minted_max_strike: u64,
@@ -133,7 +125,7 @@ public(package) fun live_value(
     );
 
     let mut value = math::mul(nav.base_qty, constants::float_scaling!());
-    let (mut page_lo, mut slot_lo) = nav.unchecked_strike_to_coords(curve[0].strike());
+    let (mut page_lo, mut slot_lo) = strike_to_coords(grid, curve[0].strike());
     let (start, end) = nav.boundary_weighted_quantities(page_lo, slot_lo);
     value = value + math::mul(start.quantity, curve[0].up_price());
     value = value - math::mul(end.quantity, curve[0].up_price());
@@ -144,7 +136,7 @@ public(package) fun live_value(
         let strike_hi = curve[ci].strike();
         let price_lo = curve[ci - 1].up_price();
         let price_hi = curve[ci].up_price();
-        let (page_hi, slot_hi) = nav.unchecked_strike_to_coords(strike_hi);
+        let (page_hi, slot_hi) = strike_to_coords(grid, strike_hi);
         let (start_delta, end_delta) = nav.accumulate_segment_values(
             page_lo,
             slot_lo,
@@ -170,15 +162,11 @@ public(package) fun live_value(
 public(package) fun destroy(nav: StrikeNavMatrix) {
     let StrikeNavMatrix {
         mut pages,
-        page_totals: _,
-        tick_size: _,
-        min_strike: _,
-        max_strike: _,
-        total_strikes,
+        page_totals,
         base_qty: _,
         floor_shares: _,
     } = nav;
-    let page_count = page_count(total_strikes);
+    let page_count = page_totals.length();
     let mut page_key = 0;
     while (page_key < page_count) {
         if (pages.contains(page_key)) {
@@ -191,23 +179,25 @@ public(package) fun destroy(nav: StrikeNavMatrix) {
 
 fun apply_range(
     nav: &mut StrikeNavMatrix,
+    grid: &StrikeGrid,
     lower: u64,
     higher: u64,
     qty: u64,
     floor_shares: u64,
     add: bool,
 ) {
-    nav.assert_range_boundaries(lower, higher, qty);
+    grid.assert_range_boundaries(lower, higher);
+    assert!(qty > 0, EZeroQuantity);
     apply_exact_delta(&mut nav.floor_shares, floor_shares, add);
 
     if (lower == constants::neg_inf!()) {
         apply_exact_delta(&mut nav.base_qty, qty, add);
     } else {
-        nav.apply_boundary_delta(lower, qty, true, add);
+        nav.apply_boundary_delta(grid, lower, qty, true, add);
     };
 
     if (higher != constants::pos_inf!()) {
-        nav.apply_boundary_delta(higher, qty, false, add);
+        nav.apply_boundary_delta(grid, higher, qty, false, add);
     };
 }
 
@@ -219,12 +209,13 @@ fun floor_amount(floor_shares: u64, floor_index: u64): u64 {
 
 fun apply_boundary_delta(
     nav: &mut StrikeNavMatrix,
+    grid: &StrikeGrid,
     strike: u64,
     qty: u64,
     is_start: bool,
     add: bool,
 ) {
-    let (page_key, slot) = nav.unchecked_strike_to_coords(strike);
+    let (page_key, slot) = strike_to_coords(grid, strike);
     let weighted = weighted_quantity(qty, math::mul(qty, strike));
     nav.ensure_page(page_key);
     {
@@ -240,7 +231,7 @@ fun apply_boundary_delta(
         let mut i = slot;
         while (i < PAGE_SLOTS) {
             let tick_index = page_key * PAGE_SLOTS + i;
-            if (tick_index >= nav.total_strikes) break;
+            if (tick_index >= grid.total_strikes()) break;
 
             let node = &mut page[i];
             if (is_start) {
@@ -335,15 +326,6 @@ fun page_prefix_totals(nav: &StrikeNavMatrix, page_key: u64, slot: u64): NavTota
     }
 }
 
-fun assert_valid_grid(min_strike: u64, tick_size: u64, max_strike: u64) {
-    assert!(tick_size > 0, EInvalidTickSize);
-    assert!(min_strike <= max_strike, EInvalidStrikeRange);
-    assert!(min_strike % tick_size == 0 && max_strike % tick_size == 0, EUnalignedStrike);
-
-    let total_strikes = (max_strike - min_strike) / tick_size + 1;
-    assert!(total_strikes <= constants::oracle_strike_grid_ticks!() + 1, ETooManyStrikes);
-}
-
 fun assert_valid_preallocated_ticks(total_strikes: u64, preallocated_ticks: u64) {
     assert!(preallocated_ticks <= total_strikes - 1, EInvalidPreallocatedTicks);
 }
@@ -355,26 +337,6 @@ fun preallocated_page_bounds(total_strikes: u64, preallocated_ticks: u64): (u64,
     let end_tick = start_tick + preallocated_ticks;
 
     (start_tick / PAGE_SLOTS, end_tick / PAGE_SLOTS)
-}
-
-fun assert_range_boundaries(nav: &StrikeNavMatrix, lower: u64, higher: u64, qty: u64) {
-    assert_range_shape(lower, higher, qty);
-    if (lower != constants::neg_inf!()) nav.assert_finite_boundary(lower);
-    if (higher != constants::pos_inf!()) nav.assert_finite_boundary(higher);
-}
-
-fun assert_finite_boundary(nav: &StrikeNavMatrix, strike: u64) {
-    assert!(strike >= nav.min_strike && strike <= nav.max_strike, EInvalidStrikeRange);
-    assert!((strike - nav.min_strike) % nav.tick_size == 0, EUnalignedStrike);
-}
-
-fun assert_range_shape(lower: u64, higher: u64, qty: u64) {
-    assert!(lower < higher, EInvalidStrikeRange);
-    assert!(
-        !(lower == constants::neg_inf!() && higher == constants::pos_inf!()),
-        EInvalidStrikeRange,
-    );
-    assert!(qty > 0, EZeroQuantity);
 }
 
 fun weighted_quantity(quantity: u64, strike_quantity: u64): WeightedQuantity {
@@ -420,8 +382,8 @@ fun weighted_segment_value(
     math::mul(weighted.quantity, price)
 }
 
-fun unchecked_strike_to_coords(nav: &StrikeNavMatrix, strike: u64): (u64, u64) {
-    let tick_index = (strike - nav.min_strike) / nav.tick_size;
+fun strike_to_coords(grid: &StrikeGrid, strike: u64): (u64, u64) {
+    let tick_index = grid.finite_strike_index(strike);
     let page_key = tick_index / PAGE_SLOTS;
     let slot = tick_index % PAGE_SLOTS;
     (page_key, slot)

--- a/packages/predict/sources/strike_exposure/index/strike_payout_tree.move
+++ b/packages/predict/sources/strike_exposure/index/strike_payout_tree.move
@@ -9,23 +9,16 @@
 /// conservative lookup. Settled liability uses exact terminal-payout prefixes.
 module deepbook_predict::strike_payout_tree;
 
-use deepbook_predict::constants;
+use deepbook_predict::{constants, strike_grid::StrikeGrid};
 use sui::{bcs, hash::blake2b256, table::{Self, Table}};
 
-const EInvalidTickSize: u64 = 0;
-const EInvalidStrikeRange: u64 = 1;
 const EInsufficientPayoutTerms: u64 = 2;
-const EUnalignedStrike: u64 = 3;
-const ETooManyStrikes: u64 = 4;
 const EInvalidPayoutTerms: u64 = 5;
 
 /// Sparse payout-liability tree for strike prefixes.
 public struct StrikePayoutTree has store {
     root: Option<u64>,
     nodes: Table<u64, PayoutNode>,
-    tick_size: u64,
-    min_strike: u64,
-    max_strike: u64,
     base: PayoutTerms,
 }
 
@@ -76,20 +69,10 @@ public(package) fun settled_payout_liability(tree: &StrikePayoutTree, settlement
 }
 
 /// Create an empty sparse payout tree for the oracle strike grid.
-public(package) fun new(
-    min_strike: u64,
-    tick_size: u64,
-    max_strike: u64,
-    ctx: &mut TxContext,
-): StrikePayoutTree {
-    assert_valid_grid(min_strike, tick_size, max_strike);
-
+public(package) fun new(ctx: &mut TxContext): StrikePayoutTree {
     StrikePayoutTree {
         root: option::none(),
         nodes: table::new(ctx),
-        tick_size,
-        min_strike,
-        max_strike,
         base: payout_terms(0, 0),
     }
 }
@@ -97,23 +80,31 @@ public(package) fun new(
 /// Insert interval payout terms for `(lower, higher]`.
 public(package) fun insert_range(
     tree: &mut StrikePayoutTree,
+    grid: &StrikeGrid,
     lower: u64,
     higher: u64,
     terminal_payout: u64,
     live_backing_payout: u64,
 ) {
-    tree.apply_range(lower, higher, payout_terms(terminal_payout, live_backing_payout), true);
+    tree.apply_range(grid, lower, higher, payout_terms(terminal_payout, live_backing_payout), true);
 }
 
 /// Remove interval payout terms for `(lower, higher]`.
 public(package) fun remove_range(
     tree: &mut StrikePayoutTree,
+    grid: &StrikeGrid,
     lower: u64,
     higher: u64,
     terminal_payout: u64,
     live_backing_payout: u64,
 ) {
-    tree.apply_range(lower, higher, payout_terms(terminal_payout, live_backing_payout), false);
+    tree.apply_range(
+        grid,
+        lower,
+        higher,
+        payout_terms(terminal_payout, live_backing_payout),
+        false,
+    );
 }
 
 /// Destroy all sparse payout storage without reading settlement liability.
@@ -121,9 +112,6 @@ public(package) fun destroy(tree: StrikePayoutTree) {
     let StrikePayoutTree {
         root,
         mut nodes,
-        tick_size: _,
-        min_strike: _,
-        max_strike: _,
         base: _,
     } = tree;
     destroy_nodes(&mut nodes, root);
@@ -132,12 +120,13 @@ public(package) fun destroy(tree: StrikePayoutTree) {
 
 fun apply_range(
     tree: &mut StrikePayoutTree,
+    grid: &StrikeGrid,
     lower: u64,
     higher: u64,
     terms: PayoutTerms,
     add: bool,
 ) {
-    tree.assert_range_boundaries(lower, higher);
+    grid.assert_range_boundaries(lower, higher);
     if (terms.terminal_payout == 0 && terms.live_backing_payout == 0) return;
     assert!(terms.terminal_payout <= terms.live_backing_payout, EInvalidPayoutTerms);
 
@@ -372,34 +361,6 @@ fun destroy_nodes(nodes: &mut Table<u64, PayoutNode>, root: Option<u64>) {
     let node = nodes.remove(strike);
     destroy_nodes(nodes, node.left);
     destroy_nodes(nodes, node.right);
-}
-
-fun assert_valid_grid(min_strike: u64, tick_size: u64, max_strike: u64) {
-    assert!(tick_size > 0, EInvalidTickSize);
-    assert!(min_strike <= max_strike, EInvalidStrikeRange);
-    assert!(min_strike % tick_size == 0 && max_strike % tick_size == 0, EUnalignedStrike);
-
-    let total_strikes = (max_strike - min_strike) / tick_size + 1;
-    assert!(total_strikes <= constants::oracle_strike_grid_ticks!() + 1, ETooManyStrikes);
-}
-
-fun assert_range_boundaries(tree: &StrikePayoutTree, lower: u64, higher: u64) {
-    assert_range_shape(lower, higher);
-    if (lower != constants::neg_inf!()) tree.assert_finite_boundary(lower);
-    if (higher != constants::pos_inf!()) tree.assert_finite_boundary(higher);
-}
-
-fun assert_finite_boundary(tree: &StrikePayoutTree, strike: u64) {
-    assert!(strike >= tree.min_strike && strike <= tree.max_strike, EInvalidStrikeRange);
-    assert!((strike - tree.min_strike) % tree.tick_size == 0, EUnalignedStrike);
-}
-
-fun assert_range_shape(lower: u64, higher: u64) {
-    assert!(lower < higher, EInvalidStrikeRange);
-    assert!(
-        !(lower == constants::neg_inf!() && higher == constants::pos_inf!()),
-        EInvalidStrikeRange,
-    );
 }
 
 fun apply_terms_delta(value: &mut PayoutTerms, delta: PayoutTerms, add: bool) {

--- a/packages/predict/sources/strike_exposure/strike_exposure.move
+++ b/packages/predict/sources/strike_exposure/strike_exposure.move
@@ -23,13 +23,12 @@ use deepbook_predict::{
     pricing,
     pricing_config::PricingConfig,
     pyth_source::PythSource,
+    strike_grid::{Self, StrikeGrid},
     strike_nav_matrix::{Self, StrikeNavMatrix},
     strike_payout_tree::{Self, StrikePayoutTree}
 };
 use sui::clock::Clock;
 
-const EInvalidTickSize: u64 = 0;
-const EInvalidStrikeGrid: u64 = 1;
 const EInvalidStrikeIndex: u64 = 2;
 const ESettledLiabilityNotMaterialized: u64 = 3;
 const ESettledLiabilityUnderflow: u64 = 4;
@@ -44,18 +43,10 @@ public struct StrikeExposure has store {
     expiry_market_id: ID,
     /// Terminal timestamp used by floor-index and order floor math.
     expiry_ms: u64,
-    grid_min: u64,
-    grid_tick: u64,
-    grid_max: u64,
-    /// Max increase of the floor index over this expiry's floor window.
-    /// `200_000_000` means the index rises from 1.0 to 1.2 by expiry.
+    grid: StrikeGrid,
+    /// Frozen per-expiry leverage and liquidation terms.
     max_expiry_floor_premium: u64,
-    /// 1e9-scaled floor-to-live-value liquidation threshold snapshotted at creation.
     liquidation_ltv: u64,
-    /// Window before expiry over which the trade fee ramps up. Snapshotted at creation.
-    expiry_fee_window_ms: u64,
-    /// Fee multiplier reached at expiry, in FLOAT_SCALING; 1x disables. Snapshotted at creation.
-    expiry_fee_max_multiplier: u64,
     next_order_sequence: u64,
     /// Remaining settled liability after settlement has been materialized.
     settled_payout_liability: u64,
@@ -75,6 +66,12 @@ public struct LiveExposure has store {
     minted_max_strike: u64,
 }
 
+/// Decoded strike range for one order in this exposure grid.
+public struct OrderStrikes has copy, drop {
+    lower: u64,
+    higher: u64,
+}
+
 /// Return conservative max-live backing, or remaining settled payout liability once materialized.
 public(package) fun payout_liability(exposure: &StrikeExposure): u64 {
     if (exposure.settled_liability_materialized) {
@@ -84,34 +81,24 @@ public(package) fun payout_liability(exposure: &StrikeExposure): u64 {
     }
 }
 
-/// Return the terminal floor-index premium snapshotted for this exposure book.
+public(package) fun min_strike(exposure: &StrikeExposure): u64 {
+    exposure.grid.min_strike()
+}
+
+public(package) fun tick_size(exposure: &StrikeExposure): u64 {
+    exposure.grid.tick_size()
+}
+
+public(package) fun max_strike(exposure: &StrikeExposure): u64 {
+    exposure.grid.max_strike()
+}
+
 public(package) fun max_expiry_floor_premium(exposure: &StrikeExposure): u64 {
     exposure.max_expiry_floor_premium
 }
 
-/// Return the liquidation LTV snapshotted for this exposure book.
 public(package) fun liquidation_ltv(exposure: &StrikeExposure): u64 {
     exposure.liquidation_ltv
-}
-
-public(package) fun expiry_fee_window_ms(exposure: &StrikeExposure): u64 {
-    exposure.expiry_fee_window_ms
-}
-
-public(package) fun expiry_fee_max_multiplier(exposure: &StrikeExposure): u64 {
-    exposure.expiry_fee_max_multiplier
-}
-
-public(package) fun min_strike(exposure: &StrikeExposure): u64 {
-    exposure.grid_min
-}
-
-public(package) fun tick_size(exposure: &StrikeExposure): u64 {
-    exposure.grid_tick
-}
-
-public(package) fun max_strike(exposure: &StrikeExposure): u64 {
-    exposure.grid_max
 }
 
 /// Evaluate live user-position liability over the current minted strike range.
@@ -132,15 +119,16 @@ public(package) fun valuation_liability(
     let curve = pricing::build_curve(
         &svi,
         forward,
-        exposure.grid_min,
-        exposure.grid_tick,
-        exposure.grid_max,
+        exposure.grid.min_strike(),
+        exposure.grid.tick_size(),
+        exposure.grid.max_strike(),
         minted_min_strike,
         minted_max_strike,
     );
     live
         .nav
         .live_value(
+            &exposure.grid,
             &curve,
             minted_min_strike,
             minted_max_strike,
@@ -153,37 +141,64 @@ public(package) fun is_liquidated_order(exposure: &StrikeExposure, order: &Order
     exposure.liquidation.is_liquidated(order)
 }
 
+/// Decode an order into `(lower, higher)` strikes for this grid.
+public(package) fun order_strikes(exposure: &StrikeExposure, order: &Order): OrderStrikes {
+    let open_index = order::open_strike_index();
+    let min_strike_index = order.min_strike_index();
+    let max_strike_index = order.max_strike_index();
+
+    let lower = if (min_strike_index == open_index) {
+        constants::neg_inf!()
+    } else {
+        let strike = exposure.grid.min_strike() + min_strike_index * exposure.grid.tick_size();
+        assert!(strike <= exposure.grid.max_strike(), EInvalidStrikeIndex);
+        strike
+    };
+
+    let higher = if (max_strike_index == open_index) {
+        constants::pos_inf!()
+    } else {
+        let strike = exposure.grid.min_strike() + max_strike_index * exposure.grid.tick_size();
+        assert!(strike <= exposure.grid.max_strike(), EInvalidStrikeIndex);
+        strike
+    };
+
+    OrderStrikes { lower, higher }
+}
+
+public(package) fun lower(strikes: &OrderStrikes): u64 {
+    strikes.lower
+}
+
+public(package) fun higher(strikes: &OrderStrikes): u64 {
+    strikes.higher
+}
+
 /// Create a strike exposure book for the oracle grid.
 public(package) fun new(
     expiry_market_id: ID,
     expiry_ms: u64,
     min_strike: u64,
     tick_size: u64,
-    preallocated_ticks: u64,
     max_expiry_floor_premium: u64,
     liquidation_ltv: u64,
-    expiry_fee_window_ms: u64,
-    expiry_fee_max_multiplier: u64,
+    preallocated_ticks: u64,
     ctx: &mut TxContext,
 ): StrikeExposure {
-    let max_strike = validated_max_strike(min_strike, tick_size);
+    let grid = strike_grid::new(min_strike, tick_size);
     StrikeExposure {
         expiry_market_id,
         expiry_ms,
-        grid_min: min_strike,
-        grid_tick: tick_size,
-        grid_max: max_strike,
+        grid,
         max_expiry_floor_premium,
         liquidation_ltv,
-        expiry_fee_window_ms,
-        expiry_fee_max_multiplier,
         next_order_sequence: 0,
         settled_payout_liability: 0,
         settled_liability_materialized: false,
         liquidation: liquidation_book::new(ctx),
         live: option::some(LiveExposure {
-            nav: strike_nav_matrix::new(min_strike, tick_size, max_strike, preallocated_ticks, ctx),
-            payout: strike_payout_tree::new(min_strike, tick_size, max_strike, ctx),
+            nav: strike_nav_matrix::new(&grid, preallocated_ticks, ctx),
+            payout: strike_payout_tree::new(ctx),
             minted_min_strike: max_u64(),
             minted_max_strike: 0,
         }),
@@ -202,40 +217,17 @@ public(package) fun close_settled_order(
     user_payout
 }
 
-/// Quote and allocate a live mint order over this exposure book's strike grid.
-///
-/// Returns `(order, fee_amount)`.
+/// Allocate a live mint order over this exposure book's strike grid.
 public(package) fun allocate_mint_order(
     exposure: &mut StrikeExposure,
-    config: &PricingConfig,
-    market: &MarketOracle,
-    pyth: &PythSource,
     lower: u64,
     higher: u64,
     quantity: u64,
     leverage: u64,
+    entry_probability: u64,
     clock: &Clock,
-): (Order, u64) {
+): Order {
     let (min_strike_index, max_strike_index) = exposure.strike_indices(lower, higher);
-    let entry_probability = pricing::live_range_probability(
-        config,
-        market,
-        pyth,
-        lower,
-        higher,
-        clock,
-    );
-    order::assert_mint_leverage_tier(entry_probability, leverage);
-    let fee_rate = pricing::assert_mint_fee_rate(
-        config,
-        market,
-        exposure.expiry_fee_window_ms,
-        exposure.expiry_fee_max_multiplier,
-        entry_probability,
-        clock,
-    );
-    let fee_amount = math::mul(fee_rate, quantity);
-
     let sequence = exposure.next_order_sequence;
     let allocated_order = order::new_from_strike_indices(
         clock.timestamp_ms(),
@@ -253,55 +245,36 @@ public(package) fun allocate_mint_order(
     exposure.next_order_sequence = sequence + 1;
     exposure.insert_live_order(&allocated_order, lower, higher);
 
-    (allocated_order, fee_amount)
+    allocated_order
 }
 
 /// Close live indexed quantity and return redeem terms.
 ///
-/// Returns `(resulting_order, redeem_amount, trading_fee)`.
+/// Returns `(resulting_order, redeem_amount)`.
 /// `resulting_order` is the original order for a full close, or the replacement
 /// order that remains after a partial close.
-public(package) fun close_and_quote_live_order(
+public(package) fun close_live_order(
     exposure: &mut StrikeExposure,
-    config: &PricingConfig,
-    market: &MarketOracle,
-    pyth: &PythSource,
     order: &Order,
     close_quantity: u64,
+    range_probability: u64,
     clock: &Clock,
-): (Order, u64, u64) {
-    let (lower, higher) = exposure.order_strikes(order);
+): (Order, u64) {
     let old_quantity = order.quantity();
     order::assert_valid_quantity(close_quantity);
     assert!(close_quantity <= old_quantity, EInvalidCloseQuantity);
-    let range_probability = pricing::live_range_probability(
-        config,
-        market,
-        pyth,
-        lower,
-        higher,
-        clock,
-    );
-    let fee_rate = pricing::fee_rate(
-        config,
-        market,
-        exposure.expiry_fee_window_ms,
-        exposure.expiry_fee_max_multiplier,
-        range_probability,
-        clock,
-    );
 
+    let strikes = exposure.order_strikes(order);
     let (resulting_order, closed_floor_amount) = exposure.close_live_exposure(
         order,
-        lower,
-        higher,
+        strikes.lower,
+        strikes.higher,
         close_quantity,
         clock,
     );
     let gross_redeem_amount = math::mul(range_probability, close_quantity);
     let redeem_amount = gross_redeem_amount - gross_redeem_amount.min(closed_floor_amount);
-    let fee_amount = math::mul(fee_rate, close_quantity).min(redeem_amount);
-    (resulting_order, redeem_amount, fee_amount)
+    (resulting_order, redeem_amount)
 }
 
 /// Clear one liquidated-order tombstone after its manager position is closed.
@@ -381,18 +354,18 @@ fun liquidate_candidates(
     let mut i = 0;
     while (i < candidates.length()) {
         let order = order::from_order_id(candidates[i]);
-        let (lower, higher) = exposure.order_strikes(&order);
+        let strikes = exposure.order_strikes(&order);
         let range_probability = pricing::compute_range_price(
             svi,
             forward,
-            lower,
-            higher,
+            strikes.lower,
+            strikes.higher,
         );
         if (
             exposure.liquidate_candidate_if_under_floor(
                 &order,
-                lower,
-                higher,
+                strikes.lower,
+                strikes.higher,
                 range_probability,
                 clock,
             )
@@ -406,8 +379,8 @@ fun liquidate_candidates(
 
 /// Return terminal payout for one order at settlement, including the contract floor.
 fun settled_order_payout(exposure: &StrikeExposure, order: &Order, settlement: u64): u64 {
-    let (lower, higher) = exposure.order_strikes(order);
-    if (settlement > lower && settlement <= higher) {
+    let strikes = exposure.order_strikes(order);
+    if (settlement > strikes.lower && settlement <= strikes.higher) {
         let (_, terminal_payout, _) = exposure.order_index_update_terms(order);
         terminal_payout
     } else {
@@ -432,10 +405,7 @@ fun order_index_update_terms(exposure: &StrikeExposure, order: &Order): (u64, u6
         terminal_floor < max_terminal_floor_before_liquidation,
         ETerminalFloorExceedsLiquidationLtv,
     );
-    let floor_at_open = exposure.floor_amount_at_ms(
-        floor_shares,
-        order.opened_at_ms(),
-    );
+    let floor_at_open = exposure.floor_amount_at_ms(floor_shares, order.opened_at_ms());
     (floor_shares, quantity - terminal_floor, quantity - floor_at_open)
 }
 
@@ -494,24 +464,9 @@ fun minted_strike_range(live: &LiveExposure): (u64, u64) {
     )
 }
 
-/// Validate the creation grid and return its finite max strike.
-fun validated_max_strike(min_strike: u64, tick_size: u64): u64 {
-    assert!(tick_size > 0, EInvalidTickSize);
-    assert!(tick_size % constants::oracle_tick_size_unit!() == 0, EInvalidTickSize);
-    assert!(min_strike > 0, EInvalidStrikeGrid);
-    assert!(min_strike % tick_size == 0, EInvalidStrikeGrid);
-    let ticks = constants::oracle_strike_grid_ticks!();
-    assert!(ticks > 0, EInvalidStrikeGrid);
-    min_strike + tick_size * ticks
-}
-
 /// Convert raw order strikes into `(min_strike_index, max_strike_index)` for this grid.
 fun strike_indices(exposure: &StrikeExposure, lower: u64, higher: u64): (u64, u64) {
-    assert!(lower < higher, EInvalidStrikeGrid);
-    assert!(
-        !(lower == constants::neg_inf!() && higher == constants::pos_inf!()),
-        EInvalidStrikeGrid,
-    );
+    exposure.grid.assert_range_boundaries(lower, higher);
     let open_index = order::open_strike_index();
     let min_strike_index = if (lower == constants::neg_inf!()) {
         open_index
@@ -529,34 +484,7 @@ fun strike_indices(exposure: &StrikeExposure, lower: u64, higher: u64): (u64, u6
 
 /// Validate one finite strike and return its grid index.
 fun checked_finite_strike_index(exposure: &StrikeExposure, strike: u64): u64 {
-    assert!(strike >= exposure.grid_min && strike <= exposure.grid_max, EInvalidStrikeGrid);
-    assert!((strike - exposure.grid_min) % exposure.grid_tick == 0, EInvalidStrikeGrid);
-    (strike - exposure.grid_min) / exposure.grid_tick
-}
-
-/// Decode an order into `(lower, higher)` strikes for this grid.
-fun order_strikes(exposure: &StrikeExposure, order: &Order): (u64, u64) {
-    let open_index = order::open_strike_index();
-    let min_strike_index = order.min_strike_index();
-    let max_strike_index = order.max_strike_index();
-
-    let lower = if (min_strike_index == open_index) {
-        constants::neg_inf!()
-    } else {
-        let strike = exposure.grid_min + min_strike_index * exposure.grid_tick;
-        assert!(strike <= exposure.grid_max, EInvalidStrikeIndex);
-        strike
-    };
-
-    let higher = if (max_strike_index == open_index) {
-        constants::pos_inf!()
-    } else {
-        let strike = exposure.grid_min + max_strike_index * exposure.grid_tick;
-        assert!(strike <= exposure.grid_max, EInvalidStrikeIndex);
-        strike
-    };
-
-    (lower, higher)
+    exposure.grid.finite_strike_index(strike)
 }
 
 /// Close live exposure and return `(resulting_order, closed_floor_amount)`.
@@ -630,16 +558,18 @@ fun remove_closed_live_order(
         clock.timestamp_ms(),
     );
 
+    let grid = exposure.grid;
     let live = exposure.live.borrow_mut();
     live
         .payout
         .remove_range(
+            &grid,
             lower,
             higher,
             closed_terminal_payout,
             closed_live_backing_payout,
         );
-    live.nav.remove_range(lower, higher, close_quantity, closed_floor_shares);
+    live.nav.remove_range(&grid, lower, higher, close_quantity, closed_floor_shares);
     closed_floor_amount
 }
 
@@ -667,9 +597,10 @@ fun liquidate_candidate_if_under_floor(
     let (floor_shares, terminal_payout, live_backing_payout) = exposure.order_index_update_terms(
         order,
     );
+    let grid = exposure.grid;
     let live = exposure.live.borrow_mut();
-    live.payout.remove_range(lower, higher, terminal_payout, live_backing_payout);
-    live.nav.remove_range(lower, higher, quantity, floor_shares);
+    live.payout.remove_range(&grid, lower, higher, terminal_payout, live_backing_payout);
+    live.nav.remove_range(&grid, lower, higher, quantity, floor_shares);
     exposure.liquidation.mark_liquidated(order);
     order_events::emit_order_liquidated(
         exposure.expiry_market_id,
@@ -705,9 +636,10 @@ fun insert_live_order(exposure: &mut StrikeExposure, order: &Order, lower: u64, 
         order,
     );
     exposure.assert_mint_above_liquidation_threshold(order, floor_shares);
+    let grid = exposure.grid;
     let live = exposure.live.borrow_mut();
-    live.payout.insert_range(lower, higher, terminal_payout, live_backing_payout);
-    live.nav.insert_range(lower, higher, quantity, floor_shares);
+    live.payout.insert_range(&grid, lower, higher, terminal_payout, live_backing_payout);
+    live.nav.insert_range(&grid, lower, higher, quantity, floor_shares);
     live.track_minted_boundaries(lower, higher);
     exposure.liquidation.insert_order(order);
 }

--- a/packages/predict/sources/strike_exposure/strike_grid.move
+++ b/packages/predict/sources/strike_exposure/strike_grid.move
@@ -1,0 +1,73 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Shared strike-grid boundary for expiry-local exposure indexes.
+///
+/// `StrikeExposure` owns the grid. Leaf indexes borrow it when they need to
+/// validate finite boundaries, convert strikes to dense coordinates, or apply
+/// range updates.
+module deepbook_predict::strike_grid;
+
+use deepbook_predict::constants;
+
+const EInvalidTickSize: u64 = 0;
+const EInvalidStrikeGrid: u64 = 1;
+
+/// Canonical finite oracle strike grid for one expiry exposure book.
+public struct StrikeGrid has copy, drop, store {
+    min_strike: u64,
+    tick_size: u64,
+    max_strike: u64,
+    total_strikes: u64,
+}
+
+public(package) fun new(min_strike: u64, tick_size: u64): StrikeGrid {
+    assert!(tick_size > 0, EInvalidTickSize);
+    assert!(tick_size % constants::oracle_tick_size_unit!() == 0, EInvalidTickSize);
+    assert!(min_strike > 0, EInvalidStrikeGrid);
+    assert!(min_strike % tick_size == 0, EInvalidStrikeGrid);
+    let ticks = constants::oracle_strike_grid_ticks!();
+    assert!(ticks > 0, EInvalidStrikeGrid);
+    StrikeGrid {
+        min_strike,
+        tick_size,
+        max_strike: min_strike + tick_size * ticks,
+        total_strikes: ticks + 1,
+    }
+}
+
+public(package) fun min_strike(grid: &StrikeGrid): u64 {
+    grid.min_strike
+}
+
+public(package) fun tick_size(grid: &StrikeGrid): u64 {
+    grid.tick_size
+}
+
+public(package) fun max_strike(grid: &StrikeGrid): u64 {
+    grid.max_strike
+}
+
+public(package) fun total_strikes(grid: &StrikeGrid): u64 {
+    grid.total_strikes
+}
+
+public(package) fun assert_range_boundaries(grid: &StrikeGrid, lower: u64, higher: u64) {
+    assert!(lower < higher, EInvalidStrikeGrid);
+    assert!(
+        !(lower == constants::neg_inf!() && higher == constants::pos_inf!()),
+        EInvalidStrikeGrid,
+    );
+    if (lower != constants::neg_inf!()) grid.assert_finite_boundary(lower);
+    if (higher != constants::pos_inf!()) grid.assert_finite_boundary(higher);
+}
+
+public(package) fun assert_finite_boundary(grid: &StrikeGrid, strike: u64) {
+    let _ = grid.finite_strike_index(strike);
+}
+
+public(package) fun finite_strike_index(grid: &StrikeGrid, strike: u64): u64 {
+    assert!(strike >= grid.min_strike && strike <= grid.max_strike, EInvalidStrikeGrid);
+    assert!((strike - grid.min_strike) % grid.tick_size == 0, EInvalidStrikeGrid);
+    (strike - grid.min_strike) / grid.tick_size
+}

--- a/packages/predict/tests/admin_setters_tests.move
+++ b/packages/predict/tests/admin_setters_tests.move
@@ -247,8 +247,10 @@ fun set_trading_paused_round_trips_through_config_getter() {
 fun set_pyth_feed_expiry_fee_max_multiplier_updates_config() {
     let ctx = &mut tx_context::dummy();
     let (mut reg, admin_cap) = registry::new_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
     registry::create_pyth_source(
         &mut reg,
+        &mut config,
         &admin_cap,
         PYTH_FEED_BTC,
         BTC_TICK_SIZE,
@@ -257,18 +259,19 @@ fun set_pyth_feed_expiry_fee_max_multiplier_updates_config() {
         ctx,
     );
 
-    registry::set_pyth_feed_expiry_fee_max_multiplier(
-        &mut reg,
+    protocol_config::set_pyth_feed_expiry_fee_max_multiplier(
+        &mut config,
         &admin_cap,
         PYTH_FEED_BTC,
         2 * float!(),
     );
     assert_eq!(
-        *registry::pyth_feed_expiry_fee_max_multiplier(&reg, PYTH_FEED_BTC).borrow(),
+        *protocol_config::pyth_feed_expiry_fee_max_multiplier(&config, PYTH_FEED_BTC).borrow(),
         2 * float!(),
     );
 
     registry::destroy_registry_drop_for_testing(reg);
+    destroy(config);
     destroy(admin_cap);
 }
 
@@ -276,8 +279,10 @@ fun set_pyth_feed_expiry_fee_max_multiplier_updates_config() {
 fun set_pyth_feed_expiry_fee_window_updates_config() {
     let ctx = &mut tx_context::dummy();
     let (mut reg, admin_cap) = registry::new_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
     registry::create_pyth_source(
         &mut reg,
+        &mut config,
         &admin_cap,
         PYTH_FEED_BTC,
         BTC_TICK_SIZE,
@@ -286,18 +291,19 @@ fun set_pyth_feed_expiry_fee_window_updates_config() {
         ctx,
     );
 
-    registry::set_pyth_feed_expiry_fee_window_ms(
-        &mut reg,
+    protocol_config::set_pyth_feed_expiry_fee_window_ms(
+        &mut config,
         &admin_cap,
         PYTH_FEED_BTC,
         config_constants::min_expiry_fee_window_ms!(),
     );
     assert_eq!(
-        *registry::pyth_feed_expiry_fee_window_ms(&reg, PYTH_FEED_BTC).borrow(),
+        *protocol_config::pyth_feed_expiry_fee_window_ms(&config, PYTH_FEED_BTC).borrow(),
         config_constants::min_expiry_fee_window_ms!(),
     );
 
     registry::destroy_registry_drop_for_testing(reg);
+    destroy(config);
     destroy(admin_cap);
 }
 
@@ -305,8 +311,10 @@ fun set_pyth_feed_expiry_fee_window_updates_config() {
 fun set_pyth_feed_expiry_fee_multiplier_below_min_aborts() {
     let ctx = &mut tx_context::dummy();
     let (mut reg, admin_cap) = registry::new_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
     registry::create_pyth_source(
         &mut reg,
+        &mut config,
         &admin_cap,
         PYTH_FEED_BTC,
         BTC_TICK_SIZE,
@@ -315,8 +323,8 @@ fun set_pyth_feed_expiry_fee_multiplier_below_min_aborts() {
         ctx,
     );
 
-    registry::set_pyth_feed_expiry_fee_max_multiplier(
-        &mut reg,
+    protocol_config::set_pyth_feed_expiry_fee_max_multiplier(
+        &mut config,
         &admin_cap,
         PYTH_FEED_BTC,
         config_constants::min_expiry_fee_max_multiplier!() - 1,
@@ -328,8 +336,10 @@ fun set_pyth_feed_expiry_fee_multiplier_below_min_aborts() {
 fun set_pyth_feed_expiry_fee_window_below_min_aborts() {
     let ctx = &mut tx_context::dummy();
     let (mut reg, admin_cap) = registry::new_for_testing(ctx);
+    let mut config = protocol_config::new_for_testing(ctx);
     registry::create_pyth_source(
         &mut reg,
+        &mut config,
         &admin_cap,
         PYTH_FEED_BTC,
         BTC_TICK_SIZE,
@@ -338,8 +348,8 @@ fun set_pyth_feed_expiry_fee_window_below_min_aborts() {
         ctx,
     );
 
-    registry::set_pyth_feed_expiry_fee_window_ms(
-        &mut reg,
+    protocol_config::set_pyth_feed_expiry_fee_window_ms(
+        &mut config,
         &admin_cap,
         PYTH_FEED_BTC,
         config_constants::min_expiry_fee_window_ms!() - 1,

--- a/packages/predict/tests/flows/plp_rebate_flow_tests.move
+++ b/packages/predict/tests/flows/plp_rebate_flow_tests.move
@@ -180,6 +180,7 @@ fun setup_pool_with_pyth(): Fixture {
     scenario.next_tx(test_constants::admin());
     let pyth_id = registry::create_pyth_source(
         &mut registry,
+        &mut config,
         &admin_cap,
         PYTH_FEED_ID,
         TICK_SIZE,

--- a/packages/predict/tests/helper/test_helpers.move
+++ b/packages/predict/tests/helper/test_helpers.move
@@ -11,7 +11,12 @@
 #[test_only]
 module deepbook_predict::test_helpers;
 
-use deepbook_predict::{admin::AdminCap, registry::Registry, test_constants};
+use deepbook_predict::{
+    admin::AdminCap,
+    protocol_config::ProtocolConfig,
+    registry::Registry,
+    test_constants
+};
 use std::unit_test::destroy;
 use sui::test_scenario::{Self as test, Scenario};
 
@@ -66,8 +71,33 @@ public fun begin_registry_test(): (Scenario, Registry, AdminCap) {
     (scenario, registry, admin_cap)
 }
 
+/// Begin a scenario-backed registry/config test transaction and take the real
+/// `Registry`, `ProtocolConfig`, and `AdminCap` created by package-style setup.
+public fun begin_registry_config_test(): (Scenario, Registry, ProtocolConfig, AdminCap) {
+    let (mut scenario, registry_id) = setup_test();
+    scenario.next_tx(test_constants::admin());
+    let registry = scenario.take_shared_by_id<Registry>(registry_id);
+    let config = scenario.take_shared<ProtocolConfig>();
+    let admin_cap = scenario.take_from_sender<AdminCap>();
+
+    (scenario, registry, config, admin_cap)
+}
+
 /// Return the shared registry and destroy the test-owned admin cap.
 public fun finish_registry_test(scenario: Scenario, registry: Registry, admin_cap: AdminCap) {
+    test::return_shared(registry);
+    destroy(admin_cap);
+    scenario.end();
+}
+
+/// Return shared registry/config state and destroy the test-owned admin cap.
+public fun finish_registry_config_test(
+    scenario: Scenario,
+    registry: Registry,
+    config: ProtocolConfig,
+    admin_cap: AdminCap,
+) {
+    test::return_shared(config);
     test::return_shared(registry);
     destroy(admin_cap);
     scenario.end();

--- a/packages/predict/tests/pool/plp_tests.move
+++ b/packages/predict/tests/pool/plp_tests.move
@@ -462,6 +462,7 @@ fun setup_pool_with_pyth(): Fixture {
     scenario.next_tx(test_constants::admin());
     let pyth_id = registry::create_pyth_source(
         &mut registry,
+        &mut config,
         &admin_cap,
         PYTH_FEED_ID,
         TICK_SIZE,

--- a/packages/predict/tests/registry_create_tests.move
+++ b/packages/predict/tests/registry_create_tests.move
@@ -12,7 +12,7 @@ use deepbook_predict::{
     market_oracle::{Self, MarketOracle, MarketOracleCap},
     plp::{Self, PoolVault},
     pricing,
-    protocol_config::ProtocolConfig,
+    protocol_config::{Self, ProtocolConfig},
     pyth_source::PythSource,
     registry,
     test_constants,
@@ -46,10 +46,11 @@ const POOL_SUPPLY: u64 = 100_000_000_000;
 
 #[test]
 fun create_pyth_source_returns_id_and_registers() {
-    let (mut scenario, mut reg, admin_cap) = test_helpers::begin_registry_test();
+    let (mut scenario, mut reg, mut config, admin_cap) = test_helpers::begin_registry_config_test();
 
     let pyth_id = registry::create_pyth_source(
         &mut reg,
+        &mut config,
         &admin_cap,
         PYTH_FEED_BTC,
         BTC_TICK_SIZE,
@@ -60,28 +61,29 @@ fun create_pyth_source_returns_id_and_registers() {
     let registered = registry::pyth_source_id(&reg, PYTH_FEED_BTC);
     assert!(registered.is_some());
     assert!(*registered.borrow() == pyth_id);
-    let tick_size = registry::pyth_feed_tick_size(&reg, PYTH_FEED_BTC);
+    let tick_size = protocol_config::pyth_feed_tick_size(&config, PYTH_FEED_BTC);
     assert!(tick_size.is_some());
     assert!(*tick_size.borrow() == BTC_TICK_SIZE);
-    let window = registry::pyth_feed_expiry_fee_window_ms(&reg, PYTH_FEED_BTC);
+    let window = protocol_config::pyth_feed_expiry_fee_window_ms(&config, PYTH_FEED_BTC);
     assert!(*window.borrow() == config_constants::default_expiry_fee_window_ms!());
-    let multiplier = registry::pyth_feed_expiry_fee_max_multiplier(&reg, PYTH_FEED_BTC);
+    let multiplier = protocol_config::pyth_feed_expiry_fee_max_multiplier(&config, PYTH_FEED_BTC);
     assert!(*multiplier.borrow() == EXPIRY_FEE_MAX_MULTIPLIER_DISABLED);
     // Other feed ids must remain unmapped.
     assert!(registry::pyth_source_id(&reg, PYTH_FEED_ETH).is_none());
-    assert!(registry::pyth_feed_tick_size(&reg, PYTH_FEED_ETH).is_none());
-    assert!(registry::pyth_feed_expiry_fee_window_ms(&reg, PYTH_FEED_ETH).is_none());
-    assert!(registry::pyth_feed_expiry_fee_max_multiplier(&reg, PYTH_FEED_ETH).is_none());
+    assert!(protocol_config::pyth_feed_tick_size(&config, PYTH_FEED_ETH).is_none());
+    assert!(protocol_config::pyth_feed_expiry_fee_window_ms(&config, PYTH_FEED_ETH).is_none());
+    assert!(protocol_config::pyth_feed_expiry_fee_max_multiplier(&config, PYTH_FEED_ETH).is_none());
 
-    test_helpers::finish_registry_test(scenario, reg, admin_cap);
+    test_helpers::finish_registry_config_test(scenario, reg, config, admin_cap);
 }
 
 #[test]
 fun create_pyth_source_distinct_feeds_yield_distinct_ids() {
-    let (mut scenario, mut reg, admin_cap) = test_helpers::begin_registry_test();
+    let (mut scenario, mut reg, mut config, admin_cap) = test_helpers::begin_registry_config_test();
 
     let btc_id = registry::create_pyth_source(
         &mut reg,
+        &mut config,
         &admin_cap,
         PYTH_FEED_BTC,
         BTC_TICK_SIZE,
@@ -91,6 +93,7 @@ fun create_pyth_source_distinct_feeds_yield_distinct_ids() {
     );
     let eth_id = registry::create_pyth_source(
         &mut reg,
+        &mut config,
         &admin_cap,
         PYTH_FEED_ETH,
         ETH_TICK_SIZE,
@@ -100,15 +103,16 @@ fun create_pyth_source_distinct_feeds_yield_distinct_ids() {
     );
     assert!(btc_id != eth_id);
 
-    test_helpers::finish_registry_test(scenario, reg, admin_cap);
+    test_helpers::finish_registry_config_test(scenario, reg, config, admin_cap);
 }
 
 #[test, expected_failure(abort_code = registry::EPythSourceAlreadyCreated)]
 fun create_pyth_source_duplicate_feed_aborts() {
-    let (mut scenario, mut reg, admin_cap) = test_helpers::begin_registry_test();
+    let (mut scenario, mut reg, mut config, admin_cap) = test_helpers::begin_registry_config_test();
 
     registry::create_pyth_source(
         &mut reg,
+        &mut config,
         &admin_cap,
         PYTH_FEED_BTC,
         BTC_TICK_SIZE,
@@ -118,6 +122,7 @@ fun create_pyth_source_duplicate_feed_aborts() {
     );
     registry::create_pyth_source(
         &mut reg,
+        &mut config,
         &admin_cap,
         PYTH_FEED_BTC,
         BTC_TICK_SIZE,
@@ -133,7 +138,7 @@ fun create_pyth_source_with_current_version_disabled_aborts() {
     // Admin can disable current_version via the version-management path (which
     // bypasses the version gate). Subsequent create_pyth_source then fails the
     // mirrored-version check.
-    let (mut scenario, mut reg, admin_cap) = test_helpers::begin_registry_test();
+    let (mut scenario, mut reg, mut config, admin_cap) = test_helpers::begin_registry_config_test();
     let current = constants::current_version!();
     let next = current + 1;
     registry::enable_version(&mut reg, &admin_cap, next);
@@ -141,6 +146,7 @@ fun create_pyth_source_with_current_version_disabled_aborts() {
 
     registry::create_pyth_source(
         &mut reg,
+        &mut config,
         &admin_cap,
         PYTH_FEED_BTC,
         BTC_TICK_SIZE,
@@ -153,10 +159,11 @@ fun create_pyth_source_with_current_version_disabled_aborts() {
 
 #[test, expected_failure(abort_code = deepbook_predict::config_constants::EInvalidOracleTickSize)]
 fun create_pyth_source_unaligned_tick_size_aborts() {
-    let (mut scenario, mut reg, admin_cap) = test_helpers::begin_registry_test();
+    let (mut scenario, mut reg, mut config, admin_cap) = test_helpers::begin_registry_config_test();
 
     registry::create_pyth_source(
         &mut reg,
+        &mut config,
         &admin_cap,
         PYTH_FEED_BTC,
         INVALID_TICK_SIZE,
@@ -171,23 +178,24 @@ fun create_pyth_source_unaligned_tick_size_aborts() {
 
 #[test]
 fun pyth_source_id_returns_none_for_unmapped_feed() {
-    let (scenario, reg, admin_cap) = test_helpers::begin_registry_test();
+    let (scenario, reg, config, admin_cap) = test_helpers::begin_registry_config_test();
 
     assert!(registry::pyth_source_id(&reg, PYTH_FEED_BTC).is_none());
-    assert!(registry::pyth_feed_tick_size(&reg, PYTH_FEED_BTC).is_none());
-    assert!(registry::pyth_feed_expiry_fee_window_ms(&reg, PYTH_FEED_BTC).is_none());
+    assert!(protocol_config::pyth_feed_tick_size(&config, PYTH_FEED_BTC).is_none());
+    assert!(protocol_config::pyth_feed_expiry_fee_window_ms(&config, PYTH_FEED_BTC).is_none());
 
-    test_helpers::finish_registry_test(scenario, reg, admin_cap);
+    test_helpers::finish_registry_config_test(scenario, reg, config, admin_cap);
 }
 
 // === pyth feed tick size admin setter ===
 
 #[test]
 fun set_pyth_feed_tick_size_updates_registered_feed() {
-    let (mut scenario, mut reg, admin_cap) = test_helpers::begin_registry_test();
+    let (mut scenario, mut reg, mut config, admin_cap) = test_helpers::begin_registry_config_test();
 
     registry::create_pyth_source(
         &mut reg,
+        &mut config,
         &admin_cap,
         PYTH_FEED_BTC,
         BTC_TICK_SIZE,
@@ -195,20 +203,25 @@ fun set_pyth_feed_tick_size_updates_registered_feed() {
         EXPIRY_FEE_MAX_MULTIPLIER_DISABLED,
         scenario.ctx(),
     );
-    registry::set_pyth_feed_tick_size(&mut reg, &admin_cap, PYTH_FEED_BTC, WIDER_BTC_TICK_SIZE);
+    protocol_config::set_pyth_feed_tick_size(
+        &mut config,
+        &admin_cap,
+        PYTH_FEED_BTC,
+        WIDER_BTC_TICK_SIZE,
+    );
 
-    let tick_size = registry::pyth_feed_tick_size(&reg, PYTH_FEED_BTC);
+    let tick_size = protocol_config::pyth_feed_tick_size(&config, PYTH_FEED_BTC);
     assert!(tick_size.is_some());
     assert!(*tick_size.borrow() == WIDER_BTC_TICK_SIZE);
 
-    test_helpers::finish_registry_test(scenario, reg, admin_cap);
+    test_helpers::finish_registry_config_test(scenario, reg, config, admin_cap);
 }
 
-#[test, expected_failure(abort_code = registry::EPythFeedNotRegistered)]
+#[test, expected_failure(abort_code = protocol_config::EFeedTemplateNotFound)]
 fun set_pyth_feed_tick_size_unknown_feed_aborts() {
-    let (_scenario, mut reg, admin_cap) = test_helpers::begin_registry_test();
+    let (_scenario, _reg, mut config, admin_cap) = test_helpers::begin_registry_config_test();
 
-    registry::set_pyth_feed_tick_size(&mut reg, &admin_cap, PYTH_FEED_BTC, BTC_TICK_SIZE);
+    protocol_config::set_pyth_feed_tick_size(&mut config, &admin_cap, PYTH_FEED_BTC, BTC_TICK_SIZE);
     abort 999
 }
 
@@ -339,10 +352,12 @@ fun setup_ready_expiry_creation(expiry_tick_size: u64): (Scenario, ID, ID, Marke
 
     scenario.next_tx(test_constants::admin());
     let mut reg = scenario.take_shared_by_id<registry::Registry>(registry_id);
+    let mut config = scenario.take_shared<ProtocolConfig>();
     let admin_cap = scenario.take_from_sender<AdminCap>();
     let cap = market_oracle::create_cap(&admin_cap, scenario.ctx());
     let pyth_id = registry::create_pyth_source(
         &mut reg,
+        &mut config,
         &admin_cap,
         PYTH_FEED_BTC,
         INITIAL_EXPIRY_TICK_SIZE,
@@ -350,19 +365,25 @@ fun setup_ready_expiry_creation(expiry_tick_size: u64): (Scenario, ID, ID, Marke
         EXPIRY_FEE_MAX_MULTIPLIER_DISABLED,
         scenario.ctx(),
     );
-    registry::set_pyth_feed_tick_size(&mut reg, &admin_cap, PYTH_FEED_BTC, expiry_tick_size);
-    registry::set_pyth_feed_expiry_fee_window_ms(
-        &mut reg,
+    protocol_config::set_pyth_feed_tick_size(
+        &mut config,
+        &admin_cap,
+        PYTH_FEED_BTC,
+        expiry_tick_size,
+    );
+    protocol_config::set_pyth_feed_expiry_fee_window_ms(
+        &mut config,
         &admin_cap,
         PYTH_FEED_BTC,
         RAMP_WINDOW_MS,
     );
-    registry::set_pyth_feed_expiry_fee_max_multiplier(
-        &mut reg,
+    protocol_config::set_pyth_feed_expiry_fee_max_multiplier(
+        &mut config,
         &admin_cap,
         PYTH_FEED_BTC,
         RAMP_MAX_MULTIPLIER,
     );
+    return_shared(config);
     return_shared(reg);
     destroy(admin_cap);
 


### PR DESCRIPTION
## Summary
- Centralizes Predict config authoring by moving feed templates and per-expiry mutable controls into `ProtocolConfig`.
- Localizes frozen expiry terms into `ExpiryMarket` and `StrikeExposure` so hot paths read owned state instead of central snapshots.
- Extracts `StrikeGrid`, removes duplicate grid storage in exposure indexes, and drops redundant registry expiry uniqueness state.

## Key decisions
- `ProtocolConfig` owns per-expiry bindings, mint pause, and oracle policy; `Registry` keeps Pyth source uniqueness, version sync, pause caps, and creation orchestration.
- Frozen per-expiry values are stamped once at creation and copied into their owning objects instead of stored as central mutable-row snapshots.
- `StrikeExposure` keeps order strike decoding and live index ownership; this PR avoids `LiveExposure` or `StrikeRange` extraction.

## Test plan
- [x] `npx -y prettier-move -c packages/predict/sources/registry.move packages/predict/sources/config/protocol_config.move --write`
- [x] `sui move build --path packages/predict`
- [x] `git diff --check`
- [ ] `sui move test --path packages/predict --gas-limit 100000000000` (not run; source-only branch, tests still need API updates)