### PR TITLE
Add Predict mint fee incentives

### DIFF
--- a/packages/predict/simulations/python_replay.py
+++ b/packages/predict/simulations/python_replay.py
@@ -1541,6 +1541,7 @@ def order_minted_update(
         "quantity": str(mint["quantity"]),
         "contribution": str(terms["contribution"]),
         "trading_fee": str(fee_amount),
+        "fee_incentive_subsidy": "0",
         "builder_fee": "0",
         "penalty_fee": "0",
     }
@@ -1550,10 +1551,13 @@ def apply_update(state: dict[str, int], update: dict[str, Any]) -> None:
     if update["type"] == "order_minted":
         contribution = int(update["contribution"])
         trading_fee = int(update["trading_fee"])
+        fee_incentive_subsidy = int(update.get("fee_incentive_subsidy", 0))
         builder_fee = int(update["builder_fee"])
         penalty_fee = int(update["penalty_fee"])
         quantity = int(update["quantity"])
-        state["manager_balance"] -= contribution + trading_fee + builder_fee + penalty_fee
+        state["manager_balance"] -= (
+            contribution + (trading_fee - fee_incentive_subsidy) + builder_fee + penalty_fee
+        )
         state["expiry_cash_balance"] += contribution + trading_fee + penalty_fee
         state["expiry_unresolved_trading_fees"] += trading_fee
         state["open_order_count"] += 1
@@ -1939,7 +1943,9 @@ def apply_manager_summary_update(summary: dict[str, int], update: dict[str, Any]
     update_type = update["type"]
     if update_type == "order_minted":
         summary["gross_paid_to_expiry"] += int(update["contribution"])
-        summary["trading_fees_paid"] += int(update["trading_fee"])
+        summary["trading_fees_paid"] += int(update["trading_fee"]) - int(
+            update.get("fee_incentive_subsidy", 0)
+        )
     elif update_type == "live_order_redeemed":
         summary["gross_received_from_expiry"] += int(update["redeem_amount"])
         summary["trading_fees_paid"] += int(update["trading_fee"])

--- a/packages/predict/simulations/src/sim.ts
+++ b/packages/predict/simulations/src/sim.ts
@@ -398,6 +398,7 @@ function normalizeOrderMinted(event: any, row: ScenarioRow): Record<string, unkn
         quantity: decimal(json.quantity),
         contribution: decimal(json.net_premium),
         trading_fee: decimal(json.trading_fee),
+        fee_incentive_subsidy: decimal(json.fee_incentive_subsidy ?? 0),
         builder_fee: decimal(json.builder_fee),
         penalty_fee: decimal(json.penalty_fee),
     };
