### PR TITLE
Split predict redeem by authority (owner vs permissionless)

### DIFF
--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -36,6 +36,7 @@ const EPackageVersionDisabled: u64 = 4;
 const EMintPaused: u64 = 5;
 const EUnresolvedTradingFeesUnderflow: u64 = 6;
 const EFullCloseRequired: u64 = 7;
+const ENotPermissionlesslyRedeemable: u64 = 8;
 
 /// Per-expiry market state.
 public struct ExpiryMarket has key {
@@ -190,11 +191,13 @@ public fun mint(
     )
 }
 
-/// Redeem live or settled order quantity.
+/// Redeem one of the caller's own order positions.
 ///
-/// Live redeems can close part or all of an order. Settled and liquidated-order
-/// redeems require a full close and return no replacement. Returns
-/// `(closed_order_id, replacement_order_id)`.
+/// Owner-gated: only the manager owner may close their position. Live redeems
+/// can close part or all of an order; settled and liquidated-order redeems
+/// require a full close and return no replacement. For keeper-driven cleanup of
+/// any manager's settled or liquidated orders, use `redeem_permissionless`.
+/// Returns `(closed_order_id, replacement_order_id)`.
 public fun redeem(
     market: &mut ExpiryMarket,
     manager: &mut PredictManager,
@@ -209,47 +212,52 @@ public fun redeem(
     market.assert_version_allowed();
     config.assert_not_valuation_in_progress();
     market.assert_market_oracle(market_oracle);
-    let redeemed_order = order::from_order_id(order_id);
-    if (market.strike_exposure.is_liquidated_order(&redeemed_order)) {
-        market.redeem_liquidated_order(manager, &redeemed_order, close_quantity);
-        return (redeemed_order.id(), option::none())
-    };
+    manager.assert_owner(ctx);
+    market.redeem_internal(
+        manager,
+        config,
+        market_oracle,
+        pyth,
+        order_id,
+        close_quantity,
+        clock,
+        ctx,
+    )
+}
 
-    if (market_oracle.is_settled()) {
-        assert!(close_quantity == redeemed_order.quantity(), EFullCloseRequired);
-        market.redeem_settled_internal(manager, market_oracle, &redeemed_order, ctx);
-        (redeemed_order.id(), option::none())
-    } else {
-        market.run_liquidation_pass(
-            config.pricing_config(),
-            market_oracle,
-            pyth,
-            config.risk_config().trade_liquidation_budget(),
-            clock,
-        );
-        if (market.strike_exposure.is_liquidated_order(&redeemed_order)) {
-            market.redeem_liquidated_order(manager, &redeemed_order, close_quantity);
-            return (redeemed_order.id(), option::none())
-        };
-        let replacement_order_id = market.redeem_live_internal(
-            manager,
-            config,
-            market_oracle,
-            pyth,
-            &redeemed_order,
-            close_quantity,
-            clock,
-            ctx,
-        );
-        (redeemed_order.id(), replacement_order_id)
-    }
+/// Permissionlessly finalize a settled or liquidated order for its manager.
+///
+/// Callable by anyone (e.g. a keeper): a liquidated order is closed with no
+/// payout; a settled order pays its terminal payout to the manager, never to the
+/// caller. Always a full close. Aborts on a live order — only the owner can close
+/// a live position, through `redeem`. Returns the closed order id.
+public fun redeem_permissionless(
+    market: &mut ExpiryMarket,
+    manager: &mut PredictManager,
+    config: &ProtocolConfig,
+    market_oracle: &MarketOracle,
+    order_id: u256,
+    ctx: &mut TxContext,
+): u256 {
+    market.assert_version_allowed();
+    config.assert_not_valuation_in_progress();
+    market.assert_market_oracle(market_oracle);
+    let order = order::from_order_id(order_id);
+    if (market.strike_exposure.is_liquidated_order(&order)) {
+        market.redeem_liquidated_order(manager, &order, order.quantity());
+        return order.id()
+    };
+    assert!(market_oracle.is_settled(), ENotPermissionlesslyRedeemable);
+    market.redeem_settled_internal(manager, market_oracle, &order, ctx);
+    order.id()
 }
 
 /// Run one bounded liquidation pass over active leveraged orders.
 ///
 /// The liquidation book selects up to `budget` candidates and returns the
-/// number of orders liquidated. It does not touch PredictManagers; users clear
-/// their liquidated position later through `redeem`, receiving no payout.
+/// number of orders liquidated. It does not touch PredictManagers; the position
+/// is cleared later through `redeem` (owner) or `redeem_permissionless` (keeper),
+/// receiving no payout.
 public fun liquidate(
     market: &mut ExpiryMarket,
     config: &ProtocolConfig,
@@ -600,6 +608,56 @@ fun mint_internal(
     minted_order.id()
 }
 
+/// Lifecycle dispatch for an owner-authorized redeem: liquidated cleanup,
+/// settled full close, or live close (which runs a liquidation pass first).
+/// `redeem` owns the version, valuation, oracle-binding, and owner gates.
+fun redeem_internal(
+    market: &mut ExpiryMarket,
+    manager: &mut PredictManager,
+    config: &ProtocolConfig,
+    market_oracle: &MarketOracle,
+    pyth: &PythSource,
+    order_id: u256,
+    close_quantity: u64,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): (u256, Option<u256>) {
+    let redeemed_order = order::from_order_id(order_id);
+    if (market.strike_exposure.is_liquidated_order(&redeemed_order)) {
+        market.redeem_liquidated_order(manager, &redeemed_order, close_quantity);
+        return (redeemed_order.id(), option::none())
+    };
+
+    if (market_oracle.is_settled()) {
+        assert!(close_quantity == redeemed_order.quantity(), EFullCloseRequired);
+        market.redeem_settled_internal(manager, market_oracle, &redeemed_order, ctx);
+        (redeemed_order.id(), option::none())
+    } else {
+        market.run_liquidation_pass(
+            config.pricing_config(),
+            market_oracle,
+            pyth,
+            config.risk_config().trade_liquidation_budget(),
+            clock,
+        );
+        if (market.strike_exposure.is_liquidated_order(&redeemed_order)) {
+            market.redeem_liquidated_order(manager, &redeemed_order, close_quantity);
+            return (redeemed_order.id(), option::none())
+        };
+        let replacement_order_id = market.redeem_live_internal(
+            manager,
+            config,
+            market_oracle,
+            pyth,
+            &redeemed_order,
+            close_quantity,
+            clock,
+            ctx,
+        );
+        (redeemed_order.id(), replacement_order_id)
+    }
+}
+
 fun redeem_live_internal(
     market: &mut ExpiryMarket,
     manager: &mut PredictManager,
@@ -611,7 +669,6 @@ fun redeem_live_internal(
     clock: &Clock,
     ctx: &mut TxContext,
 ): Option<u256> {
-    manager.assert_owner(ctx);
     manager.update_stake(ctx);
     market.assert_pyth_feed(pyth);
     pricing::assert_live_quote_available(config.pricing_config(), market_oracle, pyth, clock);

--- a/packages/predict/tests/flows/plp_rebate_flow_tests.move
+++ b/packages/predict/tests/flows/plp_rebate_flow_tests.move
@@ -8,12 +8,12 @@ use deepbook_predict::{
     admin::AdminCap,
     config_constants,
     constants::{Self, float_scaling as float},
-    expiry_market::ExpiryMarket,
+    expiry_market::{Self, ExpiryMarket},
     i64,
     market_oracle::{Self, MarketOracle, MarketOracleCap},
     order,
     plp::{Self, PLP, PoolVault},
-    predict_manager::PredictManager,
+    predict_manager::{Self, PredictManager},
     protocol_config::{Self, ProtocolConfig},
     pyth_source::PythSource,
     registry::{Self, Registry},
@@ -151,6 +151,163 @@ fun same_expiry_residual_rebate_cash_materializes_new_terminal_profit() {
     return_shared(pyth);
     destroy(manager);
     finish(fixture);
+}
+
+#[test]
+fun redeem_permissionless_settles_for_non_owner() {
+    let mut fixture = setup_pool_with_pyth();
+    let (expiry_id, oracle_id) = create_expiry(&mut fixture, EXPIRY_MS);
+    let mut manager = create_manager_for_testing(&mut fixture);
+
+    let mut pyth = fixture.scenario.take_shared_by_id<PythSource>(fixture.pyth_id);
+    let mut vault = fixture.scenario.take_shared_by_id<PoolVault>(fixture.vault_id);
+    let mut market = fixture.scenario.take_shared_by_id<ExpiryMarket>(expiry_id);
+    let mut oracle = fixture.scenario.take_shared_by_id<MarketOracle>(oracle_id);
+
+    prepare_live_oracle_for_trading(&fixture, &mut oracle, &mut pyth);
+    sync_expiry_for_testing(&mut fixture, &mut vault, &mut market, &oracle, &pyth);
+
+    manager.deposit(
+        coin::mint_for_testing<DUSDC>(MIN_FEE_MINT_DEPOSIT, fixture.scenario.ctx()),
+        fixture.scenario.ctx(),
+    );
+    let order_id = market.mint(
+        &mut manager,
+        &fixture.config,
+        &oracle,
+        &pyth,
+        MIN_FEE_LOWER_STRIKE,
+        constants::pos_inf!(),
+        MIN_FEE_MINT_QUANTITY,
+        order::leverage_one_x(),
+        &fixture.clock,
+        fixture.scenario.ctx(),
+    );
+
+    settle_oracle(&mut fixture, &mut oracle, &mut pyth);
+    sync_expiry_for_testing(&mut fixture, &mut vault, &mut market, &oracle, &pyth);
+
+    // Manager is owned by alice; finalize it from a different sender to prove
+    // `redeem_permissionless` does not require ownership.
+    return_shared(oracle);
+    return_shared(market);
+    return_shared(vault);
+    return_shared(pyth);
+    fixture.scenario.next_tx(test_constants::admin());
+    let oracle = fixture.scenario.take_shared_by_id<MarketOracle>(oracle_id);
+    let mut market = fixture.scenario.take_shared_by_id<ExpiryMarket>(expiry_id);
+
+    let closed_order_id = market.redeem_permissionless(
+        &mut manager,
+        &fixture.config,
+        &oracle,
+        order_id,
+        fixture.scenario.ctx(),
+    );
+    assert_eq!(closed_order_id, order_id);
+    assert!(!manager.has_position(expiry_id, order_id));
+    assert_eq!(manager.expiry_position_count(expiry_id), 0);
+
+    return_shared(oracle);
+    return_shared(market);
+    destroy(manager);
+    finish(fixture);
+}
+
+#[test, expected_failure(abort_code = expiry_market::ENotPermissionlesslyRedeemable)]
+fun redeem_permissionless_live_order_aborts() {
+    let mut fixture = setup_pool_with_pyth();
+    let (expiry_id, oracle_id) = create_expiry(&mut fixture, EXPIRY_MS);
+    let mut manager = create_manager_for_testing(&mut fixture);
+
+    let mut pyth = fixture.scenario.take_shared_by_id<PythSource>(fixture.pyth_id);
+    let mut vault = fixture.scenario.take_shared_by_id<PoolVault>(fixture.vault_id);
+    let mut market = fixture.scenario.take_shared_by_id<ExpiryMarket>(expiry_id);
+    let mut oracle = fixture.scenario.take_shared_by_id<MarketOracle>(oracle_id);
+
+    prepare_live_oracle_for_trading(&fixture, &mut oracle, &mut pyth);
+    sync_expiry_for_testing(&mut fixture, &mut vault, &mut market, &oracle, &pyth);
+
+    manager.deposit(
+        coin::mint_for_testing<DUSDC>(MIN_FEE_MINT_DEPOSIT, fixture.scenario.ctx()),
+        fixture.scenario.ctx(),
+    );
+    let order_id = market.mint(
+        &mut manager,
+        &fixture.config,
+        &oracle,
+        &pyth,
+        MIN_FEE_LOWER_STRIKE,
+        constants::pos_inf!(),
+        MIN_FEE_MINT_QUANTITY,
+        order::leverage_one_x(),
+        &fixture.clock,
+        fixture.scenario.ctx(),
+    );
+
+    // Oracle is not settled and the order is live: there is no permissionless path.
+    market.redeem_permissionless(
+        &mut manager,
+        &fixture.config,
+        &oracle,
+        order_id,
+        fixture.scenario.ctx(),
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = predict_manager::ENotOwner)]
+fun redeem_by_non_owner_aborts() {
+    let mut fixture = setup_pool_with_pyth();
+    let (expiry_id, oracle_id) = create_expiry(&mut fixture, EXPIRY_MS);
+    let mut manager = create_manager_for_testing(&mut fixture);
+
+    let mut pyth = fixture.scenario.take_shared_by_id<PythSource>(fixture.pyth_id);
+    let mut vault = fixture.scenario.take_shared_by_id<PoolVault>(fixture.vault_id);
+    let mut market = fixture.scenario.take_shared_by_id<ExpiryMarket>(expiry_id);
+    let mut oracle = fixture.scenario.take_shared_by_id<MarketOracle>(oracle_id);
+
+    prepare_live_oracle_for_trading(&fixture, &mut oracle, &mut pyth);
+    sync_expiry_for_testing(&mut fixture, &mut vault, &mut market, &oracle, &pyth);
+
+    manager.deposit(
+        coin::mint_for_testing<DUSDC>(MIN_FEE_MINT_DEPOSIT, fixture.scenario.ctx()),
+        fixture.scenario.ctx(),
+    );
+    let order_id = market.mint(
+        &mut manager,
+        &fixture.config,
+        &oracle,
+        &pyth,
+        MIN_FEE_LOWER_STRIKE,
+        constants::pos_inf!(),
+        MIN_FEE_MINT_QUANTITY,
+        order::leverage_one_x(),
+        &fixture.clock,
+        fixture.scenario.ctx(),
+    );
+
+    // Switch to a non-owner sender; the owner-gated `redeem` must reject them.
+    return_shared(oracle);
+    return_shared(market);
+    return_shared(vault);
+    return_shared(pyth);
+    fixture.scenario.next_tx(test_constants::admin());
+    let oracle = fixture.scenario.take_shared_by_id<MarketOracle>(oracle_id);
+    let mut market = fixture.scenario.take_shared_by_id<ExpiryMarket>(expiry_id);
+    let pyth = fixture.scenario.take_shared_by_id<PythSource>(fixture.pyth_id);
+
+    market.redeem(
+        &mut manager,
+        &fixture.config,
+        &oracle,
+        &pyth,
+        order_id,
+        MIN_FEE_MINT_QUANTITY,
+        &fixture.clock,
+        fixture.scenario.ctx(),
+    );
+    abort 999
 }
 
 fun setup_pool_with_pyth(): Fixture {


### PR DESCRIPTION
## Summary
- `expiry_market::redeem` carried three different authority models selected by control flow — the liquidated and settled branches were permissionless, the live branch was owner-only — with the owner check buried inside `redeem_live_internal`. The public signature gave no hint that the function was sometimes keeper-callable.
- Make `redeem` **owner-gated at the entry** (hoist `manager.assert_owner`); it handles the owner's own live / settled / liquidated closes.
- Add **`redeem_permissionless`** for keeper-driven finalization of any manager's settled or liquidated order. It pays the manager (never the caller) and aborts on a live order.
- Extract lifecycle dispatch into a private `redeem_internal`; drop the now-redundant owner check in `redeem_live_internal`.
- Add the `ENotPermissionlesslyRedeemable` abort code.

## Key decisions
- **2-way split** (`redeem` owner / `redeem_permissionless` keeper) rather than three lifecycle entrypoints: authority now maps to the function name, and no single function contains branches with differing authority. The owner path still handles the owner's own settled/liquidated orders for convenience.
- `redeem_permissionless` drops `close_quantity` / `pyth` / `clock` — it is always a full close and runs no liquidation pass, finalizing only already-terminal (settled or tombstoned) orders. The keeper flow is `liquidate` (to tombstone underwater orders) then `redeem_permissionless` (to clear them).
- Based off `main` **independent** of the live-pricing-context PR (per request). The two edit `expiry_market.move` and will need a rebase when the first merges.

## Test plan
- [x] `sui move test --path packages/predict --gas-limit 100000000000` — 449 passed, 0 failed
- [x] `redeem_permissionless_settles_for_non_owner` — non-owner finalizes a settled order; position cleared, returned id matches
- [x] `redeem_permissionless_live_order_aborts` — `ENotPermissionlesslyRedeemable` on a live order
- [x] `redeem_by_non_owner_aborts` — `predict_manager::ENotOwner` on the owner-gated `redeem`
- [ ] Follow-up: extract a shared expiry-market flow fixture so redeem tests don't live in `plp_rebate_flow_tests.move`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
