### PR TITLE
Predict: name same-typed money-return tuples

### DIFF
--- a/packages/account/sources/account.move
+++ b/packages/account/sources/account.move
@@ -68,7 +68,7 @@ public struct Account has store {
 public struct DataKey<phantom App>() has copy, drop, store;
 
 /// Per-coin bag key.
-public struct CoinKey<phantom T> has copy, drop, store {}
+public struct CoinKey<phantom T>() has copy, drop, store;
 
 /// Hot-potato authority to mutably open an `AccountWrapper`.
 public struct Auth {
@@ -285,7 +285,7 @@ fun assert_owner(self: &AccountWrapper, owner: address) {
 }
 
 fun stored_balance<T>(self: &Account): u64 {
-    let key = CoinKey<T> {};
+    let key = CoinKey<T>();
     if (self.balances.contains(key)) {
         let bal: &Balance<T> = &self.balances[key];
         bal.value()
@@ -311,7 +311,7 @@ fun settled_this_timestamp<T>(self: &Account, clock: &Clock): bool {
 }
 
 fun last_settlement_ms<T>(self: &Account): u64 {
-    let key = CoinKey<T> {};
+    let key = CoinKey<T>();
     if (self.settlements.contains(key)) {
         let timestamp: &u64 = &self.settlements[key];
         *timestamp
@@ -321,7 +321,7 @@ fun last_settlement_ms<T>(self: &Account): u64 {
 }
 
 fun set_last_settlement_ms<T>(self: &mut Account, timestamp: u64) {
-    let key = CoinKey<T> {};
+    let key = CoinKey<T>();
     if (self.settlements.contains(key)) {
         let last_settlement_ms: &mut u64 = &mut self.settlements[key];
         *last_settlement_ms = timestamp;
@@ -331,7 +331,7 @@ fun set_last_settlement_ms<T>(self: &mut Account, timestamp: u64) {
 }
 
 fun deposit_balance<T>(self: &mut Account, balance: Balance<T>) {
-    let key = CoinKey<T> {};
+    let key = CoinKey<T>();
     if (self.balances.contains(key)) {
         let bal: &mut Balance<T> = &mut self.balances[key];
         bal.join(balance);
@@ -341,7 +341,7 @@ fun deposit_balance<T>(self: &mut Account, balance: Balance<T>) {
 }
 
 fun withdraw_balance<T>(self: &mut Account, amount: u64): Balance<T> {
-    let key = CoinKey<T> {};
+    let key = CoinKey<T>();
     assert!(self.balances.contains(key), EBalanceTooLow);
     let bal: &mut Balance<T> = &mut self.balances[key];
     assert!(bal.value() >= amount, EBalanceTooLow);

--- a/packages/account/sources/account_registry.move
+++ b/packages/account/sources/account_registry.move
@@ -75,21 +75,7 @@ public fun derived_wrapper_exists(registry: &AccountRegistry, owner: address): b
 /// Create the sender's canonical derived account wrapper.
 public fun new(registry: &mut AccountRegistry, ctx: &mut TxContext): AccountWrapper {
     let owner = ctx.sender();
-    registry.assert_account_does_not_exist(owner);
-    let wrapper = account::new_derived(
-        &mut registry.id,
-        AccountWrapperKey(owner),
-        AccountKey(owner),
-        owner,
-        ctx,
-    );
-    account_events::emit_account_created(
-        wrapper.load_account().account_id(),
-        wrapper.id(),
-        owner,
-        false,
-    );
-    wrapper
+    registry.new_for_owner(owner, false, ctx)
 }
 
 /// Create the canonical derived account wrapper owned by `owner_uid`'s object address.
@@ -99,21 +85,7 @@ public fun new_self_owned(
     ctx: &mut TxContext,
 ): AccountWrapper {
     let owner = owner_uid.to_inner().to_address();
-    registry.assert_account_does_not_exist(owner);
-    let wrapper = account::new_derived(
-        &mut registry.id,
-        AccountWrapperKey(owner),
-        AccountKey(owner),
-        owner,
-        ctx,
-    );
-    account_events::emit_account_created(
-        wrapper.load_account().account_id(),
-        wrapper.id(),
-        owner,
-        true,
-    );
-    wrapper
+    registry.new_for_owner(owner, true, ctx)
 }
 
 /// Return whether `App` is authorized for app-driven account access.
@@ -148,6 +120,29 @@ public fun generate_auth_as_app<App>(registry: &AccountRegistry, _permit: Permit
 }
 
 // === Private Functions ===
+fun new_for_owner(
+    registry: &mut AccountRegistry,
+    owner: address,
+    self_owned: bool,
+    ctx: &mut TxContext,
+): AccountWrapper {
+    registry.assert_account_does_not_exist(owner);
+    let wrapper = account::new_derived(
+        &mut registry.id,
+        AccountWrapperKey(owner),
+        AccountKey(owner),
+        owner,
+        ctx,
+    );
+    account_events::emit_account_created(
+        wrapper.load_account().account_id(),
+        wrapper.id(),
+        owner,
+        self_owned,
+    );
+    wrapper
+}
+
 fun assert_account_does_not_exist(registry: &AccountRegistry, owner: address) {
     assert!(
         !registry.derived_exists(owner) && !registry.derived_wrapper_exists(owner),

--- a/packages/account/sources/account_registry.move
+++ b/packages/account/sources/account_registry.move
@@ -120,6 +120,13 @@ public fun generate_auth_as_app<App>(registry: &AccountRegistry, _permit: Permit
 }
 
 // === Private Functions ===
+fun assert_account_does_not_exist(registry: &AccountRegistry, owner: address) {
+    assert!(
+        !registry.derived_exists(owner) && !registry.derived_wrapper_exists(owner),
+        EAccountAlreadyExists,
+    );
+}
+
 fun new_for_owner(
     registry: &mut AccountRegistry,
     owner: address,
@@ -141,11 +148,4 @@ fun new_for_owner(
         self_owned,
     );
     wrapper
-}
-
-fun assert_account_does_not_exist(registry: &AccountRegistry, owner: address) {
-    assert!(
-        !registry.derived_exists(owner) && !registry.derived_wrapper_exists(owner),
-        EAccountAlreadyExists,
-    );
 }

--- a/packages/block_scholes_oracle/sources/update.move
+++ b/packages/block_scholes_oracle/sources/update.move
@@ -46,12 +46,12 @@ public struct SVIUpdate has copy, drop {
     svi_m_is_negative: bool,
 }
 
-// STUB: the production verifier validates BS signatures; this does not.
+/// STUB: the production verifier validates BS signatures; this does not.
 public fun new_spot_update(source_id: u32, published_at_ms: u64, spot: u64): SpotUpdate {
     SpotUpdate { source_id, published_at_ms, spot }
 }
 
-// STUB: the production verifier validates BS signatures; this does not.
+/// STUB: the production verifier validates BS signatures; this does not.
 public fun new_forward_update(
     source_id: u32,
     expiry_ms: u64,
@@ -61,7 +61,7 @@ public fun new_forward_update(
     ForwardUpdate { source_id, expiry_ms, published_at_ms, forward }
 }
 
-// STUB: the production verifier validates BS signatures; this does not.
+/// STUB: the production verifier validates BS signatures; this does not.
 public fun new_svi_update(
     source_id: u32,
     expiry_ms: u64,

--- a/packages/fixed_math/sources/math.move
+++ b/packages/fixed_math/sources/math.move
@@ -69,7 +69,7 @@ const LN2_U128: u128 = 693_147_180;
 // Largest exp input guaranteed to keep the u64 result in range even at the 1e-7
 // precision ceiling: e^x * 1e9 * (1 + 1e-7) <= u64::MAX. Set ~100 units below the
 // exact math bound (64*ln2 - 9*ln10 ≈ 23.638) so the named EExpOverflow guard
-// always fires before the `as u64` cast (line ~148) could overflow on a hot impl.
+// always fires before the result's `as u64` cast could overflow on a hot impl.
 const EXP_MAX_INPUT: u64 = 23_638_153_618;
 
 // Cody rational approximation coefficients (scaled to F = 1e9)

--- a/packages/fixed_math/sources/math.move
+++ b/packages/fixed_math/sources/math.move
@@ -208,11 +208,7 @@ public fun sqrt(x: u64, precision: u64): u64 {
 public fun pow10(n: u64): u64 {
     assert!(n <= 18, EPow10ExponentTooLarge);
     let mut result: u64 = 1;
-    let mut i = 0;
-    while (i < n) {
-        result = result * 10;
-        i = i + 1;
-    };
+    n.do!(|_| result = result * 10);
     result
 }
 

--- a/packages/predict/docs/concepts/fees-and-rebates.md
+++ b/packages/predict/docs/concepts/fees-and-rebates.md
@@ -115,7 +115,7 @@ fee_after_discount = trading_fee - trading_fee * discount_fraction
 
 ### Lazy epoch rollover
 
-Newly staked DEEP becomes `inactive_stake` and only counts as `active_stake` in a later epoch. The rollover is **lazy**: `active_stake_mut` moves inactive into active the first time the account is touched in a new epoch, guarded so it is a no-op within the same epoch. Every fee- or rebate-bearing flow (mint, live redeem, rebate claim) rolls stake before reading `active_stake`, so the discount always reflects stake that has been active since the start of the current epoch. Stake added this epoch does not earn a same-epoch discount.
+Newly staked DEEP becomes `inactive_stake` and only counts as `active_stake` in a later epoch. The rollover is **lazy**: `roll_active_stake` moves inactive into active the first time the account is touched in a new epoch, guarded so it is a no-op within the same epoch. Every fee- or rebate-bearing flow (mint, live redeem, rebate claim) rolls stake before reading `active_stake`, so the discount always reflects stake that has been active since the start of the current epoch. Stake added this epoch does not earn a same-epoch discount.
 
 ## 6. Trading-loss rebate
 

--- a/packages/predict/sources/config/strike_exposure_config.move
+++ b/packages/predict/sources/config/strike_exposure_config.move
@@ -50,6 +50,13 @@ public struct StrikeExposureConfig has store {
     expiry_fee_max_multiplier: u64,
 }
 
+/// Mint admission outcome: the per-contract net premium charged and the static
+/// floor `F` (`floor_shares`), returned together so callers read them by name.
+public struct MintAdmission has drop {
+    net_premium: u64,
+    floor_shares: u64,
+}
+
 // === Public-Package Functions ===
 
 public(package) fun liquidation_ltv(config: &StrikeExposureConfig): u64 {
@@ -120,8 +127,8 @@ public(package) fun assert_mint_probability_and_leverage_policy(
     );
 }
 
-/// Assert entry probability, leverage, net-premium, and barrier policy; return
-/// `(net_premium, floor_shares)`.
+/// Assert entry probability, leverage, net-premium, and barrier policy; return a
+/// `MintAdmission` carrying the net premium and the static floor `F`.
 ///
 /// `floor_shares` is the static dollar floor `F = financed_amount = entry_value -
 /// net_premium`. Leverage must be at least 1x and no greater than the
@@ -133,7 +140,7 @@ public(package) fun assert_mint_admission(
     entry_probability: u64,
     quantity: u64,
     leverage: u64,
-): (u64, u64) {
+): MintAdmission {
     config.assert_mint_probability_and_leverage_policy(entry_probability, leverage);
 
     let entry_value = math::mul(entry_probability, quantity);
@@ -146,7 +153,15 @@ public(package) fun assert_mint_admission(
         assert!(entry_value > liquidation_threshold_at_open, EOrderBelowLiquidationThreshold);
     };
 
-    (net_premium, floor_shares)
+    MintAdmission { net_premium, floor_shares }
+}
+
+public(package) fun net_premium(admission: &MintAdmission): u64 {
+    admission.net_premium
+}
+
+public(package) fun floor_shares(admission: &MintAdmission): u64 {
+    admission.floor_shares
 }
 
 /// Return the largest raw quantity whose derived net premium is at most `net_premium`.

--- a/packages/predict/sources/config/strike_exposure_config.move
+++ b/packages/predict/sources/config/strike_exposure_config.move
@@ -50,7 +50,7 @@ public struct StrikeExposureConfig has store {
     expiry_fee_max_multiplier: u64,
 }
 
-/// Mint admission outcome: the per-contract net premium charged and the static
+/// Mint admission outcome: the net premium charged for the order and the static
 /// floor `F` (`floor_shares`), returned together so callers read them by name.
 public struct MintAdmission has drop {
     net_premium: u64,

--- a/packages/predict/sources/constants.move
+++ b/packages/predict/sources/constants.move
@@ -99,9 +99,6 @@ public(package) macro fun one_month_ms(): u64 { 30 * one_day_ms!() }
 /// Milliseconds in a 365-day year.
 public(package) macro fun one_year_ms(): u64 { 365 * one_day_ms!() }
 
-/// Milliseconds in a 365-day year.
-public(package) macro fun ms_per_year(): u64 { one_year_ms!() }
-
 // === Staking ===
 
 /// Raw units in one whole DEEP (DEEP uses 6 decimals).

--- a/packages/predict/sources/constants.move
+++ b/packages/predict/sources/constants.move
@@ -6,7 +6,8 @@
 /// Scaling conventions (aligned with DeepBook):
 /// - Prices/percentages use FLOAT_SCALING (1e9): 500_000_000 = 50%
 /// - Quantities are in 6-decimal quote units: 1_000_000 = 1 contract = one quote unit
-/// - At settlement, winners receive `quantity` directly
+/// - At settlement, a winning order redeems `quantity - floor_shares` (the full
+///   `quantity` only when unleveraged, i.e. `floor_shares == 0`)
 /// - Use `math` for all fixed-point scaling and mul/div operations
 module deepbook_predict::constants;
 

--- a/packages/predict/sources/events/config_events.move
+++ b/packages/predict/sources/events/config_events.move
@@ -18,7 +18,9 @@ public struct TradingPausedUpdated has copy, drop, store {
 
 /// Emitted when a new expiry market is created. This is the authoritative
 /// creation event: it carries identity, cadence terms, and the immutable policy
-/// snapshot applied to the market.
+/// snapshot applied to the market. The economic policy fields mirror
+/// `StrikeExposureConfig`: the fraction / leverage / fee / probability / multiplier
+/// fields are 1e9-scaled (FLOAT_SCALING) and `expiry_fee_window_ms` is in milliseconds.
 public struct MarketCreated has copy, drop, store {
     expiry_market_id: ID,
     pool_vault_id: ID,

--- a/packages/predict/sources/ewma.move
+++ b/packages/predict/sources/ewma.move
@@ -57,6 +57,7 @@ public(package) fun penalty_fee(
     let z_score = math::div(gas_price - self.mean, std_dev);
     if (z_score <= config.z_score_threshold()) return 0;
 
+    // penalty_rate * quantity, round down
     math::mul(config.penalty_rate(), quantity)
 }
 

--- a/packages/predict/sources/ewma.move
+++ b/packages/predict/sources/ewma.move
@@ -86,7 +86,7 @@ public(package) fun update(
 
     let mean_new = math::mul(alpha, gas_price) + math::mul(one_minus_alpha, self.mean);
 
-    let diff = if (gas_price > self.mean) gas_price - self.mean else self.mean - gas_price;
+    let diff = gas_price.diff(self.mean);
     let diff_squared = math::mul(diff, diff);
     let variance_new = if (self.variance == 0) {
         diff_squared

--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -602,7 +602,8 @@ public(package) fun receive_fee_incentives(market: &mut ExpiryMarket, incentives
     market.fee_incentive_balance.join(incentives);
 }
 
-/// Resolve one account's settled trading-loss rebate and return unearned reserve.
+/// Resolve one account's settled trading-loss rebate. Returns the unearned residual
+/// rebate-reserve cash and the rebate amount paid to the account.
 public(package) fun claim_trading_loss_rebate(
     market: &mut ExpiryMarket,
     account: &mut Account,

--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -612,10 +612,9 @@ public(package) fun claim_trading_loss_rebate(
     assert!(market.is_settled(), EMarketNotSettled);
     market.materialize_settled_liability();
 
-    let (trading_fees_paid, gross_profit) = predict_account::resolve_expiry_summary(
-        account,
-        market.id(),
-    );
+    let summary = predict_account::resolve_expiry_summary(account, market.id());
+    let trading_fees_paid = summary.fees_paid();
+    let gross_profit = summary.gross_profit();
     if (trading_fees_paid == 0) {
         return (balance::zero(), 0)
     };
@@ -829,7 +828,7 @@ fun mint_prepared_exact_quantity(
     clock: &Clock,
     ctx: &mut TxContext,
 ): u256 {
-    let (minted_order, entry_probability, net_premium) = market
+    let mint_quote = market
         .strike_exposure
         .allocate_mint_order(
             pricer,
@@ -838,6 +837,9 @@ fun mint_prepared_exact_quantity(
             quantity,
             leverage,
         );
+    let minted_order = mint_quote.allocated_order();
+    let entry_probability = mint_quote.entry_probability();
+    let net_premium = mint_quote.net_premium();
     assert!(entry_probability <= max_probability, EMintProbabilityAboveMax);
     let raw_fee_amount = market.strike_exposure.trading_fee(entry_probability, quantity, clock);
     let fee_amount = config.stake_config().fee_amount_after_discount(raw_fee_amount, active_stake);
@@ -929,9 +931,12 @@ fun redeem_live_internal(
         ctx,
     );
 
-    let (resulting_order, redeem_amount, range_probability) = market
+    let close_quote = market
         .strike_exposure
         .close_and_quote_live_order(pricer, order, close_quantity);
+    let resulting_order = close_quote.resulting_order();
+    let redeem_amount = close_quote.redeem_amount();
+    let range_probability = close_quote.range_probability();
     // Close-side slippage floor: reject if the quoted per-contract probability has
     // slipped below the caller's bound. `0` disables.
     assert!(range_probability >= min_probability, ERedeemProbabilityBelowMin);

--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -265,7 +265,7 @@ public fun mint_exact_quantity(
     market.assert_live_mint_allowed(config, pricer);
     wrapper.settle<DUSDC>(root, clock);
     let account = wrapper.load_account_mut(auth);
-    let active_stake = predict_account::active_stake_mut(account, ctx);
+    let active_stake = predict_account::roll_active_stake(account, ctx);
     market
         .strike_exposure
         .liquidate_live_orders(
@@ -316,7 +316,7 @@ public fun mint_exact_amount(
     wrapper.settle<DUSDC>(root, clock);
     let amount = amount.min(wrapper.load_account().balance<DUSDC>(root, clock));
     let account = wrapper.load_account_mut(auth);
-    let active_stake = predict_account::active_stake_mut(account, ctx);
+    let active_stake = predict_account::roll_active_stake(account, ctx);
     market
         .strike_exposure
         .liquidate_live_orders(
@@ -624,7 +624,7 @@ public(package) fun claim_trading_loss_rebate(
         .cash
         .resolve_rebate_reserve_for_fee_basis(trading_fees_paid);
     let eligible_rebate = resolved_rebate_reserve.saturating_sub(gross_profit);
-    let active_stake = predict_account::active_stake_mut(account, ctx);
+    let active_stake = predict_account::roll_active_stake(account, ctx);
     let rebate_amount = config.stake_config().rebate_amount(eligible_rebate, active_stake);
 
     if (rebate_amount > 0) {
@@ -924,7 +924,7 @@ fun redeem_live_internal(
     let opened_at_ms = predict_account::position_opened_at_ms(account, market.id(), order.id());
     assert!(clock.timestamp_ms() != opened_at_ms, EMintRedeemSameTimestamp);
 
-    let active_stake = predict_account::active_stake_mut(account, ctx);
+    let active_stake = predict_account::roll_active_stake(account, ctx);
     let position_root_id = predict_account::remove_position(
         account,
         market.id(),

--- a/packages/predict/sources/order.move
+++ b/packages/predict/sources/order.move
@@ -4,7 +4,7 @@
 /// Immutable contract terms encoded in a Predict order ID.
 ///
 /// An `Order` represents the durable contract terms needed after mint: the lower
-/// and higher strike ticks, quantity, the static floor amount (`floor_shares = F`),
+/// and higher strike ticks, quantity, the static floor `F` (`floor_shares`),
 /// and the expiry-local sequence. Mint-only inputs such as entry probability,
 /// leverage, net premium, and fee policy intentionally live outside this module.
 /// The packed ID is the single source of truth at protocol boundaries; raw strike

--- a/packages/predict/sources/order.move
+++ b/packages/predict/sources/order.move
@@ -29,10 +29,15 @@ const LOWER_TICK_OFFSET: u8 = 70;
 const HIGHER_TICK_OFFSET: u8 = 40;
 const ORDER_ID_BITS: u8 = 196;
 
-const TICK_MASK: u256 = (1u256 << 30) - 1;
 const U32_MASK: u256 = (1u256 << 32) - 1;
 const U40_MASK: u256 = (1u256 << 40) - 1;
 const U64_MASK: u256 = (1u256 << 64) - 1;
+
+/// u256 mask for the `tick_bits!()`-wide tick fields in the packed order id.
+/// Derived from `constants::tick_bits!()` so it can't drift from the tick width.
+macro fun tick_mask(): u256 {
+    (1u256 << constants::tick_bits!()) - 1
+}
 
 /// Validated typed view over one packed Predict order ID.
 public struct Order has copy, drop {
@@ -140,8 +145,8 @@ fun new(
     quantity_lots: u64,
     sequence: u64,
 ): Order {
-    assert!(lower_tick <= TICK_MASK as u64, EInvalidTick);
-    assert!(higher_tick <= TICK_MASK as u64, EInvalidTick);
+    assert!(lower_tick <= tick_mask!() as u64, EInvalidTick);
+    assert!(higher_tick <= tick_mask!() as u64, EInvalidTick);
     assert!(quantity_lots > 0 && quantity_lots <= U32_MASK as u64, EInvalidQuantity);
     assert!(sequence <= U40_MASK as u64, EInvalidSequence);
     let quantity = quantity_lots * constants::position_lot_size!();
@@ -163,7 +168,7 @@ fun new(
 // === Private Functions ===
 
 fun decode_tick(id: u256, offset: u8): u64 {
-    ((id >> offset) & TICK_MASK) as u64
+    ((id >> offset) & tick_mask!()) as u64
 }
 
 fun decode_u32(id: u256, offset: u8): u64 {

--- a/packages/predict/sources/plp/lp_book.move
+++ b/packages/predict/sources/plp/lp_book.move
@@ -66,7 +66,7 @@ public struct RequestQueue<phantom T> has store {
 /// Frozen flush share-price mark: `pool_value` over `total_supply`. Carried as one
 /// value so the supply/withdraw pricing helpers read each term by name and cannot
 /// transpose the numerator and denominator.
-public struct FlushMark has copy, drop {
+public struct FlushMark has drop {
     pool_value: u64,
     total_supply: u64,
 }

--- a/packages/predict/sources/plp/lp_book.move
+++ b/packages/predict/sources/plp/lp_book.move
@@ -348,14 +348,9 @@ fun page_id_for_index(index: u64): u64 {
 }
 
 fun entry_offset(entries: &vector<RequestEntry>, index: u64): u64 {
-    let mut offset = 0;
-    while (offset < entries.length()) {
-        if (entries[offset].index == index) {
-            return offset
-        };
-        offset = offset + 1;
-    };
-    abort ERequestNotFound
+    let offset = entries.find_index!(|e| e.index == index);
+    assert!(offset.is_some(), ERequestNotFound);
+    offset.destroy_some()
 }
 
 // === Pricing Helpers ===

--- a/packages/predict/sources/plp/lp_book.move
+++ b/packages/predict/sources/plp/lp_book.move
@@ -63,6 +63,14 @@ public struct RequestQueue<phantom T> has store {
     escrow: Balance<T>,
 }
 
+/// Frozen flush share-price mark: `pool_value` over `total_supply`. Carried as one
+/// value so the supply/withdraw pricing helpers read each term by name and cannot
+/// transpose the numerator and denominator.
+public struct FlushMark has copy, drop {
+    pool_value: u64,
+    total_supply: u64,
+}
+
 // === Public-Package Functions ===
 
 public(package) fun new<LP>(treasury_cap: TreasuryCap<LP>, ctx: &mut TxContext): LpBook<LP> {
@@ -131,6 +139,10 @@ public(package) fun cancel_withdraw_request<LP>(
     (request.account_id, request.amount, refund)
 }
 
+public(package) fun new_flush_mark(pool_value: u64, total_supply: u64): FlushMark {
+    FlushMark { pool_value, total_supply }
+}
+
 /// Drain both LP queues at the frozen flush mark (`pool_value` over `total_supply`),
 /// supplies first then withdrawals. `supply_budget` / `withdraw_budget` bound how many
 /// live requests each queue may fill this flush; `None` drains that queue fully. The
@@ -141,8 +153,7 @@ public(package) fun drain<LP>(
     book: &mut LpBook<LP>,
     pool_vault_id: ID,
     ledger: &mut Ledger,
-    pool_value: u64,
-    total_supply: u64,
+    mark: FlushMark,
     supply_budget: Option<u64>,
     withdraw_budget: Option<u64>,
     ctx: &mut TxContext,
@@ -152,7 +163,7 @@ public(package) fun drain<LP>(
 
     while (under_budget(&supply_budget, supplies_filled) && !book.supply_queue.is_empty()) {
         let (request, escrowed) = book.supply_queue.pop_front();
-        let shares = supply_shares(request.amount, total_supply, pool_value);
+        let shares = supply_shares(request.amount, &mark);
         assert!(shares > 0, EInvalidDrainMark);
         ledger.receive_idle(escrowed);
         let shares_minted = book.treasury_cap.mint_balance(shares);
@@ -170,7 +181,7 @@ public(package) fun drain<LP>(
 
     while (under_budget(&withdraw_budget, withdrawals_filled) && !book.withdraw_queue.is_empty()) {
         let request = book.withdraw_queue.front_request();
-        let payout = withdraw_dusdc(request.amount, total_supply, pool_value);
+        let payout = withdraw_dusdc(request.amount, &mark);
         assert!(payout > 0, EInvalidDrainMark);
         if (ledger.idle_balance() < payout) {
             // FIFO-until-dry: idle can't cover the head request, so stop and carry
@@ -352,14 +363,14 @@ fun entry_offset(entries: &vector<RequestEntry>, index: u64): u64 {
 /// LP shares minted for `amount` DUSDC at the frozen flush mark. `total_supply > 0`
 /// is guaranteed by the genesis lock (`plp::lock_capital`), so there is no
 /// supply==0 bootstrap branch.
-fun supply_shares(amount: u64, total_supply: u64, pool_value: u64): u64 {
-    assert!(pool_value > 0, EInvalidDrainMark);
-    math::mul_div_down(amount, total_supply, pool_value)
+fun supply_shares(amount: u64, mark: &FlushMark): u64 {
+    assert!(mark.pool_value > 0, EInvalidDrainMark);
+    math::mul_div_down(amount, mark.total_supply, mark.pool_value)
 }
 
 /// DUSDC owed for `shares` LP at the frozen flush mark.
-fun withdraw_dusdc(shares: u64, total_supply: u64, pool_value: u64): u64 {
-    assert!(total_supply > 0, EInvalidDrainMark);
-    assert!(pool_value > 0, EInvalidDrainMark);
-    math::mul_div_down(shares, pool_value, total_supply)
+fun withdraw_dusdc(shares: u64, mark: &FlushMark): u64 {
+    assert!(mark.total_supply > 0, EInvalidDrainMark);
+    assert!(mark.pool_value > 0, EInvalidDrainMark);
+    math::mul_div_down(shares, mark.pool_value, mark.total_supply)
 }

--- a/packages/predict/sources/plp/lp_book.move
+++ b/packages/predict/sources/plp/lp_book.move
@@ -365,6 +365,8 @@ fun entry_offset(entries: &vector<RequestEntry>, index: u64): u64 {
 /// supply==0 bootstrap branch.
 fun supply_shares(amount: u64, mark: &FlushMark): u64 {
     assert!(mark.pool_value > 0, EInvalidDrainMark);
+    // = amount * total_supply / pool_value, round down (supplier mints ≤1 ulp
+    // fewer shares; the pool keeps the dust).
     math::mul_div_down(amount, mark.total_supply, mark.pool_value)
 }
 
@@ -372,5 +374,7 @@ fun supply_shares(amount: u64, mark: &FlushMark): u64 {
 fun withdraw_dusdc(shares: u64, mark: &FlushMark): u64 {
     assert!(mark.total_supply > 0, EInvalidDrainMark);
     assert!(mark.pool_value > 0, EInvalidDrainMark);
+    // = shares * pool_value / total_supply, round down (withdrawer is paid ≤1 ulp
+    // less; the pool keeps the dust).
     math::mul_div_down(shares, mark.pool_value, mark.total_supply)
 }

--- a/packages/predict/sources/plp/plp.move
+++ b/packages/predict/sources/plp/plp.move
@@ -324,13 +324,13 @@ public fun finish_flush(
     // valuation, so the single FlushExecuted event carries the priced mark and its
     // idle + active-NAV breakdown.
     let vault_id = vault.id();
+    let mark = lp_book::new_flush_mark(pool_nav, total_supply);
     let (supplies_filled, withdrawals_filled) = vault
         .lp
         .drain(
             vault_id,
             &mut vault.expiry_accounting,
-            pool_nav,
-            total_supply,
+            mark,
             supply_budget,
             withdraw_budget,
             ctx,

--- a/packages/predict/sources/plp/plp.move
+++ b/packages/predict/sources/plp/plp.move
@@ -354,7 +354,7 @@ public fun finish_flush(
 
 /// Stake DEEP for trading benefits. The DEEP is held in the pool vault; the
 /// amount is recorded as inactive on the account and activates next epoch
-/// (`predict_account::active_stake_mut`, run by trade/claim flows). Callable
+/// (`predict_account::roll_active_stake`, run by trade/claim flows). Callable
 /// anytime, any number of times.
 public fun stake_deep(
     vault: &mut PoolVault,
@@ -370,7 +370,7 @@ public fun stake_deep(
     wrapper.settle<DEEP>(root, clock);
     let account = wrapper.load_account_mut(auth);
     let deep = account.withdraw<DEEP>(amount, ctx);
-    predict_account::active_stake_mut(account, ctx);
+    predict_account::roll_active_stake(account, ctx);
     predict_account::add_inactive_stake(account, amount, ctx);
     vault.staked_deep.join(deep.into_balance());
     vault_events::emit_deep_staked(

--- a/packages/predict/sources/plp/pool_accounting.move
+++ b/packages/predict/sources/plp/pool_accounting.move
@@ -82,27 +82,13 @@ public(package) fun idle_balance(ledger: &Ledger): u64 {
 
 /// Return the expiry market IDs still contributing active pool valuation/risk.
 public(package) fun active_expiry_markets(ledger: &Ledger): vector<ID> {
-    let mut ids = vector[];
-    let mut i = 0;
-    while (i < ledger.active_expiry_markets.length()) {
-        ids.push_back(ledger.active_expiry_markets[i].expiry_market_id);
-        i = i + 1;
-    };
-    ids
+    ledger.active_expiry_markets.map_ref!(|m| m.expiry_market_id)
 }
 
 /// Count active markets whose expiry is still in the future and therefore need
 /// live NAV valuation rather than terminal settlement/sweep handling.
 public(package) fun active_live_expiry_count(ledger: &Ledger, now_ms: u64): u64 {
-    let mut count = 0;
-    let mut i = 0;
-    while (i < ledger.active_expiry_markets.length()) {
-        if (ledger.active_expiry_markets[i].expiry_ms > now_ms) {
-            count = count + 1;
-        };
-        i = i + 1;
-    };
-    count
+    ledger.active_expiry_markets.count!(|m| m.expiry_ms > now_ms)
 }
 
 public(package) fun profit_basis_debits(ledger: &Ledger): u64 {
@@ -172,15 +158,9 @@ public(package) fun register_expiry(
 /// Remove an expiry from active valuation if present, returning whether it was active.
 public(package) fun deactivate_expiry_if_present(ledger: &mut Ledger, expiry_market_id: ID): bool {
     ledger.assert_registered_expiry(expiry_market_id);
-    let mut i = 0;
-    let len = ledger.active_expiry_markets.length();
-    while (i < len && ledger.active_expiry_markets[i].expiry_market_id != expiry_market_id) {
-        i = i + 1;
-    };
-    if (i == len) {
-        return false
-    };
-    ledger.active_expiry_markets.swap_remove(i);
+    let idx = ledger.active_expiry_markets.find_index!(|m| m.expiry_market_id == expiry_market_id);
+    if (idx.is_none()) return false;
+    ledger.active_expiry_markets.swap_remove(idx.destroy_some());
     true
 }
 

--- a/packages/predict/sources/predict_account.move
+++ b/packages/predict/sources/predict_account.move
@@ -72,7 +72,7 @@ public struct PredictData has store {
     /// pooled in `PoolVault`; this is this account's active share.
     active_stake: u64,
     /// DEEP staked this epoch, not yet active; rolls into `active_stake` on the
-    /// first discount-bearing interaction in a later epoch (`active_stake_mut`).
+    /// first discount-bearing interaction in a later epoch (`roll_active_stake`).
     inactive_stake: u64,
     /// Epoch the active/inactive split was last reconciled in.
     stake_epoch: u64,
@@ -192,7 +192,8 @@ public(package) fun add_position(
     let key = position_key(expiry_market_id, order_id);
     assert!(!d.positions.contains(key), EPositionAlreadyExists);
     d.positions.add(key, Position { root_id: position_root_id, opened_at_ms });
-    let summary = d.summary_mut(expiry_market_id);
+    d.ensure_summary(expiry_market_id);
+    let summary = &mut d.expiry_summaries[expiry_market_id];
     summary.open_position_count = summary.open_position_count + 1;
 }
 
@@ -207,7 +208,8 @@ public(package) fun remove_position(
     let key = position_key(expiry_market_id, order_id);
     assert!(d.positions.contains(key), EPositionNotFound);
     let Position { root_id, opened_at_ms: _ } = d.positions.remove(key);
-    let summary = d.summary_mut(expiry_market_id);
+    d.ensure_summary(expiry_market_id);
+    let summary = &mut d.expiry_summaries[expiry_market_id];
     assert!(summary.open_position_count > 0, EInsufficientPosition);
     summary.open_position_count = summary.open_position_count - 1;
     root_id
@@ -221,7 +223,9 @@ public(package) fun record_trading_fee_paid(
     ctx: &mut TxContext,
 ) {
     if (amount == 0) return;
-    let summary = data_mut(account, ctx).summary_mut(expiry_market_id);
+    let d = data_mut(account, ctx);
+    d.ensure_summary(expiry_market_id);
+    let summary = &mut d.expiry_summaries[expiry_market_id];
     summary.trading_fees_paid = summary.trading_fees_paid + amount;
 }
 
@@ -233,7 +237,9 @@ public(package) fun record_gross_paid_to_expiry(
     ctx: &mut TxContext,
 ) {
     if (amount == 0) return;
-    let summary = data_mut(account, ctx).summary_mut(expiry_market_id);
+    let d = data_mut(account, ctx);
+    d.ensure_summary(expiry_market_id);
+    let summary = &mut d.expiry_summaries[expiry_market_id];
     summary.gross_paid_to_expiry = summary.gross_paid_to_expiry + amount;
 }
 
@@ -245,7 +251,9 @@ public(package) fun record_gross_received_from_expiry(
     ctx: &mut TxContext,
 ) {
     if (amount == 0) return;
-    let summary = data_mut(account, ctx).summary_mut(expiry_market_id);
+    let d = data_mut(account, ctx);
+    d.ensure_summary(expiry_market_id);
+    let summary = &mut d.expiry_summaries[expiry_market_id];
     summary.gross_received_from_expiry = summary.gross_received_from_expiry + amount;
 }
 
@@ -285,7 +293,7 @@ public(package) fun gross_profit(summary: &ResolvedExpirySummary): u64 {
 
 /// Roll inactive stake into active if needed, then return the active amount for
 /// protocol execution paths that apply stake discounts.
-public(package) fun active_stake_mut(account: &mut Account, ctx: &mut TxContext): u64 {
+public(package) fun roll_active_stake(account: &mut Account, ctx: &mut TxContext): u64 {
     let epoch = ctx.epoch();
     let d = data_mut(account, ctx);
     if (d.stake_epoch != epoch) {
@@ -339,7 +347,7 @@ fun position_key(expiry_market_id: ID, order_id: u256): PositionKey {
     PositionKey { expiry_market_id, order_id }
 }
 
-fun summary_mut(d: &mut PredictData, expiry_market_id: ID): &mut ExpiryTradingSummary {
+fun ensure_summary(d: &mut PredictData, expiry_market_id: ID) {
     if (!d.expiry_summaries.contains(expiry_market_id)) {
         d
             .expiry_summaries
@@ -353,5 +361,4 @@ fun summary_mut(d: &mut PredictData, expiry_market_id: ID): &mut ExpiryTradingSu
                 },
             );
     };
-    &mut d.expiry_summaries[expiry_market_id]
 }

--- a/packages/predict/sources/predict_account.move
+++ b/packages/predict/sources/predict_account.move
@@ -54,6 +54,14 @@ public struct ExpiryTradingSummary has store {
     gross_received_from_expiry: u64,
 }
 
+/// Resolved trading-loss-rebate inputs for one fully-closed expiry: the fees the
+/// account paid into the expiry and its realized gross profit, returned together
+/// so the rebate flow reads them by name.
+public struct ResolvedExpirySummary has drop {
+    fees_paid: u64,
+    gross_profit: u64,
+}
+
 /// Predict's per-account state, attached to an `Account` under `PredictApp`.
 public struct PredictData has store {
     /// Open positions scoped by expiry market.
@@ -241,14 +249,18 @@ public(package) fun record_gross_received_from_expiry(
     summary.gross_received_from_expiry = summary.gross_received_from_expiry + amount;
 }
 
-/// Remove and return aggregate fees paid and gross profit once all positions close.
+/// Remove and return the resolved trading-loss-rebate inputs once all positions close.
 public(package) fun resolve_expiry_summary(
     account: &mut Account,
     expiry_market_id: ID,
-): (u64, u64) {
-    if (!account.has_data<PredictApp>()) return (0, 0);
+): ResolvedExpirySummary {
+    if (!account.has_data<PredictApp>()) {
+        return ResolvedExpirySummary { fees_paid: 0, gross_profit: 0 }
+    };
     let d = account.borrow_data_mut<PredictApp, PredictData>(permit<PredictApp>());
-    if (!d.expiry_summaries.contains(expiry_market_id)) return (0, 0);
+    if (!d.expiry_summaries.contains(expiry_market_id)) {
+        return ResolvedExpirySummary { fees_paid: 0, gross_profit: 0 }
+    };
     assert!(
         d.expiry_summaries[expiry_market_id].open_position_count == 0,
         EExpirySummaryHasOpenPositions,
@@ -260,7 +272,15 @@ public(package) fun resolve_expiry_summary(
         gross_received_from_expiry,
     } = d.expiry_summaries.remove(expiry_market_id);
     let gross_profit = gross_received_from_expiry.saturating_sub(gross_paid_to_expiry);
-    (trading_fees_paid, gross_profit)
+    ResolvedExpirySummary { fees_paid: trading_fees_paid, gross_profit }
+}
+
+public(package) fun fees_paid(summary: &ResolvedExpirySummary): u64 {
+    summary.fees_paid
+}
+
+public(package) fun gross_profit(summary: &ResolvedExpirySummary): u64 {
+    summary.gross_profit
 }
 
 /// Roll inactive stake into active if needed, then return the active amount for

--- a/packages/predict/sources/pricing/pricing.move
+++ b/packages/predict/sources/pricing/pricing.move
@@ -224,9 +224,9 @@ fun live_inputs(
     (forward, svi)
 }
 
-fun timestamp_is_fresh(timestamp: u64, max_age_ms: u64, clock: &Clock): bool {
+fun timestamp_is_fresh(source_timestamp_ms: u64, max_age_ms: u64, clock: &Clock): bool {
     let now = clock.timestamp_ms();
-    timestamp > 0 && timestamp <= now && now - timestamp <= max_age_ms
+    source_timestamp_ms > 0 && source_timestamp_ms <= now && now - source_timestamp_ms <= max_age_ms
 }
 
 fun assert_inputs_pricing_safe(spot: u64, forward: u64, svi: &SVIParams) {

--- a/packages/predict/sources/registry/market_manager.move
+++ b/packages/predict/sources/registry/market_manager.move
@@ -241,21 +241,18 @@ public(package) fun set_cadence_config(
     initial_expiry_cash: u64,
     window_size: u64,
 ) {
-    assert_cadence_config(
+    let config = CadenceConfig {
         tick_size,
         admission_tick_size,
         max_expiry_allocation,
         initial_expiry_cash,
         window_size,
-    );
+    };
+    assert_cadence_config(&config);
     let cadence_index = cadence_index(cadence_id);
     let cadence =
         &mut manager.underlying_config_mut(propbook_underlying_id).cadences[cadence_index];
-    cadence.tick_size = tick_size;
-    cadence.admission_tick_size = admission_tick_size;
-    cadence.max_expiry_allocation = max_expiry_allocation;
-    cadence.initial_expiry_cash = initial_expiry_cash;
-    cadence.window_size = window_size;
+    *cadence = config;
 }
 
 public(package) fun record_expiry_creation(
@@ -329,13 +326,14 @@ fun cadence_index(cadence_id: u8): u64 {
     (cadence_id as u64)
 }
 
-fun assert_cadence_config(
-    tick_size: u64,
-    admission_tick_size: u64,
-    max_expiry_allocation: u64,
-    initial_expiry_cash: u64,
-    window_size: u64,
-) {
+fun assert_cadence_config(config: &CadenceConfig) {
+    let CadenceConfig {
+        tick_size,
+        admission_tick_size,
+        max_expiry_allocation,
+        initial_expiry_cash,
+        window_size,
+    } = *config;
     let disabled =
         tick_size == 0
             && admission_tick_size == 0

--- a/packages/predict/sources/strike_exposure/index/liquidation_book.move
+++ b/packages/predict/sources/strike_exposure/index/liquidation_book.move
@@ -280,8 +280,7 @@ fun collect_passive_candidates(
         added = added + 1;
         last_order_id = option::some(order_id);
         visited = visited + 1;
-        let next = book.next_cursor(candidate);
-        candidate = if (next.is_some()) next.destroy_some() else tail_start_cursor;
+        candidate = book.next_cursor(candidate).destroy_or!(tail_start_cursor);
     };
 
     if (last_order_id.is_some()) {

--- a/packages/predict/sources/strike_exposure/index/strike_payout_tree.move
+++ b/packages/predict/sources/strike_exposure/index/strike_payout_tree.move
@@ -154,7 +154,7 @@ public(package) fun insert_range(
     floor_shares: u64,
 ) {
     let terms = payout_terms(quantity, floor_shares);
-    if (terms.quantity == 0 && terms.floor_shares == 0) return;
+    if (terms.is_zero_terms()) return;
 
     let mut new_nodes = 0;
     if (lower_tick != 0 && !tree.nodes.contains(lower_tick)) {
@@ -215,7 +215,7 @@ fun apply_range(
     add: bool,
 ) {
     // Skip a fully-zero delta; index any order with nonzero quantity.
-    if (terms.quantity == 0 && terms.floor_shares == 0) return;
+    if (terms.is_zero_terms()) return;
 
     if (lower_tick == 0) {
         apply_terms_delta(&mut tree.base, terms, add);

--- a/packages/predict/sources/strike_exposure/index/strike_payout_tree.move
+++ b/packages/predict/sources/strike_exposure/index/strike_payout_tree.move
@@ -595,10 +595,6 @@ fun tick_priority(tick: u64): u64 {
     let bytes = bcs::to_bytes(&tick);
     let hash = blake2b256(&bytes);
     let mut out = 0;
-    let mut i = 0;
-    while (i < 8) {
-        out = (out << 8) | (hash[i] as u64);
-        i = i + 1;
-    };
+    8u64.do!(|i| out = (out << 8) | (hash[i] as u64));
     out
 }

--- a/packages/predict/sources/strike_exposure/strike_exposure.move
+++ b/packages/predict/sources/strike_exposure/strike_exposure.move
@@ -57,6 +57,47 @@ public struct StrikeExposure has store {
     payout: StrikePayoutTree,
 }
 
+/// Quote and allocation result for a live mint order, returned by name so callers
+/// cannot transpose the entry probability and the cash net premium.
+public struct MintQuote has drop {
+    allocated_order: Order,
+    entry_probability: u64,
+    net_premium: u64,
+}
+
+/// Redeem terms from closing live indexed quantity. `resulting_order` is the
+/// original order for a full close, or the replacement that remains after a
+/// partial close.
+public struct CloseQuote has drop {
+    resulting_order: Order,
+    redeem_amount: u64,
+    range_probability: u64,
+}
+
+public(package) fun allocated_order(quote: &MintQuote): Order {
+    quote.allocated_order
+}
+
+public(package) fun entry_probability(quote: &MintQuote): u64 {
+    quote.entry_probability
+}
+
+public(package) fun net_premium(quote: &MintQuote): u64 {
+    quote.net_premium
+}
+
+public(package) fun resulting_order(quote: &CloseQuote): Order {
+    quote.resulting_order
+}
+
+public(package) fun redeem_amount(quote: &CloseQuote): u64 {
+    quote.redeem_amount
+}
+
+public(package) fun range_probability(quote: &CloseQuote): u64 {
+    quote.range_probability
+}
+
 /// Return the buffered live reserve, or exact remaining settled payout liability once materialized.
 ///
 /// Live reserve is the settlement floor (max single-point net payout) plus a
@@ -206,8 +247,7 @@ public(package) fun close_settled_order(
 }
 
 /// Quote and allocate a live mint order for the tick range `(lower_tick, higher_tick]`.
-///
-/// Returns `(allocated_order, entry_probability, net_premium)`.
+/// Returns a `MintQuote` with the allocated order, entry probability, and net premium.
 public(package) fun allocate_mint_order(
     exposure: &mut StrikeExposure,
     pricer: &Pricer,
@@ -215,7 +255,7 @@ public(package) fun allocate_mint_order(
     higher_tick: u64,
     quantity: u64,
     leverage: u64,
-): (Order, u64, u64) {
+): MintQuote {
     exposure.assert_admitted_mint_ticks(lower_tick, higher_tick);
     let (lower, higher) = range_codec::strikes_from_ticks(
         lower_tick,
@@ -223,13 +263,15 @@ public(package) fun allocate_mint_order(
         exposure.tick_size,
     );
     let entry_probability = pricer.range_price(lower, higher);
-    let (net_premium, floor_shares) = exposure
+    let admission = exposure
         .config
         .assert_mint_admission(
             entry_probability,
             quantity,
             leverage,
         );
+    let net_premium = admission.net_premium();
+    let floor_shares = admission.floor_shares();
 
     let sequence = exposure.next_order_sequence;
     let allocated_order = order::new_from_ticks(
@@ -244,7 +286,7 @@ public(package) fun allocate_mint_order(
     exposure.liquidation.insert_order(&allocated_order);
     exposure.payout.insert_range(lower_tick, higher_tick, quantity, floor_shares);
 
-    (allocated_order, entry_probability, net_premium)
+    MintQuote { allocated_order, entry_probability, net_premium }
 }
 
 /// Set the reference fine-grid tick that can bypass coarser mint admission once wired.
@@ -279,10 +321,9 @@ public(package) fun quote_mint_entry_probability(
     entry_probability
 }
 
-/// Close live indexed quantity and return redeem terms.
+/// Close live indexed quantity and return redeem terms as a `CloseQuote`.
 ///
-/// Returns `(resulting_order, redeem_amount, range_probability)`.
-/// The trade fee is recovered via `trading_fee` from the returned price.
+/// The trade fee is recovered via `trading_fee` from the returned `range_probability`.
 /// `resulting_order` is the original order for a full close, or the replacement
 /// order that remains after a partial close.
 public(package) fun close_and_quote_live_order(
@@ -290,7 +331,7 @@ public(package) fun close_and_quote_live_order(
     pricer: &Pricer,
     order: &Order,
     close_quantity: u64,
-): (Order, u64, u64) {
+): CloseQuote {
     order::assert_valid_quantity(close_quantity);
     let old_quantity = order.quantity();
     assert!(close_quantity <= old_quantity, EInvalidCloseQuantity);
@@ -323,7 +364,7 @@ public(package) fun close_and_quote_live_order(
     let redeem_amount = gross_redeem_amount.saturating_sub(removed_floor_amount);
 
     if (remaining_quantity == 0) {
-        return (*order, redeem_amount, range_probability)
+        return CloseQuote { resulting_order: *order, redeem_amount, range_probability }
     };
 
     let replacement_order = order::replacement(
@@ -335,7 +376,7 @@ public(package) fun close_and_quote_live_order(
     exposure.liquidation.insert_order(&replacement_order);
     exposure.next_order_sequence = exposure.next_order_sequence + 1;
 
-    (replacement_order, redeem_amount, range_probability)
+    CloseQuote { resulting_order: replacement_order, redeem_amount, range_probability }
 }
 
 /// Clear one liquidated-order tombstone after its account position is closed.

--- a/packages/predict/tests/config/strike_exposure_config_tests.move
+++ b/packages/predict/tests/config/strike_exposure_config_tests.move
@@ -314,13 +314,13 @@ fun mint_admission_half_probability_two_and_half_x_succeeds() {
     // p = 0.5 and quantity = 1e9 gives entry value 500_000_000.
     // At 2.5x, net premium = 500_000_000 / 2.5 = 200_000_000 and
     // floor shares = 500_000_000 - 200_000_000 = 300_000_000.
-    let (net_premium, floor_shares) = config.assert_mint_admission(
+    let admission = config.assert_mint_admission(
         ENTRY_PROBABILITY_HALF,
         test_constants::mint_quantity(),
         LEVERAGE_TWO_AND_HALF_X,
     );
-    assert_eq!(net_premium, HALF_PROBABILITY_TWO_AND_HALF_X_NET_PREMIUM);
-    assert_eq!(floor_shares, HALF_PROBABILITY_TWO_AND_HALF_X_FLOOR_SHARES);
+    assert_eq!(admission.net_premium(), HALF_PROBABILITY_TWO_AND_HALF_X_NET_PREMIUM);
+    assert_eq!(admission.floor_shares(), HALF_PROBABILITY_TWO_AND_HALF_X_FLOOR_SHARES);
     destroy(config);
 }
 
@@ -343,13 +343,13 @@ fun mint_admission_net_premium_one_lot_below_minimum_aborts() {
 fun mint_admission_net_premium_at_minimum_succeeds() {
     let config = strike_exposure_config::new();
 
-    let (net_premium, floor_shares) = config.assert_mint_admission(
+    let admission = config.assert_mint_admission(
         ENTRY_PROBABILITY_HALF,
         2 * constants::min_net_premium!(),
         test_constants::leverage_one_x(),
     );
-    assert_eq!(net_premium, constants::min_net_premium!());
-    assert_eq!(floor_shares, UNLEVERAGED_FLOOR_SHARES);
+    assert_eq!(admission.net_premium(), constants::min_net_premium!());
+    assert_eq!(admission.floor_shares(), UNLEVERAGED_FLOOR_SHARES);
     destroy(config);
 }
 

--- a/packages/predict/tests/plp/lp_book_tests.move
+++ b/packages/predict/tests/plp/lp_book_tests.move
@@ -57,8 +57,7 @@ fun supply_drain_mints_at_mark_and_joins_idle() {
     let (supplies_filled, withdrawals_filled) = book.drain(
         vault_id(),
         &mut ledger,
-        min_supply!(),
-        min_supply!(),
+        lp_book::new_flush_mark(min_supply!(), min_supply!()),
         option::none(),
         option::none(),
         scenario.ctx(),
@@ -85,8 +84,7 @@ fun priced_supply_mints_proportional_shares() {
     book.drain(
         vault_id(),
         &mut ledger,
-        60_000_000,
-        30_000_000,
+        lp_book::new_flush_mark(60_000_000, 30_000_000),
         option::none(),
         option::none(),
         scenario.ctx(),
@@ -111,8 +109,7 @@ fun priced_withdraw_burns_and_pays_from_idle() {
     book.drain(
         vault_id(),
         &mut ledger,
-        60_000_000,
-        30_000_000,
+        lp_book::new_flush_mark(60_000_000, 30_000_000),
         option::none(),
         option::none(),
         scenario.ctx(),
@@ -139,8 +136,7 @@ fun two_withdrawals_share_one_frozen_mark() {
     book.drain(
         vault_id(),
         &mut ledger,
-        50_000_000,
-        30_000_000,
+        lp_book::new_flush_mark(50_000_000, 30_000_000),
         option::none(),
         option::none(),
         scenario.ctx(),
@@ -169,8 +165,7 @@ fun withdrawals_stop_when_idle_is_dry_and_carry() {
     let (_s, withdrawals_filled) = book.drain(
         vault_id(),
         &mut ledger,
-        30_000_000,
-        30_000_000,
+        lp_book::new_flush_mark(30_000_000, 30_000_000),
         option::none(),
         option::none(),
         scenario.ctx(),
@@ -202,8 +197,7 @@ fun unbounded_flush_drains_every_queued_supply() {
     let (supplies_filled, _w) = book.drain(
         vault_id(),
         &mut ledger,
-        min_supply!(),
-        min_supply!(),
+        lp_book::new_flush_mark(min_supply!(), min_supply!()),
         option::none(),
         option::none(),
         scenario.ctx(),
@@ -232,8 +226,7 @@ fun bounded_supply_budget_fills_up_to_budget_and_carries() {
     let (filled, _w) = book.drain(
         vault_id(),
         &mut ledger,
-        min_supply!(),
-        min_supply!(),
+        lp_book::new_flush_mark(min_supply!(), min_supply!()),
         option::some(2),
         option::none(),
         scenario.ctx(),
@@ -247,8 +240,7 @@ fun bounded_supply_budget_fills_up_to_budget_and_carries() {
     book.drain(
         vault_id(),
         &mut ledger,
-        2 * min_supply!(),
-        3 * min_supply!(),
+        lp_book::new_flush_mark(2 * min_supply!(), 3 * min_supply!()),
         option::none(),
         option::none(),
         scenario.ctx(),
@@ -277,8 +269,7 @@ fun independent_budgets_let_withdrawals_drain_under_supply_pressure() {
     let (supplies_filled, withdrawals_filled) = book.drain(
         vault_id(),
         &mut ledger,
-        30_000_000,
-        30_000_000,
+        lp_book::new_flush_mark(30_000_000, 30_000_000),
         option::some(1),
         option::some(1),
         scenario.ctx(),
@@ -357,8 +348,7 @@ fun cancelled_supply_requests_do_not_spend_drain_budget() {
     let (filled, _w) = book.drain(
         vault_id(),
         &mut ledger,
-        min_supply!(),
-        min_supply!(),
+        lp_book::new_flush_mark(min_supply!(), min_supply!()),
         option::some(1),
         option::none(),
         scenario.ctx(),
@@ -406,8 +396,7 @@ fun priced_supply_with_zero_pool_value_aborts() {
     book.drain(
         vault_id(),
         &mut ledger,
-        0,
-        min_supply!(),
+        lp_book::new_flush_mark(0, min_supply!()),
         option::none(),
         option::none(),
         scenario.ctx(),

--- a/packages/predict/tests/predict_account_tests.move
+++ b/packages/predict/tests/predict_account_tests.move
@@ -207,19 +207,19 @@ fun add_inactive_stake_goes_to_inactive() {
 }
 
 #[test]
-fun active_stake_mut_is_noop_within_epoch() {
+fun roll_active_stake_is_noop_within_epoch() {
     let (mut scenario, mut wrapper) = new_account();
     let account = wrapper.load_account_mut(auth(&mut scenario));
     predict_account::add_inactive_stake(account, STAKE_1, scenario.ctx());
     // Same epoch as the slot's creation: no roll.
-    assert_eq!(predict_account::active_stake_mut(account, scenario.ctx()), 0);
+    assert_eq!(predict_account::roll_active_stake(account, scenario.ctx()), 0);
     assert_eq!(predict_account::inactive_stake(account), STAKE_1);
     assert_eq!(predict_account::active_stake(account), 0);
     finish(scenario, wrapper);
 }
 
 #[test]
-fun active_stake_mut_activates_inactive_next_epoch() {
+fun roll_active_stake_activates_inactive_next_epoch() {
     let (mut scenario, mut wrapper) = new_account();
     {
         let account = wrapper.load_account_mut(auth(&mut scenario));
@@ -227,7 +227,7 @@ fun active_stake_mut_activates_inactive_next_epoch() {
     };
     scenario.next_epoch(ALICE);
     let account = wrapper.load_account_mut(auth(&mut scenario));
-    assert_eq!(predict_account::active_stake_mut(account, scenario.ctx()), STAKE_1);
+    assert_eq!(predict_account::roll_active_stake(account, scenario.ctx()), STAKE_1);
     assert_eq!(predict_account::active_stake(account), STAKE_1);
     assert_eq!(predict_account::inactive_stake(account), 0);
 
@@ -247,7 +247,7 @@ fun remove_all_stake_sums_active_plus_inactive_and_zeroes() {
     };
     scenario.next_epoch(ALICE);
     let account = wrapper.load_account_mut(auth(&mut scenario));
-    predict_account::active_stake_mut(account, scenario.ctx()); // STAKE_1 now active
+    predict_account::roll_active_stake(account, scenario.ctx()); // STAKE_1 now active
     predict_account::add_inactive_stake(account, STAKE_2, scenario.ctx()); // plus inactive
 
     assert_eq!(predict_account::remove_all_stake(account, scenario.ctx()), STAKE_1 + STAKE_2);

--- a/packages/predict/tests/reference_tick_tests.move
+++ b/packages/predict/tests/reference_tick_tests.move
@@ -145,7 +145,7 @@ fun reference_tick_admits_up_and_down_ranges() {
 
     assert_reference_tick_is_off_admission_grid(ADMISSIBLE_OFF_GRID_REFERENCE_TICK);
     harness.exposure.set_reference_tick(ADMISSIBLE_OFF_GRID_REFERENCE_TICK);
-    let (up_order, _, _) = harness
+    let up_order = harness
         .exposure
         .allocate_mint_order(
             &pricer,
@@ -153,8 +153,9 @@ fun reference_tick_admits_up_and_down_ranges() {
             constants::pos_inf_tick!(),
             test_constants::mint_quantity(),
             test_constants::leverage_one_x(),
-        );
-    let (down_order, _, _) = harness
+        )
+        .allocated_order();
+    let down_order = harness
         .exposure
         .allocate_mint_order(
             &pricer,
@@ -162,7 +163,8 @@ fun reference_tick_admits_up_and_down_ranges() {
             ADMISSIBLE_OFF_GRID_REFERENCE_TICK,
             test_constants::mint_quantity(),
             test_constants::leverage_one_x(),
-        );
+        )
+        .allocated_order();
 
     assert_range(&up_order, ADMISSIBLE_OFF_GRID_REFERENCE_TICK, constants::pos_inf_tick!());
     assert_range(&down_order, 0, ADMISSIBLE_OFF_GRID_REFERENCE_TICK);

--- a/packages/predict/tests/strike_exposure/liquidated_settled_redeem_tests.move
+++ b/packages/predict/tests/strike_exposure/liquidated_settled_redeem_tests.move
@@ -74,7 +74,7 @@ fun liquidated_order_fixture(): (OracleFixture, OracleBundle, ExposureHarness, O
     fx.prepare_live_oracle_bundle(&mut oracle, test_constants::default_live_price());
 
     let pricer = fx.load_pricer_bundle(&oracle);
-    let (order, _, _) = harness
+    let order = harness
         .exposure
         .allocate_mint_order(
             &pricer,
@@ -82,7 +82,8 @@ fun liquidated_order_fixture(): (OracleFixture, OracleBundle, ExposureHarness, O
             constants::pos_inf_tick!(),
             test_constants::mint_quantity(),
             LEVERAGE_TWO_X,
-        );
+        )
+        .allocated_order();
 
     fx.set_pyth_bundle(&mut oracle, DROPPED_SPOT, DROPPED_SOURCE_TIMESTAMP_MS);
     let liquidation_pricer = fx.load_pricer_bundle(&oracle);

--- a/packages/propbook/sources/feeds/block_scholes_forward_feed.move
+++ b/packages/propbook/sources/feeds/block_scholes_forward_feed.move
@@ -110,7 +110,7 @@ public fun raw_forward_value(raw: &RawForward): u64 {
 
 // === Write Functions ===
 
-/// Ingest a verified BS forward update into this feed's generic oracle lane.
+/// Ingest a verified BS forward update into the oracle lane for the update's expiry.
 public fun update(
     feed: &mut BlockScholesForwardFeed,
     update: ForwardUpdate,

--- a/packages/propbook/sources/feeds/block_scholes_forward_feed.move
+++ b/packages/propbook/sources/feeds/block_scholes_forward_feed.move
@@ -10,7 +10,6 @@ module propbook::block_scholes_forward_feed;
 
 use block_scholes_oracle::update::ForwardUpdate;
 use propbook::{constants, oracle_lane::{Self, OracleLane, OracleRead}};
-use std::option::{Self, Option};
 use sui::{clock::Clock, table::{Self, Table}};
 
 const EWrongSource: u64 = 0;

--- a/packages/propbook/sources/feeds/block_scholes_spot_feed.move
+++ b/packages/propbook/sources/feeds/block_scholes_spot_feed.move
@@ -11,7 +11,6 @@ module propbook::block_scholes_spot_feed;
 
 use block_scholes_oracle::update::SpotUpdate;
 use propbook::{constants, oracle_lane::{Self, OracleLane, OracleRead}};
-use std::option::{Self, Option};
 use sui::clock::Clock;
 
 const EWrongSource: u64 = 0;

--- a/packages/propbook/sources/feeds/block_scholes_svi_feed.move
+++ b/packages/propbook/sources/feeds/block_scholes_svi_feed.move
@@ -140,7 +140,7 @@ public fun sigma(params: &SVIParams): u64 {
 
 // === Write Functions ===
 
-/// Ingest a verified BS SVI update into this feed's generic oracle lane.
+/// Ingest a verified BS SVI update into the oracle lane for the update's expiry.
 public fun update(
     feed: &mut BlockScholesSVIFeed,
     update: SVIUpdate,

--- a/packages/propbook/sources/feeds/block_scholes_svi_feed.move
+++ b/packages/propbook/sources/feeds/block_scholes_svi_feed.move
@@ -11,7 +11,6 @@ module propbook::block_scholes_svi_feed;
 use block_scholes_oracle::update::SVIUpdate;
 use fixed_math::i64::{Self, I64};
 use propbook::{constants, oracle_lane::{Self, OracleLane, OracleRead}};
-use std::option::{Self, Option};
 use sui::{clock::Clock, table::{Self, Table}};
 
 const EWrongSource: u64 = 0;

--- a/packages/propbook/sources/feeds/pyth_feed.move
+++ b/packages/propbook/sources/feeds/pyth_feed.move
@@ -20,7 +20,7 @@ const EWrongVersion: u64 = 0;
 const ENotNewerVersion: u64 = 1;
 const ERawSpotNotFound: u64 = 2;
 const ELazerFeedNotFound: u64 = 3;
-const ELazerPriceUnavailable: u64 = 4;
+const ELazerValueUnavailable: u64 = 4;
 const EInsertTimestampNotExactMillisecond: u64 = 5;
 
 /// Source-native Pyth Lazer spot fields for this feed. The generic oracle lane
@@ -76,16 +76,16 @@ public fun normalized_spot(feed: &PythFeed): Option<OracleRead<u64>> {
     normalized_spot_from_read(&read.destroy_some())
 }
 
-/// Exact raw Pyth spot read for `timestamp_ms`.
-public fun raw_spot_at(feed: &PythFeed, timestamp_ms: u64): OracleRead<RawSpot> {
-    let read = feed.lane.read_at(timestamp_ms);
+/// Exact raw Pyth spot read for `source_timestamp_ms`.
+public fun raw_spot_at(feed: &PythFeed, source_timestamp_ms: u64): OracleRead<RawSpot> {
+    let read = feed.lane.read_at(source_timestamp_ms);
     assert!(read.is_some(), ERawSpotNotFound);
     read.destroy_some()
 }
 
-/// Exact Propbook-normalized spot in 1e9 price scaling for `timestamp_ms`.
-public fun normalized_spot_at(feed: &PythFeed, timestamp_ms: u64): Option<OracleRead<u64>> {
-    let read = feed.lane.read_at(timestamp_ms);
+/// Exact Propbook-normalized spot in 1e9 price scaling for `source_timestamp_ms`.
+public fun normalized_spot_at(feed: &PythFeed, source_timestamp_ms: u64): Option<OracleRead<u64>> {
+    let read = feed.lane.read_at(source_timestamp_ms);
     if (read.is_none()) return option::none();
     normalized_spot_from_read(&read.destroy_some())
 }
@@ -239,14 +239,14 @@ fun new_raw_insert_read(raw: RawSpot, update_timestamp_ms: u64): OracleRead<RawS
 fun extract_lazer_price(price_outer: Option<Option<LazerI64>>): LazerI64 {
     // Both Option layers must be Some: the field must exist in the update, and
     // the value must be present (Lazer returns None without enough publishers).
-    assert!(price_outer.is_some(), ELazerPriceUnavailable);
+    assert!(price_outer.is_some(), ELazerValueUnavailable);
     let price_inner = price_outer.destroy_some();
-    assert!(price_inner.is_some(), ELazerPriceUnavailable);
+    assert!(price_inner.is_some(), ELazerValueUnavailable);
     price_inner.destroy_some()
 }
 
 fun extract_lazer_exponent(exp_outer: Option<LazerI16>): LazerI16 {
-    assert!(exp_outer.is_some(), ELazerPriceUnavailable);
+    assert!(exp_outer.is_some(), ELazerValueUnavailable);
     exp_outer.destroy_some()
 }
 

--- a/packages/propbook/sources/feeds/pyth_feed.move
+++ b/packages/propbook/sources/feeds/pyth_feed.move
@@ -14,7 +14,6 @@ module propbook::pyth_feed;
 use fixed_math::math;
 use propbook::{constants, oracle_lane::{Self, OracleLane, OracleRead}};
 use pyth_lazer::{i16::I16 as LazerI16, i64::I64 as LazerI64, update::Update as LazerUpdate};
-use std::option::{Self, Option};
 use sui::clock::Clock;
 
 const EWrongVersion: u64 = 0;
@@ -180,7 +179,7 @@ fun raw_spot_from_update(update: &LazerUpdate, pyth_source_id: u32): RawSpot {
     let source_timestamp_us = update.timestamp();
     let feeds = update.feeds_ref();
     let idx_opt = feeds.find_index!(|f| f.feed_id() == pyth_source_id);
-    assert_lazer_feed_found(idx_opt.is_some());
+    assert!(idx_opt.is_some(), ELazerFeedNotFound);
     let feed = &feeds[idx_opt.destroy_some()];
 
     let price = extract_lazer_price(feed.price());
@@ -228,17 +227,13 @@ fun new_raw_spot(
 
 fun new_raw_read(raw: RawSpot, update_timestamp_ms: u64): OracleRead<RawSpot> {
     let source_timestamp_us = raw.source_timestamp_us;
-    oracle_lane::new_read(us_to_ms_ceil(source_timestamp_us), update_timestamp_ms, raw)
+    oracle_lane::new_read(source_timestamp_us.div_ceil(1000), update_timestamp_ms, raw)
 }
 
 fun new_raw_insert_read(raw: RawSpot, update_timestamp_ms: u64): OracleRead<RawSpot> {
     let source_timestamp_us = raw.source_timestamp_us;
     assert!(source_timestamp_us % 1000 == 0, EInsertTimestampNotExactMillisecond);
     oracle_lane::new_read(source_timestamp_us / 1000, update_timestamp_ms, raw)
-}
-
-fun assert_lazer_feed_found(feed_found: bool) {
-    assert!(feed_found, ELazerFeedNotFound);
 }
 
 fun extract_lazer_price(price_outer: Option<Option<LazerI64>>): LazerI64 {
@@ -253,11 +248,6 @@ fun extract_lazer_price(price_outer: Option<Option<LazerI64>>): LazerI64 {
 fun extract_lazer_exponent(exp_outer: Option<LazerI16>): LazerI16 {
     assert!(exp_outer.is_some(), ELazerPriceUnavailable);
     exp_outer.destroy_some()
-}
-
-fun us_to_ms_ceil(timestamp_us: u64): u64 {
-    let ms = timestamp_us / 1000;
-    if (timestamp_us % 1000 == 0) ms else ms + 1
 }
 
 fun normalized_spot_from_read(read: &OracleRead<RawSpot>): Option<OracleRead<u64>> {

--- a/packages/propbook/sources/oracle_lane/oracle_lane.move
+++ b/packages/propbook/sources/oracle_lane/oracle_lane.move
@@ -12,7 +12,6 @@
 /// lane writes that are future, zero, stale, or duplicate are no-ops.
 module propbook::oracle_lane;
 
-use std::option::{Self, Option};
 use sui::{event, table::{Self, Table}};
 
 /// Timestamped oracle read. Raw and normalized reads use the same timestamp

--- a/packages/propbook/sources/oracle_lane/oracle_lane.move
+++ b/packages/propbook/sources/oracle_lane/oracle_lane.move
@@ -19,7 +19,10 @@ use sui::{event, table::{Self, Table}};
 /// envelope, so consumers can apply one freshness policy regardless of which
 /// projection they read.
 public struct OracleRead<Value: copy + drop + store> has copy, drop, store {
+    /// Publisher/source observation time carried in the pushed update.
     source_timestamp_ms: u64,
+    /// On-chain landing time (`clock.timestamp_ms()` when recorded); the freshness
+    /// invariant is `0 < source_timestamp_ms <= update_timestamp_ms`.
     update_timestamp_ms: u64,
     value: Value,
 }

--- a/packages/propbook/sources/registry.move
+++ b/packages/propbook/sources/registry.move
@@ -338,7 +338,6 @@ public fun bind_pyth_to_underlying(
 ) {
     registry.bind_oracle(
         admin_cap,
-        propbook_underlying_id,
         pyth_source_key(pyth_feed::pyth_source_id(feed)),
         pyth_feed::id(feed),
         pyth_binding_key(propbook_underlying_id),
@@ -354,7 +353,6 @@ public fun bind_block_scholes_spot_to_underlying(
 ) {
     registry.bind_oracle(
         admin_cap,
-        propbook_underlying_id,
         block_scholes_spot_source_key(block_scholes_spot_feed::bs_source_id(feed)),
         block_scholes_spot_feed::id(feed),
         block_scholes_spot_binding_key(propbook_underlying_id),
@@ -393,14 +391,12 @@ public fun bind_block_scholes_surface_to_underlying(
 
     registry.bind_oracle(
         admin_cap,
-        propbook_underlying_id,
         forward_source_key,
         block_scholes_forward_feed::id(forward_feed),
         forward_binding_key,
     );
     registry.bind_oracle(
         admin_cap,
-        propbook_underlying_id,
         svi_source_key,
         block_scholes_svi_feed::id(svi_feed),
         svi_binding_key,
@@ -435,11 +431,11 @@ fun record_source(registry: &mut OracleRegistry, source_key: OracleSourceKey, pr
 fun bind_oracle(
     registry: &mut OracleRegistry,
     _admin_cap: &RegistryAdminCap,
-    propbook_underlying_id: u32,
     source_key: OracleSourceKey,
     propbook_oracle_id: ID,
     binding_key: OracleBindingKey,
 ) {
+    let propbook_underlying_id = binding_key.propbook_underlying_id;
     registry.assert_registered_source_object(source_key, propbook_oracle_id);
     registry.assert_binding_available(binding_key);
 

--- a/packages/propbook/sources/registry.move
+++ b/packages/propbook/sources/registry.move
@@ -17,12 +17,11 @@
 module propbook::registry;
 
 use propbook::{
-    block_scholes_forward_feed::{Self as block_scholes_forward_feed, BlockScholesForwardFeed},
-    block_scholes_spot_feed::{Self as block_scholes_spot_feed, BlockScholesSpotFeed},
-    block_scholes_svi_feed::{Self as block_scholes_svi_feed, BlockScholesSVIFeed},
-    pyth_feed::{Self as pyth_feed, PythFeed}
+    block_scholes_forward_feed::{Self, BlockScholesForwardFeed},
+    block_scholes_spot_feed::{Self, BlockScholesSpotFeed},
+    block_scholes_svi_feed::{Self, BlockScholesSVIFeed},
+    pyth_feed::{Self, PythFeed}
 };
-use std::option::{Self, Option};
 use sui::{event, table::{Self, Table}};
 
 const ESourceAlreadyExists: u64 = 0;


### PR DESCRIPTION
## Summary
Replace bare same-typed tuple returns on the mint/redeem/admission/rebate paths with named package-only summary structs (read via `public(package)` field getters, since Move struct fields are module-private), closing the silent positional-swap bug class:
- `strike_exposure`: `allocate_mint_order` → `MintQuote`, `close_and_quote_live_order` → `CloseQuote`
- `strike_exposure_config`: `assert_mint_admission` → `MintAdmission`
- `predict_account`: `resolve_expiry_summary` → `ResolvedExpirySummary` (`fees_paid` avoids the existing `trading_fees_paid` getter)

`net_payout_reserve_terms` stays a `(u64, u64)` tuple: its sole consumer subtracts the two terms and `max <= total` always holds, so a transposition underflow-aborts rather than misprices — a struct would add no safety.

## Key decisions
- Behavior-preserving: identical values, aborts, and events; the summary structs are stack-only (no `key`/`store`).

## Test plan
- [x] `sui move build --path packages/predict --warnings-are-errors`
- [x] `sui move test --path packages/predict` (346/346)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0152ryjDZu25BfDv1raij4Zd
