### PR TITLE
Split PropBook oracle schema from Predict

### DIFF
--- a/.claude/rules/predict-indexer.md
+++ b/.claude/rules/predict-indexer.md
@@ -3,11 +3,14 @@ paths:
   - "crates/predict-server/**"
   - "crates/predict-indexer/**"
   - "crates/predict-schema/**"
+  - "crates/oracle-server/**"
+  - "crates/oracle-indexer/**"
+  - "crates/oracle-schema/**"
 ---
 
 # Predict Indexer / Server Rules
 
-Read this when editing `crates/predict-schema/**`, `crates/predict-indexer/**`, or `crates/predict-server/**`. These crates index the Predict package's on-chain events into Postgres and serve them over HTTP. They **mirror** the core DeepBook crates (`crates/{schema,indexer,server}`) but are independent and intentionally improve on a few core patterns. When a rule here conflicts with what core does, this file wins **for Predict crates only** — do not change core to match, and do not copy core's known weaknesses forward.
+Read this when editing `crates/predict-schema/**`, `crates/predict-indexer/**`, `crates/predict-server/**`, `crates/oracle-schema/**`, `crates/oracle-indexer/**`, or `crates/oracle-server/**`. These crates index the Predict and Propbook packages' on-chain events into Postgres and serve them over HTTP. They **mirror** the core DeepBook crates (`crates/{schema,indexer,server}`) but are independent and intentionally improve on a few core patterns. When a rule here conflicts with what core does, this file wins **for Predict / Propbook crates only** — do not change core to match, and do not copy core's known weaknesses forward.
 
 Also read `.claude/rules/indexer.md` (shared operational gotchas: migrations can't use `CREATE INDEX CONCURRENTLY`, `IF NOT EXISTS` for idempotency, 3 connection pools, the `to_timestamp()::timestamp` cast).
 
@@ -16,7 +19,10 @@ Also read `.claude/rules/indexer.md` (shared operational gotchas: migrations can
 - `predict-schema` — **lib** crate. Diesel `embed_migrations!`, generated `schema.rs`, `models.rs`. Mirrors `crates/schema`.
 - `predict-indexer` — **binary**. Event handlers, `PredictEventMeta`, `PredictEnv`, the handler macro, `main.rs` bootstrap, materialized-view refresh. Mirrors `crates/indexer`.
 - `predict-server` — **binary**. `Reader`, routes, `/status`, `/health`. Mirrors `crates/server`.
-- Same Postgres DB as core, **separate tables**, separate indexer process, separate watermark namespace (pipeline names are unique). Core crates stay untouched.
+- `oracle-schema` — **lib** crate for Propbook/oracle tables and migrations. Keep oracle migrations here, never in `predict-schema`.
+- `oracle-indexer` — **binary**. Propbook event handlers, `OracleEventMeta`, `OracleEnv`, own materialized-view refresh.
+- `oracle-server` — **binary**. Propbook/oracle HTTP API.
+- Predict and Propbook use **separate Postgres DBs** and separate schema crates. The oracle binaries use `ORACLE_DATABASE_URL` and run `oracle_schema::MIGRATIONS`; they must not run `predict_schema::MIGRATIONS`.
 
 ## Mirror Core Verbatim (do not reinvent)
 
@@ -64,7 +70,7 @@ The framework reprocesses checkpoints **at-least-once** and concurrent pipelines
 - Basic analytics MV tables (vault NAV/PnL timeline, liquidation stats, funding/exposure) live here for quick local/quant tests; the real scale work is ClickHouse, so keep these few and simple.
 - Every MV **must** have a `UNIQUE` index (required for `REFRESH ... CONCURRENTLY`). Register its name in `MATERIALIZED_VIEWS_TO_REFRESH` (`crates/predict-indexer/src/materialized_view_refresh.rs`).
 - Build MVs over the raw tables, ordered by the `(checkpoint, tx_index, event_index)` triple.
-- **Bound every time-bucketed MV to a 30-day trailing window** (`checkpoint_timestamp_ms >= EXTRACT(EPOCH FROM now())::BIGINT * 1000 - 2592000000`): `REFRESH` is a full recompute, so an unwindowed MV gets slower forever. Current MVs: `market_activity_1h`, `vault_flows_1h`, `liquidation_stats_1h`, `oracle_prices_1m` (windowed) and `position_cashflow` (keyed by position root, NOT windowed — revisit before mainnet). Bucket with integer math `(checkpoint_timestamp_ms / 3600000) * 3600000`, not `date_trunc`.
+- **Bound every time-bucketed MV to a 30-day trailing window** (`checkpoint_timestamp_ms >= EXTRACT(EPOCH FROM now())::BIGINT * 1000 - 2592000000`): `REFRESH` is a full recompute, so an unwindowed MV gets slower forever. Current Predict MVs: `market_activity_1h`, `vault_flows_1h`, `liquidation_stats_1h` (windowed) and `position_cashflow` (keyed by position root, NOT windowed — revisit before mainnet). Current Propbook MV: `oracle_spot_1m` in `oracle-schema` (windowed). Bucket with integer math, not `date_trunc`.
 
 ## Large tables / aggregation
 
@@ -87,9 +93,9 @@ Pre-deploy, the Predict package address is empty. `PredictEnv::package_addresses
 
 ## Pre-Push Checklist (per crate)
 
-1. `cargo fmt -p predict-schema -p predict-indexer -p predict-server` — CI fails on formatting.
-2. `cargo build -p predict-indexer -p predict-server` — catch compile errors.
-3. `cargo test -p predict-indexer -p predict-server`.
+1. `cargo fmt -p predict-schema -p predict-indexer -p predict-server -p oracle-schema -p oracle-indexer -p oracle-server` — CI fails on formatting.
+2. `cargo build -p predict-indexer -p predict-server -p oracle-indexer -p oracle-server` — catch compile errors.
+3. `cargo test -p predict-schema -p predict-indexer -p predict-server -p oracle-schema -p oracle-indexer -p oracle-server`.
 4. New raw table → confirm: 7-col header + `tx_index` + `event_index`, composite index on `(checkpoint, tx_index, event_index)`, lookup-id indexes, `TEXT` for u256, `NUMERIC` for unbounded u64, and the matching `schema.rs` `table!` block + `models.rs` Insertable (omit the DB-default `timestamp`).
 
 ## Package Config

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ DeepBook is a decentralized order book on the Sui blockchain.
 - **Unit tests** (`packages/**/tests/**`) → `.claude/rules/unit-tests.md`
 - **Predict simulations** (`packages/predict/simulations/**`) → `.claude/rules/predict-simulations.md`
 - **Core indexer** (`crates/{server,schema,indexer}/**`) → `.claude/rules/indexer.md`
-- **Predict indexer** (`crates/predict-{server,schema,indexer}/**`) → `.claude/rules/predict-indexer.md` *(also read `indexer.md` for shared operational gotchas)*
+- **Predict / Propbook indexers** (`crates/{predict,oracle}-{server,schema,indexer}/**`) → `.claude/rules/predict-indexer.md` *(also read `indexer.md` for shared operational gotchas)*
 - **Scripts** (`scripts/**`) → `.claude/rules/scripts.md`
 
 ### Manual-Trigger Rules — read when the request matches

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5862,7 +5862,7 @@ dependencies = [
  "diesel",
  "diesel-async",
  "move-core-types",
- "predict-schema",
+ "oracle-schema",
  "prometheus",
  "serde",
  "serde_json",
@@ -5880,6 +5880,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "oracle-schema"
+version = "0.1.0"
+dependencies = [
+ "bigdecimal",
+ "chrono",
+ "diesel",
+ "diesel_migrations",
+ "serde",
+ "sui-field-count",
+]
+
+[[package]]
 name = "oracle-server"
 version = "0.1.0"
 dependencies = [
@@ -5894,7 +5906,7 @@ dependencies = [
  "futures",
  "governor",
  "http-body-util",
- "predict-schema",
+ "oracle-schema",
  "prometheus",
  "secrecy",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/predict-schema",
     "crates/predict-indexer",
     "crates/predict-server",
+    "crates/oracle-schema",
     "crates/oracle-indexer",
     "crates/oracle-server",
 ]

--- a/crates/oracle-indexer/Cargo.toml
+++ b/crates/oracle-indexer/Cargo.toml
@@ -31,7 +31,7 @@ sui-types.workspace = true
 move-core-types.workspace = true
 telemetry-subscribers.workspace = true
 
-predict-schema = { path = "../predict-schema" }
+oracle-schema = { path = "../oracle-schema" }
 
 [[bin]]
 name = "oracle-indexer"

--- a/crates/oracle-indexer/src/handlers/block_scholes_observation_inserted_handler.rs
+++ b/crates/oracle-indexer/src/handlers/block_scholes_observation_inserted_handler.rs
@@ -9,7 +9,7 @@ use crate::meta::OracleEventMeta;
 use crate::models::{BlockScholesObservationEvent, ObservationInserted};
 use crate::traits::MoveStruct;
 use crate::OracleEnv;
-use predict_schema::models::BlockScholesObservation as Row;
+use oracle_schema::models::BlockScholesObservation as Row;
 use sui_indexer_alt_framework::pipeline::Processor;
 use sui_indexer_alt_framework::types::full_checkpoint_content::Checkpoint;
 
@@ -67,7 +67,7 @@ impl sui_indexer_alt_framework::postgres::handler::Handler
     ) -> anyhow::Result<usize> {
         use diesel_async::RunQueryDsl;
         Ok(
-            diesel::insert_into(predict_schema::schema::block_scholes_observation::table)
+            diesel::insert_into(oracle_schema::schema::block_scholes_observation::table)
                 .values(values)
                 .on_conflict_do_nothing()
                 .execute(conn)

--- a/crates/oracle-indexer/src/handlers/block_scholes_observation_recorded_handler.rs
+++ b/crates/oracle-indexer/src/handlers/block_scholes_observation_recorded_handler.rs
@@ -9,7 +9,7 @@ use crate::meta::OracleEventMeta;
 use crate::models::{BlockScholesObservationEvent, ObservationRecorded};
 use crate::traits::MoveStruct;
 use crate::OracleEnv;
-use predict_schema::models::BlockScholesObservation as Row;
+use oracle_schema::models::BlockScholesObservation as Row;
 use sui_indexer_alt_framework::pipeline::Processor;
 use sui_indexer_alt_framework::types::full_checkpoint_content::Checkpoint;
 
@@ -67,7 +67,7 @@ impl sui_indexer_alt_framework::postgres::handler::Handler
     ) -> anyhow::Result<usize> {
         use diesel_async::RunQueryDsl;
         Ok(
-            diesel::insert_into(predict_schema::schema::block_scholes_observation::table)
+            diesel::insert_into(oracle_schema::schema::block_scholes_observation::table)
                 .values(values)
                 .on_conflict_do_nothing()
                 .execute(conn)

--- a/crates/oracle-indexer/src/handlers/mod.rs
+++ b/crates/oracle-indexer/src/handlers/mod.rs
@@ -16,7 +16,7 @@ pub mod pyth_observation_recorded_handler;
 /// tx-filter differ. The `process` loop iterates
 /// `checkpoint.transactions.iter().enumerate()` to capture `tx_index`, and per
 /// event sets `package` from the event's own type address. The insert target is
-/// `predict_schema::schema::$table`.
+/// `oracle_schema::schema::$table`.
 ///
 /// This is the right tool for the registry events (`OracleSourceRegistered`,
 /// `OracleBound`) which are concrete (non-generic) structs. The observation
@@ -85,7 +85,7 @@ macro_rules! define_oracle_handler {
                 conn: &mut sui_pg_db::Connection<'a>,
             ) -> anyhow::Result<usize> {
                 use diesel_async::RunQueryDsl;
-                Ok(diesel::insert_into(predict_schema::schema::$table::table)
+                Ok(diesel::insert_into(oracle_schema::schema::$table::table)
                     .values(values)
                     .on_conflict_do_nothing()
                     .execute(conn)

--- a/crates/oracle-indexer/src/handlers/observation_map.rs
+++ b/crates/oracle-indexer/src/handlers/observation_map.rs
@@ -16,7 +16,7 @@ use crate::meta::OracleEventMeta;
 use crate::models::{BlockScholesObservationEvent, PythObservationEvent, I64};
 use bigdecimal::BigDecimal;
 use move_core_types::language_storage::{StructTag, TypeTag};
-use predict_schema::models::{BlockScholesObservation as BsRow, PythObservation as PythRow};
+use oracle_schema::models::{BlockScholesObservation as BsRow, PythObservation as PythRow};
 
 /// Walk one generic step into a `StructTag`'s first type parameter, returning
 /// the inner `StructTag` when it is a struct type.

--- a/crates/oracle-indexer/src/handlers/oracle_bound_handler.rs
+++ b/crates/oracle-indexer/src/handlers/oracle_bound_handler.rs
@@ -1,6 +1,6 @@
 use crate::meta::OracleEventMeta;
 use crate::models::OracleBound as Ev;
-use predict_schema::models::OracleBound as Row;
+use oracle_schema::models::OracleBound as Row;
 
 pub fn map(ev: &Ev, meta: &OracleEventMeta) -> Row {
     Row {
@@ -28,7 +28,7 @@ crate::define_oracle_handler! {
     name: OracleBoundHandler,
     processor_name: "oracle_bound",
     event_type: crate::models::OracleBound,
-    db_model: predict_schema::models::OracleBound,
+    db_model: oracle_schema::models::OracleBound,
     table: oracle_bound,
     map_event: |event, meta| map(&event, &meta)
 }

--- a/crates/oracle-indexer/src/handlers/oracle_source_registered_handler.rs
+++ b/crates/oracle-indexer/src/handlers/oracle_source_registered_handler.rs
@@ -1,6 +1,6 @@
 use crate::meta::OracleEventMeta;
 use crate::models::OracleSourceRegistered as Ev;
-use predict_schema::models::OracleSourceRegistered as Row;
+use oracle_schema::models::OracleSourceRegistered as Row;
 
 pub fn map(ev: &Ev, meta: &OracleEventMeta) -> Row {
     Row {
@@ -24,7 +24,7 @@ crate::define_oracle_handler! {
     name: OracleSourceRegisteredHandler,
     processor_name: "oracle_source_registered",
     event_type: crate::models::OracleSourceRegistered,
-    db_model: predict_schema::models::OracleSourceRegistered,
+    db_model: oracle_schema::models::OracleSourceRegistered,
     table: oracle_source_registered,
     map_event: |event, meta| map(&event, &meta)
 }

--- a/crates/oracle-indexer/src/handlers/pyth_observation_inserted_handler.rs
+++ b/crates/oracle-indexer/src/handlers/pyth_observation_inserted_handler.rs
@@ -8,7 +8,7 @@ use crate::meta::OracleEventMeta;
 use crate::models::{ObservationInserted, PythObservationEvent};
 use crate::traits::MoveStruct;
 use crate::OracleEnv;
-use predict_schema::models::PythObservation as Row;
+use oracle_schema::models::PythObservation as Row;
 use sui_indexer_alt_framework::pipeline::Processor;
 use sui_indexer_alt_framework::types::full_checkpoint_content::Checkpoint;
 
@@ -64,7 +64,7 @@ impl sui_indexer_alt_framework::postgres::handler::Handler for PythObservationIn
     ) -> anyhow::Result<usize> {
         use diesel_async::RunQueryDsl;
         Ok(
-            diesel::insert_into(predict_schema::schema::pyth_observation::table)
+            diesel::insert_into(oracle_schema::schema::pyth_observation::table)
                 .values(values)
                 .on_conflict_do_nothing()
                 .execute(conn)

--- a/crates/oracle-indexer/src/handlers/pyth_observation_recorded_handler.rs
+++ b/crates/oracle-indexer/src/handlers/pyth_observation_recorded_handler.rs
@@ -8,7 +8,7 @@ use crate::meta::OracleEventMeta;
 use crate::models::{ObservationRecorded, PythObservationEvent};
 use crate::traits::MoveStruct;
 use crate::OracleEnv;
-use predict_schema::models::PythObservation as Row;
+use oracle_schema::models::PythObservation as Row;
 use sui_indexer_alt_framework::pipeline::Processor;
 use sui_indexer_alt_framework::types::full_checkpoint_content::Checkpoint;
 
@@ -64,7 +64,7 @@ impl sui_indexer_alt_framework::postgres::handler::Handler for PythObservationRe
     ) -> anyhow::Result<usize> {
         use diesel_async::RunQueryDsl;
         Ok(
-            diesel::insert_into(predict_schema::schema::pyth_observation::table)
+            diesel::insert_into(oracle_schema::schema::pyth_observation::table)
                 .values(values)
                 .on_conflict_do_nothing()
                 .execute(conn)

--- a/crates/oracle-indexer/src/main.rs
+++ b/crates/oracle-indexer/src/main.rs
@@ -10,7 +10,7 @@ use oracle_indexer::materialized_view_refresh::{
     materialized_view_refresh_service, MaterializedViewRefreshMetrics,
 };
 use oracle_indexer::OracleEnv;
-use predict_schema::MIGRATIONS;
+use oracle_schema::MIGRATIONS;
 use prometheus::Registry;
 use std::net::SocketAddr;
 use sui_indexer_alt_framework::ingestion::ingestion_client::IngestionClientArgs;
@@ -40,9 +40,9 @@ struct Args {
     #[clap(env, long, default_value = "0.0.0.0:9186")]
     metrics_address: SocketAddr,
     #[clap(
-        env,
+        env = "ORACLE_DATABASE_URL",
         long,
-        default_value = "postgres://postgres:postgrespw@localhost:5432/predict"
+        default_value = "postgres://postgres:postgrespw@localhost:5432/propbook"
     )]
     database_url: Url,
     /// Oracle environment.

--- a/crates/oracle-schema/Cargo.toml
+++ b/crates/oracle-schema/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "oracle-schema"
+version = "0.1.0"
+authors = ["Mysten Labs <build@mystenlabs.com>"]
+license = "Apache-2.0"
+publish = false
+edition = "2021"
+
+[dependencies]
+sui-field-count = { git = "https://github.com/MystenLabs/sui.git", branch = "testnet" }
+diesel = { workspace = true, features = ["postgres", "uuid", "chrono", "serde_json", "numeric"] }
+diesel_migrations.workspace = true
+serde = { workspace = true }
+bigdecimal = { version = "0.4", features = ["serde"] }
+chrono = "0.4"

--- a/crates/oracle-schema/migrations/2026-06-13-000000-0000_oracle_lane/up.sql
+++ b/crates/oracle-schema/migrations/2026-06-13-000000-0000_oracle_lane/up.sql
@@ -1,9 +1,8 @@
--- Oracle-lane tables for the standalone Propbook oracle indexer.
+-- Oracle-lane tables for the standalone Propbook oracle indexer and server.
 --
--- These tables live in the shared `predict` Postgres DB but are written by the
--- separate `oracle-indexer` process (own watermark namespace) and read by
--- `oracle-server`. `embed_migrations!` runs every migration from both indexers;
--- the IF NOT EXISTS guards make that double-run idempotent.
+-- These tables live in the Propbook oracle Postgres DB, separate from the
+-- Predict DB. They are written by the `oracle-indexer` process (own watermark
+-- namespace) and read by `oracle-server`.
 --
 -- Standard 9-column event header (event_digest PK + digest/sender/checkpoint/
 -- tx_index/event_index/timestamp/checkpoint_timestamp_ms/package) mirrors the

--- a/crates/oracle-schema/src/lib.rs
+++ b/crates/oracle-schema/src/lib.rs
@@ -1,0 +1,6 @@
+use diesel_migrations::{embed_migrations, EmbeddedMigrations};
+
+pub mod models;
+pub mod schema;
+
+pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations");

--- a/crates/oracle-schema/src/models.rs
+++ b/crates/oracle-schema/src/models.rs
@@ -1,0 +1,108 @@
+use crate::schema::{
+    block_scholes_observation, oracle_bound, oracle_source_registered, oracle_spot_1m,
+    pyth_observation,
+};
+use bigdecimal::BigDecimal;
+use diesel::{Identifiable, Insertable, Queryable, Selectable};
+use serde::Serialize;
+use sui_field_count::FieldCount;
+
+#[derive(Queryable, Selectable, Insertable, Identifiable, Debug, FieldCount, Serialize)]
+#[diesel(table_name = pyth_observation, primary_key(event_digest))]
+pub struct PythObservation {
+    pub event_digest: String,
+    pub digest: String,
+    pub sender: String,
+    pub checkpoint: i64,
+    pub tx_index: i64,
+    pub event_index: i64,
+    pub checkpoint_timestamp_ms: i64,
+    pub package: String,
+    pub propbook_oracle_id: String,
+    pub pyth_source_id: i64,
+    pub price_magnitude: BigDecimal,
+    pub price_is_negative: bool,
+    pub exponent_magnitude: i32,
+    pub exponent_is_negative: bool,
+    pub source_timestamp_us: BigDecimal,
+    pub normalized_spot: Option<BigDecimal>,
+    pub source_timestamp_ms: i64,
+    pub update_timestamp_ms: i64,
+    pub is_exact: bool,
+}
+
+#[derive(Queryable, Selectable, Insertable, Identifiable, Debug, FieldCount, Serialize)]
+#[diesel(table_name = block_scholes_observation, primary_key(event_digest))]
+pub struct BlockScholesObservation {
+    pub event_digest: String,
+    pub digest: String,
+    pub sender: String,
+    pub checkpoint: i64,
+    pub tx_index: i64,
+    pub event_index: i64,
+    pub checkpoint_timestamp_ms: i64,
+    pub package: String,
+    pub propbook_oracle_id: String,
+    pub bs_source_id: i64,
+    pub expiry_ms: i64,
+    pub spot: BigDecimal,
+    pub forward: BigDecimal,
+    pub svi_a: BigDecimal,
+    pub svi_b: BigDecimal,
+    pub svi_rho: BigDecimal,
+    pub svi_m: BigDecimal,
+    pub svi_sigma: BigDecimal,
+    pub normalized_spot: Option<BigDecimal>,
+    pub normalized_forward: Option<BigDecimal>,
+    pub source_timestamp_ms: i64,
+    pub update_timestamp_ms: i64,
+    pub is_exact: bool,
+}
+
+#[derive(Queryable, Selectable, Insertable, Identifiable, Debug, FieldCount, Serialize)]
+#[diesel(table_name = oracle_source_registered, primary_key(event_digest))]
+pub struct OracleSourceRegistered {
+    pub event_digest: String,
+    pub digest: String,
+    pub sender: String,
+    pub checkpoint: i64,
+    pub tx_index: i64,
+    pub event_index: i64,
+    pub checkpoint_timestamp_ms: i64,
+    pub package: String,
+    pub oracle_kind: i16,
+    pub source_id: i64,
+    pub propbook_oracle_id: String,
+}
+
+#[derive(Queryable, Selectable, Insertable, Identifiable, Debug, FieldCount, Serialize)]
+#[diesel(table_name = oracle_bound, primary_key(event_digest))]
+pub struct OracleBound {
+    pub event_digest: String,
+    pub digest: String,
+    pub sender: String,
+    pub checkpoint: i64,
+    pub tx_index: i64,
+    pub event_index: i64,
+    pub checkpoint_timestamp_ms: i64,
+    pub package: String,
+    pub propbook_underlying_id: i64,
+    pub oracle_kind: i16,
+    pub source_id: i64,
+    pub propbook_oracle_id: String,
+    pub value_kind: i16,
+}
+
+#[derive(Queryable, Selectable, Debug, Serialize)]
+#[diesel(table_name = oracle_spot_1m)]
+pub struct OracleSpot1m {
+    pub propbook_oracle_id: String,
+    pub expiry_ms: i64,
+    pub bucket_ms: i64,
+    pub open: BigDecimal,
+    pub high: BigDecimal,
+    pub low: BigDecimal,
+    pub close: BigDecimal,
+    pub forward: BigDecimal,
+    pub update_count: i64,
+}

--- a/crates/oracle-schema/src/schema.rs
+++ b/crates/oracle-schema/src/schema.rs
@@ -1,0 +1,127 @@
+// @generated automatically by Diesel CLI.
+
+diesel::table! {
+    watermarks (pipeline) {
+        pipeline -> Text,
+        epoch_hi_inclusive -> Int8,
+        checkpoint_hi_inclusive -> Int8,
+        tx_hi -> Int8,
+        timestamp_ms_hi_inclusive -> Int8,
+        reader_lo -> Int8,
+        pruner_timestamp -> Timestamp,
+        pruner_hi -> Int8,
+    }
+}
+
+diesel::table! {
+    pyth_observation (event_digest) {
+        event_digest -> Text,
+        digest -> Text,
+        sender -> Text,
+        checkpoint -> Int8,
+        tx_index -> Int8,
+        event_index -> Int8,
+        timestamp -> Timestamp,
+        checkpoint_timestamp_ms -> Int8,
+        package -> Text,
+        propbook_oracle_id -> Text,
+        pyth_source_id -> Int8,
+        price_magnitude -> Numeric,
+        price_is_negative -> Bool,
+        exponent_magnitude -> Int4,
+        exponent_is_negative -> Bool,
+        source_timestamp_us -> Numeric,
+        normalized_spot -> Nullable<Numeric>,
+        source_timestamp_ms -> Int8,
+        update_timestamp_ms -> Int8,
+        is_exact -> Bool,
+    }
+}
+
+diesel::table! {
+    block_scholes_observation (event_digest) {
+        event_digest -> Text,
+        digest -> Text,
+        sender -> Text,
+        checkpoint -> Int8,
+        tx_index -> Int8,
+        event_index -> Int8,
+        timestamp -> Timestamp,
+        checkpoint_timestamp_ms -> Int8,
+        package -> Text,
+        propbook_oracle_id -> Text,
+        bs_source_id -> Int8,
+        expiry_ms -> Int8,
+        spot -> Numeric,
+        forward -> Numeric,
+        svi_a -> Numeric,
+        svi_b -> Numeric,
+        svi_rho -> Numeric,
+        svi_m -> Numeric,
+        svi_sigma -> Numeric,
+        normalized_spot -> Nullable<Numeric>,
+        normalized_forward -> Nullable<Numeric>,
+        source_timestamp_ms -> Int8,
+        update_timestamp_ms -> Int8,
+        is_exact -> Bool,
+    }
+}
+
+diesel::table! {
+    oracle_source_registered (event_digest) {
+        event_digest -> Text,
+        digest -> Text,
+        sender -> Text,
+        checkpoint -> Int8,
+        tx_index -> Int8,
+        event_index -> Int8,
+        timestamp -> Timestamp,
+        checkpoint_timestamp_ms -> Int8,
+        package -> Text,
+        oracle_kind -> Int2,
+        source_id -> Int8,
+        propbook_oracle_id -> Text,
+    }
+}
+
+diesel::table! {
+    oracle_bound (event_digest) {
+        event_digest -> Text,
+        digest -> Text,
+        sender -> Text,
+        checkpoint -> Int8,
+        tx_index -> Int8,
+        event_index -> Int8,
+        timestamp -> Timestamp,
+        checkpoint_timestamp_ms -> Int8,
+        package -> Text,
+        propbook_underlying_id -> Int8,
+        oracle_kind -> Int2,
+        source_id -> Int8,
+        propbook_oracle_id -> Text,
+        value_kind -> Int2,
+    }
+}
+
+diesel::table! {
+    oracle_spot_1m (propbook_oracle_id, expiry_ms, bucket_ms) {
+        propbook_oracle_id -> Text,
+        expiry_ms -> Int8,
+        bucket_ms -> Int8,
+        open -> Numeric,
+        high -> Numeric,
+        low -> Numeric,
+        close -> Numeric,
+        forward -> Numeric,
+        update_count -> Int8,
+    }
+}
+
+diesel::allow_tables_to_appear_in_same_query!(
+    block_scholes_observation,
+    oracle_bound,
+    oracle_source_registered,
+    oracle_spot_1m,
+    pyth_observation,
+    watermarks,
+);

--- a/crates/oracle-schema/tests/schema_boundary_tests.rs
+++ b/crates/oracle-schema/tests/schema_boundary_tests.rs
@@ -1,0 +1,29 @@
+use std::fs;
+
+const ORACLE_SCHEMA_MARKERS: &[&str] = &[
+    "pyth_observation",
+    "block_scholes_observation",
+    "oracle_source_registered",
+    "oracle_bound",
+    "oracle_spot_1m",
+];
+
+#[test]
+fn oracle_migrations_create_oracle_tables() {
+    let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
+    let mut migration_sql = String::new();
+    for entry in fs::read_dir(migrations_dir).expect("read oracle migrations dir") {
+        let up_sql = entry.expect("read migration entry").path().join("up.sql");
+        if up_sql.exists() {
+            migration_sql.push_str(&fs::read_to_string(&up_sql).expect("read migration up.sql"));
+        }
+    }
+
+    for marker in ORACLE_SCHEMA_MARKERS {
+        assert!(
+            migration_sql.contains(marker),
+            "oracle migrations should define oracle schema marker `{}`",
+            marker,
+        );
+    }
+}

--- a/crates/oracle-server/Cargo.toml
+++ b/crates/oracle-server/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 edition = "2021"
 
 [dependencies]
-predict-schema = { path = "../predict-schema" }
+oracle-schema = { path = "../oracle-schema" }
 tokio.workspace = true
 futures = "0.3.31"
 clap = { workspace = true, features = ["env"] }

--- a/crates/oracle-server/src/main.rs
+++ b/crates/oracle-server/src/main.rs
@@ -17,9 +17,9 @@ struct Args {
     #[clap(env, long, default_value = "0.0.0.0:9187")]
     metrics_address: SocketAddr,
     #[clap(
-        env,
+        env = "ORACLE_DATABASE_URL",
         long,
-        default_value = "postgres://postgres:postgrespw@localhost:5432/predict"
+        default_value = "postgres://postgres:postgrespw@localhost:5432/propbook"
     )]
     database_url: Url,
     #[clap(env, long, default_value = "https://fullnode.mainnet.sui.io:443")]

--- a/crates/oracle-server/src/reader.rs
+++ b/crates/oracle-server/src/reader.rs
@@ -4,10 +4,10 @@
 use crate::error::OracleError;
 use crate::metrics::RpcMetrics;
 use diesel::{ExpressionMethods, OptionalExtension, QueryDsl, SelectableHelper};
-use predict_schema::models::{
+use oracle_schema::models::{
     BlockScholesObservation, OracleBound, OracleSourceRegistered, OracleSpot1m, PythObservation,
 };
-use predict_schema::schema;
+use oracle_schema::schema;
 use serde_json::Value;
 
 use diesel_async::RunQueryDsl;

--- a/crates/predict-schema/migrations/2026-06-10-000000-0000_predict_schema/up.sql
+++ b/crates/predict-schema/migrations/2026-06-10-000000-0000_predict_schema/up.sql
@@ -351,7 +351,7 @@ CREATE TABLE IF NOT EXISTS market_created (
     package                          TEXT      NOT NULL,
     expiry_market_id                 TEXT      NOT NULL,
     pool_vault_id                    TEXT      NOT NULL,
-    propbook_underlying_id           BIGINT    NOT NULL, -- u32 Propbook underlying; join oracle_bound for the oracle
+    propbook_underlying_id           BIGINT    NOT NULL, -- u32 Propbook underlying; join Propbook oracle binding data for the oracle
     expiry                           BIGINT    NOT NULL,
     tick_size                        NUMERIC   NOT NULL  -- raw-price-per-tick; raw strike = order tick * tick_size
 );

--- a/crates/predict-schema/src/models.rs
+++ b/crates/predict-schema/src/models.rs
@@ -1,14 +1,12 @@
-use crate::schema::block_scholes_observation;
 use crate::schema::{
     builder_code_created, builder_code_set, builder_fees_claimed, deep_staked, deep_unstaked,
     ewma_config_updated, expiry_cash_rebalanced, expiry_cash_received,
     expiry_cash_template_config_updated, expiry_market_mint_paused_updated,
     expiry_profit_materialized, flush_executed, liquidated_order_redeemed, liquidation_stats_1h,
     live_order_redeemed, lp_request_state, market_activity_1h, market_config_snapshot,
-    market_created, market_settled, oracle_bound, oracle_source_registered, oracle_spot_1m,
-    order_liquidated, order_minted, order_state, position_cashflow, predict_deposit_cap_minted,
-    predict_manager_created, predict_trade_cap_minted, predict_withdraw_cap_minted,
-    pricing_config_updated, pyth_observation, request_cancelled, risk_config_updated,
+    market_created, market_settled, order_liquidated, order_minted, order_state, position_cashflow,
+    predict_deposit_cap_minted, predict_manager_created, predict_trade_cap_minted,
+    predict_withdraw_cap_minted, pricing_config_updated, request_cancelled, risk_config_updated,
     settled_order_redeemed, stake_config_updated, strike_exposure_template_config_updated,
     supply_filled, supply_requested, trading_paused_updated, vault_flows_1h, withdraw_filled,
     withdraw_requested,
@@ -797,107 +795,4 @@ pub struct PositionCashflow {
     pub settled_payout: BigDecimal,
     pub settled_quantity_closed: BigDecimal,
     pub liquidated_quantity_closed: BigDecimal,
-}
-
-// Oracle-lane raw models, inserted by the standalone oracle-indexer. As with
-// the predict raw models, the DB-default `timestamp` column is omitted.
-
-#[derive(Queryable, Selectable, Insertable, Identifiable, Debug, FieldCount, Serialize)]
-#[diesel(table_name = pyth_observation, primary_key(event_digest))]
-pub struct PythObservation {
-    pub event_digest: String,
-    pub digest: String,
-    pub sender: String,
-    pub checkpoint: i64,
-    pub tx_index: i64,
-    pub event_index: i64,
-    pub checkpoint_timestamp_ms: i64,
-    pub package: String,
-    pub propbook_oracle_id: String,
-    pub pyth_source_id: i64,
-    pub price_magnitude: BigDecimal,
-    pub price_is_negative: bool,
-    pub exponent_magnitude: i32,
-    pub exponent_is_negative: bool,
-    pub source_timestamp_us: BigDecimal,
-    pub normalized_spot: Option<BigDecimal>,
-    pub source_timestamp_ms: i64,
-    pub update_timestamp_ms: i64,
-    pub is_exact: bool,
-}
-
-#[derive(Queryable, Selectable, Insertable, Identifiable, Debug, FieldCount, Serialize)]
-#[diesel(table_name = block_scholes_observation, primary_key(event_digest))]
-pub struct BlockScholesObservation {
-    pub event_digest: String,
-    pub digest: String,
-    pub sender: String,
-    pub checkpoint: i64,
-    pub tx_index: i64,
-    pub event_index: i64,
-    pub checkpoint_timestamp_ms: i64,
-    pub package: String,
-    pub propbook_oracle_id: String,
-    pub bs_source_id: i64,
-    pub expiry_ms: i64,
-    pub spot: BigDecimal,
-    pub forward: BigDecimal,
-    pub svi_a: BigDecimal,
-    pub svi_b: BigDecimal,
-    pub svi_rho: BigDecimal,
-    pub svi_m: BigDecimal,
-    pub svi_sigma: BigDecimal,
-    pub normalized_spot: Option<BigDecimal>,
-    pub normalized_forward: Option<BigDecimal>,
-    pub source_timestamp_ms: i64,
-    pub update_timestamp_ms: i64,
-    pub is_exact: bool,
-}
-
-#[derive(Queryable, Selectable, Insertable, Identifiable, Debug, FieldCount, Serialize)]
-#[diesel(table_name = oracle_source_registered, primary_key(event_digest))]
-pub struct OracleSourceRegistered {
-    pub event_digest: String,
-    pub digest: String,
-    pub sender: String,
-    pub checkpoint: i64,
-    pub tx_index: i64,
-    pub event_index: i64,
-    pub checkpoint_timestamp_ms: i64,
-    pub package: String,
-    pub oracle_kind: i16,
-    pub source_id: i64,
-    pub propbook_oracle_id: String,
-}
-
-#[derive(Queryable, Selectable, Insertable, Identifiable, Debug, FieldCount, Serialize)]
-#[diesel(table_name = oracle_bound, primary_key(event_digest))]
-pub struct OracleBound {
-    pub event_digest: String,
-    pub digest: String,
-    pub sender: String,
-    pub checkpoint: i64,
-    pub tx_index: i64,
-    pub event_index: i64,
-    pub checkpoint_timestamp_ms: i64,
-    pub package: String,
-    pub propbook_underlying_id: i64,
-    pub oracle_kind: i16,
-    pub source_id: i64,
-    pub propbook_oracle_id: String,
-    pub value_kind: i16,
-}
-
-#[derive(Queryable, Selectable, Debug, Serialize)]
-#[diesel(table_name = oracle_spot_1m)]
-pub struct OracleSpot1m {
-    pub propbook_oracle_id: String,
-    pub expiry_ms: i64,
-    pub bucket_ms: i64,
-    pub open: BigDecimal,
-    pub high: BigDecimal,
-    pub low: BigDecimal,
-    pub close: BigDecimal,
-    pub forward: BigDecimal,
-    pub update_count: i64,
 }

--- a/crates/predict-schema/src/schema.rs
+++ b/crates/predict-schema/src/schema.rs
@@ -788,115 +788,7 @@ diesel::table! {
     }
 }
 
-// Oracle-lane tables, written by the standalone oracle-indexer (own watermark
-// namespace) into the shared predict DB; see the 2026-06-13 oracle_lane
-// migration.
-diesel::table! {
-    pyth_observation (event_digest) {
-        event_digest -> Text,
-        digest -> Text,
-        sender -> Text,
-        checkpoint -> Int8,
-        tx_index -> Int8,
-        event_index -> Int8,
-        timestamp -> Timestamp,
-        checkpoint_timestamp_ms -> Int8,
-        package -> Text,
-        propbook_oracle_id -> Text,
-        pyth_source_id -> Int8,
-        price_magnitude -> Numeric,
-        price_is_negative -> Bool,
-        exponent_magnitude -> Int4,
-        exponent_is_negative -> Bool,
-        source_timestamp_us -> Numeric,
-        normalized_spot -> Nullable<Numeric>,
-        source_timestamp_ms -> Int8,
-        update_timestamp_ms -> Int8,
-        is_exact -> Bool,
-    }
-}
-
-diesel::table! {
-    block_scholes_observation (event_digest) {
-        event_digest -> Text,
-        digest -> Text,
-        sender -> Text,
-        checkpoint -> Int8,
-        tx_index -> Int8,
-        event_index -> Int8,
-        timestamp -> Timestamp,
-        checkpoint_timestamp_ms -> Int8,
-        package -> Text,
-        propbook_oracle_id -> Text,
-        bs_source_id -> Int8,
-        expiry_ms -> Int8,
-        spot -> Numeric,
-        forward -> Numeric,
-        svi_a -> Numeric,
-        svi_b -> Numeric,
-        svi_rho -> Numeric,
-        svi_m -> Numeric,
-        svi_sigma -> Numeric,
-        normalized_spot -> Nullable<Numeric>,
-        normalized_forward -> Nullable<Numeric>,
-        source_timestamp_ms -> Int8,
-        update_timestamp_ms -> Int8,
-        is_exact -> Bool,
-    }
-}
-
-diesel::table! {
-    oracle_source_registered (event_digest) {
-        event_digest -> Text,
-        digest -> Text,
-        sender -> Text,
-        checkpoint -> Int8,
-        tx_index -> Int8,
-        event_index -> Int8,
-        timestamp -> Timestamp,
-        checkpoint_timestamp_ms -> Int8,
-        package -> Text,
-        oracle_kind -> Int2,
-        source_id -> Int8,
-        propbook_oracle_id -> Text,
-    }
-}
-
-diesel::table! {
-    oracle_bound (event_digest) {
-        event_digest -> Text,
-        digest -> Text,
-        sender -> Text,
-        checkpoint -> Int8,
-        tx_index -> Int8,
-        event_index -> Int8,
-        timestamp -> Timestamp,
-        checkpoint_timestamp_ms -> Int8,
-        package -> Text,
-        propbook_underlying_id -> Int8,
-        oracle_kind -> Int2,
-        source_id -> Int8,
-        propbook_oracle_id -> Text,
-        value_kind -> Int2,
-    }
-}
-
-diesel::table! {
-    oracle_spot_1m (propbook_oracle_id, expiry_ms, bucket_ms) {
-        propbook_oracle_id -> Text,
-        expiry_ms -> Int8,
-        bucket_ms -> Int8,
-        open -> Numeric,
-        high -> Numeric,
-        low -> Numeric,
-        close -> Numeric,
-        forward -> Numeric,
-        update_count -> Int8,
-    }
-}
-
 diesel::allow_tables_to_appear_in_same_query!(
-    block_scholes_observation,
     builder_code_created,
     builder_code_set,
     builder_fees_claimed,
@@ -917,14 +809,10 @@ diesel::allow_tables_to_appear_in_same_query!(
     market_config_snapshot,
     market_created,
     market_settled,
-    oracle_bound,
-    oracle_source_registered,
-    oracle_spot_1m,
     order_liquidated,
     order_minted,
     order_state,
     position_cashflow,
-    pyth_observation,
     predict_deposit_cap_minted,
     predict_manager_created,
     predict_trade_cap_minted,

--- a/crates/predict-schema/tests/schema_boundary_tests.rs
+++ b/crates/predict-schema/tests/schema_boundary_tests.rs
@@ -1,0 +1,37 @@
+use std::fs;
+
+const ORACLE_SCHEMA_MARKERS: &[&str] = &[
+    "pyth_observation",
+    "block_scholes_observation",
+    "oracle_source_registered",
+    "oracle_bound",
+    "oracle_spot_1m",
+];
+
+#[test]
+fn predict_schema_does_not_define_oracle_tables() {
+    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let checked_dirs = [manifest_dir.join("migrations"), manifest_dir.join("src")];
+    for dir in checked_dirs {
+        assert_no_oracle_markers(&dir);
+    }
+}
+
+fn assert_no_oracle_markers(dir: &std::path::Path) {
+    for entry in fs::read_dir(dir).expect("read predict schema dir") {
+        let path = entry.expect("read predict schema entry").path();
+        if path.is_dir() {
+            assert_no_oracle_markers(&path);
+            continue;
+        }
+        let contents = fs::read_to_string(&path).expect("read predict schema file");
+        for marker in ORACLE_SCHEMA_MARKERS {
+            assert!(
+                !contents.contains(marker),
+                "predict schema file {} unexpectedly references oracle schema marker `{}`",
+                path.display(),
+                marker,
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Split PropBook/oracle tables and migrations into a new `oracle-schema` crate.
- Point `oracle-indexer` and `oracle-server` at `oracle_schema::MIGRATIONS` and `ORACLE_DATABASE_URL`, defaulting to the local `propbook` DB.
- Remove oracle tables from `predict-schema` and add boundary tests/guidance to keep the schemas separate.

## Key decisions
- Kept Predict DB owning only Predict migrations and row models; the oracle service now owns PropBook tables including `oracle_spot_1m`.
- Kept the framework `watermarks` Diesel table in `oracle-schema` because `oracle-server` status reads it, while oracle migrations only create oracle-owned objects.
- Used `ORACLE_DATABASE_URL` for oracle binaries so deployment cannot accidentally reuse Predict `DATABASE_URL` defaults.

## Test plan
- [x] `cargo fmt -p predict-schema -p oracle-schema -p oracle-indexer -p oracle-server`
- [x] `CARGO_NET_GIT_FETCH_WITH_CLI=true cargo build -p predict-indexer -p predict-server -p oracle-indexer -p oracle-server`
- [x] `PATH=/opt/homebrew/opt/postgresql@15/bin:$PATH CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p predict-schema -p oracle-schema -p predict-indexer -p predict-server -p oracle-indexer -p oracle-server`