@@ -612,10 +613,12 @@ function applyUpdate(state: EconomicState, update: Record<string, unknown>) {
     if (update.type === "order_minted") {
         const contribution = BigInt(decimal(update.contribution));
         const tradingFee = BigInt(decimal(update.trading_fee));
+        const feeIncentiveSubsidy = BigInt(decimal(update.fee_incentive_subsidy ?? 0));
         const builderFee = BigInt(decimal(update.builder_fee));
         const penaltyFee = BigInt(decimal(update.penalty_fee));
         const quantity = BigInt(decimal(update.quantity));
-        state.managerBalance -= contribution + tradingFee + builderFee + penaltyFee;
+        state.managerBalance -=
+            contribution + (tradingFee - feeIncentiveSubsidy) + builderFee + penaltyFee;
         state.expiryCashBalance += contribution + tradingFee + penaltyFee;
         state.expiryUnresolvedTradingFees += tradingFee;
         state.openOrderCount += 1n;

--- a/packages/predict/sources/constants.move
+++ b/packages/predict/sources/constants.move
@@ -108,6 +108,20 @@ public macro fun builder_fee_multiplier(): u64 { 100_000_000 }
 /// Maximum all-in builder fee rate per traded quantity.
 public macro fun max_builder_fee_rate(): u64 { 5_000_000 }
 
+// === Fee Incentives ===
+
+/// Fraction of the post-staking trading fee paid by sponsor-funded incentives.
+public(package) macro fun fee_incentive_subsidy_rate(): u64 { 200_000_000 }
+
+/// Fraction of normal expiry funding an expiry can hold in live fee incentives.
+public(package) macro fun fee_incentive_live_target_rate(): u64 { 20_000_000 }
+
+/// Fraction of normal expiry funding an expiry can receive over its lifetime.
+public(package) macro fun fee_incentive_lifetime_cap_rate(): u64 { 100_000_000 }
+
+/// Minimum DUSDC a single fee-incentive sponsorship may contribute.
+public(package) macro fun min_fee_incentive_sponsorship(): u64 { 10_000_000 }
+
 // === Time Constants ===
 
 /// Milliseconds in a 365-day year.

--- a/packages/predict/sources/events/order_events.move
+++ b/packages/predict/sources/events/order_events.move
@@ -32,7 +32,10 @@ public struct OrderMinted has copy, drop, store {
     quantity: u64,
     /// Net premium the user paid into LP backing, in DUSDC base units.
     net_premium: u64,
+    /// Full trading fee collected by the expiry, including any sponsor-paid subsidy.
     trading_fee: u64,
+    /// Portion of `trading_fee` paid from expiry-local fee incentives.
+    fee_incentive_subsidy: u64,
     builder_fee: u64,
     /// EWMA gas-price congestion surcharge retained by the pool, in DUSDC base units.
     penalty_fee: u64,
@@ -114,6 +117,7 @@ public(package) fun emit_order_minted(
     entry_probability: u64,
     net_premium: u64,
     trading_fee: u64,
+    fee_incentive_subsidy: u64,
     builder_fee: u64,
     penalty_fee: u64,
 ) {
@@ -130,6 +134,7 @@ public(package) fun emit_order_minted(
         quantity: order.quantity(),
         net_premium,
         trading_fee,
+        fee_incentive_subsidy,
         builder_fee,
         penalty_fee,
         builder_code_id: if (builder_fee == 0) option::none() else builder_code_id,

--- a/packages/predict/sources/events/vault_events.move
+++ b/packages/predict/sources/events/vault_events.move
@@ -1,9 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Pool-vault events for Predict: DEEP staking, expiry cash/profit, and the async
-/// LP supply/withdraw request → flush lifecycle (the flush event carries the
-/// full-pool valuation it priced fills at).
+/// Pool-vault events for Predict: DEEP staking, expiry cash/profit, fee
+/// incentives, and the async LP supply/withdraw request → flush lifecycle (the
+/// flush event carries the full-pool valuation it priced fills at).
 module deepbook_predict::vault_events;
 
 use sui::event;
@@ -161,6 +161,34 @@ public struct FlushExecuted has copy, drop, store {
 public struct CapitalLocked has copy, drop, store {
     pool_vault_id: ID,
     amount: u64,
+}
+
+/// Emitted when a sponsor contributes DUSDC to the pool-level fee incentive reserve.
+public struct FeeIncentivesSponsored has copy, drop, store {
+    pool_vault_id: ID,
+    sponsor: address,
+    amount: u64,
+    reserve_after: u64,
+}
+
+/// Emitted when pool-level sponsor funds are allocated into an expiry's local
+/// fee-incentive balance.
+public struct FeeIncentivesAllocated has copy, drop, store {
+    pool_vault_id: ID,
+    expiry_market_id: ID,
+    amount: u64,
+    pool_reserve_after: u64,
+    expiry_incentive_balance_after: u64,
+    expiry_incentives_allocated_after: u64,
+}
+
+/// Emitted when a settled expiry returns unused local fee incentives to the
+/// pool-level reserve.
+public struct FeeIncentivesReturned has copy, drop, store {
+    pool_vault_id: ID,
+    expiry_market_id: ID,
+    amount: u64,
+    pool_reserve_after: u64,
 }
 
 // === Public-Package Functions ===
@@ -375,4 +403,50 @@ public(package) fun emit_flush_executed(
 
 public(package) fun emit_capital_locked(pool_vault_id: ID, amount: u64) {
     event::emit(CapitalLocked { pool_vault_id, amount });
+}
+
+public(package) fun emit_fee_incentives_sponsored(
+    pool_vault_id: ID,
+    sponsor: address,
+    amount: u64,
+    reserve_after: u64,
+) {
+    event::emit(FeeIncentivesSponsored {
+        pool_vault_id,
+        sponsor,
+        amount,
+        reserve_after,
+    });
+}
+
+public(package) fun emit_fee_incentives_allocated(
+    pool_vault_id: ID,
+    expiry_market_id: ID,
+    amount: u64,
+    pool_reserve_after: u64,
+    expiry_incentive_balance_after: u64,
+    expiry_incentives_allocated_after: u64,
+) {
+    event::emit(FeeIncentivesAllocated {
+        pool_vault_id,
+        expiry_market_id,
+        amount,
+        pool_reserve_after,
+        expiry_incentive_balance_after,
+        expiry_incentives_allocated_after,
+    });
+}
+
+public(package) fun emit_fee_incentives_returned(
+    pool_vault_id: ID,
+    expiry_market_id: ID,
+    amount: u64,
+    pool_reserve_after: u64,
+) {
+    event::emit(FeeIncentivesReturned {
+        pool_vault_id,
+        expiry_market_id,
+        amount,
+        pool_reserve_after,
+    });
 }

--- a/packages/predict/sources/expiry_cash.move
+++ b/packages/predict/sources/expiry_cash.move
@@ -51,11 +51,6 @@ public(package) fun free_cash(cash: &ExpiryCash): u64 {
     cash.balance().saturating_sub(cash.rebate_reserve())
 }
 
-/// Return payout plus unresolved rebate reserve cash required to keep the expiry backed.
-public(package) fun required_cash(cash: &ExpiryCash, payout_liability: u64): u64 {
-    payout_liability + cash.rebate_reserve()
-}
-
 /// Abort unless current cash covers payout liability plus unresolved rebate reserve.
 public(package) fun assert_backing(cash: &ExpiryCash, payout_liability: u64) {
     assert!(cash.balance() >= cash.required_cash(payout_liability), EInsufficientCash);
@@ -87,11 +82,12 @@ public(package) fun pay_authorized(cash: &mut ExpiryCash, amount: u64): Balance<
 }
 
 /// Join trade-fee cash and add nonzero fees to unresolved rebate basis.
-public(package) fun collect_trade_fee(cash: &mut ExpiryCash, fee: Balance<DUSDC>): u64 {
+public(package) fun collect_trade_fee(cash: &mut ExpiryCash, fee: Balance<DUSDC>) {
     let fee_amount = fee.value();
     cash.cash_balance.join(fee);
-    if (fee_amount > 0) {
-        cash.unresolved_trading_fees_paid = cash.unresolved_trading_fees_paid + fee_amount;
-    };
-    fee_amount
+    cash.unresolved_trading_fees_paid = cash.unresolved_trading_fees_paid + fee_amount;
+}
+
+fun required_cash(cash: &ExpiryCash, payout_liability: u64): u64 {
+    payout_liability + cash.rebate_reserve()
 }

--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -5,10 +5,10 @@
 ///
 /// An ExpiryMarket is the hot shared object for one expiry. It owns trade
 /// execution, strike exposure state, and an embedded expiry-cash custody
-/// component. Live oracle validation is delegated to `pricing::load_live_pricer`;
-/// this module owns market flow policy and then passes loaded `Pricer` snapshots
-/// into exposure business logic. Pool-wide PLP accounting and profit accounting
-/// remain outside this module.
+/// component, plus local sponsor-funded fee incentives. Live oracle validation is
+/// delegated to `pricing::load_live_pricer`; this module owns market flow policy
+/// and then passes loaded `Pricer` snapshots into exposure business logic.
+/// Pool-wide PLP accounting and profit accounting remain outside this module.
 module deepbook_predict::expiry_market;
 
 use account::{account::{Account, AccountWrapper, Auth}, account_registry::AccountRegistry};
@@ -46,6 +46,8 @@ public struct ExpiryMarket has key {
     settlement_price: Option<u64>,
     /// DUSDC custody, payout backing, and unresolved rebate reserve basis.
     cash: ExpiryCash,
+    /// Sponsor-funded DUSDC available to subsidize this market's taker fees.
+    fee_incentive_balance: Balance<DUSDC>,
     /// Exposure lifecycle state for this expiry's strike ticks.
     strike_exposure: StrikeExposure,
     /// Smoothed gas-price stats backing the congestion trade penalty.
@@ -81,6 +83,11 @@ public fun cash_balance(market: &ExpiryMarket): u64 {
 /// Return DUSDC reserved for unresolved trading loss rebates.
 public fun rebate_reserve(market: &ExpiryMarket): u64 {
     market.cash.rebate_reserve()
+}
+
+/// Return sponsor-funded DUSDC available to subsidize this market's taker fees.
+public fun fee_incentive_balance(market: &ExpiryMarket): u64 {
+    market.fee_incentive_balance.value()
 }
 
 /// Return the trading loss rebate rate snapshotted for this expiry.
@@ -384,6 +391,18 @@ public(package) fun receive_pool_cash(market: &mut ExpiryMarket, cash: Balance<D
     market.assert_cash_backing();
 }
 
+/// Receive sponsor-funded fee incentives allocated by the pool vault.
+public(package) fun receive_fee_incentives(market: &mut ExpiryMarket, incentives: Balance<DUSDC>) {
+    market.fee_incentive_balance.join(incentives);
+}
+
+/// Release all unused local fee incentives back to the pool reserve.
+public(package) fun release_fee_incentives(market: &mut ExpiryMarket): Balance<DUSDC> {
+    let amount = market.fee_incentive_balance.value();
+    if (amount == 0) return balance::zero();
+    market.fee_incentive_balance.split(amount)
+}
+
 /// Release pool cash while preserving expiry-local payout and rebate backing.
 public(package) fun release_pool_cash(market: &mut ExpiryMarket, amount: u64): Balance<DUSDC> {
     if (amount == 0) {
@@ -403,7 +422,7 @@ public(package) fun release_pool_cash(market: &mut ExpiryMarket, amount: u64): B
 public(package) fun release_settled_pool_cash(market: &mut ExpiryMarket): (Balance<DUSDC>, u64) {
     let settlement_price = market.settlement_price();
     let settled_liability = market.materialize_settled_liability();
-    let reserved_cash = market.cash.required_cash(settled_liability);
+    let reserved_cash = settled_liability + market.cash.rebate_reserve();
     market.cash.assert_backing(settled_liability);
 
     let returned_cash_amount = market.cash.balance() - reserved_cash;
@@ -441,6 +460,7 @@ public(package) fun create_and_share(
         expiry,
         settlement_price: option::none(),
         cash: expiry_cash::new(cash_config),
+        fee_incentive_balance: balance::zero(),
         strike_exposure: strike_exposure::new(
             expiry_market_id,
             expiry,
@@ -505,6 +525,12 @@ fun builder_fee_amount(builder_code_id: &Option<ID>, fee_amount: u64, quantity: 
     } else {
         0
     }
+}
+
+fun fee_incentive_subsidy_amount(market: &ExpiryMarket, fee_amount: u64): u64 {
+    math::mul(fee_amount, constants::fee_incentive_subsidy_rate!())
+        .min(fee_amount)
+        .min(market.fee_incentive_balance.value())
 }
 
 fun redeem_liquidated_order(
@@ -591,7 +617,8 @@ fun mint_internal(
     let fee_amount = config.stake_config().fee_amount_after_discount(raw_fee_amount, active_stake);
     let penalty_amount = market.ewma_penalty(config.ewma_config(), quantity, clock, ctx);
 
-    let (builder_fee_amount, builder_code_id) = market.settle_mint_payment(
+    let builder_code_id = predict_account::builder_code_id(account);
+    let (builder_fee_amount, fee_incentive_subsidy) = market.settle_mint_payment(
         account,
         &minted_order,
         net_premium,
@@ -609,6 +636,7 @@ fun mint_internal(
         entry_probability,
         net_premium,
         fee_amount,
+        fee_incentive_subsidy,
         builder_fee_amount,
         penalty_amount,
     );
@@ -711,7 +739,8 @@ fun redeem_live_internal(
         option::some(replacement_order_id)
     };
 
-    let (builder_fee_amount, penalty_amount, builder_code_id) = market.settle_live_redeem_payment(
+    let builder_code_id = predict_account::builder_code_id(account);
+    let (builder_fee_amount, penalty_amount) = market.settle_live_redeem_payment(
         account,
         redeem_amount,
         fee_amount,
@@ -766,11 +795,12 @@ fun redeem_settled_internal(
     );
 }
 
-/// Settle a mint payment and return the builder fee paid.
+/// Settle a mint payment and return the builder fee and fee incentive subsidy.
 ///
 /// The EWMA penalty is withdrawn alongside the net premium and fees, but rides
 /// into expiry cash as surplus: it is not part of the rebate fee basis and
-/// earns no builder cut.
+/// earns no builder cut. Fee incentives subsidize only the trader-paid portion
+/// of the trading fee; the expiry still collects the full fee amount.
 fun settle_mint_payment(
     market: &mut ExpiryMarket,
     account: &mut Account,
@@ -779,23 +809,26 @@ fun settle_mint_payment(
     fee_amount: u64,
     penalty_amount: u64,
     ctx: &mut TxContext,
-): (u64, Option<ID>) {
+): (u64, u64) {
     let quantity = order.quantity();
     let builder_code_id = predict_account::builder_code_id(account);
     let builder_fee_amount = builder_fee_amount(&builder_code_id, fee_amount, quantity);
-    let withdraw_amount = net_premium + fee_amount + builder_fee_amount + penalty_amount;
+    let fee_subsidy_amount = market.fee_incentive_subsidy_amount(fee_amount);
+    let trader_fee_amount = fee_amount - fee_subsidy_amount;
+    let withdraw_amount = net_premium + trader_fee_amount + builder_fee_amount + penalty_amount;
 
     predict_account::add_position(account, market.id(), order.id(), order.id(), ctx);
     let mut payment = account.withdraw<DUSDC>(withdraw_amount, ctx).into_balance();
     let builder_fee_payment = payment.split(builder_fee_amount);
     send_builder_fee(copy builder_code_id, builder_fee_payment);
-    let fee_payment = payment.split(fee_amount);
-    market.collect_trade_fee(account, fee_payment, ctx);
+    let mut fee_payment = payment.split(trader_fee_amount);
+    fee_payment.join(market.fee_incentive_balance.split(fee_subsidy_amount));
+    market.collect_trade_fee(account, fee_payment, trader_fee_amount, ctx);
     // Remaining balance is the net premium plus the penalty surplus.
     market.cash.receive(payment);
 
     market.assert_cash_backing();
-    (builder_fee_amount, builder_code_id)
+    (builder_fee_amount, fee_subsidy_amount)
 }
 
 /// Settle a live redeem and return the builder fee and penalty actually applied.
@@ -811,7 +844,7 @@ fun settle_live_redeem_payment(
     penalty_amount: u64,
     redeemed_quantity: u64,
     ctx: &mut TxContext,
-): (u64, u64, Option<ID>) {
+): (u64, u64) {
     let builder_code_id = predict_account::builder_code_id(account);
     let builder_fee_amount = builder_fee_amount(
         &builder_code_id,
@@ -825,14 +858,14 @@ fun settle_live_redeem_payment(
     let mut payout = market.cash.pay_authorized(redeem_amount);
     let fee = payout.split(fee_amount);
     let builder_fee = payout.split(builder_fee_amount);
-    market.collect_trade_fee(account, fee, ctx);
+    market.collect_trade_fee(account, fee, fee_amount, ctx);
     send_builder_fee(copy builder_code_id, builder_fee);
     // Penalty surplus stays in expiry cash rather than flowing to the redeemer.
     market.cash.receive(payout.split(penalty_amount));
 
     market.assert_cash_backing();
     account.deposit<DUSDC>(payout.into_coin(ctx));
-    (builder_fee_amount, penalty_amount, builder_code_id)
+    (builder_fee_amount, penalty_amount)
 }
 
 fun settle_settled_redeem_payment(
@@ -855,11 +888,11 @@ fun collect_trade_fee(
     market: &mut ExpiryMarket,
     account: &mut Account,
     fee: Balance<DUSDC>,
+    trader_fee_amount: u64,
     ctx: &mut TxContext,
 ) {
-    let fee_amount = market.cash.collect_trade_fee(fee);
-    if (fee_amount == 0) return;
-    predict_account::record_trading_fee_paid(account, market.id(), fee_amount, ctx);
+    market.cash.collect_trade_fee(fee);
+    predict_account::record_trading_fee_paid(account, market.id(), trader_fee_amount, ctx);
 }
 
 fun send_builder_fee(builder_code_id: Option<ID>, fee: Balance<DUSDC>) {

--- a/packages/predict/sources/plp/plp.move
+++ b/packages/predict/sources/plp/plp.move
@@ -4,15 +4,16 @@
 /// PLP token and pool vault.
 ///
 /// PoolVault owns the PLP treasury cap, the pooled DEEP staked by accounts, idle
-/// DUSDC, the protocol reserve, per-expiry cash accounting, and the async LP
-/// supply/withdraw queues. It coordinates the full-pool NAV valuation (a hot-potato
-/// aggregation over every active market) and the unified per-market cash flow
-/// (initial funding, live rebalance/sweep, and settled-market sweep with terminal
-/// profit materialization). LPs queue supply/withdraw requests routed through a
-/// loaded Account; the daily flush (`finish_flush`) drains them at the frozen pool
-/// NAV, minting/burning PLP and delivering fills to each account via the balance
-/// accumulator. Incentives moved to a separate staking contract; DEEP staking is an
-/// unrelated trading feature.
+/// DUSDC, the protocol reserve, sponsor-funded fee incentives, per-expiry cash
+/// accounting, and the async LP supply/withdraw queues. It coordinates the
+/// full-pool NAV valuation (a hot-potato aggregation over every active market) and
+/// the unified per-market cash flow (initial funding, live rebalance/sweep, and
+/// settled-market sweep with terminal profit materialization). LPs queue
+/// supply/withdraw requests routed through a loaded Account; the daily flush
+/// (`finish_flush`) drains them at the frozen pool NAV, minting/burning PLP and
+/// delivering fills to each account via the balance accumulator. PLP incentives
+/// moved to a separate staking contract; DEEP staking is an unrelated trading
+/// feature.
 module deepbook_predict::plp;
 
 use account::account::{AccountWrapper, Auth};
@@ -49,6 +50,7 @@ const EPlpPriceAboveCircuitBreaker: u64 = 12;
 const EAlreadyBootstrapped: u64 = 13;
 const EPoolNavDust: u64 = 14;
 const EBelowMinBootstrapLiquidity: u64 = 15;
+const EBelowMinFeeIncentiveSponsorship: u64 = 16;
 
 /// One-time witness type for Predict LP token registration.
 public struct PLP has drop {}
@@ -59,6 +61,8 @@ public struct PoolVault has key {
     /// Protocol-owned DUSDC (the materialized terminal-profit cut) excluded from
     /// PLP redemption.
     protocol_reserve_balance: Balance<DUSDC>,
+    /// Sponsor-funded DUSDC reserved for taker fee sponsorship, excluded from PLP NAV.
+    fee_incentive_reserve: Balance<DUSDC>,
     /// Pooled DEEP staked by all accounts for trading benefits. Per-account
     /// active/inactive amounts are mirrored in Predict account data.
     staked_deep: Balance<DEEP>,
@@ -123,6 +127,11 @@ public fun idle_balance(vault: &PoolVault): u64 {
 /// Return protocol-owned DUSDC excluded from PLP redemption.
 public fun protocol_reserve_balance(vault: &PoolVault): u64 {
     vault.protocol_reserve_balance.value()
+}
+
+/// Return sponsor-funded DUSDC available for future fee-incentive allocation.
+public fun fee_incentive_reserve(vault: &PoolVault): u64 {
+    vault.fee_incentive_reserve.value()
 }
 
 /// Return the total PLP share supply outstanding.
@@ -371,6 +380,31 @@ public fun rebalance_expiry_cash(
     vault.rebalance_expiry_cash_inner(market, config, propbook_registry, pyth, clock);
 }
 
+/// Sponsor taker fee incentives with DUSDC. Anyone may contribute; the payment
+/// joins a pool-level reserve that is excluded from PLP NAV and later allocated to
+/// expiry markets by the normal rebalance flow.
+public fun sponsor_fee_incentives(
+    vault: &mut PoolVault,
+    config: &ProtocolConfig,
+    payment: Coin<DUSDC>,
+    ctx: &TxContext,
+) {
+    config.assert_version();
+    config.assert_not_valuation_in_progress();
+    let amount = payment.value();
+    assert!(
+        amount >= constants::min_fee_incentive_sponsorship!(),
+        EBelowMinFeeIncentiveSponsorship,
+    );
+    vault.fee_incentive_reserve.join(payment.into_balance());
+    vault_events::emit_fee_incentives_sponsored(
+        vault.id(),
+        ctx.sender(),
+        amount,
+        vault.fee_incentive_reserve.value(),
+    );
+}
+
 /// Bootstrap the pool exactly once: permanently lock `payment` DUSDC of minimum
 /// liquidity. Mints matching PLP (1:1) into the book's locked balance — never
 /// withdrawable, so the caller receives no shares — and joins the DUSDC into idle.
@@ -504,6 +538,7 @@ public(package) fun new(treasury_cap: TreasuryCap<PLP>, ctx: &mut TxContext): Po
     PoolVault {
         id: object::new(ctx),
         protocol_reserve_balance: balance::zero(),
+        fee_incentive_reserve: balance::zero(),
         staked_deep: balance::zero(),
         lp: lp_book::new(treasury_cap, ctx),
         expiry_accounting: pool_accounting::new(ctx),
@@ -546,6 +581,8 @@ public(package) fun rebalance_expiry_cash_inner(
         vault.unregister_settled_expiry(market, config);
         return true
     };
+
+    vault.sync_fee_incentives(market, expiry_market_id);
 
     let (cash_balance, target_cash, sweep_threshold_cash) = expiry_rebalance_cash_terms(market);
     if (cash_balance < target_cash) {
@@ -617,6 +654,53 @@ public(package) fun lp_pool_value(
 
 // === Private Functions ===
 
+fun fee_incentive_live_target(): u64 {
+    math::mul(
+        constants::expiry_max_funding!(),
+        constants::fee_incentive_live_target_rate!(),
+    )
+}
+
+fun fee_incentive_lifetime_cap(): u64 {
+    math::mul(
+        constants::expiry_max_funding!(),
+        constants::fee_incentive_lifetime_cap_rate!(),
+    )
+}
+
+fun sync_fee_incentives(
+    vault: &mut PoolVault,
+    market: &mut ExpiryMarket,
+    expiry_market_id: ID,
+) {
+    let requested_allocation = fee_incentive_live_target()
+        .saturating_sub(market.fee_incentive_balance())
+        .min(vault.fee_incentive_reserve.value());
+    if (requested_allocation == 0) return;
+
+    let (allocation, allocated_after) = vault
+        .expiry_accounting
+        .record_fee_incentives_allocated_up_to(
+            expiry_market_id,
+            fee_incentive_lifetime_cap(),
+            requested_allocation,
+        );
+    if (allocation == 0) return;
+
+    let incentives = vault
+        .fee_incentive_reserve
+        .split(allocation);
+    market.receive_fee_incentives(incentives);
+    vault_events::emit_fee_incentives_allocated(
+        vault.id(),
+        expiry_market_id,
+        allocation,
+        vault.fee_incentive_reserve.value(),
+        market.fee_incentive_balance(),
+        allocated_after,
+    );
+}
+
 /// Abort before draining LP requests if the frozen mark implies a PLP price or pool
 /// NAV outside the executable protocol envelope. `total_supply > 0` is guaranteed by
 /// the genesis lock (`lock_capital`) + the `ENotBootstrapped` flush-start gate, so
@@ -659,11 +743,10 @@ fun expiry_rebalance_cash_terms(market: &ExpiryMarket): (u64, u64, u64) {
     (market.cash_balance(), target_cash, sweep_threshold_cash)
 }
 
-/// Settled-market sweep: deactivate the expiry, return its free cash to idle, and
-/// materialize its terminal profit. Idempotent — a settled market already swept
-/// returns zero cash and recognizes no further profit, so a second pass is a
-/// no-op. Emits only when something actually moved (cash returned or it was still
-/// active).
+/// Settled-market sweep: deactivate the expiry, return its free cash to idle,
+/// materialize its terminal profit, and return unused fee incentives to the pool
+/// reserve. Idempotent — a settled market already swept returns zero cash and
+/// recognizes no further profit, so a second pass is a no-op.
 fun unregister_settled_expiry(
     vault: &mut PoolVault,
     market: &mut ExpiryMarket,
@@ -676,9 +759,20 @@ fun unregister_settled_expiry(
         .expiry_accounting
         .receive_expiry_cash(expiry_market_id, returned_cash);
     vault.materialize_expiry_profit(config, expiry_market_id);
+    let returned_incentives = market.release_fee_incentives();
+    let returned_incentive_amount = returned_incentives.value();
+    vault.fee_incentive_reserve.join(returned_incentives);
 
     if (deactivated || returned_cash_amount > 0) {
         vault.emit_expiry_cash_received(market, returned_cash_amount, settlement_price);
+    };
+    if (returned_incentive_amount > 0) {
+        vault_events::emit_fee_incentives_returned(
+            vault.id(),
+            expiry_market_id,
+            returned_incentive_amount,
+            vault.fee_incentive_reserve.value(),
+        );
     };
 }
 

--- a/packages/predict/sources/plp/pool_accounting.move
+++ b/packages/predict/sources/plp/pool_accounting.move
@@ -6,9 +6,10 @@
 /// This module owns pool idle DUSDC custody, the durable set of expiries
 /// registered to a pool, the active expiry index used for valuation, DUSDC sent
 /// from the main pool into each expiry, DUSDC received back from each expiry,
-/// terminal cash watermarks, and per-expiry net funding cap checks. It does not
-/// classify expiry-local liabilities or apply PLP reserve policy; PoolVault uses
-/// the aggregate profit basis to price PLP and decide protocol reserve transfers.
+/// lifetime fee-incentive allocations, terminal cash watermarks, and per-expiry
+/// cap checks. It does not classify expiry-local liabilities or apply PLP reserve
+/// policy; PoolVault uses the aggregate profit basis to price PLP and decide
+/// protocol reserve transfers.
 module deepbook_predict::pool_accounting;
 
 use deepbook_predict::constants;
@@ -47,6 +48,8 @@ public struct RegisteredExpiry has store {
     sent_to_expiry: u64,
     /// DUSDC returned from this expiry to the main pool.
     received_from_expiry: u64,
+    /// Lifetime sponsor-funded fee incentives allocated to this expiry.
+    fee_incentives_allocated: u64,
     /// True once this expiry has started terminal profit/loss accounting.
     terminal_accounting_started: bool,
     /// Received amount already consumed by terminal accounting.
@@ -124,6 +127,7 @@ public(package) fun register_expiry(ledger: &mut Ledger, expiry_market_id: ID) {
             RegisteredExpiry {
                 sent_to_expiry: 0,
                 received_from_expiry: 0,
+                fee_incentives_allocated: 0,
                 terminal_accounting_started: false,
                 terminal_received_watermark: 0,
             },
@@ -166,6 +170,25 @@ public(package) fun send_expiry_cash(
     if (amount == 0) return balance::zero();
     ledger.record_sent_to_expiry(expiry_market_id, max_expiry_funding, amount);
     ledger.idle_balance.split(amount)
+}
+
+/// Record up to `requested_amount` of sponsor-funded fee incentives under the
+/// expiry lifetime cap. Returns the amount recorded and lifetime allocated total
+/// after the update.
+public(package) fun record_fee_incentives_allocated_up_to(
+    ledger: &mut Ledger,
+    expiry_market_id: ID,
+    max_fee_incentives: u64,
+    requested_amount: u64,
+): (u64, u64) {
+    ledger.assert_registered_expiry(expiry_market_id);
+    let flow = ledger.registered_expiries.borrow_mut(expiry_market_id);
+    assert!(!flow.terminal_accounting_started, ETerminalAccountingStarted);
+    let amount = requested_amount.min(
+        max_fee_incentives.saturating_sub(flow.fee_incentives_allocated),
+    );
+    flow.fee_incentives_allocated = flow.fee_incentives_allocated + amount;
+    (amount, flow.fee_incentives_allocated)
 }
 
 /// Receive DUSDC returned from an expiry.

--- a/packages/predict/sources/predict_account.move
+++ b/packages/predict/sources/predict_account.move
@@ -78,7 +78,7 @@ public fun expiry_position_count(account: &Account, expiry_market_id: ID): u64 {
     }
 }
 
-/// Return aggregate pool trading fees paid for one expiry market.
+/// Return aggregate pool trading fees this account paid for one expiry market.
 public fun trading_fees_paid(account: &Account, expiry_market_id: ID): u64 {
     if (!account.has_data<PredictApp>()) return 0;
     let d = data(account);
@@ -177,7 +177,7 @@ public(package) fun remove_position(
     position_root_id
 }
 
-/// Record pool trading fees paid for one expiry market.
+/// Record pool trading fees paid by this account for one expiry market.
 public(package) fun record_trading_fee_paid(
     account: &mut Account,
     expiry_market_id: ID,

--- a/packages/predict/tests/expiry_cash_tests.move
+++ b/packages/predict/tests/expiry_cash_tests.move
@@ -63,12 +63,11 @@ fun collecting_trade_fee_increases_cash_and_rebate_reserve() {
     config.set_trading_loss_rebate_rate(REBATE_RATE);
     let mut cash = expiry_cash::new(config);
 
-    let collected = cash.collect_trade_fee(coin::mint_for_testing<DUSDC>(
+    cash.collect_trade_fee(coin::mint_for_testing<DUSDC>(
         FEE_AMOUNT,
         ctx,
     ).into_balance());
 
-    assert_eq!(collected, FEE_AMOUNT);
     assert_eq!(cash.balance(), FEE_AMOUNT);
     assert_eq!(cash.rebate_reserve(), EXPECTED_REBATE_RESERVE);
     let remaining_cash = cash.pay_authorized(FEE_AMOUNT);
@@ -86,11 +85,10 @@ fun free_cash_nets_out_rebate_reserve_and_floors_at_zero() {
     let mut cash = expiry_cash::new(config);
 
     // Collect a fee: cash = 40, rebate_reserve = floor(40 * 0.5) = 20.
-    let collected = cash.collect_trade_fee(coin::mint_for_testing<DUSDC>(
+    cash.collect_trade_fee(coin::mint_for_testing<DUSDC>(
         FEE_AMOUNT,
         ctx,
     ).into_balance());
-    assert_eq!(collected, FEE_AMOUNT);
     assert_eq!(cash.free_cash(), FEE_AMOUNT - EXPECTED_REBATE_RESERVE); // 40 - 20 = 20
 
     // Drain cash below the reserve (pay 30 -> cash 10, reserve still 20): free cash

--- a/packages/predict/tests/flows/fee_incentive_flow_tests.move
+++ b/packages/predict/tests/flows/fee_incentive_flow_tests.move
@@ -1,0 +1,67 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Active flow coverage for sponsor-funded Predict fee incentives.
+#[test_only]
+module deepbook_predict::fee_incentive_flow_tests;
+
+use deepbook_predict::{constants, flow_test_helpers as helpers, plp, test_constants};
+use dusdc::dusdc::DUSDC;
+use std::unit_test::assert_eq;
+use sui::coin;
+
+/// Sponsor amount deliberately above the minimum sponsorship and below the
+/// per-market live target, so one rebalance allocates it all.
+const SPONSOR_AMOUNT: u64 = 20_000_000;
+
+#[test]
+fun sponsor_fee_incentives_increases_reserve_without_idle_nav() {
+    let mut fx = helpers::setup_market_default();
+    let expiry_id = fx.create_expiry(test_constants::default_expiry_ms());
+    fx.scenario_mut().next_tx(test_constants::admin());
+    let (pyth, bs, oracle_registry, mut vault, market, config) = fx.take_market(expiry_id);
+    let payment = coin::mint_for_testing<DUSDC>(SPONSOR_AMOUNT, fx.scenario_mut().ctx());
+
+    vault.sponsor_fee_incentives(&config, payment, fx.scenario_mut().ctx());
+
+    assert_eq!(vault.fee_incentive_reserve(), SPONSOR_AMOUNT);
+    assert_eq!(vault.idle_balance(), 0);
+    assert_eq!(vault.plp_total_supply(), 0);
+    helpers::return_market(pyth, bs, oracle_registry, vault, market, config);
+    fx.finish();
+}
+
+#[test, expected_failure(abort_code = plp::EBelowMinFeeIncentiveSponsorship)]
+fun sponsor_fee_incentives_below_minimum_aborts() {
+    let mut fx = helpers::setup_market_default();
+    let expiry_id = fx.create_expiry(test_constants::default_expiry_ms());
+    fx.scenario_mut().next_tx(test_constants::admin());
+    let (_pyth, _bs, _oracle_registry, mut vault, _market, config) = fx.take_market(expiry_id);
+    let payment = coin::mint_for_testing<DUSDC>(
+        constants::min_fee_incentive_sponsorship!() - 1,
+        fx.scenario_mut().ctx(),
+    );
+
+    vault.sponsor_fee_incentives(&config, payment, fx.scenario_mut().ctx());
+
+    abort 999
+}
+
+#[test]
+fun live_rebalance_allocates_fee_incentives_without_cash_top_up() {
+    let mut fx = helpers::setup_market_default();
+    let expiry_id = fx.create_expiry(test_constants::default_expiry_ms());
+    fx.scenario_mut().next_tx(test_constants::admin());
+    let (pyth, bs, oracle_registry, mut vault, mut market, config) = fx.take_market(expiry_id);
+    let payment = coin::mint_for_testing<DUSDC>(SPONSOR_AMOUNT, fx.scenario_mut().ctx());
+    vault.sponsor_fee_incentives(&config, payment, fx.scenario_mut().ctx());
+
+    fx.rebalance_expiry_cash(&mut vault, &mut market, &config, &oracle_registry, &pyth);
+
+    assert_eq!(vault.fee_incentive_reserve(), 0);
+    assert_eq!(vault.idle_balance(), 0);
+    assert_eq!(market.fee_incentive_balance(), SPONSOR_AMOUNT);
+    assert_eq!(market.cash_balance(), 0);
+    helpers::return_market(pyth, bs, oracle_registry, vault, market, config);
+    fx.finish();
+}

--- a/packages/predict/tests/plp/pool_accounting_tests.move
+++ b/packages/predict/tests/plp/pool_accounting_tests.move
@@ -18,6 +18,9 @@ use sui::balance;
 
 const EXPIRY_A: address = @0xA;
 const EXPIRY_B: address = @0xB;
+const FEE_INCENTIVE_CAP: u64 = 100;
+const FIRST_FEE_INCENTIVE_ALLOCATION: u64 = 40;
+const OVER_CAP_FEE_INCENTIVE_REQUEST: u64 = 80;
 
 #[test]
 fun send_and_receive_track_profit_basis() {
@@ -42,6 +45,40 @@ fun send_and_receive_track_profit_basis() {
     let (sent, received) = ledger.expiry_flow_amounts(id);
     assert_eq!(sent, 700);
     assert_eq!(received, 250);
+
+    destroy(ledger);
+}
+
+#[test]
+fun fee_incentives_allocate_up_to_lifetime_cap() {
+    let ctx = &mut tx_context::dummy();
+    let mut ledger = pool_accounting::new(ctx);
+    let id = object::id_from_address(EXPIRY_A);
+    ledger.register_expiry(id);
+
+    let (allocated, allocated_after) = ledger.record_fee_incentives_allocated_up_to(
+        id,
+        FEE_INCENTIVE_CAP,
+        FIRST_FEE_INCENTIVE_ALLOCATION,
+    );
+    assert_eq!(allocated, FIRST_FEE_INCENTIVE_ALLOCATION);
+    assert_eq!(allocated_after, FIRST_FEE_INCENTIVE_ALLOCATION);
+
+    let (allocated, allocated_after) = ledger.record_fee_incentives_allocated_up_to(
+        id,
+        FEE_INCENTIVE_CAP,
+        OVER_CAP_FEE_INCENTIVE_REQUEST,
+    );
+    assert_eq!(allocated, FEE_INCENTIVE_CAP - FIRST_FEE_INCENTIVE_ALLOCATION);
+    assert_eq!(allocated_after, FEE_INCENTIVE_CAP);
+
+    let (allocated, allocated_after) = ledger.record_fee_incentives_allocated_up_to(
+        id,
+        FEE_INCENTIVE_CAP,
+        FIRST_FEE_INCENTIVE_ALLOCATION,
+    );
+    assert_eq!(allocated, 0);
+    assert_eq!(allocated_after, FEE_INCENTIVE_CAP);
 
     destroy(ledger);
 }
@@ -127,6 +164,23 @@ fun funding_after_terminal_accounting_started_aborts() {
     // Latch terminal accounting, then attempt to fund the expiry again.
     ledger.materialize_expiry_profit(id);
     destroy(ledger.send_expiry_cash(id, 1000, 100));
+
+    abort 999
+}
+
+#[test, expected_failure(abort_code = pool_accounting::ETerminalAccountingStarted)]
+fun fee_incentive_allocation_after_terminal_accounting_started_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let mut ledger = pool_accounting::new(ctx);
+    let id = object::id_from_address(EXPIRY_A);
+    ledger.register_expiry(id);
+
+    ledger.materialize_expiry_profit(id);
+    ledger.record_fee_incentives_allocated_up_to(
+        id,
+        FEE_INCENTIVE_CAP,
+        FIRST_FEE_INCENTIVE_ALLOCATION,
+    );
 
     abort 999
 }


### PR DESCRIPTION
## Summary
- Add sponsor-funded Predict taker fee incentives that subsidize mint fees while keeping gross fees in expiry cash.
- Track incentive sponsorship, reserve allocation, lifetime caps, and returned balances through PLP/accounting events and state.
- Update tests and simulation mirrors for mint fee subsidies and fee accounting.

## Key decisions
- Subsidies are mint-only; live redeem fees remain unsubsidized.
- Fee incentives are sponsored into a pool-level reserve and allocated to live markets during rebalance up to live target/lifetime cap.
- Simulation scenarios do not sponsor incentives yet; mirrors now carry fee_incentive_subsidy and treat it as zero unless present.

## Test plan
- [x] sui move test --path packages/predict --gas-limit 100000000000
- [x] npx tsc --noEmit (packages/predict/simulations)
- [x] python3 -m py_compile python_replay.py
- [x] bash -n run.sh
- [x] generated and replayed normal + long Python scenarios into /tmp