### PR TITLE
Add redeem_live close-side slippage floors (min_probability + min_proceeds)

### DIFF
--- a/packages/predict/simulations/src/runtime.ts
+++ b/packages/predict/simulations/src/runtime.ts
@@ -530,6 +530,9 @@ function addRedeem(tx: Transaction, params: RedeemParams): void {
             pricer,
             tx.pure.u256(BigInt(params.orderId)),
             tx.pure.u64(params.closeQuantity),
+            // `min_probability` close-side slippage floor; the benchmark never
+            // sets a floor, so pass 0 to disable (mirrors mint's U64_MAX caps).
+            tx.pure.u64(0),
             // `redeem_live` loads the account and ambient-settles it (`settle<DUSDC>`)
             // before crediting the payout, so it reads the singleton AccumulatorRoot at 0xacc.
             tx.object(ACCUMULATOR_ROOT_ID),

--- a/packages/predict/simulations/src/runtime.ts
+++ b/packages/predict/simulations/src/runtime.ts
@@ -530,8 +530,10 @@ function addRedeem(tx: Transaction, params: RedeemParams): void {
             pricer,
             tx.pure.u256(BigInt(params.orderId)),
             tx.pure.u64(params.closeQuantity),
-            // `min_probability` close-side slippage floor; the benchmark never
-            // sets a floor, so pass 0 to disable (mirrors mint's U64_MAX caps).
+            // `min_probability` then `min_proceeds` close-side slippage floors; the
+            // benchmark never sets a floor, so pass 0 to disable both (mirrors mint's
+            // U64_MAX caps).
+            tx.pure.u64(0),
             tx.pure.u64(0),
             // `redeem_live` loads the account and ambient-settles it (`settle<DUSDC>`)
             // before crediting the payout, so it reads the singleton AccumulatorRoot at 0xacc.

--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -49,6 +49,7 @@ const EWrongPricer: u64 = 7;
 const EReferenceTickObservationMissing: u64 = 8;
 const EReferenceTickTimestampMismatch: u64 = 9;
 const EMintRedeemSameTimestamp: u64 = 10;
+const ERedeemProbabilityBelowMin: u64 = 11;
 
 /// Per-expiry market state.
 public struct ExpiryMarket has key {
@@ -347,6 +348,11 @@ public fun mint_exact_amount(
 /// fully closed with zero payout. Settled orders must use `redeem_settled`.
 /// Returns `(closed_order_id, replacement_order_id)`; a replacement is present
 /// only when a live partial close leaves quantity open.
+///
+/// `min_probability` is the close-side slippage floor on the quoted per-contract
+/// range probability (same units as mint's `max_probability`); pass `0` to
+/// disable. It only gates the live-priced path — a liquidated tombstone closes at
+/// zero payout regardless, since its value is deterministic, not market-quoted.
 public fun redeem_live(
     market: &mut ExpiryMarket,
     wrapper: &mut AccountWrapper,
@@ -355,6 +361,7 @@ public fun redeem_live(
     pricer: &Pricer,
     order_id: u256,
     close_quantity: u64,
+    min_probability: u64,
     root: &AccumulatorRoot,
     clock: &Clock,
     ctx: &mut TxContext,
@@ -375,6 +382,7 @@ public fun redeem_live(
         pricer,
         &redeemed_order,
         close_quantity,
+        min_probability,
         clock,
         ctx,
     );
@@ -856,6 +864,7 @@ fun redeem_live_internal(
     pricer: &Pricer,
     order: &Order,
     close_quantity: u64,
+    min_probability: u64,
     clock: &Clock,
     ctx: &mut TxContext,
 ): Option<u256> {
@@ -877,6 +886,9 @@ fun redeem_live_internal(
     let (resulting_order, redeem_amount, range_probability) = market
         .strike_exposure
         .close_and_quote_live_order(pricer, order, close_quantity);
+    // Close-side slippage floor: reject if the quoted per-contract probability has
+    // slipped below the caller's bound. `0` disables.
+    assert!(range_probability >= min_probability, ERedeemProbabilityBelowMin);
     let fee_amount = market
         .strike_exposure
         .trading_fee(

--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -50,6 +50,7 @@ const EReferenceTickObservationMissing: u64 = 8;
 const EReferenceTickTimestampMismatch: u64 = 9;
 const EMintRedeemSameTimestamp: u64 = 10;
 const ERedeemProbabilityBelowMin: u64 = 11;
+const ERedeemProceedsBelowMin: u64 = 12;
 
 /// Per-expiry market state.
 public struct ExpiryMarket has key {
@@ -349,10 +350,14 @@ public fun mint_exact_amount(
 /// Returns `(closed_order_id, replacement_order_id)`; a replacement is present
 /// only when a live partial close leaves quantity open.
 ///
-/// `min_probability` is the close-side slippage floor on the quoted per-contract
-/// range probability (same units as mint's `max_probability`); pass `0` to
-/// disable. It only gates the live-priced path — a liquidated tombstone closes at
-/// zero payout regardless, since its value is deterministic, not market-quoted.
+/// Two close-side slippage floors, the mirror of mint's `max_probability` /
+/// `max_cost` pair; pass `0` to disable either. `min_probability` floors the
+/// quoted per-contract range probability (same units as mint's `max_probability`).
+/// `min_proceeds` floors the all-in net DUSDC credited to the account
+/// (`redeem_amount` minus trading fee, builder fee, and EWMA penalty), the mirror
+/// of mint's all-in `max_cost`. Both only gate the live-priced path — a liquidated
+/// tombstone closes at zero payout regardless, since its value is deterministic,
+/// not market-quoted.
 public fun redeem_live(
     market: &mut ExpiryMarket,
     wrapper: &mut AccountWrapper,
@@ -362,6 +367,7 @@ public fun redeem_live(
     order_id: u256,
     close_quantity: u64,
     min_probability: u64,
+    min_proceeds: u64,
     root: &AccumulatorRoot,
     clock: &Clock,
     ctx: &mut TxContext,
@@ -383,6 +389,7 @@ public fun redeem_live(
         &redeemed_order,
         close_quantity,
         min_probability,
+        min_proceeds,
         clock,
         ctx,
     );
@@ -865,6 +872,7 @@ fun redeem_live_internal(
     order: &Order,
     close_quantity: u64,
     min_probability: u64,
+    min_proceeds: u64,
     clock: &Clock,
     ctx: &mut TxContext,
 ): Option<u256> {
@@ -923,6 +931,15 @@ fun redeem_live_internal(
         penalty_amount,
         close_quantity,
         ctx,
+    );
+    // Close-side all-in slippage floor: the net credited to the account is
+    // `redeem_amount` minus the (post-clamp) fee, builder fee, and penalty that
+    // `settle_live_redeem_payment` just deducted. Subtraction is exact — each
+    // deduction is clamped at or below the running remainder inside settle. `0`
+    // disables. Mirror of mint's `max_cost`.
+    assert!(
+        redeem_amount - fee_amount - builder_fee_amount - penalty_amount >= min_proceeds,
+        ERedeemProceedsBelowMin,
     );
 
     order_events::emit_live_order_redeemed(

--- a/packages/predict/tests/flows/redeem_limit_price_tests.move.disabled
+++ b/packages/predict/tests/flows/redeem_limit_price_tests.move.disabled
@@ -1,0 +1,175 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Flow coverage for the live-redeem close-side slippage floor: `redeem_live`'s
+/// `min_probability` rejects a close whose quoted per-contract range probability
+/// has slipped below the caller's bound, and admits the close when the bound is
+/// disabled. Both tests advance the clock and re-seed the oracle first so the
+/// same-timestamp mint -> redeem guard does not pre-empt the floor.
+#[test_only]
+module deepbook_predict::redeem_limit_price_tests;
+
+use deepbook_predict::{constants, expiry_market, flow_test_helpers as helpers, test_constants};
+use std::unit_test::assert_eq;
+
+/// Lot-aligned position size minted in both tests.
+const QUANTITY: u64 = 840_000_000;
+/// 1x leverage in 1e9 fixed point: no floor, so no liquidation interaction.
+const LEVERAGE_ONE_X: u64 = 1_000_000_000;
+/// One second past the fixture's `now_ms()` open time — distinct timestamp, still
+/// inside the oracle freshness window.
+const REDEEM_MS: u64 = 121_000;
+const REDEEM_SOURCE_TS: u64 = 120_000;
+/// Probability 1.0 in 1e9 fixed point. A finite-strike digital can never quote
+/// certainty, so a floor at this value always trips.
+const MIN_PROBABILITY_CERTAIN: u64 = 1_000_000_000;
+/// Disabled floor: every non-negative quote clears it.
+const MIN_PROBABILITY_DISABLED: u64 = 0;
+
+#[test, expected_failure(abort_code = expiry_market::ERedeemProbabilityBelowMin)]
+fun redeem_below_min_probability_aborts() {
+    let (mut fx, expiry_id, trader) = helpers::setup_live_market(
+        test_constants::default_expiry_ms(),
+        test_constants::default_live_price(),
+    );
+    fx.scenario_mut().next_tx(test_constants::alice());
+    let (
+        mut pyth,
+        mut bs_spot,
+        mut bs_forward,
+        mut bs_svi,
+        oracle_registry,
+        _vault,
+        mut market,
+        config,
+    ) = fx.take_market(expiry_id);
+    let mut wrapper = fx.take_account(&trader);
+    let root = fx.take_root();
+
+    let order = fx.mint(
+        &config,
+        &oracle_registry,
+        &mut wrapper,
+        &root,
+        &mut market,
+        &pyth,
+        &bs_spot,
+        &bs_forward,
+        &bs_svi,
+        helpers::strike_tick(),
+        constants::pos_inf_tick!(),
+        QUANTITY,
+        LEVERAGE_ONE_X,
+    );
+
+    // Advance past the open timestamp and re-seed a fresh live oracle so the
+    // same-timestamp guard passes and the probability floor is the live gate.
+    fx.set_clock_for_testing(REDEEM_MS);
+    fx.prepare_live_oracle_at(
+        &market,
+        &mut pyth,
+        &mut bs_spot,
+        &mut bs_forward,
+        &mut bs_svi,
+        test_constants::default_live_price(),
+        REDEEM_SOURCE_TS,
+    );
+
+    // Demanding certainty is unsatisfiable for a finite-strike digital: the floor trips.
+    fx.redeem(
+        &config,
+        &oracle_registry,
+        &mut wrapper,
+        &root,
+        &mut market,
+        &pyth,
+        &bs_spot,
+        &bs_forward,
+        &bs_svi,
+        order,
+        QUANTITY,
+        MIN_PROBABILITY_CERTAIN,
+    );
+
+    abort 999
+}
+
+#[test]
+fun redeem_with_disabled_floor_succeeds() {
+    let (mut fx, expiry_id, trader) = helpers::setup_live_market(
+        test_constants::default_expiry_ms(),
+        test_constants::default_live_price(),
+    );
+    fx.scenario_mut().next_tx(test_constants::alice());
+    let (
+        mut pyth,
+        mut bs_spot,
+        mut bs_forward,
+        mut bs_svi,
+        oracle_registry,
+        vault,
+        mut market,
+        config,
+    ) = fx.take_market(expiry_id);
+    let mut wrapper = fx.take_account(&trader);
+    let root = fx.take_root();
+
+    let order = fx.mint(
+        &config,
+        &oracle_registry,
+        &mut wrapper,
+        &root,
+        &mut market,
+        &pyth,
+        &bs_spot,
+        &bs_forward,
+        &bs_svi,
+        helpers::strike_tick(),
+        constants::pos_inf_tick!(),
+        QUANTITY,
+        LEVERAGE_ONE_X,
+    );
+
+    fx.set_clock_for_testing(REDEEM_MS);
+    fx.prepare_live_oracle_at(
+        &market,
+        &mut pyth,
+        &mut bs_spot,
+        &mut bs_forward,
+        &mut bs_svi,
+        test_constants::default_live_price(),
+        REDEEM_SOURCE_TS,
+    );
+
+    let (closed, replacement) = fx.redeem(
+        &config,
+        &oracle_registry,
+        &mut wrapper,
+        &root,
+        &mut market,
+        &pyth,
+        &bs_spot,
+        &bs_forward,
+        &bs_svi,
+        order,
+        QUANTITY,
+        MIN_PROBABILITY_DISABLED,
+    );
+
+    assert_eq!(closed, order);
+    assert!(replacement.is_none());
+    assert!(!helpers::has_position(&wrapper, expiry_id, order));
+
+    helpers::return_account(wrapper, root);
+    helpers::return_market(
+        pyth,
+        bs_spot,
+        bs_forward,
+        bs_svi,
+        oracle_registry,
+        vault,
+        market,
+        config,
+    );
+    fx.finish();
+}

--- a/packages/predict/tests/flows/redeem_limit_price_tests.move.disabled
+++ b/packages/predict/tests/flows/redeem_limit_price_tests.move.disabled
@@ -1,18 +1,18 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Flow coverage for the live-redeem close-side slippage floor: `redeem_live`'s
-/// `min_probability` rejects a close whose quoted per-contract range probability
-/// has slipped below the caller's bound, and admits the close when the bound is
-/// disabled. Both tests advance the clock and re-seed the oracle first so the
-/// same-timestamp mint -> redeem guard does not pre-empt the floor.
+/// Flow coverage for `redeem_live`'s two close-side slippage floors: `min_probability`
+/// rejects a close whose quoted per-contract range probability has slipped below the
+/// bound, `min_proceeds` rejects a close whose all-in net payout falls below the bound,
+/// and both are admitted when disabled. Every test advances the clock and re-seeds the
+/// oracle first so the same-timestamp mint -> redeem guard does not pre-empt the floors.
 #[test_only]
 module deepbook_predict::redeem_limit_price_tests;
 
 use deepbook_predict::{constants, expiry_market, flow_test_helpers as helpers, test_constants};
 use std::unit_test::assert_eq;
 
-/// Lot-aligned position size minted in both tests.
+/// Lot-aligned position size minted in every test.
 const QUANTITY: u64 = 840_000_000;
 /// 1x leverage in 1e9 fixed point: no floor, so no liquidation interaction.
 const LEVERAGE_ONE_X: u64 = 1_000_000_000;
@@ -21,10 +21,11 @@ const LEVERAGE_ONE_X: u64 = 1_000_000_000;
 const REDEEM_MS: u64 = 121_000;
 const REDEEM_SOURCE_TS: u64 = 120_000;
 /// Probability 1.0 in 1e9 fixed point. A finite-strike digital can never quote
-/// certainty, so a floor at this value always trips.
+/// certainty, so a probability floor at this value always trips.
 const MIN_PROBABILITY_CERTAIN: u64 = 1_000_000_000;
-/// Disabled floor: every non-negative quote clears it.
+/// Disabled floors: every non-negative quote / payout clears them.
 const MIN_PROBABILITY_DISABLED: u64 = 0;
+const MIN_PROCEEDS_DISABLED: u64 = 0;
 
 #[test, expected_failure(abort_code = expiry_market::ERedeemProbabilityBelowMin)]
 fun redeem_below_min_probability_aborts() {
@@ -89,13 +90,82 @@ fun redeem_below_min_probability_aborts() {
         order,
         QUANTITY,
         MIN_PROBABILITY_CERTAIN,
+        MIN_PROCEEDS_DISABLED,
+    );
+
+    abort 999
+}
+
+#[test, expected_failure(abort_code = expiry_market::ERedeemProceedsBelowMin)]
+fun redeem_below_min_proceeds_aborts() {
+    let (mut fx, expiry_id, trader) = helpers::setup_live_market(
+        test_constants::default_expiry_ms(),
+        test_constants::default_live_price(),
+    );
+    fx.scenario_mut().next_tx(test_constants::alice());
+    let (
+        mut pyth,
+        mut bs_spot,
+        mut bs_forward,
+        mut bs_svi,
+        oracle_registry,
+        _vault,
+        mut market,
+        config,
+    ) = fx.take_market(expiry_id);
+    let mut wrapper = fx.take_account(&trader);
+    let root = fx.take_root();
+
+    let order = fx.mint(
+        &config,
+        &oracle_registry,
+        &mut wrapper,
+        &root,
+        &mut market,
+        &pyth,
+        &bs_spot,
+        &bs_forward,
+        &bs_svi,
+        helpers::strike_tick(),
+        constants::pos_inf_tick!(),
+        QUANTITY,
+        LEVERAGE_ONE_X,
+    );
+
+    fx.set_clock_for_testing(REDEEM_MS);
+    fx.prepare_live_oracle_at(
+        &market,
+        &mut pyth,
+        &mut bs_spot,
+        &mut bs_forward,
+        &mut bs_svi,
+        test_constants::default_live_price(),
+        REDEEM_SOURCE_TS,
+    );
+
+    // Probability floor disabled; a max-value proceeds floor exceeds any finite net
+    // payout, so the all-in floor trips after settlement deducts fees and penalty.
+    fx.redeem(
+        &config,
+        &oracle_registry,
+        &mut wrapper,
+        &root,
+        &mut market,
+        &pyth,
+        &bs_spot,
+        &bs_forward,
+        &bs_svi,
+        order,
+        QUANTITY,
+        MIN_PROBABILITY_DISABLED,
+        std::u64::max_value!(),
     );
 
     abort 999
 }
 
 #[test]
-fun redeem_with_disabled_floor_succeeds() {
+fun redeem_with_disabled_floors_succeeds() {
     let (mut fx, expiry_id, trader) = helpers::setup_live_market(
         test_constants::default_expiry_ms(),
         test_constants::default_live_price(),
@@ -154,6 +224,7 @@ fun redeem_with_disabled_floor_succeeds() {
         order,
         QUANTITY,
         MIN_PROBABILITY_DISABLED,
+        MIN_PROCEEDS_DISABLED,
     );
 
     assert_eq!(closed, order);

--- a/packages/predict/tests/helper/flow_test_helpers.move
+++ b/packages/predict/tests/helper/flow_test_helpers.move
@@ -751,6 +751,7 @@ public fun redeem(
     bs_svi: &BlockScholesSVIFeed,
     order_id: u256,
     close_quantity: u64,
+    min_probability: u64,
 ): (u256, Option<u256>) {
     let auth = account::generate_auth(self.scenario.ctx());
     let pricer = market.load_live_pricer(
@@ -769,6 +770,7 @@ public fun redeem(
         &pricer,
         order_id,
         close_quantity,
+        min_probability,
         root,
         &self.clock,
         self.scenario.ctx(),

--- a/packages/predict/tests/helper/flow_test_helpers.move
+++ b/packages/predict/tests/helper/flow_test_helpers.move
@@ -752,6 +752,7 @@ public fun redeem(
     order_id: u256,
     close_quantity: u64,
     min_probability: u64,
+    min_proceeds: u64,
 ): (u256, Option<u256>) {
     let auth = account::generate_auth(self.scenario.ctx());
     let pricer = market.load_live_pricer(
@@ -771,6 +772,7 @@ public fun redeem(
         order_id,
         close_quantity,
         min_probability,
+        min_proceeds,
         root,
         &self.clock,
         self.scenario.ctx(),


### PR DESCRIPTION
## Summary
- Gives `expiry_market::redeem_live` the full close-side mirror of mint's two slippage guards (`max_probability` + `max_cost`), both opt-in via a `0` sentinel:
  - **`min_probability`** — floors the quoted per-contract range probability (`pricer.range_price`), the mirror of mint's `max_probability`. Aborts `ERedeemProbabilityBelowMin`.
  - **`min_proceeds`** — floors the all-in net DUSDC credited to the account (`redeem_amount − trading fee − builder fee − EWMA penalty`), the mirror of mint's all-in `max_cost`. Aborts `ERedeemProceedsBelowMin`.
- Threads both through `redeem_live_internal`; asserts the price floor right after the quote and the proceeds floor right after `settle_live_redeem_payment`.
- Updates the `flow_test_helpers::redeem` helper and the simulation `runtime.ts` caller (passes `0`/`0` — the benchmark never sets a floor).
- Adds `redeem_limit_price_tests.move.disabled` covering both aborts + a both-floors-disabled success path.
- **No new public functions** — two params, one error const, one assert added to the existing entrypoint.

## Security
- **Disabled sentinel is a provable no-op.** `min_probability=0` ⇒ `range_probability >= 0` (always true); `min_proceeds=0` ⇒ `net >= 0` (always true, since the net never underflows). With both `0` — the default and what the sim passes — behavior is byte-identical to before; the feature is strictly opt-in.
- **Caller-scoped, no griefing/DoS.** Both floors are caller-supplied and only abort the caller's own tx. They touch no shared state, no other account, no pool accounting. A rejected redeem reverts cleanly; the order stays open and closable later.
- **No underflow.** `redeem_amount − fee − builder_fee − penalty` is exact: `settle_live_redeem_payment` clamps each deduction at/below the running remainder, and the assert uses settle's returned post-clamp values.
- **Atomic revert past side effects.** The `min_proceeds` assert sits after settle, which deposits to the account and pays the builder via `send_funds` → `funds_accumulator::add_impl` — an ordinary in-tx write, so an abort rolls it all back. No "fee charged but redeem reverted" hazard.
- **Only rejects, never inflates** payout or accounting — no value-extraction vector.
- **Liquidated tombstone intentionally not gated** (its branch returns before the floors), so a stale/high floor can't brick a deterministic 0-payout clear.

## Key decisions
- **Why `redeem_live` only.** Mint already had slippage protection; settled redeem is deterministic ($0/$1 per contract); liquidated tombstones are deterministic 0 payout. Live redeem was the one stochastic exit with no guard.
- **Where the proceeds floor is asserted.** Mint *adds* fees onto cost, so it asserts `max_cost` *before* settle. Redeem *subtracts* fees from the payout with clamps inside `settle_live_redeem_payment`, so the exact net is only known post-settle — `min_proceeds` is asserted *after* settle using the returned post-clamp `builder_fee_amount`/`penalty_amount`. Computing it before settle would duplicate settle's clamp logic.
- **Inherent (correct) asymmetries.** (1) Mint's `max_cost` uses `trader_fee = fee − fee_subsidy` (mint fees are subsidized); redeem has no subsidy, so `min_proceeds` subtracts the full fee — each bound reflects its side's real cash flow. (2) Param order currently differs (mint `max_cost, max_probability`; redeem `min_probability, min_proceeds`) — semantically symmetric, positionally reversed; left as-is.
- **Test is `.disabled`.** The `AccumulatorRoot` test constructor (`sui::accumulator::create_for_testing`) ships only in nightly Sui, so all root-dependent mint/redeem flow tests are `.disabled` on this branch (see `tests/helper/accumulator_support.move`).

## Test coverage
- `redeem_below_min_probability_aborts` — price floor trips (`ERedeemProbabilityBelowMin`, code 11).
- `redeem_below_min_proceeds_aborts` — proceeds floor trips (`ERedeemProceedsBelowMin`, code 12).
- `redeem_with_disabled_floors_succeeds` — both floors disabled, full close succeeds.
- Both new error codes have `expected_failure` coverage; all three compile against the real signatures and abort only at `take_root` on the missing nightly root, so they are re-enable-ready.
- **Deferred to re-enable** (need a price-quote seam / liquidation setup, can't run on this branch): a floor-active-but-satisfied boundary pass, and the liquidated-tombstone bypass.

## Test plan
- [x] `sui move build --path packages/predict --warnings-are-errors` — clean
- [x] `sui move test --path packages/predict --gas-limit 100000000000` — 250 passed, 0 failed (real suite)
- [x] Temporarily enabled the disabled test: compiles clean, expects abort codes 11/12, fails only at `take_root` on the missing nightly root
- [x] `bunx prettier-move -c` on all modified Move files — already conformant
- [x] Confirmed `min_proceeds` arg introduces no TS error in the `runtime.ts` edit region (pre-existing env/dep tsc errors are unrelated)
- [ ] Re-enable the root-dependent flow tests (pending nightly accumulator constructor) and confirm all three `redeem_limit_price_tests` run green

🤖 Generated with [Claude Code](https://claude.com/claude-code)