### PR TITLE
fix(scripts): split SUI transfers from the gas coin in transferFunds

### DIFF
--- a/scripts/transactions/transferFunds.ts
+++ b/scripts/transactions/transferFunds.ts
@@ -31,15 +31,22 @@ export type Network = "mainnet" | "testnet" | "devnet" | "localnet";
   // Update receiving address as needed
   const recevingAddress =
     "0x126bdaa2ef314de60c8214c82a2248e4cc21875330a5c32977eb303be585cab8";
-  const coinType = "SUI"; // "SUI" or "DEEP" or "USDC"
+  const coinType = "SUI" as keyof typeof config; // "SUI" or "DEEP" or "USDC"
   const amount = 10_000;
 
   const totalAmount = amount * config[coinType].scalar;
-  const coin = coinWithBalance({
-    balance: totalAmount,
-    type: config[coinType].type,
-    useGasCoin: false,
-  })(transaction);
+  // For SUI, split from the gas coin itself. The gas object set via GAS_OBJECT is
+  // also a SUI coin, so sourcing the transfer with coinWithBalance can re-select it
+  // and make the same object appear twice in the transaction (gas + input), which
+  // the network rejects. Splitting from tx.gas avoids the duplicate object.
+  const coin =
+    coinType === "SUI"
+      ? transaction.splitCoins(transaction.gas, [totalAmount])[0]
+      : coinWithBalance({
+          balance: totalAmount,
+          type: config[coinType].type,
+          useGasCoin: false,
+        })(transaction);
 
   transaction.transferObjects([coin], recevingAddress);
   let res = await prepareMultisigTx(transaction, env, adminAddress);


### PR DESCRIPTION
## Summary
- `transferFunds.ts` set `GAS_OBJECT` as the gas payment **and** sourced the transfer with `coinWithBalance`. For a **SUI** transfer the funding coin is the same type as gas, so coin selection could re-pick the gas object, making it appear twice in one transaction.
- The dry run in `prepareMultisigTx` then failed with `Mutable object 0x4850… cannot appear more than one in one transaction` (the `0x4850…` default `gas_object_id` from the `Build Deepbook TX` workflow).
- Fix: for SUI, split the amount directly from `tx.gas` (`transaction.splitCoins(transaction.gas, [totalAmount])[0]`), so no separate input coin is referenced. DEEP/USDC transfers keep using `coinWithBalance` (their funding coin is a different object than the SUI gas coin, so no collision).

## Key decisions
- Splitting from `tx.gas` (vs. just passing a different `GAS_OBJECT`) is the robust fix: coin selection is non-deterministic, so a distinct gas object could still be re-picked. This guarantees the gas coin is referenced exactly once. Requires the gas coin to hold `> amount + gas budget` SUI.
- `coinType` is now `"SUI" as keyof typeof config` purely so the SUI/DEEP/USDC ternary type-checks under `tsc --strict` (const-literal narrowing otherwise makes the non-SUI branch `never`). CI runs via `tsx` (esbuild, no type-check), so this is cosmetic but keeps the file clean.
- No SDK bump: the failure was transaction construction, not an SDK issue; the fix works on the currently pinned `@mysten/sui@2.17.0`.

## Test plan
- [ ] Re-run the `Build Deepbook TX` workflow for `transferFunds.ts` with the default `gas_object_id` and confirm the dry run succeeds (no duplicate-object error) and `tx/tx-data.txt` is produced.
- [ ] Confirm the dry-run effects show 10,000 SUI transferred to `0x126bdaa2…585cab8` and the gas coin retains its remaining balance.
- [ ] Sanity-check a DEEP/USDC transfer still builds (unchanged `coinWithBalance` path).