### PR TITLE
Use permanent Block Scholes surface feeds

### DIFF
--- a/packages/predict/docs/concepts/markets-and-positions.md
+++ b/packages/predict/docs/concepts/markets-and-positions.md
@@ -126,7 +126,7 @@ While the market is active, leveraged positions are subject to liquidation. `liq
 | `Registry` | Underlying approval, minimum tick sizes, expiry uniqueness, versions, pause caps, creation entrypoints | package init | shared |
 | `PythFeed` (propbook) | One Pyth Lazer feed's global spot | `propbook` (permissionless) | shared |
 | `BlockScholesSpotFeed` (propbook) | One source id's BS spot + exact timestamp history | `propbook` (permissionless) | shared |
-| `BlockScholesForwardFeed` / `BlockScholesSVIFeed` (propbook) | One expiry's BS forward and SVI streams + exact timestamp history | `propbook` (permissionless) | shared |
+| `BlockScholesForwardFeed` / `BlockScholesSVIFeed` (propbook) | One source id's BS forward and SVI surfaces with per-expiry streams + exact timestamp history | `propbook` (permissionless) | shared |
 | `ExpiryMarket` | Per-expiry exposure, payout backing, cash, NAV; Propbook underlying ID | `create_expiry_market` (one per underlying and expiry) | shared |
 | `PredictManager` | DUSDC custody + positions keyed by `(expiry_market_id, order_id)` | `create_manager` / `create_self_owned_manager` | owned or shared |
 

--- a/packages/predict/docs/concepts/pricing-and-oracles.md
+++ b/packages/predict/docs/concepts/pricing-and-oracles.md
@@ -4,14 +4,14 @@ Predict prices its range digitals (binary options) off external Propbook feeds a
 
 ## Propbook feeds
 
-Predict separates the *spot* of the underlying asset, the per-expiry forward, and the SVI shape of the implied distribution into separate `propbook` feed objects. The feeds are permissionless to update — a verified provider payload is its own provenance proof — and none of them knows anything about Predict, markets, expiries, or positions.
+Predict separates the *spot* of the underlying asset, the forward surface, and the SVI shape of the implied distribution into separate permanent `propbook` feed objects. Forward and SVI values are keyed by expiry inside those feeds. The feeds are permissionless to update — a verified provider payload is its own provenance proof — and none of them knows anything about Predict, markets, expiries, or positions.
 
 | Input | propbook feed | What it carries | How Predict reads it |
 | --- | --- | --- | --- |
 | Spot price | `propbook::pyth_feed::PythFeed` | One global source-native Pyth payload per Pyth Lazer feed id, plus exact timestamp inserts | `normalized_spot()` and its `OracleRead` timestamp |
 | Block Scholes spot | `propbook::block_scholes_spot_feed::BlockScholesSpotFeed` | One source-level BS spot stream plus exact timestamp inserts | `normalized_spot()` and its `OracleRead` timestamp |
-| Block Scholes forward | `propbook::block_scholes_forward_feed::BlockScholesForwardFeed` | One forward stream per `(source id, expiry_ms)` plus exact timestamp inserts | `normalized_forward()` and its `OracleRead` timestamp |
-| SVI params | `propbook::block_scholes_svi_feed::BlockScholesSVIFeed` | One SVI stream per `(source id, expiry_ms)` plus exact timestamp inserts | `normalized_svi()` and its `OracleRead` timestamp |
+| Block Scholes forward | `propbook::block_scholes_forward_feed::BlockScholesForwardFeed` | One source-level forward object with per-expiry streams plus exact timestamp inserts | `normalized_forward(expiry_ms)` and its `OracleRead` timestamp |
+| SVI params | `propbook::block_scholes_svi_feed::BlockScholesSVIFeed` | One source-level SVI object with per-expiry streams plus exact timestamp inserts | `normalized_svi(expiry_ms)` and its `OracleRead` timestamp |
 
 The `pricing` module is a stateless read layer over these feeds. It resolves them on demand, checks BS price and SVI freshness, computes prices, and never mutates feed, pool, expiry, or position state.
 
@@ -30,7 +30,7 @@ The generic Propbook lane records a latest update only when the publisher timest
 
 ### Block Scholes spot, forward, and SVI
 
-Block Scholes data is split into three feed types. A `BlockScholesSpotFeed` exists per BS source id. A `BlockScholesForwardFeed` and a `BlockScholesSVIFeed` exist per `(source id, expiry_ms)`. The Propbook registry binds the source-level BS spot first, then binds each expiry's forward/SVI pair with `bind_block_scholes_expiry_to_underlying`, which asserts that the forward feed, SVI feed, and already-bound spot feed all share the same `bs_source_id`.
+Block Scholes data is split into three feed types. A `BlockScholesSpotFeed`, `BlockScholesForwardFeed`, and `BlockScholesSVIFeed` each exist once per BS source id. The forward and SVI feeds keep per-expiry rows internally, so the oracle objects are permanent while updates can target any expiry. The Propbook registry binds the source-level BS spot first, then binds the permanent forward/SVI surface pair with `bind_block_scholes_surface_to_underlying`, which asserts that the forward feed, SVI feed, and already-bound spot feed all share the same `bs_source_id`.
 
 Predict uses the latest fresh BS spot and the latest fresh expiry forward to compute the **basis** = `forward / spot`. That basis lets Predict combine the high-frequency Pyth spot with the Block Scholes forward shape (see [Resolving the live forward](#resolving-the-live-forward)). The spot and forward are independent lanes, so they have independent timestamps, but both must be fresh under the BS price freshness window before Predict uses either one.
 

--- a/packages/predict/docs/design/architecture.md
+++ b/packages/predict/docs/design/architecture.md
@@ -109,8 +109,8 @@ graph TD
         OR[OracleRegistry<br/>canonical bindings]
         PF[PythFeed<br/>global spot]
         BSS[BlockScholesSpotFeed<br/>source spot]
-        BSF[BlockScholesForwardFeed<br/>per-expiry forward]
-        BSV[BlockScholesSVIFeed<br/>per-expiry SVI]
+        BSF[BlockScholesForwardFeed<br/>source forward surface]
+        BSV[BlockScholesSVIFeed<br/>source SVI surface]
     end
 
     subgraph Owned caps
@@ -179,10 +179,10 @@ The live oracle data is fully outside Predict, in standalone, Predict-unaware sh
 
 - **`propbook::pyth_feed::PythFeed`** — one global source-native Pyth payload per Pyth Lazer feed ID plus exact timestamp inserts. Updated permissionlessly by anyone holding a verified `pyth_lazer::Update` (`update`); the verified update is its own provenance proof, so there is no writer cap. Predict reads `normalized_spot()` and the read's `source_timestamp_ms`, while raw source fields remain available through raw getters.
 - **`propbook::block_scholes_spot_feed::BlockScholesSpotFeed`** — one source-level BS spot payload plus exact timestamp inserts.
-- **`propbook::block_scholes_forward_feed::BlockScholesForwardFeed`** — one BS forward payload per `(source_id, expiry_ms)` plus exact timestamp inserts.
-- **`propbook::block_scholes_svi_feed::BlockScholesSVIFeed`** — one BS SVI payload per `(source_id, expiry_ms)` plus exact timestamp inserts.
+- **`propbook::block_scholes_forward_feed::BlockScholesForwardFeed`** — one source-level BS forward surface with per-expiry rows plus exact timestamp inserts.
+- **`propbook::block_scholes_svi_feed::BlockScholesSVIFeed`** — one source-level BS SVI surface with per-expiry rows plus exact timestamp inserts.
 
-Propbook binds the BS spot feed first, then binds an expiry's forward/SVI pair with a same-`bs_source_id` invariant. `pricing.move` resolves the live forward from these feeds: if the normalized Pyth spot is present and fresh, `forward = pyth_spot * (bs.forward / bs.spot)`; otherwise it falls back to the normalized Block Scholes `forward`. Missing, stale, or non-positive/unrepresentable Pyth spot is a fallback; an oversized normalized Pyth spot still aborts under Predict's pricing envelope. BS spot and forward must be fresh under `block_scholes_price_freshness_ms`, and SVI must be fresh under the looser `block_scholes_svi_freshness_ms`. `pricing` owns current Propbook binding, pre-expiry live-pricing liveness, feed freshness, the pricing-safe envelope, and the SVI binary-pricing math. The feeds carry their own package version and a forward-only `migrate`; Predict does **not** gate them under its version set. See [pricing and oracles](../concepts/pricing-and-oracles.md).
+Propbook binds the BS spot feed first, then binds the permanent forward/SVI surface pair with a same-`bs_source_id` invariant. `pricing.move` resolves the live forward from these feeds: if the normalized Pyth spot is present and fresh, `forward = pyth_spot * (bs.forward / bs.spot)`; otherwise it falls back to the normalized Block Scholes `forward` for the market expiry. Missing, stale, or non-positive/unrepresentable Pyth spot is a fallback; an oversized normalized Pyth spot still aborts under Predict's pricing envelope. BS spot and forward must be fresh under `block_scholes_price_freshness_ms`, and SVI must be fresh under the looser `block_scholes_svi_freshness_ms`. `pricing` owns current Propbook binding, pre-expiry live-pricing liveness, feed freshness, the pricing-safe envelope, and the SVI binary-pricing math. The feeds carry their own package version and a forward-only `migrate`; Predict does **not** gate them under its version set. See [pricing and oracles](../concepts/pricing-and-oracles.md).
 
 ## The pool, NAV, and the async LP layer
 

--- a/packages/predict/docs/design/decisions.md
+++ b/packages/predict/docs/design/decisions.md
@@ -143,10 +143,11 @@ the invariants these decisions must preserve, see [invariants.md](./invariants.m
 	  `market_oracle_config`, `market_oracle_writer_cap`, and `oracle_events` modules
 	  were deleted. Live data now comes from Predict-unaware Propbook feeds:
 	  `propbook::pyth_feed::PythFeed` (one global spot per Lazer feed), a source-level
-	  `propbook::block_scholes_spot_feed::BlockScholesSpotFeed`, and per-expiry
+	  `propbook::block_scholes_spot_feed::BlockScholesSpotFeed`, and source-level
 	  `propbook::block_scholes_forward_feed::BlockScholesForwardFeed` /
-	  `propbook::block_scholes_svi_feed::BlockScholesSVIFeed` objects. Each is updated
-	  permissionlessly from a self-authenticating verified update, so there is no writer capability.
+	  `propbook::block_scholes_svi_feed::BlockScholesSVIFeed` objects with per-expiry
+	  rows. Each is updated permissionlessly from a self-authenticating verified
+	  update, so there is no writer capability.
   *Rationale:* the oracle suite is reusable by the wider ecosystem and has a clean,
   Predict-agnostic boundary; possessing a verified `Update` is the only proof
   needed. *Rejected:* keeping the bespoke in-package oracle with an `AdminCap`-minted

--- a/packages/predict/docs/glossary.md
+++ b/packages/predict/docs/glossary.md
@@ -97,13 +97,14 @@ Predict reads it but does not own it.
 - **`BlockScholesSpotFeed`** — one source-level BS spot object plus exact
   timestamp history. Predict reads `normalized_spot()` and the read's
   `source_timestamp_ms`. Code module `propbook::block_scholes_spot_feed`.
-- **`BlockScholesForwardFeed`** — one BS forward object per `(source id,
-  expiry_ms)` plus exact timestamp history. Predict reads `normalized_forward()`
-  and the read's `source_timestamp_ms`. Code module
+- **`BlockScholesForwardFeed`** — one BS forward object per source id, with
+  per-expiry rows plus exact timestamp history. Predict reads
+  `normalized_forward(expiry_ms)` and the read's `source_timestamp_ms`. Code module
   `propbook::block_scholes_forward_feed`.
-- **`BlockScholesSVIFeed`** — one BS SVI object per `(source id, expiry_ms)` plus
-  exact timestamp history. Predict reads `normalized_svi()` and the read's
-  `source_timestamp_ms`. Code module `propbook::block_scholes_svi_feed`.
+- **`BlockScholesSVIFeed`** — one BS SVI object per source id, with per-expiry
+  rows plus exact timestamp history. Predict reads `normalized_svi(expiry_ms)`
+  and the read's `source_timestamp_ms`. Code module
+  `propbook::block_scholes_svi_feed`.
 - **SVI** — the stochastic-volatility-inspired parameterization of the implied
   volatility smile; the curve range probabilities are
   differenced off. Predict enforces its pricing-safe SVI envelope at read time

--- a/packages/predict/docs/overview.md
+++ b/packages/predict/docs/overview.md
@@ -20,7 +20,7 @@ Because the tick domain is absolute and fixed in advance, **market creation read
 
 ### Prices come from external feeds
 
-Live prices come from standalone, Predict-unaware feeds in the **propbook** package. A `PythFeed` holds one global source-native spot payload per Pyth Lazer feed id, updated permissionlessly from a verified Lazer payload and exposed through a normalized spot read. Block Scholes data is split into a source-level spot feed plus per-expiry forward and SVI feeds. Predict builds a forward and differences each range's probability off the SVI curve: when the normalized Pyth spot is fresh and usable it uses `forward = spot × basis(expiry)`; when the Pyth spot is absent, unusable, or stale it falls back to the BS forward feed. BS spot/forward must be fresh under the price window, and SVI must be fresh under its looser window. Propbook stores source facts; Predict validates the pricing-safe envelope at read time.
+Live prices come from standalone, Predict-unaware feeds in the **propbook** package. A `PythFeed` holds one global source-native spot payload per Pyth Lazer feed id, updated permissionlessly from a verified Lazer payload and exposed through a normalized spot read. Block Scholes data is split into permanent source-level spot, forward, and SVI feeds; the forward and SVI feeds store per-expiry rows. Predict builds a forward and differences each range's probability off the SVI curve: when the normalized Pyth spot is fresh and usable it uses `forward = spot × basis(expiry)`; when the Pyth spot is absent, unusable, or stale it falls back to the BS forward feed. BS spot/forward must be fresh under the price window, and SVI must be fresh under its looser window. Propbook stores source facts; Predict validates the pricing-safe envelope at read time.
 
 ### Settlement is passive
 
@@ -39,7 +39,7 @@ The pool (`PoolVault`) is the counterparty. Liquidity providers deposit DUSDC an
 | `PredictManager` | Per-trader DUSDC custody + positions, staking mirror, builder attribution | owned or shared |
 | `BuilderCode` | Accrues and claims builder fees for order-flow routers | derived shared |
 
-Oracle data is **not** a Predict object: the `PythFeed`, `BlockScholesSpotFeed`, `BlockScholesForwardFeed`, and `BlockScholesSVIFeed` shared objects are owned by the separate `propbook` package. Predict markets store a Propbook underlying ID; live pricing validates passed feed objects against Propbook's current canonical bindings for that underlying and expiry.
+Oracle data is **not** a Predict object: the `PythFeed`, `BlockScholesSpotFeed`, `BlockScholesForwardFeed`, and `BlockScholesSVIFeed` shared objects are owned by the separate `propbook` package. Predict markets store a Propbook underlying ID; live pricing validates passed feed objects against Propbook's current canonical bindings for that underlying and then reads the expiry row from the forward/SVI surfaces.
 
 Capabilities are owned objects: `AdminCap` (global policy, plus genesis-bootstrapping the pool), `MarketLifecycleCap` (market creation and the sole authority to start the pool flush), `PauseCap` (one-way emergency brake), and the per-manager `PredictTradeCap` / `PredictDepositCap` / `PredictWithdrawCap`. Block Scholes updates are submitted through propbook, not Predict. Detail in [architecture](./design/architecture.md).
 

--- a/packages/predict/simulations/src/runtime.ts
+++ b/packages/predict/simulations/src/runtime.ts
@@ -232,7 +232,7 @@ export async function nextOneMonthExpiryMs(): Promise<bigint> {
     return ((now / ONE_MONTH_MS) + 1n) * ONE_MONTH_MS;
 }
 
-interface SplitBlockScholesFeedIds {
+interface BlockScholesSurfaceFeedIds {
     bsSpotFeedId: string;
     bsForwardFeedId: string;
     bsSviFeedId: string;
@@ -563,8 +563,9 @@ export function mintLifecycleCapTx(recipient: string): Transaction {
 }
 
 // Admin-approve one Propbook underlying for Predict and permissionlessly create
-// the global Pyth spot feed plus the global BS spot feed. Per-expiry BS
-// forward/SVI feeds are created after the harness precomputes the cadence expiry.
+// the permanent Pyth spot feed plus the permanent BS spot feed. The permanent BS
+// forward/SVI surface feeds are created after this transaction so their IDs can be
+// captured from object changes.
 export function registerUnderlyingAndCreateFeedsTx(feedId: number): Transaction {
     const tx = new Transaction();
     tx.moveCall({
@@ -588,23 +589,15 @@ export function registerUnderlyingAndCreateFeedsTx(feedId: number): Transaction 
     return tx;
 }
 
-export function createBlockScholesExpiryFeedsTx(expiry: bigint): Transaction {
+export function createBlockScholesSurfaceFeedsTx(): Transaction {
     const tx = new Transaction();
     tx.moveCall({
         target: propbookTarget("registry", "create_and_share_block_scholes_forward_feed"),
-        arguments: [
-            tx.object(ORACLE_REGISTRY_ID),
-            tx.pure.u32(BS_UNDERLYING_ID),
-            tx.pure.u64(expiry),
-        ],
+        arguments: [tx.object(ORACLE_REGISTRY_ID), tx.pure.u32(BS_UNDERLYING_ID)],
     });
     tx.moveCall({
         target: propbookTarget("registry", "create_and_share_block_scholes_svi_feed"),
-        arguments: [
-            tx.object(ORACLE_REGISTRY_ID),
-            tx.pure.u32(BS_UNDERLYING_ID),
-            tx.pure.u64(expiry),
-        ],
+        arguments: [tx.object(ORACLE_REGISTRY_ID), tx.pure.u32(BS_UNDERLYING_ID)],
     });
     return tx;
 }
@@ -637,8 +630,8 @@ export function setCadenceConfigTx(params: {
 }
 
 // Admin-bind the Pyth spot feed and BS spot feed to one canonical Propbook
-// underlying. Must run after the feeds are shared. Per-expiry BS forward/SVI feeds
-// are bound separately before market creation.
+// underlying. Must run after the feeds are shared. The permanent BS forward/SVI
+// surface is bound separately before market creation.
 export function bindFeedsToUnderlyingTx(params: {
     pythFeedId: string;
     bsSpotFeedId: string;
@@ -665,12 +658,12 @@ export function bindFeedsToUnderlyingTx(params: {
     return tx;
 }
 
-export function bindBlockScholesExpiryFeedsToUnderlyingTx(
-    params: Pick<SplitBlockScholesFeedIds, "bsForwardFeedId" | "bsSviFeedId">,
+export function bindBlockScholesSurfaceToUnderlyingTx(
+    params: Pick<BlockScholesSurfaceFeedIds, "bsForwardFeedId" | "bsSviFeedId">,
 ): Transaction {
     const tx = new Transaction();
     tx.moveCall({
-        target: propbookTarget("registry", "bind_block_scholes_expiry_to_underlying"),
+        target: propbookTarget("registry", "bind_block_scholes_surface_to_underlying"),
         arguments: [
             tx.object(ORACLE_REGISTRY_ID),
             tx.object(ORACLE_REGISTRY_ADMIN_CAP_ID),
@@ -744,9 +737,9 @@ export function updatePythTrustedSignerTx(): Transaction {
 // Seed the split Block Scholes feeds (and Pyth spot) for the market's expiry. Market
 // creation itself reads NO spot now (absolute ticks need no grid centering), but a
 // fresh BS price/SVI source set must exist before the first mint and before any
-// flush valuation can price `current_nav`. The per-expiry feeds must already be
-// created and bound before market creation, but seeding the feed values happens
-// after the market is created.
+// flush valuation can price `current_nav`. The permanent forward/SVI feeds must
+// already be created and bound before market creation, but seeding the per-expiry
+// feed rows happens after the market is created.
 export async function seedOracleTx(params: {
     pythFeedId: string;
     bsSpotFeedId: string;

--- a/packages/predict/simulations/src/sim.ts
+++ b/packages/predict/simulations/src/sim.ts
@@ -28,9 +28,9 @@ import {
     POOL_VAULT_ID,
     PROTOCOL_CONFIG_ID,
     address,
-    bindBlockScholesExpiryFeedsToUnderlyingTx,
+    bindBlockScholesSurfaceToUnderlyingTx,
     bindFeedsToUnderlyingTx,
-    createBlockScholesExpiryFeedsTx,
+    createBlockScholesSurfaceFeedsTx,
     createAccountTx,
     createExpiryMarketTx,
     depositToAccountTx,
@@ -1126,8 +1126,8 @@ async function setupSimulation(
 
     const expectedExpiryMs = await nextOneMonthExpiryMs();
     result = await executeAndWait(
-        createBlockScholesExpiryFeedsTx(expectedExpiryMs),
-        "create_block_scholes_expiry_feeds",
+        createBlockScholesSurfaceFeedsTx(),
+        "create_block_scholes_surface_feeds",
     );
     const bsForwardFeedChange = result.objectChanges.find(
         (change: any) =>
@@ -1142,14 +1142,14 @@ async function setupSimulation(
     const bsForwardFeedId: string = bsForwardFeedChange.objectId;
     const bsSviFeedId: string = bsSviFeedChange.objectId;
     console.log(
-        `[${ts()}]   BlockScholes expiry feeds: expiry=${expectedExpiryMs} forward=${bsForwardFeedId} svi=${bsSviFeedId}`,
+        `[${ts()}]   BlockScholes surface feeds: forward=${bsForwardFeedId} svi=${bsSviFeedId}`,
     );
 
     await executeAndWait(
-        bindBlockScholesExpiryFeedsToUnderlyingTx({ bsForwardFeedId, bsSviFeedId }),
-        "bind_block_scholes_expiry_feeds",
+        bindBlockScholesSurfaceToUnderlyingTx({ bsForwardFeedId, bsSviFeedId }),
+        "bind_block_scholes_surface_feeds",
     );
-    console.log(`[${ts()}]   BlockScholes expiry feeds bound to underlying`);
+    console.log(`[${ts()}]   BlockScholes surface feeds bound to underlying`);
 
     result = await executeAndWait(
         createExpiryMarketTx({

--- a/packages/predict/sources/pricing/pricing.move
+++ b/packages/predict/sources/pricing/pricing.move
@@ -90,10 +90,9 @@ public(package) fun load_live_pricer(
         bs_spot,
         bs_forward,
         bs_svi,
-        expiry,
     );
     assert!(clock.timestamp_ms() < expiry, ELivePricingExpired);
-    let (forward, svi) = live_inputs(config, pyth, bs_spot, bs_forward, bs_svi, clock);
+    let (forward, svi) = live_inputs(config, pyth, bs_spot, bs_forward, bs_svi, expiry, clock);
     Pricer { expiry_market_id, forward, svi }
 }
 
@@ -116,7 +115,6 @@ fun assert_current_oracles(
     bs_spot: &BlockScholesSpotFeed,
     bs_forward: &BlockScholesForwardFeed,
     bs_svi: &BlockScholesSVIFeed,
-    expiry: u64,
 ) {
     assert!(
         propbook_registry
@@ -132,19 +130,13 @@ fun assert_current_oracles(
     );
     assert!(
         propbook_registry
-            .propbook_block_scholes_forward_id_for_underlying_expiry(
-                propbook_underlying_id,
-                expiry,
-            )
+            .propbook_block_scholes_forward_id_for_underlying(propbook_underlying_id)
             .contains(&bs_forward.id()),
         EWrongBlockScholesForwardFeed,
     );
     assert!(
         propbook_registry
-            .propbook_block_scholes_svi_id_for_underlying_expiry(
-                propbook_underlying_id,
-                expiry,
-            )
+            .propbook_block_scholes_svi_id_for_underlying(propbook_underlying_id)
             .contains(&bs_svi.id()),
         EWrongBlockScholesSVIFeed,
     );
@@ -163,6 +155,7 @@ fun live_inputs(
     bs_spot: &BlockScholesSpotFeed,
     bs_forward: &BlockScholesForwardFeed,
     bs_svi: &BlockScholesSVIFeed,
+    expiry: u64,
     clock: &Clock,
 ): (u64, SVIParams) {
     let bs_spot_read = bs_spot.normalized_spot();
@@ -178,7 +171,7 @@ fun live_inputs(
     );
     let bs_spot = bs_spot_read.read_value();
 
-    let bs_forward_read = bs_forward.normalized_forward();
+    let bs_forward_read = bs_forward.normalized_forward(expiry);
     assert!(bs_forward_read.is_some(), EBlockScholesPriceStale);
     let bs_forward_read = bs_forward_read.destroy_some();
     assert!(
@@ -191,7 +184,7 @@ fun live_inputs(
     );
     let bs_forward = bs_forward_read.read_value();
 
-    let svi_read = bs_svi.normalized_svi();
+    let svi_read = bs_svi.normalized_svi(expiry);
     assert!(svi_read.is_some(), EBlockScholesSVIStale);
     let svi_read = svi_read.destroy_some();
     assert!(

--- a/packages/predict/sources/registry/market_manager.move
+++ b/packages/predict/sources/registry/market_manager.move
@@ -156,19 +156,13 @@ public(package) fun next_deployable_market(
             );
             assert!(
                 propbook_registry
-                    .propbook_block_scholes_forward_id_for_underlying_expiry(
-                        propbook_underlying_id,
-                        expiry,
-                    )
+                    .propbook_block_scholes_forward_id_for_underlying(propbook_underlying_id)
                     .is_some(),
                 EBlockScholesForwardFeedNotBoundToUnderlying,
             );
             assert!(
                 propbook_registry
-                    .propbook_block_scholes_svi_id_for_underlying_expiry(
-                        propbook_underlying_id,
-                        expiry,
-                    )
+                    .propbook_block_scholes_svi_id_for_underlying(propbook_underlying_id)
                     .is_some(),
                 EBlockScholesSVIFeedNotBoundToUnderlying,
             );

--- a/packages/predict/tests/helper/flow_test_helpers.move
+++ b/packages/predict/tests/helper/flow_test_helpers.move
@@ -75,6 +75,8 @@ public struct Fixture {
     vault_id: ID,
     pyth_id: ID,
     bs_spot_id: ID,
+    bs_forward_id: ID,
+    bs_svi_id: ID,
 }
 
 /// A trader handle: the canonical `AccountWrapper` ID plus its owner. The wrapper is
@@ -86,12 +88,11 @@ public struct Trader has copy, drop, store {
     owner: address,
 }
 
-/// Stand up a registry + protocol config + an empty PLP vault + the global Pyth and
-/// BS spot feeds for the default cadence's `tick` size. Per-expiry BS forward/SVI
-/// feeds are created and bound when each expiry is created. base_fee is floored to 1
-/// and min_ask to 0 so small test quantities are admissible. Creation reads no spot
-/// (strikes are absolute ticks), so no spot is seeded here — `prepare_live_oracle`
-/// seeds the live spot + surface for pricing.
+/// Stand up a registry + protocol config + an empty PLP vault + the permanent
+/// Pyth, BS spot, BS forward, and BS SVI feeds for the default cadence's `tick`
+/// size. base_fee is floored to 1 and min_ask to 0 so small test quantities are
+/// admissible. Creation reads no spot (strikes are absolute ticks), so no spot is
+/// seeded here — `prepare_live_oracle` seeds the live spot + surface for pricing.
 public fun setup_market(tick: u64): Fixture {
     let mut scenario = test::begin(test_constants::admin());
     // Ask the accumulator seam to construct the shared root up front. On this
@@ -141,6 +142,16 @@ public fun setup_market(tick: u64): Fixture {
         test_constants::pyth_feed_id(),
         scenario.ctx(),
     );
+    let bs_forward_id = propbook_registry::create_and_share_block_scholes_forward_feed(
+        &mut oracle_registry,
+        test_constants::pyth_feed_id(),
+        scenario.ctx(),
+    );
+    let bs_svi_id = propbook_registry::create_and_share_block_scholes_svi_feed(
+        &mut oracle_registry,
+        test_constants::pyth_feed_id(),
+        scenario.ctx(),
+    );
     return_shared(oracle_registry);
     let mut clock = clock::create_for_testing(scenario.ctx());
     clock.set_for_testing(test_constants::now_ms());
@@ -152,6 +163,8 @@ public fun setup_market(tick: u64): Fixture {
     let mut oracle_registry = scenario.take_shared<OracleRegistry>();
     let pyth = scenario.take_shared_by_id<PythFeed>(pyth_id);
     let bs_spot = scenario.take_shared_by_id<BlockScholesSpotFeed>(bs_spot_id);
+    let bs_forward = scenario.take_shared_by_id<BlockScholesForwardFeed>(bs_forward_id);
+    let bs_svi = scenario.take_shared_by_id<BlockScholesSVIFeed>(bs_svi_id);
     propbook_registry::bind_pyth_to_underlying(
         &mut oracle_registry,
         &propbook_admin_cap,
@@ -164,6 +177,15 @@ public fun setup_market(tick: u64): Fixture {
         &bs_spot,
         test_constants::propbook_underlying_id(),
     );
+    propbook_registry::bind_block_scholes_surface_to_underlying(
+        &mut oracle_registry,
+        &propbook_admin_cap,
+        &bs_forward,
+        &bs_svi,
+        test_constants::propbook_underlying_id(),
+    );
+    return_shared(bs_svi);
+    return_shared(bs_forward);
     return_shared(bs_spot);
     return_shared(pyth);
     return_shared(oracle_registry);
@@ -191,6 +213,8 @@ public fun setup_market(tick: u64): Fixture {
         vault_id,
         pyth_id,
         bs_spot_id,
+        bs_forward_id,
+        bs_svi_id,
     }
 }
 
@@ -249,7 +273,6 @@ fun setup_funded_live_market(expiry_ms: u64, live_price: u64, deposit: u64): (Fi
 /// Create the market for `expiry` through the production path, returning its id.
 public fun create_expiry(self: &mut Fixture, expiry: u64): ID {
     self.scenario.next_tx(test_constants::admin());
-    self.create_and_bind_bs_expiry_feeds(expiry);
     let mut vault = self.scenario.take_shared_by_id<PoolVault>(self.vault_id);
     let mut registry = self.scenario.take_shared<Registry>();
     let oracle_registry = self.scenario.take_shared<OracleRegistry>();
@@ -277,8 +300,6 @@ public fun create_expiry(self: &mut Fixture, expiry: u64): ID {
 
 public fun create_next_expiry_for_cadence(self: &mut Fixture, cadence_id: u8): ID {
     self.scenario.next_tx(test_constants::admin());
-    let expiry = self.next_expiry_for_cadence(cadence_id);
-    self.create_and_bind_bs_expiry_feeds(expiry);
     let mut vault = self.scenario.take_shared_by_id<PoolVault>(self.vault_id);
     let mut registry = self.scenario.take_shared<Registry>();
     let oracle_registry = self.scenario.take_shared<OracleRegistry>();
@@ -299,60 +320,6 @@ public fun create_next_expiry_for_cadence(self: &mut Fixture, cadence_id: u8): I
     return_shared(vault);
     self.scenario.next_tx(test_constants::admin());
     expiry_id
-}
-
-fun create_and_bind_bs_expiry_feeds(self: &mut Fixture, expiry: u64) {
-    let mut oracle_registry = self.scenario.take_shared<OracleRegistry>();
-    let bs_forward_id = propbook_registry::create_and_share_block_scholes_forward_feed(
-        &mut oracle_registry,
-        test_constants::pyth_feed_id(),
-        expiry,
-        self.scenario.ctx(),
-    );
-    let bs_svi_id = propbook_registry::create_and_share_block_scholes_svi_feed(
-        &mut oracle_registry,
-        test_constants::pyth_feed_id(),
-        expiry,
-        self.scenario.ctx(),
-    );
-    return_shared(oracle_registry);
-
-    self.scenario.next_tx(test_constants::admin());
-    let mut oracle_registry = self.scenario.take_shared<OracleRegistry>();
-    let bs_forward = self.scenario.take_shared_by_id<BlockScholesForwardFeed>(bs_forward_id);
-    let bs_svi = self.scenario.take_shared_by_id<BlockScholesSVIFeed>(bs_svi_id);
-    propbook_registry::bind_block_scholes_expiry_to_underlying(
-        &mut oracle_registry,
-        &self.propbook_admin_cap,
-        &bs_forward,
-        &bs_svi,
-        test_constants::propbook_underlying_id(),
-    );
-    return_shared(bs_svi);
-    return_shared(bs_forward);
-    return_shared(oracle_registry);
-    self.scenario.next_tx(test_constants::admin());
-}
-
-fun next_expiry_for_cadence(self: &Fixture, cadence_id: u8): u64 {
-    let period_ms = cadence_period_ms(cadence_id);
-    ((self.clock.timestamp_ms() / period_ms) + 1) * period_ms
-}
-
-fun cadence_period_ms(cadence_id: u8): u64 {
-    if (cadence_id == market_manager::cadence_one_minute!()) {
-        constants::one_minute_ms!()
-    } else if (cadence_id == market_manager::cadence_five_minute!()) {
-        constants::five_minutes_ms!()
-    } else if (cadence_id == market_manager::cadence_one_hour!()) {
-        constants::one_hour_ms!()
-    } else if (cadence_id == market_manager::cadence_one_day!()) {
-        constants::one_day_ms!()
-    } else if (cadence_id == market_manager::cadence_one_week!()) {
-        constants::one_week_ms!()
-    } else {
-        constants::one_month_ms!()
-    }
 }
 
 public fun set_trade_liquidation_budget(self: &Fixture, config: &mut ProtocolConfig, budget: u64) {
@@ -416,23 +383,11 @@ public fun take_market(
 ) {
     let market = self.scenario.take_shared_by_id<ExpiryMarket>(expiry_id);
     let oracle_registry = self.scenario.take_shared<OracleRegistry>();
-    let bs_forward_id = oracle_registry
-        .propbook_block_scholes_forward_id_for_underlying_expiry(
-            market.propbook_underlying_id(),
-            market.expiry(),
-        )
-        .destroy_some();
-    let bs_svi_id = oracle_registry
-        .propbook_block_scholes_svi_id_for_underlying_expiry(
-            market.propbook_underlying_id(),
-            market.expiry(),
-        )
-        .destroy_some();
     (
         self.scenario.take_shared_by_id<PythFeed>(self.pyth_id),
         self.scenario.take_shared_by_id<BlockScholesSpotFeed>(self.bs_spot_id),
-        self.scenario.take_shared_by_id<BlockScholesForwardFeed>(bs_forward_id),
-        self.scenario.take_shared_by_id<BlockScholesSVIFeed>(bs_svi_id),
+        self.scenario.take_shared_by_id<BlockScholesForwardFeed>(self.bs_forward_id),
+        self.scenario.take_shared_by_id<BlockScholesSVIFeed>(self.bs_svi_id),
         oracle_registry,
         self.scenario.take_shared_by_id<PoolVault>(self.vault_id),
         market,
@@ -632,6 +587,7 @@ public fun seed_bs_surface(
             forward,
         ),
         &self.clock,
+        self.scenario.ctx(),
     );
     bs_svi.update(
         update::new_svi_update(
@@ -647,6 +603,7 @@ public fun seed_bs_surface(
             false,
         ),
         &self.clock,
+        self.scenario.ctx(),
     );
 }
 
@@ -1151,6 +1108,8 @@ public fun finish(self: Fixture) {
         vault_id: _,
         pyth_id: _,
         bs_spot_id: _,
+        bs_forward_id: _,
+        bs_svi_id: _,
     } = self;
     lifecycle_cap.destroy();
     destroy(propbook_admin_cap);

--- a/packages/predict/tests/helper/oracle_fixture.move
+++ b/packages/predict/tests/helper/oracle_fixture.move
@@ -95,13 +95,11 @@ public fun setup_oracle(_spot: u64, tick: u64, expiry: u64): OracleFixture {
     let bs_forward_id = propbook_registry::create_and_share_block_scholes_forward_feed(
         &mut oracle_registry,
         test_constants::pyth_feed_id(),
-        expiry,
         scenario.ctx(),
     );
     let bs_svi_id = propbook_registry::create_and_share_block_scholes_svi_feed(
         &mut oracle_registry,
         test_constants::pyth_feed_id(),
-        expiry,
         scenario.ctx(),
     );
     return_shared(oracle_registry);
@@ -290,6 +288,7 @@ public fun prepare_real_oracle(
     bs_forward.update(
         update::new_forward_update(test_constants::pyth_feed_id(), self.expiry, live_ts, forward),
         &self.clock,
+        self.scenario.ctx(),
     );
     bs_svi.update(
         update::new_svi_update(
@@ -305,6 +304,28 @@ public fun prepare_real_oracle(
             svi_m_is_negative,
         ),
         &self.clock,
+        self.scenario.ctx(),
+    );
+}
+
+/// Overwrite only the BS forward row for this fixture's expiry through the real
+/// ingest path. Used by stale-surface guard tests that need fresh prices but a
+/// stale SVI row.
+public fun set_bs_forward_for_testing(
+    self: &mut OracleFixture,
+    bs_forward: &mut BlockScholesForwardFeed,
+    source_timestamp_ms: u64,
+    forward: u64,
+) {
+    bs_forward.update(
+        update::new_forward_update(
+            test_constants::pyth_feed_id(),
+            self.expiry,
+            source_timestamp_ms,
+            forward,
+        ),
+        &self.clock,
+        self.scenario.ctx(),
     );
 }
 

--- a/packages/predict/tests/helper/test_helpers.move
+++ b/packages/predict/tests/helper/test_helpers.move
@@ -151,7 +151,7 @@ public fun bind_feeds_to_underlying(
         &bs_spot,
         test_constants::propbook_underlying_id(),
     );
-    propbook_registry::bind_block_scholes_expiry_to_underlying(
+    propbook_registry::bind_block_scholes_surface_to_underlying(
         &mut oracle_registry,
         &admin_cap,
         &bs_forward,

--- a/packages/predict/tests/pricing/pricing_guard_tests.move
+++ b/packages/predict/tests/pricing/pricing_guard_tests.move
@@ -168,15 +168,7 @@ fun live_quote_with_fresh_prices_but_stale_svi_aborts() {
         ),
         fx.clock(),
     );
-    bs_forward.update(
-        update::new_forward_update(
-            test_constants::pyth_feed_id(),
-            fx.expiry(),
-            stale_now,
-            test_constants::default_live_price(),
-        ),
-        fx.clock(),
-    );
+    fx.set_bs_forward_for_testing(&mut bs_forward, stale_now, test_constants::default_live_price());
 
     live_quote(
         &fx,

--- a/packages/predict/tests/registry_guard_tests.move
+++ b/packages/predict/tests/registry_guard_tests.move
@@ -41,7 +41,6 @@ use sui::{clock::{Self, Clock}, object, test_scenario::{Self, Scenario, return_s
 const UNREGISTERED_UNDERLYING_ID: u32 = 777;
 const START_OF_TIME_MS: u64 = 0;
 const WINDOW_SIZE_THREE: u64 = 3;
-const PREBOUND_ONE_MINUTE_EXPIRIES: u64 = 10;
 
 // === builder_code owner guard ===
 
@@ -304,17 +303,20 @@ fun create_expiry_market_skips_occupied_lower_rank_collision() {
         propbook_admin_cap,
         pyth_id,
         bs_spot_id,
+        bs_forward_id,
+        bs_svi_id,
     ) = setup_registered_feeds();
 
     scenario.next_tx(test_constants::admin());
-    bind_pyth_and_spot(&scenario, &propbook_admin_cap, pyth_id, bs_spot_id);
-    scenario.next_tx(test_constants::admin());
-    create_and_bind_bs_expiry_feeds(&mut scenario, &propbook_admin_cap, constants::one_week_ms!());
-    create_and_bind_bs_expiry_feeds(
-        &mut scenario,
+    bind_pyth_spot_and_surface(
+        &scenario,
         &propbook_admin_cap,
-        2 * constants::one_week_ms!(),
+        pyth_id,
+        bs_spot_id,
+        bs_forward_id,
+        bs_svi_id,
     );
+    scenario.next_tx(test_constants::admin());
 
     let mut daily_clock = clock::create_for_testing(scenario.ctx());
     let mut reg = scenario.take_shared_by_id<Registry>(registry_id);
@@ -450,6 +452,8 @@ fun create_expiry_market_with_unbound_pyth_feed_aborts() {
         _propbook_admin_cap,
         _pyth_id,
         _bs_spot_id,
+        _bs_forward_id,
+        _bs_svi_id,
     ) = setup_registered_feeds();
 
     scenario.next_tx(test_constants::admin());
@@ -483,6 +487,8 @@ fun create_expiry_market_with_unbound_block_scholes_spot_feed_aborts() {
         propbook_admin_cap,
         pyth_id,
         _bs_spot_id,
+        _bs_forward_id,
+        _bs_svi_id,
     ) = setup_registered_feeds();
 
     scenario.next_tx(test_constants::admin());
@@ -510,9 +516,9 @@ fun create_expiry_market_with_unbound_block_scholes_spot_feed_aborts() {
 }
 
 #[test, expected_failure(abort_code = market_manager::EBlockScholesForwardFeedNotBoundToUnderlying)]
-fun create_expiry_market_with_unbound_block_scholes_expiry_feed_aborts() {
-    // Pyth and BS spot are bound, but no forward/SVI pair is bound for the target
-    // expiry, so the forward check fails first.
+fun create_expiry_market_with_unbound_block_scholes_surface_aborts() {
+    // Pyth and BS spot are bound, but no forward/SVI surface is bound for the
+    // underlying, so the forward check fails first.
     let (
         mut scenario,
         registry_id,
@@ -520,6 +526,8 @@ fun create_expiry_market_with_unbound_block_scholes_expiry_feed_aborts() {
         propbook_admin_cap,
         pyth_id,
         bs_spot_id,
+        _bs_forward_id,
+        _bs_svi_id,
     ) = setup_registered_feeds();
 
     scenario.next_tx(test_constants::admin());
@@ -549,7 +557,7 @@ fun create_expiry_market_with_unbound_block_scholes_expiry_feed_aborts() {
 /// Init all registries, approve the canonical underlying + default cadence, and create
 /// the base real propbook feeds (catalog-only, NOT yet bound to an underlying).
 /// Returns positioned for the caller to bind (or not) then create the market.
-fun setup_registered_feeds(): (Scenario, ID, AdminCap, RegistryAdminCap, ID, ID) {
+fun setup_registered_feeds(): (Scenario, ID, AdminCap, RegistryAdminCap, ID, ID, ID, ID) {
     let (mut scenario, mut reg, config, admin_cap) = test_helpers::begin_registry_test();
     plp::init_for_testing(scenario.ctx());
     propbook_registry::init_for_testing(scenario.ctx());
@@ -580,9 +588,28 @@ fun setup_registered_feeds(): (Scenario, ID, AdminCap, RegistryAdminCap, ID, ID)
         test_constants::pyth_feed_id(),
         scenario.ctx(),
     );
+    let bs_forward_id = propbook_registry::create_and_share_block_scholes_forward_feed(
+        &mut oracle_registry,
+        test_constants::pyth_feed_id(),
+        scenario.ctx(),
+    );
+    let bs_svi_id = propbook_registry::create_and_share_block_scholes_svi_feed(
+        &mut oracle_registry,
+        test_constants::pyth_feed_id(),
+        scenario.ctx(),
+    );
     return_shared(oracle_registry);
 
-    (scenario, registry_id, admin_cap, propbook_admin_cap, pyth_id, bs_spot_id)
+    (
+        scenario,
+        registry_id,
+        admin_cap,
+        propbook_admin_cap,
+        pyth_id,
+        bs_spot_id,
+        bs_forward_id,
+        bs_svi_id,
+    )
 }
 
 fun setup_bound_creation_context(
@@ -604,16 +631,20 @@ fun setup_bound_creation_context(
         propbook_admin_cap,
         pyth_id,
         bs_spot_id,
+        bs_forward_id,
+        bs_svi_id,
     ) = setup_registered_feeds();
 
     scenario.next_tx(test_constants::admin());
-    bind_pyth_and_spot(&scenario, &propbook_admin_cap, pyth_id, bs_spot_id);
-    scenario.next_tx(test_constants::admin());
-    prebind_one_minute_expiry_feeds(
-        &mut scenario,
+    bind_pyth_spot_and_surface(
+        &scenario,
         &propbook_admin_cap,
-        PREBOUND_ONE_MINUTE_EXPIRIES,
+        pyth_id,
+        bs_spot_id,
+        bs_forward_id,
+        bs_svi_id,
     );
+    scenario.next_tx(test_constants::admin());
     destroy(propbook_admin_cap);
 
     let mut reg = scenario.take_shared_by_id<Registry>(registry_id);
@@ -679,7 +710,7 @@ fun bind_only_pyth(scenario: &Scenario, admin_cap: &RegistryAdminCap, pyth_id: I
 }
 
 /// Bind the global Pyth and BS spot feeds to the canonical underlying, leaving
-/// per-expiry forward/SVI feeds to be bound separately.
+/// the BS forward/SVI surface unbound.
 fun bind_pyth_and_spot(
     scenario: &Scenario,
     admin_cap: &RegistryAdminCap,
@@ -706,43 +737,33 @@ fun bind_pyth_and_spot(
     return_shared(oracle_registry);
 }
 
-fun prebind_one_minute_expiry_feeds(
-    scenario: &mut Scenario,
+/// Bind all permanent feeds to the canonical underlying.
+fun bind_pyth_spot_and_surface(
+    scenario: &Scenario,
     admin_cap: &RegistryAdminCap,
-    count: u64,
-) {
-    let mut i = 1;
-    while (i <= count) {
-        create_and_bind_bs_expiry_feeds(scenario, admin_cap, i * constants::one_minute_ms!());
-        i = i + 1;
-    }
-}
-
-fun create_and_bind_bs_expiry_feeds(
-    scenario: &mut Scenario,
-    admin_cap: &RegistryAdminCap,
-    expiry: u64,
+    pyth_id: ID,
+    bs_spot_id: ID,
+    bs_forward_id: ID,
+    bs_svi_id: ID,
 ) {
     let mut oracle_registry = scenario.take_shared<OracleRegistry>();
-    let bs_forward_id = propbook_registry::create_and_share_block_scholes_forward_feed(
-        &mut oracle_registry,
-        test_constants::pyth_feed_id(),
-        expiry,
-        scenario.ctx(),
-    );
-    let bs_svi_id = propbook_registry::create_and_share_block_scholes_svi_feed(
-        &mut oracle_registry,
-        test_constants::pyth_feed_id(),
-        expiry,
-        scenario.ctx(),
-    );
-    return_shared(oracle_registry);
-
-    scenario.next_tx(test_constants::admin());
-    let mut oracle_registry = scenario.take_shared<OracleRegistry>();
+    let pyth = scenario.take_shared_by_id<PythFeed>(pyth_id);
+    let bs_spot = scenario.take_shared_by_id<BlockScholesSpotFeed>(bs_spot_id);
     let bs_forward = scenario.take_shared_by_id<BlockScholesForwardFeed>(bs_forward_id);
     let bs_svi = scenario.take_shared_by_id<BlockScholesSVIFeed>(bs_svi_id);
-    propbook_registry::bind_block_scholes_expiry_to_underlying(
+    propbook_registry::bind_pyth_to_underlying(
+        &mut oracle_registry,
+        admin_cap,
+        &pyth,
+        test_constants::propbook_underlying_id(),
+    );
+    propbook_registry::bind_block_scholes_spot_to_underlying(
+        &mut oracle_registry,
+        admin_cap,
+        &bs_spot,
+        test_constants::propbook_underlying_id(),
+    );
+    propbook_registry::bind_block_scholes_surface_to_underlying(
         &mut oracle_registry,
         admin_cap,
         &bs_forward,
@@ -751,8 +772,9 @@ fun create_and_bind_bs_expiry_feeds(
     );
     return_shared(bs_svi);
     return_shared(bs_forward);
+    return_shared(bs_spot);
+    return_shared(pyth);
     return_shared(oracle_registry);
-    scenario.next_tx(test_constants::admin());
 }
 
 // === PauseCap ===

--- a/packages/propbook/README.md
+++ b/packages/propbook/README.md
@@ -48,8 +48,8 @@ exact-history normalized spot reads derive a positive 1e9-scaled Propbook spot
 from those fields. Missing data, negative source prices, zero normalized spots,
 overflow, or unsupported exponent shapes return `none`.
 
-For Block Scholes, raw reads expose source spot, per-expiry forward, and
-per-expiry SVI payloads from separate feed objects. Normalized spot and forward
+For Block Scholes, raw reads expose source spot plus per-expiry forward and SVI
+payloads from permanent source-level feed objects. Normalized spot and forward
 reads return `none` when the requested observation is absent or zero; normalized
 SVI reads expose the stored SVI parameters directly.
 
@@ -93,13 +93,14 @@ Block Scholes data is split across three shared-object types:
 
 - `block_scholes_spot_feed::BlockScholesSpotFeed`: one source-level spot stream
   per Block Scholes source id.
-- `block_scholes_forward_feed::BlockScholesForwardFeed`: one forward stream per
-  `(source id, expiry_ms)`.
-- `block_scholes_svi_feed::BlockScholesSVIFeed`: one SVI stream per
-  `(source id, expiry_ms)`.
+- `block_scholes_forward_feed::BlockScholesForwardFeed`: one source-level
+  forward object per Block Scholes source id, with per-expiry lanes.
+- `block_scholes_svi_feed::BlockScholesSVIFeed`: one source-level SVI object per
+  Block Scholes source id, with per-expiry lanes.
 
-Each feed wraps one `OracleLane`, so every BS value uses the same mutation
-pattern as Pyth: latest update, exact timestamp insert, and generic lane events.
+The spot feed wraps one `OracleLane`; the forward and SVI feeds keep a table of
+`expiry_ms -> OracleLane`. Every BS value still uses the same mutation pattern as
+Pyth: latest update, exact timestamp insert, and generic lane events.
 
 The BS payloads store raw source fields:
 
@@ -116,23 +117,22 @@ Its `Update` values are forgeable until the real BS signature verifier replaces
 the stub. Permissionless BS live updates and exact inserts are not production-safe
 while this is true.
 
-Binding caveat: Propbook binds the source-level BS spot feed first, then binds a
-forward/SVI pair for each expiry with
-`registry::bind_block_scholes_expiry_to_underlying`. That function asserts that
+Binding caveat: Propbook binds the source-level BS spot feed first, then binds
+the permanent forward/SVI surface pair with
+`registry::bind_block_scholes_surface_to_underlying`. That function asserts that
 the forward feed, SVI feed, and already-bound spot feed all share the same
 `bs_source_id`, so consumers do not accidentally combine BS spot/basis data from
-different sources for one underlying/expiry.
+different sources for one underlying.
 
 ## Registry And Identifiers
 
 `registry::OracleRegistry` owns source discovery and canonical Propbook bindings.
 It keeps two namespaces:
 
-- Source catalog: one Propbook oracle object per source key. Source-level feeds
-  key by `(oracle_kind, source_id)`; per-expiry feeds also carry `expiry_ms`.
+- Source catalog: one Propbook oracle object per source key, keyed by
+  `(oracle_kind, source_id)`.
 - Canonical binding: one active oracle per
-  `(propbook_underlying_id, oracle_kind, value_kind)`, with `expiry_ms` included
-  for expiry-level values.
+  `(propbook_underlying_id, oracle_kind, value_kind)`.
 
 Identifier pattern:
 
@@ -165,10 +165,10 @@ Typical discovery question:
 Use `propbook_pyth_id_for_underlying(registry, propbook_underlying_id)`. The
 equivalent BS spot lookup is
 `propbook_block_scholes_spot_id_for_underlying(registry, propbook_underlying_id)`.
-Per-expiry BS lookups are
-`propbook_block_scholes_forward_id_for_underlying_expiry(registry, propbook_underlying_id, expiry_ms)`
+The BS surface lookups are
+`propbook_block_scholes_forward_id_for_underlying(registry, propbook_underlying_id)`
 and
-`propbook_block_scholes_svi_id_for_underlying_expiry(registry, propbook_underlying_id, expiry_ms)`.
+`propbook_block_scholes_svi_id_for_underlying(registry, propbook_underlying_id)`.
 
 ## Events
 
@@ -177,7 +177,7 @@ Propbook emits generic oracle events:
 - `ObservationRecorded<OracleRead<Payload>>`
 - `ObservationInserted<OracleRead<Payload>>`
 
-For per-expiry BS forward and SVI feeds, the payload includes the expiry, so the
+For BS forward and SVI rows, the payload includes the expiry, so the
 generic event is enough to index per-expiry writes. BS spot is source-level and
 does not carry an expiry. Exact-insert events include the source timestamp in the
 `OracleRead` envelope.

--- a/packages/propbook/sources/feeds/block_scholes_forward_feed.move
+++ b/packages/propbook/sources/feeds/block_scholes_forward_feed.move
@@ -1,9 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Block Scholes forward oracle: one shared object per `(source id, expiry)`,
-/// storing an independent expiry-forward stream through a generic Propbook
-/// oracle lane.
+/// Block Scholes forward oracle: one shared object per source id, storing
+/// per-expiry forward streams keyed by expiry timestamp.
 ///
 /// Predict-unaware: this module stores raw source facts and leaves feed binding,
 /// freshness, and pricing-safe envelopes to consumers.
@@ -12,10 +11,9 @@ module propbook::block_scholes_forward_feed;
 use block_scholes_oracle::update::ForwardUpdate;
 use propbook::{constants, oracle_lane::{Self, OracleLane, OracleRead}};
 use std::option::{Self, Option};
-use sui::clock::Clock;
+use sui::{clock::Clock, table::{Self, Table}};
 
 const EWrongSource: u64 = 0;
-const EWrongExpiry: u64 = 1;
 const ERawForwardNotFound: u64 = 2;
 const EWrongVersion: u64 = 3;
 const ENotNewerVersion: u64 = 4;
@@ -28,15 +26,14 @@ public struct RawForward has copy, drop, store {
     forward: u64,
 }
 
-/// One Block Scholes forward feed: version gate plus one generic oracle lane.
+/// One Block Scholes forward feed: version gate plus one generic oracle lane per expiry.
 public struct BlockScholesForwardFeed has key {
     id: UID,
     bs_source_id: u32,
-    expiry_ms: u64,
     /// Package version this feed runs at; updates require an exact match and
     /// `migrate` advances it forward-only after a package upgrade.
     version: u64,
-    lane: OracleLane<RawForward>,
+    expiries: Table<u64, OracleLane<RawForward>>,
 }
 
 // === Read Functions ===
@@ -51,46 +48,50 @@ public fun bs_source_id(feed: &BlockScholesForwardFeed): u32 {
     feed.bs_source_id
 }
 
-/// Return the expiry this feed is bound to.
-public fun expiry_ms(feed: &BlockScholesForwardFeed): u64 {
-    feed.expiry_ms
-}
-
 /// Return the package version this feed runs at.
 public fun version(feed: &BlockScholesForwardFeed): u64 {
     feed.version
 }
 
-/// Latest raw BS forward read. Aborts if no live update has landed.
-public fun raw_forward(feed: &BlockScholesForwardFeed): OracleRead<RawForward> {
-    let read = feed.lane.latest_read();
+/// Latest raw BS forward read for `expiry_ms`. Aborts if no live update has landed.
+public fun raw_forward(feed: &BlockScholesForwardFeed, expiry_ms: u64): OracleRead<RawForward> {
+    assert!(feed.expiries.contains(expiry_ms), ERawForwardNotFound);
+    let read = feed.expiries.borrow(expiry_ms).latest_read();
     assert!(read.is_some(), ERawForwardNotFound);
     read.destroy_some()
 }
 
-/// Latest Propbook-normalized forward in 1e9 price scaling.
-public fun normalized_forward(feed: &BlockScholesForwardFeed): Option<OracleRead<u64>> {
-    let read = feed.lane.latest_read();
+/// Latest Propbook-normalized forward in 1e9 price scaling for `expiry_ms`.
+public fun normalized_forward(
+    feed: &BlockScholesForwardFeed,
+    expiry_ms: u64,
+): Option<OracleRead<u64>> {
+    if (!feed.expiries.contains(expiry_ms)) return option::none();
+    let read = feed.expiries.borrow(expiry_ms).latest_read();
     if (read.is_none()) return option::none();
     normalized_forward_from_read(&read.destroy_some())
 }
 
-/// Exact raw BS forward read for `timestamp_ms`.
+/// Exact raw BS forward read for `(expiry_ms, timestamp_ms)`.
 public fun raw_forward_at(
     feed: &BlockScholesForwardFeed,
+    expiry_ms: u64,
     timestamp_ms: u64,
 ): OracleRead<RawForward> {
-    let read = feed.lane.read_at(timestamp_ms);
+    assert!(feed.expiries.contains(expiry_ms), ERawForwardNotFound);
+    let read = feed.expiries.borrow(expiry_ms).read_at(timestamp_ms);
     assert!(read.is_some(), ERawForwardNotFound);
     read.destroy_some()
 }
 
-/// Exact Propbook-normalized forward in 1e9 price scaling for `timestamp_ms`.
+/// Exact Propbook-normalized forward in 1e9 price scaling for `(expiry_ms, timestamp_ms)`.
 public fun normalized_forward_at(
     feed: &BlockScholesForwardFeed,
+    expiry_ms: u64,
     timestamp_ms: u64,
 ): Option<OracleRead<u64>> {
-    let read = feed.lane.read_at(timestamp_ms);
+    if (!feed.expiries.contains(expiry_ms)) return option::none();
+    let read = feed.expiries.borrow(expiry_ms).read_at(timestamp_ms);
     if (read.is_none()) return option::none();
     normalized_forward_from_read(&read.destroy_some())
 }
@@ -110,26 +111,36 @@ public fun raw_forward_value(raw: &RawForward): u64 {
 // === Write Functions ===
 
 /// Ingest a verified BS forward update into this feed's generic oracle lane.
-public fun update(feed: &mut BlockScholesForwardFeed, update: ForwardUpdate, clock: &Clock) {
+public fun update(
+    feed: &mut BlockScholesForwardFeed,
+    update: ForwardUpdate,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
     assert!(feed.version == constants::current_version!(), EWrongVersion);
     assert!(update.forward_source_id() == feed.bs_source_id, EWrongSource);
-    assert!(update.forward_expiry_ms() == feed.expiry_ms, EWrongExpiry);
 
     let read = feed.new_read(&update, clock.timestamp_ms());
+    let expiry = read.read_value().expiry_ms;
     let id = feed.id();
-    feed.lane.update(id, read);
+    feed.update_expiry(expiry, id, read, ctx);
 }
 
 /// Insert an exact BS forward observation keyed by the update-derived source
 /// timestamp. This does not mutate the live latest observation.
-public fun insert_at(feed: &mut BlockScholesForwardFeed, update: ForwardUpdate, clock: &Clock) {
+public fun insert_at(
+    feed: &mut BlockScholesForwardFeed,
+    update: ForwardUpdate,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
     assert!(feed.version == constants::current_version!(), EWrongVersion);
     assert!(update.forward_source_id() == feed.bs_source_id, EWrongSource);
-    assert!(update.forward_expiry_ms() == feed.expiry_ms, EWrongExpiry);
 
     let read = feed.new_read(&update, clock.timestamp_ms());
+    let expiry = read.read_value().expiry_ms;
     let id = feed.id();
-    feed.lane.insert_at(id, read);
+    feed.insert_expiry_at(expiry, id, read, ctx);
 }
 
 /// Migrate this feed to the running package version. Forward-only:
@@ -141,19 +152,17 @@ public fun migrate(feed: &mut BlockScholesForwardFeed) {
 
 // === Public-Package Functions ===
 
-/// Create and share a BS forward feed for `(bs_source_id, expiry_ms)`.
+/// Create and share a BS forward feed for `bs_source_id`.
 /// Package-only: `registry` owns source-catalog uniqueness.
 public(package) fun create_and_share(
     bs_source_id: u32,
-    expiry_ms: u64,
     ctx: &mut TxContext,
 ): ID {
     let feed = BlockScholesForwardFeed {
         id: object::new(ctx),
         bs_source_id,
-        expiry_ms,
         version: constants::current_version!(),
-        lane: oracle_lane::new(ctx),
+        expiries: table::new(ctx),
     };
     let id = feed.id();
     transfer::share_object(feed);
@@ -172,10 +181,44 @@ fun new_read(
         update_timestamp_ms,
         RawForward {
             bs_source_id: feed.bs_source_id,
-            expiry_ms: feed.expiry_ms,
+            expiry_ms: update.forward_expiry_ms(),
             forward: update.forward(),
         },
     )
+}
+
+fun update_expiry(
+    feed: &mut BlockScholesForwardFeed,
+    expiry_ms: u64,
+    propbook_oracle_id: ID,
+    read: OracleRead<RawForward>,
+    ctx: &mut TxContext,
+) {
+    if (feed.expiries.contains(expiry_ms)) {
+        feed.expiries.borrow_mut(expiry_ms).update(propbook_oracle_id, read);
+    } else {
+        if (!oracle_lane::read_has_valid_timestamp(&read)) return;
+        let mut lane = oracle_lane::new(ctx);
+        lane.update(propbook_oracle_id, read);
+        feed.expiries.add(expiry_ms, lane);
+    };
+}
+
+fun insert_expiry_at(
+    feed: &mut BlockScholesForwardFeed,
+    expiry_ms: u64,
+    propbook_oracle_id: ID,
+    read: OracleRead<RawForward>,
+    ctx: &mut TxContext,
+) {
+    if (feed.expiries.contains(expiry_ms)) {
+        feed.expiries.borrow_mut(expiry_ms).insert_at(propbook_oracle_id, read);
+    } else {
+        if (!oracle_lane::read_has_valid_timestamp(&read)) return;
+        let mut lane = oracle_lane::new(ctx);
+        lane.insert_at(propbook_oracle_id, read);
+        feed.expiries.add(expiry_ms, lane);
+    };
 }
 
 fun normalized_forward_from_read(read: &OracleRead<RawForward>): Option<OracleRead<u64>> {

--- a/packages/propbook/sources/feeds/block_scholes_svi_feed.move
+++ b/packages/propbook/sources/feeds/block_scholes_svi_feed.move
@@ -1,9 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Block Scholes SVI oracle: one shared object per `(source id, expiry)`,
-/// storing an independent expiry volatility-surface stream through a generic
-/// Propbook oracle lane.
+/// Block Scholes SVI oracle: one shared object per source id, storing
+/// per-expiry volatility-surface streams keyed by expiry timestamp.
 ///
 /// Propbook does not validate Predict's pricing-safe SVI envelope; consumers
 /// own any bounds or no-arbitrage policy needed by their pricing math.
@@ -13,10 +12,9 @@ use block_scholes_oracle::update::SVIUpdate;
 use fixed_math::i64::{Self, I64};
 use propbook::{constants, oracle_lane::{Self, OracleLane, OracleRead}};
 use std::option::{Self, Option};
-use sui::clock::Clock;
+use sui::{clock::Clock, table::{Self, Table}};
 
 const EWrongSource: u64 = 0;
-const EWrongExpiry: u64 = 1;
 const ERawSVINotFound: u64 = 2;
 const EWrongVersion: u64 = 3;
 const ENotNewerVersion: u64 = 4;
@@ -38,15 +36,14 @@ public struct RawSVI has copy, drop, store {
     svi: SVIParams,
 }
 
-/// One Block Scholes SVI feed: version gate plus one generic oracle lane.
+/// One Block Scholes SVI feed: version gate plus one generic oracle lane per expiry.
 public struct BlockScholesSVIFeed has key {
     id: UID,
     bs_source_id: u32,
-    expiry_ms: u64,
     /// Package version this feed runs at; updates require an exact match and
     /// `migrate` advances it forward-only after a package upgrade.
     version: u64,
-    lane: OracleLane<RawSVI>,
+    expiries: Table<u64, OracleLane<RawSVI>>,
 }
 
 // === Read Functions ===
@@ -61,43 +58,50 @@ public fun bs_source_id(feed: &BlockScholesSVIFeed): u32 {
     feed.bs_source_id
 }
 
-/// Return the expiry this feed is bound to.
-public fun expiry_ms(feed: &BlockScholesSVIFeed): u64 {
-    feed.expiry_ms
-}
-
 /// Return the package version this feed runs at.
 public fun version(feed: &BlockScholesSVIFeed): u64 {
     feed.version
 }
 
-/// Latest raw BS SVI read. Aborts if no live update has landed.
-public fun raw_svi(feed: &BlockScholesSVIFeed): OracleRead<RawSVI> {
-    let read = feed.lane.latest_read();
+/// Latest raw BS SVI read for `expiry_ms`. Aborts if no live update has landed.
+public fun raw_svi(feed: &BlockScholesSVIFeed, expiry_ms: u64): OracleRead<RawSVI> {
+    assert!(feed.expiries.contains(expiry_ms), ERawSVINotFound);
+    let read = feed.expiries.borrow(expiry_ms).latest_read();
     assert!(read.is_some(), ERawSVINotFound);
     read.destroy_some()
 }
 
-/// Latest Propbook-normalized SVI params.
-public fun normalized_svi(feed: &BlockScholesSVIFeed): Option<OracleRead<SVIParams>> {
-    let read = feed.lane.latest_read();
+/// Latest Propbook-normalized SVI params for `expiry_ms`.
+public fun normalized_svi(
+    feed: &BlockScholesSVIFeed,
+    expiry_ms: u64,
+): Option<OracleRead<SVIParams>> {
+    if (!feed.expiries.contains(expiry_ms)) return option::none();
+    let read = feed.expiries.borrow(expiry_ms).latest_read();
     if (read.is_none()) return option::none();
     option::some(normalized_svi_from_read(&read.destroy_some()))
 }
 
-/// Exact raw BS SVI read for `timestamp_ms`.
-public fun raw_svi_at(feed: &BlockScholesSVIFeed, timestamp_ms: u64): OracleRead<RawSVI> {
-    let read = feed.lane.read_at(timestamp_ms);
+/// Exact raw BS SVI read for `(expiry_ms, timestamp_ms)`.
+public fun raw_svi_at(
+    feed: &BlockScholesSVIFeed,
+    expiry_ms: u64,
+    timestamp_ms: u64,
+): OracleRead<RawSVI> {
+    assert!(feed.expiries.contains(expiry_ms), ERawSVINotFound);
+    let read = feed.expiries.borrow(expiry_ms).read_at(timestamp_ms);
     assert!(read.is_some(), ERawSVINotFound);
     read.destroy_some()
 }
 
-/// Exact Propbook-normalized SVI params for `timestamp_ms`.
+/// Exact Propbook-normalized SVI params for `(expiry_ms, timestamp_ms)`.
 public fun normalized_svi_at(
     feed: &BlockScholesSVIFeed,
+    expiry_ms: u64,
     timestamp_ms: u64,
 ): Option<OracleRead<SVIParams>> {
-    let read = feed.lane.read_at(timestamp_ms);
+    if (!feed.expiries.contains(expiry_ms)) return option::none();
+    let read = feed.expiries.borrow(expiry_ms).read_at(timestamp_ms);
     if (read.is_none()) return option::none();
     option::some(normalized_svi_from_read(&read.destroy_some()))
 }
@@ -137,26 +141,36 @@ public fun sigma(params: &SVIParams): u64 {
 // === Write Functions ===
 
 /// Ingest a verified BS SVI update into this feed's generic oracle lane.
-public fun update(feed: &mut BlockScholesSVIFeed, update: SVIUpdate, clock: &Clock) {
+public fun update(
+    feed: &mut BlockScholesSVIFeed,
+    update: SVIUpdate,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
     assert!(feed.version == constants::current_version!(), EWrongVersion);
     assert!(update.svi_source_id() == feed.bs_source_id, EWrongSource);
-    assert!(update.svi_expiry_ms() == feed.expiry_ms, EWrongExpiry);
 
     let read = feed.new_read(&update, clock.timestamp_ms());
+    let expiry = read.read_value().expiry_ms;
     let id = feed.id();
-    feed.lane.update(id, read);
+    feed.update_expiry(expiry, id, read, ctx);
 }
 
 /// Insert an exact BS SVI observation keyed by the update-derived source
 /// timestamp. This does not mutate the live latest observation.
-public fun insert_at(feed: &mut BlockScholesSVIFeed, update: SVIUpdate, clock: &Clock) {
+public fun insert_at(
+    feed: &mut BlockScholesSVIFeed,
+    update: SVIUpdate,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
     assert!(feed.version == constants::current_version!(), EWrongVersion);
     assert!(update.svi_source_id() == feed.bs_source_id, EWrongSource);
-    assert!(update.svi_expiry_ms() == feed.expiry_ms, EWrongExpiry);
 
     let read = feed.new_read(&update, clock.timestamp_ms());
+    let expiry = read.read_value().expiry_ms;
     let id = feed.id();
-    feed.lane.insert_at(id, read);
+    feed.insert_expiry_at(expiry, id, read, ctx);
 }
 
 /// Migrate this feed to the running package version. Forward-only:
@@ -168,19 +182,17 @@ public fun migrate(feed: &mut BlockScholesSVIFeed) {
 
 // === Public-Package Functions ===
 
-/// Create and share a BS SVI feed for `(bs_source_id, expiry_ms)`.
+/// Create and share a BS SVI feed for `bs_source_id`.
 /// Package-only: `registry` owns source-catalog uniqueness.
 public(package) fun create_and_share(
     bs_source_id: u32,
-    expiry_ms: u64,
     ctx: &mut TxContext,
 ): ID {
     let feed = BlockScholesSVIFeed {
         id: object::new(ctx),
         bs_source_id,
-        expiry_ms,
         version: constants::current_version!(),
-        lane: oracle_lane::new(ctx),
+        expiries: table::new(ctx),
     };
     let id = feed.id();
     transfer::share_object(feed);
@@ -199,7 +211,7 @@ fun new_read(
         update_timestamp_ms,
         RawSVI {
             bs_source_id: feed.bs_source_id,
-            expiry_ms: feed.expiry_ms,
+            expiry_ms: update.svi_expiry_ms(),
             svi: SVIParams {
                 a: update.svi_a(),
                 b: update.svi_b(),
@@ -209,6 +221,40 @@ fun new_read(
             },
         },
     )
+}
+
+fun update_expiry(
+    feed: &mut BlockScholesSVIFeed,
+    expiry_ms: u64,
+    propbook_oracle_id: ID,
+    read: OracleRead<RawSVI>,
+    ctx: &mut TxContext,
+) {
+    if (feed.expiries.contains(expiry_ms)) {
+        feed.expiries.borrow_mut(expiry_ms).update(propbook_oracle_id, read);
+    } else {
+        if (!oracle_lane::read_has_valid_timestamp(&read)) return;
+        let mut lane = oracle_lane::new(ctx);
+        lane.update(propbook_oracle_id, read);
+        feed.expiries.add(expiry_ms, lane);
+    };
+}
+
+fun insert_expiry_at(
+    feed: &mut BlockScholesSVIFeed,
+    expiry_ms: u64,
+    propbook_oracle_id: ID,
+    read: OracleRead<RawSVI>,
+    ctx: &mut TxContext,
+) {
+    if (feed.expiries.contains(expiry_ms)) {
+        feed.expiries.borrow_mut(expiry_ms).insert_at(propbook_oracle_id, read);
+    } else {
+        if (!oracle_lane::read_has_valid_timestamp(&read)) return;
+        let mut lane = oracle_lane::new(ctx);
+        lane.insert_at(propbook_oracle_id, read);
+        feed.expiries.add(expiry_ms, lane);
+    };
 }
 
 fun normalized_svi_from_read(read: &OracleRead<RawSVI>): OracleRead<SVIParams> {

--- a/packages/propbook/sources/registry.move
+++ b/packages/propbook/sources/registry.move
@@ -32,7 +32,6 @@ const ESourceAlreadyBound: u64 = 3;
 const EBindingAlreadyExists: u64 = 4;
 const EBlockScholesSpotNotBound: u64 = 5;
 const EWrongBlockScholesSource: u64 = 6;
-const EWrongBlockScholesExpiry: u64 = 7;
 
 /// Oracle-kind tags stored in registry keys; future oracles add a value here.
 public(package) macro fun kind_pyth(): u8 {
@@ -76,23 +75,17 @@ public struct OracleRegistry has key {
     source_bindings: Table<OracleSourceKey, u32>,
 }
 
-/// Composite source key: oracle kind plus source-local identity. Underlying-level
-/// feeds set `has_expiry = false`; per-expiry feeds carry `expiry_ms`.
+/// Composite source key: oracle kind plus source-local identity.
 public struct OracleSourceKey has copy, drop, store {
     oracle_kind: u8,
     source_id: u32,
-    has_expiry: bool,
-    expiry_ms: u64,
 }
 
 /// Canonical binding key: Propbook underlying plus oracle value identity.
-/// Expiry-level values set `has_expiry = true`.
 public struct OracleBindingKey has copy, drop, store {
     propbook_underlying_id: u32,
     oracle_kind: u8,
     value_kind: u8,
-    has_expiry: bool,
-    expiry_ms: u64,
 }
 
 /// Canonical metadata for one immutable Propbook oracle binding.
@@ -102,16 +95,12 @@ public struct OracleMetadata has copy, drop, store {
     source_id: u32,
     propbook_oracle_id: ID,
     value_kind: u8,
-    has_expiry: bool,
-    expiry_ms: u64,
 }
 
 /// Emitted when a Propbook source wrapper is created and registered.
 public struct OracleSourceRegistered has copy, drop {
     oracle_kind: u8,
     source_id: u32,
-    has_expiry: bool,
-    expiry_ms: u64,
     propbook_oracle_id: ID,
 }
 
@@ -122,8 +111,6 @@ public struct OracleBound has copy, drop {
     source_id: u32,
     propbook_oracle_id: ID,
     value_kind: u8,
-    has_expiry: bool,
-    expiry_ms: u64,
 }
 
 fun init(ctx: &mut TxContext) {
@@ -154,22 +141,20 @@ public fun contains_block_scholes_spot_source(
     registry.contains_source(block_scholes_spot_source_key(bs_source_id))
 }
 
-/// Whether a Propbook BS forward wrapper exists for `(bs_source_id, expiry_ms)`.
+/// Whether a Propbook BS forward wrapper exists for `bs_source_id`.
 public fun contains_block_scholes_forward_source(
     registry: &OracleRegistry,
     bs_source_id: u32,
-    expiry_ms: u64,
 ): bool {
-    registry.contains_source(block_scholes_forward_source_key(bs_source_id, expiry_ms))
+    registry.contains_source(block_scholes_forward_source_key(bs_source_id))
 }
 
-/// Whether a Propbook BS SVI wrapper exists for `(bs_source_id, expiry_ms)`.
+/// Whether a Propbook BS SVI wrapper exists for `bs_source_id`.
 public fun contains_block_scholes_svi_source(
     registry: &OracleRegistry,
     bs_source_id: u32,
-    expiry_ms: u64,
 ): bool {
-    registry.contains_source(block_scholes_svi_source_key(bs_source_id, expiry_ms))
+    registry.contains_source(block_scholes_svi_source_key(bs_source_id))
 }
 
 /// Propbook Pyth object ID for a Pyth source id, if a wrapper exists.
@@ -185,23 +170,20 @@ public fun propbook_block_scholes_spot_id_for_source(
     registry.source_oracle_id(block_scholes_spot_source_key(bs_source_id))
 }
 
-/// Propbook BS forward object ID for `(bs_source_id, expiry_ms)`, if a wrapper
-/// exists.
+/// Propbook BS forward object ID for `bs_source_id`, if a wrapper exists.
 public fun propbook_block_scholes_forward_id_for_source(
     registry: &OracleRegistry,
     bs_source_id: u32,
-    expiry_ms: u64,
 ): Option<ID> {
-    registry.source_oracle_id(block_scholes_forward_source_key(bs_source_id, expiry_ms))
+    registry.source_oracle_id(block_scholes_forward_source_key(bs_source_id))
 }
 
-/// Propbook BS SVI object ID for `(bs_source_id, expiry_ms)`, if a wrapper exists.
+/// Propbook BS SVI object ID for `bs_source_id`, if a wrapper exists.
 public fun propbook_block_scholes_svi_id_for_source(
     registry: &OracleRegistry,
     bs_source_id: u32,
-    expiry_ms: u64,
 ): Option<ID> {
-    registry.source_oracle_id(block_scholes_svi_source_key(bs_source_id, expiry_ms))
+    registry.source_oracle_id(block_scholes_svi_source_key(bs_source_id))
 }
 
 /// Canonical Propbook Pyth object ID for `propbook_underlying_id`, if bound.
@@ -220,25 +202,20 @@ public fun propbook_block_scholes_spot_id_for_underlying(
     registry.canonical_oracle_id(block_scholes_spot_binding_key(propbook_underlying_id))
 }
 
-/// Canonical Propbook BS forward object ID for `(underlying, expiry)`, if bound.
-public fun propbook_block_scholes_forward_id_for_underlying_expiry(
+/// Canonical Propbook BS forward object ID for `propbook_underlying_id`, if bound.
+public fun propbook_block_scholes_forward_id_for_underlying(
     registry: &OracleRegistry,
     propbook_underlying_id: u32,
-    expiry_ms: u64,
 ): Option<ID> {
-    registry
-        .canonical_oracle_id(
-            block_scholes_forward_binding_key(propbook_underlying_id, expiry_ms),
-        )
+    registry.canonical_oracle_id(block_scholes_forward_binding_key(propbook_underlying_id))
 }
 
-/// Canonical Propbook BS SVI object ID for `(underlying, expiry)`, if bound.
-public fun propbook_block_scholes_svi_id_for_underlying_expiry(
+/// Canonical Propbook BS SVI object ID for `propbook_underlying_id`, if bound.
+public fun propbook_block_scholes_svi_id_for_underlying(
     registry: &OracleRegistry,
     propbook_underlying_id: u32,
-    expiry_ms: u64,
 ): Option<ID> {
-    registry.canonical_oracle_id(block_scholes_svi_binding_key(propbook_underlying_id, expiry_ms))
+    registry.canonical_oracle_id(block_scholes_svi_binding_key(propbook_underlying_id))
 }
 
 /// Canonical Pyth metadata for `propbook_underlying_id`, if bound.
@@ -257,25 +234,20 @@ public fun block_scholes_spot_metadata_for_underlying(
     registry.canonical_metadata(block_scholes_spot_binding_key(propbook_underlying_id))
 }
 
-/// Canonical BS forward metadata for `(underlying, expiry)`, if bound.
-public fun block_scholes_forward_metadata_for_underlying_expiry(
+/// Canonical BS forward metadata for `propbook_underlying_id`, if bound.
+public fun block_scholes_forward_metadata_for_underlying(
     registry: &OracleRegistry,
     propbook_underlying_id: u32,
-    expiry_ms: u64,
 ): Option<OracleMetadata> {
-    registry
-        .canonical_metadata(
-            block_scholes_forward_binding_key(propbook_underlying_id, expiry_ms),
-        )
+    registry.canonical_metadata(block_scholes_forward_binding_key(propbook_underlying_id))
 }
 
-/// Canonical BS SVI metadata for `(underlying, expiry)`, if bound.
-public fun block_scholes_svi_metadata_for_underlying_expiry(
+/// Canonical BS SVI metadata for `propbook_underlying_id`, if bound.
+public fun block_scholes_svi_metadata_for_underlying(
     registry: &OracleRegistry,
     propbook_underlying_id: u32,
-    expiry_ms: u64,
 ): Option<OracleMetadata> {
-    registry.canonical_metadata(block_scholes_svi_binding_key(propbook_underlying_id, expiry_ms))
+    registry.canonical_metadata(block_scholes_svi_binding_key(propbook_underlying_id))
 }
 
 public fun propbook_underlying_id(metadata: &OracleMetadata): u32 {
@@ -296,14 +268,6 @@ public fun propbook_oracle_id(metadata: &OracleMetadata): ID {
 
 public fun value_kind(metadata: &OracleMetadata): u8 {
     metadata.value_kind
-}
-
-public fun has_expiry(metadata: &OracleMetadata): bool {
-    metadata.has_expiry
-}
-
-public fun expiry_ms(metadata: &OracleMetadata): u64 {
-    metadata.expiry_ms
 }
 
 /// Create and share the Propbook Pyth wrapper for `pyth_source_id`, then record
@@ -337,33 +301,30 @@ public fun create_and_share_block_scholes_spot_feed(
     propbook_spot_id
 }
 
-/// Create and share the Propbook BS forward wrapper for `(bs_source_id,
-/// expiry_ms)`, then record it in the source catalog.
+/// Create and share the Propbook BS forward wrapper for `bs_source_id`, then
+/// record it in the source catalog.
 public fun create_and_share_block_scholes_forward_feed(
     registry: &mut OracleRegistry,
     bs_source_id: u32,
-    expiry_ms: u64,
     ctx: &mut TxContext,
 ): ID {
-    let source_key = block_scholes_forward_source_key(bs_source_id, expiry_ms);
+    let source_key = block_scholes_forward_source_key(bs_source_id);
     assert_source_available(registry, source_key);
-    let propbook_forward_id =
-        block_scholes_forward_feed::create_and_share(bs_source_id, expiry_ms, ctx);
+    let propbook_forward_id = block_scholes_forward_feed::create_and_share(bs_source_id, ctx);
     registry.record_source(source_key, propbook_forward_id);
     propbook_forward_id
 }
 
-/// Create and share the Propbook BS SVI wrapper for `(bs_source_id, expiry_ms)`,
-/// then record it in the source catalog.
+/// Create and share the Propbook BS SVI wrapper for `bs_source_id`, then record
+/// it in the source catalog.
 public fun create_and_share_block_scholes_svi_feed(
     registry: &mut OracleRegistry,
     bs_source_id: u32,
-    expiry_ms: u64,
     ctx: &mut TxContext,
 ): ID {
-    let source_key = block_scholes_svi_source_key(bs_source_id, expiry_ms);
+    let source_key = block_scholes_svi_source_key(bs_source_id);
     assert_source_available(registry, source_key);
-    let propbook_svi_id = block_scholes_svi_feed::create_and_share(bs_source_id, expiry_ms, ctx);
+    let propbook_svi_id = block_scholes_svi_feed::create_and_share(bs_source_id, ctx);
     registry.record_source(source_key, propbook_svi_id);
     propbook_svi_id
 }
@@ -400,22 +361,16 @@ public fun bind_block_scholes_spot_to_underlying(
     );
 }
 
