### PR TITLE
Centralize predict live pricing context

### DIFF
--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -220,12 +220,15 @@ public fun redeem(
         market.redeem_settled_internal(manager, market_oracle, &redeemed_order, ctx);
         (redeemed_order.id(), option::none())
     } else {
-        market.run_liquidation_pass(
+        let live_context = market.live_pricing_context(
             config.pricing_config(),
             market_oracle,
             pyth,
-            config.risk_config().trade_liquidation_budget(),
             clock,
+        );
+        market.strike_exposure.liquidate_live_orders(
+            &live_context,
+            config.risk_config().trade_liquidation_budget(),
         );
         if (market.strike_exposure.is_liquidated_order(&redeemed_order)) {
             market.redeem_liquidated_order(manager, &redeemed_order, close_quantity);
@@ -234,11 +237,9 @@ public fun redeem(
         let replacement_order_id = market.redeem_live_internal(
             manager,
             config,
-            market_oracle,
-            pyth,
+            &live_context,
             &redeemed_order,
             close_quantity,
-            clock,
             ctx,
         );
         (redeemed_order.id(), replacement_order_id)
@@ -377,7 +378,6 @@ public(package) fun pool_nav(
     config.assert_valuation_in_progress();
     market.assert_market_oracle(market_oracle);
     market.assert_pyth_feed(pyth);
-    market_oracle.assert_active(clock);
     let position_liability = market
         .strike_exposure
         .valuation_liability(
@@ -404,10 +404,9 @@ public(package) fun run_liquidation_pass(
     market.assert_version_allowed();
     market.assert_market_oracle(market_oracle);
     market.assert_pyth_feed(pyth);
-    market_oracle.assert_active(clock);
     market
         .strike_exposure
-        .liquidate_live_orders(
+        .liquidate_live_orders_if_candidates(
             pricing_config,
             market_oracle,
             pyth,
@@ -514,6 +513,18 @@ fun assert_pyth_feed(market: &ExpiryMarket, pyth: &PythSource) {
     assert!(market.pyth_lazer_feed_id == pyth.feed_id(), EWrongPythSource);
 }
 
+fun live_pricing_context(
+    market: &ExpiryMarket,
+    pricing_config: &PricingConfig,
+    market_oracle: &MarketOracle,
+    pyth: &PythSource,
+    clock: &Clock,
+): pricing::LivePricingContext {
+    market.assert_market_oracle(market_oracle);
+    market.assert_pyth_feed(pyth);
+    pricing::live_context(pricing_config, market_oracle, pyth, clock)
+}
+
 fun builder_fee_amount(builder_code_id: &Option<ID>, fee_amount: u64, quantity: u64): u64 {
     if (builder_code_id.is_some()) {
         math::mul(fee_amount, constants::builder_fee_multiplier!()).min(
@@ -556,27 +567,26 @@ fun mint_internal(
 ): u256 {
     manager.assert_owner(ctx);
     manager.update_stake(ctx);
-    market.assert_market_oracle(market_oracle);
-    market.assert_pyth_feed(pyth);
-    market.run_liquidation_pass(
+    let live_context = market.live_pricing_context(
         config.pricing_config(),
         market_oracle,
         pyth,
-        config.risk_config().trade_liquidation_budget(),
         clock,
+    );
+    market.strike_exposure.liquidate_live_orders(
+        &live_context,
+        config.risk_config().trade_liquidation_budget(),
     );
 
     let (minted_order, fee_amount) = market
         .strike_exposure
         .allocate_mint_order(
             config.pricing_config(),
-            market_oracle,
-            pyth,
+            &live_context,
             lower_strike,
             higher_strike,
             quantity,
             leverage,
-            clock,
         );
     let fee_amount = config
         .stake_config()
@@ -604,28 +614,22 @@ fun redeem_live_internal(
     market: &mut ExpiryMarket,
     manager: &mut PredictManager,
     config: &ProtocolConfig,
-    market_oracle: &MarketOracle,
-    pyth: &PythSource,
+    context: &pricing::LivePricingContext,
     order: &Order,
     close_quantity: u64,
-    clock: &Clock,
     ctx: &mut TxContext,
 ): Option<u256> {
     manager.assert_owner(ctx);
     manager.update_stake(ctx);
-    market.assert_pyth_feed(pyth);
-    pricing::assert_live_quote_available(config.pricing_config(), market_oracle, pyth, clock);
     manager.remove_position(market.id(), order.id());
 
     let (resulting_order, redeem_amount, fee_amount) = market
         .strike_exposure
         .close_and_quote_live_order(
             config.pricing_config(),
-            market_oracle,
-            pyth,
+            context,
             order,
             close_quantity,
-            clock,
         );
     let fee_amount = config
         .stake_config()

--- a/packages/predict/sources/pricing/pricing.move
+++ b/packages/predict/sources/pricing/pricing.move
@@ -39,6 +39,14 @@ public struct CurvePoint has copy, drop, store {
     up_price: u64,
 }
 
+/// Live pricing inputs sampled after liveness, binding, and freshness checks.
+public struct LivePricingContext has copy, drop {
+    forward: u64,
+    svi: SVIParams,
+    now_ms: u64,
+    time_to_expiry_ms: u64,
+}
+
 // === Public Functions ===
 
 /// Return terminal settlement price, aborting if the market is unsettled.
@@ -56,17 +64,60 @@ public(package) fun up_price(point: &CurvePoint): u64 {
     point.up_price
 }
 
-/// Return the current raw probability for a live range.
-public(package) fun live_range_probability(
+public(package) fun forward(context: &LivePricingContext): u64 {
+    context.forward
+}
+
+public(package) fun svi(context: &LivePricingContext): &SVIParams {
+    &context.svi
+}
+
+public(package) fun now_ms(context: &LivePricingContext): u64 {
+    context.now_ms
+}
+
+/// Return the current time to expiry for this live pricing sample.
+public(package) fun time_to_expiry_ms(context: &LivePricingContext): u64 {
+    context.time_to_expiry_ms
+}
+
+/// Resolve the live pricing context used by all live quote paths.
+///
+/// Fresh Pyth spot is canonical for spot; forward is then derived from the
+/// latest Block Scholes basis. If Pyth is stale, pricing falls back to the
+/// fresh Block Scholes forward. SVI must be fresh either way.
+public(package) fun live_context(
     config: &PricingConfig,
     market: &MarketOracle,
     pyth: &PythSource,
+    clock: &Clock,
+): LivePricingContext {
+    market.assert_pyth_source(pyth);
+    market.assert_active(clock);
+    assert_live_oracle_fresh(config, market, clock);
+
+    let now_ms = clock.timestamp_ms();
+    let forward = if (pyth_spot_is_fresh(config, pyth, clock)) {
+        math::mul(pyth.spot(), market.block_scholes_basis())
+    } else {
+        market.block_scholes_forward()
+    };
+
+    LivePricingContext {
+        forward,
+        svi: market.block_scholes_svi(),
+        now_ms,
+        time_to_expiry_ms: market.expiry() - now_ms,
+    }
+}
+
+/// Return the current raw probability for a live range.
+public(package) fun live_range_probability(
+    context: &LivePricingContext,
     lower: u64,
     higher: u64,
-    clock: &Clock,
 ): u64 {
-    let (forward, svi) = live_inputs(config, market, pyth, clock);
-    compute_range_price(&svi, forward, lower, higher)
+    compute_range_price(&context.svi, context.forward, lower, higher)
 }
 
 /// Return the per-unit fee for a raw contract probability, scaled by the
@@ -74,20 +125,18 @@ public(package) fun live_range_probability(
 /// the market is active (`now < expiry`).
 public(package) fun fee_rate(
     config: &PricingConfig,
-    market: &MarketOracle,
+    context: &LivePricingContext,
     expiry_fee_window_ms: u64,
     expiry_fee_max_multiplier: u64,
     probability: u64,
-    clock: &Clock,
 ): u64 {
     let raw_fee = raw_bernoulli_fee_rate(config, probability);
     let min_fee = config.min_fee();
     let base = if (raw_fee > min_fee) raw_fee else min_fee;
-    let time_to_expiry_ms = market.expiry() - clock.timestamp_ms();
     let multiplier = expiry_fee_multiplier(
         expiry_fee_window_ms,
         expiry_fee_max_multiplier,
-        time_to_expiry_ms,
+        context.time_to_expiry_ms,
     );
     math::mul(base, multiplier)
 }
@@ -95,19 +144,17 @@ public(package) fun fee_rate(
 /// Return fee rate and abort unless the all-in mint price is allowed.
 public(package) fun assert_mint_fee_rate(
     config: &PricingConfig,
-    market: &MarketOracle,
+    context: &LivePricingContext,
     expiry_fee_window_ms: u64,
     expiry_fee_max_multiplier: u64,
     probability: u64,
-    clock: &Clock,
 ): u64 {
     let fee_rate = fee_rate(
         config,
-        market,
+        context,
         expiry_fee_window_ms,
         expiry_fee_max_multiplier,
         probability,
-        clock,
     );
     let ask_price = probability + fee_rate;
     assert!(
@@ -117,46 +164,12 @@ public(package) fun assert_mint_fee_rate(
     fee_rate
 }
 
-/// Abort unless the live oracle inputs needed for a quote are currently usable.
-public(package) fun assert_live_quote_available(
-    config: &PricingConfig,
-    market: &MarketOracle,
-    pyth: &PythSource,
-    clock: &Clock,
-) {
-    market.assert_pyth_source(pyth);
-    market.assert_active(clock);
-    assert_live_oracle_fresh(config, market, clock);
-}
-
 public(package) fun assert_pyth_spot_fresh(
     config: &PricingConfig,
     pyth: &PythSource,
     clock: &Clock,
 ) {
     assert!(pyth_spot_is_fresh(config, pyth, clock), EPythSpotStale);
-}
-
-/// Resolve the live forward/SVI tuple used by all live pricing paths.
-///
-/// Fresh Pyth spot is canonical for spot; forward is then derived from the
-/// latest Block Scholes basis. If Pyth is stale, pricing falls back to the
-/// fresh Block Scholes forward. SVI must be fresh either way.
-public(package) fun live_inputs(
-    config: &PricingConfig,
-    market: &MarketOracle,
-    pyth: &PythSource,
-    clock: &Clock,
-): (u64, SVIParams) {
-    assert_live_quote_available(config, market, pyth, clock);
-
-    let forward = if (pyth_spot_is_fresh(config, pyth, clock)) {
-        math::mul(pyth.spot(), market.block_scholes_basis())
-    } else {
-        market.block_scholes_forward()
-    };
-
-    (forward, market.block_scholes_svi())
 }
 
 /// Build an adaptive piecewise-linear UP-price curve over a configured grid range.

--- a/packages/predict/sources/strike_exposure/strike_exposure.move
+++ b/packages/predict/sources/strike_exposure/strike_exposure.move
@@ -16,7 +16,7 @@ use deepbook::{constants::max_u64, math};
 use deepbook_predict::{
     constants,
     liquidation_book::{Self, LiquidationBook},
-    market_oracle::{MarketOracle, SVIParams},
+    market_oracle::MarketOracle,
     math as predict_math,
     order::{Self, Order},
     order_events,
@@ -128,10 +128,10 @@ public(package) fun valuation_liability(
         return 0
     };
 
-    let (forward, svi) = pricing::live_inputs(config, market, pyth, clock);
+    let context = pricing::live_context(config, market, pyth, clock);
     let curve = pricing::build_curve(
-        &svi,
-        forward,
+        context.svi(),
+        context.forward(),
         exposure.grid_min,
         exposure.grid_tick,
         exposure.grid_max,
@@ -144,7 +144,7 @@ public(package) fun valuation_liability(
             &curve,
             minted_min_strike,
             minted_max_strike,
-            exposure.floor_index_at_ms(clock.timestamp_ms()),
+            exposure.floor_index_at_ms(context.now_ms()),
         )
 }
 
@@ -208,37 +208,27 @@ public(package) fun close_settled_order(
 public(package) fun allocate_mint_order(
     exposure: &mut StrikeExposure,
     config: &PricingConfig,
-    market: &MarketOracle,
-    pyth: &PythSource,
+    context: &pricing::LivePricingContext,
     lower: u64,
     higher: u64,
     quantity: u64,
     leverage: u64,
-    clock: &Clock,
 ): (Order, u64) {
     let (min_strike_index, max_strike_index) = exposure.strike_indices(lower, higher);
-    let entry_probability = pricing::live_range_probability(
-        config,
-        market,
-        pyth,
-        lower,
-        higher,
-        clock,
-    );
+    let entry_probability = pricing::live_range_probability(context, lower, higher);
     order::assert_mint_leverage_tier(entry_probability, leverage);
     let fee_rate = pricing::assert_mint_fee_rate(
         config,
-        market,
+        context,
         exposure.expiry_fee_window_ms,
         exposure.expiry_fee_max_multiplier,
         entry_probability,
-        clock,
     );
     let fee_amount = math::mul(fee_rate, quantity);
 
     let sequence = exposure.next_order_sequence;
     let allocated_order = order::new_from_strike_indices(
-        clock.timestamp_ms(),
+        context.now_ms(),
         min_strike_index,
         max_strike_index,
         leverage,
@@ -264,31 +254,21 @@ public(package) fun allocate_mint_order(
 public(package) fun close_and_quote_live_order(
     exposure: &mut StrikeExposure,
     config: &PricingConfig,
-    market: &MarketOracle,
-    pyth: &PythSource,
+    context: &pricing::LivePricingContext,
     order: &Order,
     close_quantity: u64,
-    clock: &Clock,
 ): (Order, u64, u64) {
     let (lower, higher) = exposure.order_strikes(order);
     let old_quantity = order.quantity();
     order::assert_valid_quantity(close_quantity);
     assert!(close_quantity <= old_quantity, EInvalidCloseQuantity);
-    let range_probability = pricing::live_range_probability(
-        config,
-        market,
-        pyth,
-        lower,
-        higher,
-        clock,
-    );
+    let range_probability = pricing::live_range_probability(context, lower, higher);
     let fee_rate = pricing::fee_rate(
         config,
-        market,
+        context,
         exposure.expiry_fee_window_ms,
         exposure.expiry_fee_max_multiplier,
         range_probability,
-        clock,
     );
 
     let (resulting_order, closed_floor_amount) = exposure.close_live_exposure(
@@ -296,7 +276,7 @@ public(package) fun close_and_quote_live_order(
         lower,
         higher,
         close_quantity,
-        clock,
+        context.now_ms(),
     );
     let gross_redeem_amount = math::mul(range_probability, close_quantity);
     let redeem_amount = gross_redeem_amount - gross_redeem_amount.min(closed_floor_amount);
@@ -312,6 +292,18 @@ public(package) fun clear_liquidated_order(exposure: &mut StrikeExposure, order:
 /// Run one bounded liquidation pass using exact per-candidate pricing.
 public(package) fun liquidate_live_orders(
     exposure: &mut StrikeExposure,
+    context: &pricing::LivePricingContext,
+    budget: u64,
+): u64 {
+    let candidates = exposure.liquidation.select_liquidation_candidates(budget);
+    if (candidates.is_empty()) return 0;
+
+    exposure.liquidate_candidates(context, candidates)
+}
+
+/// Run liquidation only if the passive scan has candidates to price.
+public(package) fun liquidate_live_orders_if_candidates(
+    exposure: &mut StrikeExposure,
     config: &PricingConfig,
     market: &MarketOracle,
     pyth: &PythSource,
@@ -321,8 +313,8 @@ public(package) fun liquidate_live_orders(
     let candidates = exposure.liquidation.select_liquidation_candidates(budget);
     if (candidates.is_empty()) return 0;
 
-    let (forward, svi) = pricing::live_inputs(config, market, pyth, clock);
-    exposure.liquidate_candidates(&svi, forward, candidates, clock)
+    let context = pricing::live_context(config, market, pyth, clock);
+    exposure.liquidate_candidates(&context, candidates)
 }
 
 /// Cache terminal settled payout liability.
@@ -372,10 +364,8 @@ public(package) fun destroy_live_indexes(exposure: &mut StrikeExposure) {
 
 fun liquidate_candidates(
     exposure: &mut StrikeExposure,
-    svi: &SVIParams,
-    forward: u64,
+    context: &pricing::LivePricingContext,
     candidates: vector<u256>,
-    clock: &Clock,
 ): u64 {
     let mut liquidated_count = 0;
     let mut i = 0;
@@ -383,8 +373,8 @@ fun liquidate_candidates(
         let order = order::from_order_id(candidates[i]);
         let (lower, higher) = exposure.order_strikes(&order);
         let range_probability = pricing::compute_range_price(
-            svi,
-            forward,
+            context.svi(),
+            context.forward(),
             lower,
             higher,
         );
@@ -394,7 +384,7 @@ fun liquidate_candidates(
                 lower,
                 higher,
                 range_probability,
-                clock,
+                context.now_ms(),
             )
         ) {
             liquidated_count = liquidated_count + 1;
@@ -569,7 +559,7 @@ fun close_live_exposure(
     lower: u64,
     higher: u64,
     close_quantity: u64,
-    clock: &Clock,
+    now_ms: u64,
 ): (Order, u64) {
     let resulting_order = exposure.resulting_order_after_close(order, close_quantity);
     let closed_floor_amount = exposure.remove_closed_live_order(
@@ -578,7 +568,7 @@ fun close_live_exposure(
         lower,
         higher,
         close_quantity,
-        clock,
+        now_ms,
     );
     exposure.liquidation.remove_order(order);
     if (resulting_order.id() != order.id()) {
@@ -608,7 +598,7 @@ fun remove_closed_live_order(
     lower: u64,
     higher: u64,
     close_quantity: u64,
-    clock: &Clock,
+    now_ms: u64,
 ): u64 {
     let (
         old_floor_shares,
@@ -627,7 +617,7 @@ fun remove_closed_live_order(
     let closed_live_backing_payout = old_live_backing_payout - remaining_live_backing_payout;
     let closed_floor_amount = exposure.floor_amount_at_ms(
         closed_floor_shares,
-        clock.timestamp_ms(),
+        now_ms,
     );
 
     let live = exposure.live.borrow_mut();
@@ -649,12 +639,12 @@ fun liquidate_candidate_if_under_floor(
     lower: u64,
     higher: u64,
     range_probability: u64,
-    clock: &Clock,
+    now_ms: u64,
 ): bool {
     let gross_value = math::mul(range_probability, order.quantity());
     let floor_amount = exposure.floor_amount_at_ms(
         exposure.order_floor_shares(order),
-        clock.timestamp_ms(),
+        now_ms,
     );
     let liquidation_threshold_value = predict_math::mul_div_round_up(
         floor_amount,

--- a/packages/predict/tests/strike_exposure/strike_exposure_tests.move
+++ b/packages/predict/tests/strike_exposure/strike_exposure_tests.move
@@ -11,6 +11,7 @@ use deepbook_predict::{
     i64,
     market_oracle,
     order,
+    pricing,
     protocol_config,
     pyth_source,
     strike_exposure
@@ -266,16 +267,15 @@ fun max_expiry_floor_premium_round_trips_at_float_scaling() {
 fun allocate_mint_order_below_min_principal_aborts() {
     let ctx = &mut tx_context::dummy();
     let (mut exposure, config, market, _cap, _admin_cap, pyth, clock) = setup_live_mint(ctx);
+    let live_context = pricing::live_context(config.pricing_config(), &market, &pyth, &clock);
 
     exposure.allocate_mint_order(
         config.pricing_config(),
-        &market,
-        &pyth,
+        &live_context,
         FORWARD_1000,
         constants::pos_inf!(),
         BELOW_MIN_PRINCIPAL_QUANTITY,
         order::leverage_one_x(),
-        &clock,
     );
     abort 999
 }
@@ -284,16 +284,15 @@ fun allocate_mint_order_below_min_principal_aborts() {
 fun allocate_mint_order_above_min_principal_succeeds() {
     let ctx = &mut tx_context::dummy();
     let (mut exposure, config, market, cap, admin_cap, pyth, clock) = setup_live_mint(ctx);
+    let live_context = pricing::live_context(config.pricing_config(), &market, &pyth, &clock);
 
     let (minted_order, _fee_amount) = exposure.allocate_mint_order(
         config.pricing_config(),
-        &market,
-        &pyth,
+        &live_context,
         FORWARD_1000,
         constants::pos_inf!(),
         ABOVE_MIN_PRINCIPAL_QUANTITY,
         order::leverage_one_x(),
-        &clock,
     );
 
     assert_eq!(minted_order.entry_probability(), UP_AT_FORWARD_PROBABILITY);


### PR DESCRIPTION
## Summary
- Introduce `pricing::LivePricingContext` (forward, SVI, `now_ms`, `time_to_expiry`) built once per flow by `pricing::live_context`, which performs the market-active and live-oracle-freshness checks a single time.
- Thread the immutable context through mint allocation, the trade-time liquidation pass, and live redeem/close instead of re-deriving forward / SVI / time at each step, so every sub-operation in a flow sees one consistent time snapshot.
- Touches `expiry_market.move`, `pricing.move`, `strike_exposure.move` (+ a strike-exposure test).

## Key decisions
- **Sample-once-thread-context**: collapses the wall-clock-axis time-dependent pricing inputs to a single sampling point per flow, reducing the "sampled the right value at the right phase" audit burden across mint, liquidation, and redeem.
- Epoch-axis state (`active_stake` via `update_stake`) is intentionally **not** folded into the context — it is a different time axis and stays sampled per-flow.

## Test plan
- [x] `sui move test --path packages/predict --gas-limit 100000000000` — 446 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