-/// Admin-bind this BS forward/SVI pair to a canonical Propbook underlying and
-/// expiry. The underlying's BS spot feed must already be bound, and all three BS
-/// feeds must come from the same source id.
-public fun bind_block_scholes_expiry_to_underlying(
+/// Admin-bind this BS forward/SVI surface pair to a canonical Propbook underlying.
+/// The underlying's BS spot feed must already be bound, and all three BS feeds
+/// must come from the same source id.
+public fun bind_block_scholes_surface_to_underlying(
     registry: &mut OracleRegistry,
     admin_cap: &RegistryAdminCap,
     forward_feed: &BlockScholesForwardFeed,
     svi_feed: &BlockScholesSVIFeed,
     propbook_underlying_id: u32,
 ) {
-    let expiry_ms = block_scholes_forward_feed::expiry_ms(forward_feed);
-    assert!(
-        expiry_ms == block_scholes_svi_feed::expiry_ms(svi_feed),
-        EWrongBlockScholesExpiry,
-    );
-
     let bs_source_id = block_scholes_forward_feed::bs_source_id(forward_feed);
     assert!(
         bs_source_id == block_scholes_svi_feed::bs_source_id(svi_feed),
@@ -423,11 +378,10 @@ public fun bind_block_scholes_expiry_to_underlying(
     );
     registry.assert_bound_block_scholes_spot_source(propbook_underlying_id, bs_source_id);
 
-    let forward_source_key = block_scholes_forward_source_key(bs_source_id, expiry_ms);
-    let svi_source_key = block_scholes_svi_source_key(bs_source_id, expiry_ms);
-    let forward_binding_key =
-        block_scholes_forward_binding_key(propbook_underlying_id, expiry_ms);
-    let svi_binding_key = block_scholes_svi_binding_key(propbook_underlying_id, expiry_ms);
+    let forward_source_key = block_scholes_forward_source_key(bs_source_id);
+    let svi_source_key = block_scholes_svi_source_key(bs_source_id);
+    let forward_binding_key = block_scholes_forward_binding_key(propbook_underlying_id);
+    let svi_binding_key = block_scholes_svi_binding_key(propbook_underlying_id);
 
     registry.assert_registered_source_object(
         forward_source_key,
@@ -471,8 +425,6 @@ fun record_source(registry: &mut OracleRegistry, source_key: OracleSourceKey, pr
     event::emit(OracleSourceRegistered {
         oracle_kind: source_key.oracle_kind,
         source_id: source_key.source_id,
-        has_expiry: source_key.has_expiry,
-        expiry_ms: source_key.expiry_ms,
         propbook_oracle_id,
     });
 }
@@ -504,8 +456,6 @@ fun bind_oracle(
         source_id: source_key.source_id,
         propbook_oracle_id,
         value_kind: binding_key.value_kind,
-        has_expiry: source_key.has_expiry,
-        expiry_ms: source_key.expiry_ms,
     };
     registry.bindings.add(binding_key, metadata);
 
@@ -519,8 +469,6 @@ fun bind_oracle(
         source_id: source_key.source_id,
         propbook_oracle_id,
         value_kind: binding_key.value_kind,
-        has_expiry: source_key.has_expiry,
-        expiry_ms: source_key.expiry_ms,
     });
 }
 
@@ -597,8 +545,6 @@ fun pyth_source_key(pyth_source_id: u32): OracleSourceKey {
     OracleSourceKey {
         oracle_kind: kind_pyth!(),
         source_id: pyth_source_id,
-        has_expiry: false,
-        expiry_ms: 0,
     }
 }
 
@@ -606,26 +552,20 @@ fun block_scholes_spot_source_key(bs_source_id: u32): OracleSourceKey {
     OracleSourceKey {
         oracle_kind: kind_block_scholes_spot!(),
         source_id: bs_source_id,
-        has_expiry: false,
-        expiry_ms: 0,
     }
 }
 
-fun block_scholes_forward_source_key(bs_source_id: u32, expiry_ms: u64): OracleSourceKey {
+fun block_scholes_forward_source_key(bs_source_id: u32): OracleSourceKey {
     OracleSourceKey {
         oracle_kind: kind_block_scholes_forward!(),
         source_id: bs_source_id,
-        has_expiry: true,
-        expiry_ms,
     }
 }
 
-fun block_scholes_svi_source_key(bs_source_id: u32, expiry_ms: u64): OracleSourceKey {
+fun block_scholes_svi_source_key(bs_source_id: u32): OracleSourceKey {
     OracleSourceKey {
         oracle_kind: kind_block_scholes_svi!(),
         source_id: bs_source_id,
-        has_expiry: true,
-        expiry_ms,
     }
 }
 
@@ -634,8 +574,6 @@ fun pyth_binding_key(propbook_underlying_id: u32): OracleBindingKey {
         propbook_underlying_id,
         oracle_kind: kind_pyth!(),
         value_kind: value_kind_spot!(),
-        has_expiry: false,
-        expiry_ms: 0,
     }
 }
 
@@ -644,34 +582,22 @@ fun block_scholes_spot_binding_key(propbook_underlying_id: u32): OracleBindingKe
         propbook_underlying_id,
         oracle_kind: kind_block_scholes_spot!(),
         value_kind: value_kind_spot!(),
-        has_expiry: false,
-        expiry_ms: 0,
     }
 }
 
-fun block_scholes_forward_binding_key(
-    propbook_underlying_id: u32,
-    expiry_ms: u64,
-): OracleBindingKey {
+fun block_scholes_forward_binding_key(propbook_underlying_id: u32): OracleBindingKey {
     OracleBindingKey {
         propbook_underlying_id,
         oracle_kind: kind_block_scholes_forward!(),
         value_kind: value_kind_forward!(),
-        has_expiry: true,
-        expiry_ms,
     }
 }
 
-fun block_scholes_svi_binding_key(
-    propbook_underlying_id: u32,
-    expiry_ms: u64,
-): OracleBindingKey {
+fun block_scholes_svi_binding_key(propbook_underlying_id: u32): OracleBindingKey {
     OracleBindingKey {
         propbook_underlying_id,
         oracle_kind: kind_block_scholes_svi!(),
         value_kind: value_kind_svi!(),
-        has_expiry: true,
-        expiry_ms,
     }
 }
 

--- a/packages/propbook/tests/block_scholes/block_scholes_feed_tests.move
+++ b/packages/propbook/tests/block_scholes/block_scholes_feed_tests.move
@@ -23,6 +23,7 @@ const UNDERLYING_ID: u32 = 42;
 const SPOT: u64 = 50_000_000_000_000;
 const SPOT_LATER: u64 = 49_000_000_000_000;
 const FORWARD_A: u64 = 50_500_000_000_000;
+const FORWARD_B: u64 = 51_500_000_000_000;
 const EXPIRY_A: u64 = 1_700_100_000_000;
 const EXPIRY_B: u64 = 1_700_200_000_000;
 const UNKNOWN_TIMESTAMP: u64 = 9_999_999_999;
@@ -75,12 +76,11 @@ fun forward_update_records_raw_and_normalized_latest() {
     let mut clock = clock::create_for_testing(scenario.ctx());
     clock.set_for_testing(LANDED_EARLY);
 
-    feed.update(forward_update(BS_SOURCE_ID, EXPIRY_A, T_EARLY, FORWARD_A), &clock);
+    feed.update(forward_update(BS_SOURCE_ID, EXPIRY_A, T_EARLY, FORWARD_A), &clock, scenario.ctx());
 
     assert_eq!(feed.bs_source_id(), BS_SOURCE_ID);
-    assert_eq!(feed.expiry_ms(), EXPIRY_A);
     assert_eq!(feed.version(), propbook::constants::current_version!());
-    let raw_read = feed.raw_forward();
+    let raw_read = feed.raw_forward(EXPIRY_A);
     assert_eq!(raw_read.read_source_timestamp_ms(), T_EARLY);
     assert_eq!(raw_read.read_update_timestamp_ms(), LANDED_EARLY);
     let raw = raw_read.read_value();
@@ -88,12 +88,12 @@ fun forward_update_records_raw_and_normalized_latest() {
     assert_eq!(forward_feed::raw_expiry_ms(&raw), EXPIRY_A);
     assert_eq!(forward_feed::raw_forward_value(&raw), FORWARD_A);
     assert_price_read(
-        &feed.normalized_forward().destroy_some(),
+        &feed.normalized_forward(EXPIRY_A).destroy_some(),
         FORWARD_A,
         T_EARLY,
         LANDED_EARLY,
     );
-    assert!(feed.normalized_forward_at(T_EARLY).is_none());
+    assert!(feed.normalized_forward_at(EXPIRY_A, T_EARLY).is_none());
 
     clock.destroy_for_testing();
     return_shared(feed);
@@ -107,20 +107,19 @@ fun svi_update_records_raw_and_normalized_latest() {
     let mut clock = clock::create_for_testing(scenario.ctx());
     clock.set_for_testing(LANDED_EARLY);
 
-    feed.update(svi_update(BS_SOURCE_ID, EXPIRY_A, T_EARLY), &clock);
+    feed.update(svi_update(BS_SOURCE_ID, EXPIRY_A, T_EARLY), &clock, scenario.ctx());
 
     assert_eq!(feed.bs_source_id(), BS_SOURCE_ID);
-    assert_eq!(feed.expiry_ms(), EXPIRY_A);
     assert_eq!(feed.version(), propbook::constants::current_version!());
-    let raw_read = feed.raw_svi();
+    let raw_read = feed.raw_svi(EXPIRY_A);
     assert_eq!(raw_read.read_source_timestamp_ms(), T_EARLY);
     assert_eq!(raw_read.read_update_timestamp_ms(), LANDED_EARLY);
     let raw = raw_read.read_value();
     assert_eq!(svi_feed::raw_bs_source_id(&raw), BS_SOURCE_ID);
     assert_eq!(svi_feed::raw_expiry_ms(&raw), EXPIRY_A);
     assert_svi_params(&svi_feed::raw_svi_params(&raw));
-    assert_svi_read(&feed.normalized_svi().destroy_some(), T_EARLY, LANDED_EARLY);
-    assert!(feed.normalized_svi_at(T_EARLY).is_none());
+    assert_svi_read(&feed.normalized_svi(EXPIRY_A).destroy_some(), T_EARLY, LANDED_EARLY);
+    assert!(feed.normalized_svi_at(EXPIRY_A, T_EARLY).is_none());
 
     clock.destroy_for_testing();
     return_shared(feed);
@@ -137,23 +136,27 @@ fun exact_inserts_do_not_mutate_latest_reads() {
     clock.set_for_testing(LANDED_HIGH);
 
     spot.insert_at(spot_update(BS_SOURCE_ID, T_EARLY, SPOT), &clock);
-    forward.insert_at(forward_update(BS_SOURCE_ID, EXPIRY_A, T_EARLY, FORWARD_A), &clock);
-    svi.insert_at(svi_update(BS_SOURCE_ID, EXPIRY_A, T_EARLY), &clock);
+    forward.insert_at(
+        forward_update(BS_SOURCE_ID, EXPIRY_A, T_EARLY, FORWARD_A),
+        &clock,
+        scenario.ctx(),
+    );
+    svi.insert_at(svi_update(BS_SOURCE_ID, EXPIRY_A, T_EARLY), &clock, scenario.ctx());
 
     assert!(spot.normalized_spot().is_none());
-    assert!(forward.normalized_forward().is_none());
-    assert!(svi.normalized_svi().is_none());
+    assert!(forward.normalized_forward(EXPIRY_A).is_none());
+    assert!(svi.normalized_svi(EXPIRY_A).is_none());
     assert_price_read(&spot.normalized_spot_at(T_EARLY).destroy_some(), SPOT, T_EARLY, LANDED_HIGH);
     assert_price_read(
-        &forward.normalized_forward_at(T_EARLY).destroy_some(),
+        &forward.normalized_forward_at(EXPIRY_A, T_EARLY).destroy_some(),
         FORWARD_A,
         T_EARLY,
         LANDED_HIGH,
     );
-    assert_svi_read(&svi.normalized_svi_at(T_EARLY).destroy_some(), T_EARLY, LANDED_HIGH);
+    assert_svi_read(&svi.normalized_svi_at(EXPIRY_A, T_EARLY).destroy_some(), T_EARLY, LANDED_HIGH);
     assert!(spot.normalized_spot_at(T_LATE).is_none());
-    assert!(forward.normalized_forward_at(T_LATE).is_none());
-    assert!(svi.normalized_svi_at(T_LATE).is_none());
+    assert!(forward.normalized_forward_at(EXPIRY_A, T_LATE).is_none());
+    assert!(svi.normalized_svi_at(EXPIRY_A, T_LATE).is_none());
 
     clock.destroy_for_testing();
     return_shared(svi);
@@ -214,7 +217,11 @@ fun updates_accept_raw_values_without_pricing_envelope_validation() {
     clock.set_for_testing(LANDED_HIGH);
 
     spot.update(spot_update(BS_SOURCE_ID, T_EARLY, 0), &clock);
-    forward.update(forward_update(BS_SOURCE_ID, EXPIRY_A, T_EARLY, 0), &clock);
+    forward.update(
+        forward_update(BS_SOURCE_ID, EXPIRY_A, T_EARLY, 0),
+        &clock,
+        scenario.ctx(),
+    );
     svi.update(
         update::new_svi_update(
             BS_SOURCE_ID,
@@ -229,13 +236,14 @@ fun updates_accept_raw_values_without_pricing_envelope_validation() {
             M_NEG,
         ),
         &clock,
+        scenario.ctx(),
     );
 
     assert_eq!(spot_feed::raw_spot_value(&spot.raw_spot().read_value()), 0);
-    assert_eq!(forward_feed::raw_forward_value(&forward.raw_forward().read_value()), 0);
+    assert_eq!(forward_feed::raw_forward_value(&forward.raw_forward(EXPIRY_A).read_value()), 0);
     assert!(spot.normalized_spot().is_none());
-    assert!(forward.normalized_forward().is_none());
-    let params = svi.normalized_svi().destroy_some().read_value();
+    assert!(forward.normalized_forward(EXPIRY_A).is_none());
+    let params = svi.normalized_svi(EXPIRY_A).destroy_some().read_value();
     assert_eq!(params.sigma(), 0);
     assert_eq!(params.rho().magnitude(), FLOAT_SCALING + 1);
     assert_eq!(params.m().magnitude(), FLOAT_SCALING + 2);
@@ -253,20 +261,20 @@ fun registry_records_split_bs_source_feeds() {
     let registry = scenario.take_shared<OracleRegistry>();
 
     assert!(registry.contains_block_scholes_spot_source(BS_SOURCE_ID));
-    assert!(registry.contains_block_scholes_forward_source(BS_SOURCE_ID, EXPIRY_A));
-    assert!(registry.contains_block_scholes_svi_source(BS_SOURCE_ID, EXPIRY_A));
+    assert!(registry.contains_block_scholes_forward_source(BS_SOURCE_ID));
+    assert!(registry.contains_block_scholes_svi_source(BS_SOURCE_ID));
     assert_eq!(
         registry.propbook_block_scholes_spot_id_for_source(BS_SOURCE_ID).destroy_some(),
         spot_id,
     );
     assert_eq!(
         registry
-            .propbook_block_scholes_forward_id_for_source(BS_SOURCE_ID, EXPIRY_A)
+            .propbook_block_scholes_forward_id_for_source(BS_SOURCE_ID)
             .destroy_some(),
         forward_id,
     );
     assert_eq!(
-        registry.propbook_block_scholes_svi_id_for_source(BS_SOURCE_ID, EXPIRY_A).destroy_some(),
+        registry.propbook_block_scholes_svi_id_for_source(BS_SOURCE_ID).destroy_some(),
         svi_id,
     );
 
@@ -289,13 +297,11 @@ fun pyth_and_split_bs_share_numeric_source_id_across_kinds() {
     let forward_id = registry::create_and_share_block_scholes_forward_feed(
         &mut registry,
         SHARED_SOURCE_ID,
-        EXPIRY_A,
         scenario.ctx(),
     );
     let svi_id = registry::create_and_share_block_scholes_svi_feed(
         &mut registry,
         SHARED_SOURCE_ID,
-        EXPIRY_A,
         scenario.ctx(),
     );
     let pyth_id = registry::create_and_share_pyth_feed(
@@ -313,13 +319,13 @@ fun pyth_and_split_bs_share_numeric_source_id_across_kinds() {
     );
     assert_eq!(
         registry
-            .propbook_block_scholes_forward_id_for_source(SHARED_SOURCE_ID, EXPIRY_A)
+            .propbook_block_scholes_forward_id_for_source(SHARED_SOURCE_ID)
             .destroy_some(),
         forward_id,
     );
     assert_eq!(
         registry
-            .propbook_block_scholes_svi_id_for_source(SHARED_SOURCE_ID, EXPIRY_A)
+            .propbook_block_scholes_svi_id_for_source(SHARED_SOURCE_ID)
             .destroy_some(),
         svi_id,
     );
@@ -340,20 +346,20 @@ fun create_duplicate_spot_source_aborts() {
 }
 
 #[test, expected_failure(abort_code = registry::EBlockScholesSpotNotBound)]
-fun bind_expiry_without_spot_binding_aborts() {
+fun bind_surface_without_spot_binding_aborts() {
     let (scenario, _spot_id, forward_id, svi_id) = setup_feeds(BS_SOURCE_ID, EXPIRY_A);
     let admin_cap = scenario.take_from_sender<RegistryAdminCap>();
     let mut registry = scenario.take_shared<OracleRegistry>();
     let forward = scenario.take_shared_by_id<BlockScholesForwardFeed>(forward_id);
     let svi = scenario.take_shared_by_id<BlockScholesSVIFeed>(svi_id);
 
-    registry.bind_block_scholes_expiry_to_underlying(&admin_cap, &forward, &svi, UNDERLYING_ID);
+    registry.bind_block_scholes_surface_to_underlying(&admin_cap, &forward, &svi, UNDERLYING_ID);
 
     abort 999
 }
 
 #[test, expected_failure(abort_code = registry::EWrongBlockScholesSource)]
-fun bind_expiry_with_different_spot_source_aborts() {
+fun bind_surface_with_different_spot_source_aborts() {
     let (mut scenario, spot_id, _forward_id, _svi_id) = setup_feeds(BS_SOURCE_ID, EXPIRY_A);
     let (other_forward_id, other_svi_id) = create_forward_and_svi(
         &mut scenario,
@@ -368,15 +374,15 @@ fun bind_expiry_with_different_spot_source_aborts() {
     let svi = scenario.take_shared_by_id<BlockScholesSVIFeed>(other_svi_id);
 
     registry.bind_block_scholes_spot_to_underlying(&admin_cap, &spot, UNDERLYING_ID);
-    registry.bind_block_scholes_expiry_to_underlying(&admin_cap, &forward, &svi, UNDERLYING_ID);
+    registry.bind_block_scholes_surface_to_underlying(&admin_cap, &forward, &svi, UNDERLYING_ID);
 
     abort 999
 }
 
-#[test, expected_failure(abort_code = registry::EWrongBlockScholesExpiry)]
-fun bind_mismatched_forward_and_svi_expiry_aborts() {
+#[test, expected_failure(abort_code = registry::EWrongBlockScholesSource)]
+fun bind_surface_with_mismatched_forward_and_svi_sources_aborts() {
     let (mut scenario, spot_id, forward_id, _svi_id) = setup_feeds(BS_SOURCE_ID, EXPIRY_A);
-    let mismatched_svi_id = registry_svi(&mut scenario, BS_SOURCE_ID, EXPIRY_B);
+    let mismatched_svi_id = registry_svi(&mut scenario, OTHER_BS_SOURCE_ID);
     scenario.next_tx(ADMIN);
     let admin_cap = scenario.take_from_sender<RegistryAdminCap>();
     let mut registry = scenario.take_shared<OracleRegistry>();
@@ -385,7 +391,7 @@ fun bind_mismatched_forward_and_svi_expiry_aborts() {
     let svi = scenario.take_shared_by_id<BlockScholesSVIFeed>(mismatched_svi_id);
 
     registry.bind_block_scholes_spot_to_underlying(&admin_cap, &spot, UNDERLYING_ID);
-    registry.bind_block_scholes_expiry_to_underlying(&admin_cap, &forward, &svi, UNDERLYING_ID);
+    registry.bind_block_scholes_surface_to_underlying(&admin_cap, &forward, &svi, UNDERLYING_ID);
 
     abort 999
 }
@@ -402,16 +408,46 @@ fun spot_update_wrong_source_aborts() {
     abort 999
 }
 
-#[test, expected_failure(abort_code = forward_feed::EWrongExpiry)]
-fun forward_update_wrong_expiry_aborts() {
+#[test]
+fun forward_and_svi_updates_store_independent_expiry_rows() {
     let (mut scenario, _spot_id, forward_id, _svi_id) = setup_feeds(BS_SOURCE_ID, EXPIRY_A);
-    let mut feed = scenario.take_shared_by_id<BlockScholesForwardFeed>(forward_id);
+    let mut forward = scenario.take_shared_by_id<BlockScholesForwardFeed>(forward_id);
+    let mut svi = scenario.take_shared_by_id<BlockScholesSVIFeed>(_svi_id);
     let mut clock = clock::create_for_testing(scenario.ctx());
     clock.set_for_testing(LANDED_HIGH);
 
-    feed.update(forward_update(BS_SOURCE_ID, EXPIRY_B, T_EARLY, FORWARD_A), &clock);
+    forward.update(
+        forward_update(BS_SOURCE_ID, EXPIRY_A, T_EARLY, FORWARD_A),
+        &clock,
+        scenario.ctx(),
+    );
+    forward.update(
+        forward_update(BS_SOURCE_ID, EXPIRY_B, T_LATE, FORWARD_B),
+        &clock,
+        scenario.ctx(),
+    );
+    svi.update(svi_update(BS_SOURCE_ID, EXPIRY_A, T_EARLY), &clock, scenario.ctx());
+    svi.update(svi_update(BS_SOURCE_ID, EXPIRY_B, T_LATE), &clock, scenario.ctx());
 
-    abort 999
+    assert_price_read(
+        &forward.normalized_forward(EXPIRY_A).destroy_some(),
+        FORWARD_A,
+        T_EARLY,
+        LANDED_HIGH,
+    );
+    assert_price_read(
+        &forward.normalized_forward(EXPIRY_B).destroy_some(),
+        FORWARD_B,
+        T_LATE,
+        LANDED_HIGH,
+    );
+    assert_svi_read(&svi.normalized_svi(EXPIRY_A).destroy_some(), T_EARLY, LANDED_HIGH);
+    assert_svi_read(&svi.normalized_svi(EXPIRY_B).destroy_some(), T_LATE, LANDED_HIGH);
+
+    clock.destroy_for_testing();
+    return_shared(svi);
+    return_shared(forward);
+    scenario.end();
 }
 
 #[test, expected_failure(abort_code = svi_feed::EWrongSource)]
@@ -421,7 +457,7 @@ fun svi_update_wrong_source_aborts() {
     let mut clock = clock::create_for_testing(scenario.ctx());
     clock.set_for_testing(LANDED_HIGH);
 
-    feed.update(svi_update(OTHER_BS_SOURCE_ID, EXPIRY_A, T_EARLY), &clock);
+    feed.update(svi_update(OTHER_BS_SOURCE_ID, EXPIRY_A, T_EARLY), &clock, scenario.ctx());
 
     abort 999
 }
@@ -484,8 +520,12 @@ fun raw_forward_at_unknown_timestamp_aborts() {
     let mut clock = clock::create_for_testing(scenario.ctx());
     clock.set_for_testing(LANDED_HIGH);
 
-    feed.insert_at(forward_update(BS_SOURCE_ID, EXPIRY_A, T_EARLY, FORWARD_A), &clock);
-    feed.raw_forward_at(UNKNOWN_TIMESTAMP);
+    feed.insert_at(
+        forward_update(BS_SOURCE_ID, EXPIRY_A, T_EARLY, FORWARD_A),
+        &clock,
+        scenario.ctx(),
+    );
+    feed.raw_forward_at(EXPIRY_A, UNKNOWN_TIMESTAMP);
 
     abort 999
 }
@@ -544,7 +584,7 @@ fun svi_update(source_id: u32, expiry: u64, published: u64): SVIUpdate {
     )
 }
 
-fun setup_feeds(source_id: u32, expiry: u64): (Scenario, ID, ID, ID) {
+fun setup_feeds(source_id: u32, _expiry: u64): (Scenario, ID, ID, ID) {
     let mut scenario = test::begin(ADMIN);
     registry::init_for_testing(scenario.ctx());
     scenario.next_tx(ADMIN);
@@ -558,13 +598,11 @@ fun setup_feeds(source_id: u32, expiry: u64): (Scenario, ID, ID, ID) {
     let forward_id = registry::create_and_share_block_scholes_forward_feed(
         &mut registry,
         source_id,
-        expiry,
         scenario.ctx(),
     );
     let svi_id = registry::create_and_share_block_scholes_svi_feed(
         &mut registry,
         source_id,
-        expiry,
         scenario.ctx(),
     );
     return_shared(registry);
@@ -576,31 +614,28 @@ fun setup_feeds(source_id: u32, expiry: u64): (Scenario, ID, ID, ID) {
 fun create_forward_and_svi(
     scenario: &mut Scenario,
     source_id: u32,
-    expiry: u64,
+    _expiry: u64,
 ): (ID, ID) {
     let mut registry = scenario.take_shared<OracleRegistry>();
     let forward_id = registry::create_and_share_block_scholes_forward_feed(
         &mut registry,
         source_id,
-        expiry,
         scenario.ctx(),
     );
     let svi_id = registry::create_and_share_block_scholes_svi_feed(
         &mut registry,
         source_id,
-        expiry,
         scenario.ctx(),
     );
     return_shared(registry);
     (forward_id, svi_id)
 }
 
-fun registry_svi(scenario: &mut Scenario, source_id: u32, expiry: u64): ID {
+fun registry_svi(scenario: &mut Scenario, source_id: u32): ID {
     let mut registry = scenario.take_shared<OracleRegistry>();
     let id = registry::create_and_share_block_scholes_svi_feed(
         &mut registry,
         source_id,
-        expiry,
         scenario.ctx(),
     );
     return_shared(registry);

--- a/packages/propbook/tests/registry_tests.move
+++ b/packages/propbook/tests/registry_tests.move
@@ -22,7 +22,6 @@ const PYTH_SOURCE_B: u32 = 11;
 const PYTH_SOURCE_UNKNOWN: u32 = 99;
 const BS_SOURCE_A: u32 = 20;
 const BS_SOURCE_B: u32 = 21;
-const EXPIRY_A: u64 = 1_700_100_000_000;
 
 #[test]
 fun bind_pyth_to_underlying_records_typed_lookup_and_metadata() {
@@ -81,7 +80,7 @@ fun bind_block_scholes_to_underlying_records_typed_lookups_and_metadata() {
     let bs_svi = scenario.take_shared_by_id<BlockScholesSVIFeed>(bs_svi_a_id);
 
     registry.bind_block_scholes_spot_to_underlying(&admin_cap, &bs_spot, BTC_UNDERLYING_ID);
-    registry.bind_block_scholes_expiry_to_underlying(
+    registry.bind_block_scholes_surface_to_underlying(
         &admin_cap,
         &bs_forward,
         &bs_svi,
@@ -100,51 +99,43 @@ fun bind_block_scholes_to_underlying_records_typed_lookups_and_metadata() {
     );
     assert_eq!(
         registry
-            .propbook_block_scholes_forward_id_for_underlying_expiry(
-                BTC_UNDERLYING_ID,
-                EXPIRY_A,
-            )
+            .propbook_block_scholes_forward_id_for_underlying(BTC_UNDERLYING_ID)
             .destroy_some(),
         bs_forward_a_id,
     );
-    assert_expiry_metadata(
+    assert_metadata(
         registry
-            .block_scholes_forward_metadata_for_underlying_expiry(
-                BTC_UNDERLYING_ID,
-                EXPIRY_A,
-            )
+            .block_scholes_forward_metadata_for_underlying(BTC_UNDERLYING_ID)
             .destroy_some(),
         BTC_UNDERLYING_ID,
         BS_SOURCE_A,
         bs_forward_a_id,
-        EXPIRY_A,
     );
     assert_eq!(
         registry
-            .propbook_block_scholes_svi_id_for_underlying_expiry(BTC_UNDERLYING_ID, EXPIRY_A)
+            .propbook_block_scholes_svi_id_for_underlying(BTC_UNDERLYING_ID)
             .destroy_some(),
         bs_svi_a_id,
     );
-    assert_expiry_metadata(
+    assert_metadata(
         registry
-            .block_scholes_svi_metadata_for_underlying_expiry(BTC_UNDERLYING_ID, EXPIRY_A)
+            .block_scholes_svi_metadata_for_underlying(BTC_UNDERLYING_ID)
             .destroy_some(),
         BTC_UNDERLYING_ID,
         BS_SOURCE_A,
         bs_svi_a_id,
-        EXPIRY_A,
     );
     assert!(
         registry.propbook_block_scholes_spot_id_for_underlying(ETH_UNDERLYING_ID).is_none(),
     );
     assert!(
         registry
-            .propbook_block_scholes_forward_id_for_underlying_expiry(ETH_UNDERLYING_ID, EXPIRY_A)
+            .propbook_block_scholes_forward_id_for_underlying(ETH_UNDERLYING_ID)
             .is_none(),
     );
     assert!(
         registry
-            .propbook_block_scholes_svi_id_for_underlying_expiry(ETH_UNDERLYING_ID, EXPIRY_A)
+            .propbook_block_scholes_svi_id_for_underlying(ETH_UNDERLYING_ID)
             .is_none(),
     );
 
@@ -280,25 +271,21 @@ fun setup_registry_with_feeds(): (Scenario, ID, ID, ID, ID, ID, ID, ID, ID) {
     let bs_forward_a_id = registry::create_and_share_block_scholes_forward_feed(
         &mut registry,
         BS_SOURCE_A,
-        EXPIRY_A,
         scenario.ctx(),
     );
     let bs_forward_b_id = registry::create_and_share_block_scholes_forward_feed(
         &mut registry,
         BS_SOURCE_B,
-        EXPIRY_A,
         scenario.ctx(),
     );
     let bs_svi_a_id = registry::create_and_share_block_scholes_svi_feed(
         &mut registry,
         BS_SOURCE_A,
-        EXPIRY_A,
         scenario.ctx(),
     );
     let bs_svi_b_id = registry::create_and_share_block_scholes_svi_feed(
         &mut registry,
         BS_SOURCE_B,
-        EXPIRY_A,
         scenario.ctx(),
     );
     return_shared(registry);
@@ -326,16 +313,4 @@ fun assert_metadata(
     assert_eq!(registry::propbook_underlying_id(&metadata), expected_underlying_id);
     assert_eq!(registry::source_id(&metadata), expected_source_id);
     assert_eq!(registry::propbook_oracle_id(&metadata), expected_oracle_id);
-}
-
-fun assert_expiry_metadata(
-    metadata: OracleMetadata,
-    expected_underlying_id: u32,
-    expected_source_id: u32,
-    expected_oracle_id: ID,
-    expected_expiry_ms: u64,
-) {
-    assert_metadata(metadata, expected_underlying_id, expected_source_id, expected_oracle_id);
-    assert_eq!(registry::has_expiry(&metadata), true);
-    assert_eq!(registry::expiry_ms(&metadata), expected_expiry_ms);
 }


### PR DESCRIPTION
## Summary
- Convert Propbook BS forward/SVI feeds from per-expiry shared objects to permanent source-level objects with per-expiry lanes.
- Update Predict pricing and market deployability checks to validate underlying-level BS surface bindings and read forward/SVI rows by expiry.
- Rewire Predict/Propbook tests, simulation setup, and docs to the permanent surface model.

## Key decisions
- Keep one permanent BS spot, forward, and SVI feed per BS source id.
- Store expiry-specific forward/SVI data inside the feed tables, keyed by expiry timestamp.
- Bind the forward/SVI surface once per underlying with the same-source invariant.

## Test plan
- [x] sui move build --path packages/propbook --warnings-are-errors
- [x] sui move build --path packages/predict --warnings-are-errors
- [x] sui move test --path packages/propbook --gas-limit 100000000000
- [x] sui move test --path packages/predict --gas-limit 100000000000
- [x] npx tsc --noEmit (packages/predict/simulations)
- [x] python3 -m py_compile packages/predict/simulations/python_replay.py
- [x] bash -n packages/predict/simulations/run.sh
- [x] git diff --check