### PR TITLE
Predict TypeScript SDK (@mysten/predict) v0 — testnet

### DIFF
--- a/packages/predict/sdk/.gitignore
+++ b/packages/predict/sdk/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/packages/predict/sdk/README.md
+++ b/packages/predict/sdk/README.md
@@ -52,7 +52,7 @@ receipt.netPremium, receipt.fees; // exact cost breakdown
 
 // Read: tradeable markets and pool state.
 const markets = await predict.read.markets();
-// -> [{ id, expiryMs, tickSize, mintPaused }, ...] — pick an expiry from here
+// -> [{ id, expiryMs, tickSize, mintPaused, referencePrice }, ...]
 const market = await predict.read.market({ underlying: "BTC", expiryMs: markets[0].expiryMs });
 console.log(market?.nav, market?.tickSize, market?.mintPaused);
 ```
@@ -85,6 +85,30 @@ primitives layer, which returns raw `bigint`s (`accountBalance`, `poolStats`, �
 
 `side: "up"` wins if the settlement price is above the strike; `"down"` below.
 
+## Reference-price markets (Polymarket-style windows)
+
+Each market carries an on-chain **reference price** — derived from the exact
+previous-window oracle observation, so consecutive windows chain naturally
+(the prior window's settlement observation anchors the next window's strike).
+Build an up/down board straight from discovery, and trade at the anchor with
+`strike: "reference"`:
+
+```ts
+const markets = await predict.read.markets();
+// each market: "BTC above $<referencePrice>?  ↑ / ↓"
+
+const tx = await predict.tx.mint(
+	myAddress,
+	{ underlying: "BTC", expiryMs: markets[0].expiryMs, strike: "reference", side: "up" },
+	{ quantity: 25, maxCost: 15 },
+);
+```
+
+The reference tick is read fresh at build time (it is unset briefly at the
+start of a window until the keeper seeds it — you get a clean
+`PredictInputError` rather than a chain abort). Numeric strikes away from the
+reference remain fully supported.
+
 ## What's in the box
 
 - **`PredictClient.tx`** — `createManager`, `deposit`, `withdraw`, `mint`,
@@ -95,7 +119,7 @@ primitives layer, which returns raw `bigint`s (`accountBalance`, `poolStats`, �
   `{ underlying, expiryMs, strike, side }` via the on-chain registry (cached
   per client).
 - **`PredictClient.read`** — `markets()` (tradeable summaries: id, expiry,
-  tick size, mint-paused), `market(desc)` (state + live NAV), `balance(owner)`,
+  tick size, mint-paused, reference price), `market(desc)` (state + live NAV), `balance(owner)`,
   `plpBalance(owner)`, `pool()`, `hasPosition(owner, marketId, orderId)`.
   All reads run over gRPC `simulateTransaction`; no indexer required.
 - **`PredictClient.decode`** — pure execution-result decoders (no network):

--- a/packages/predict/sdk/README.md
+++ b/packages/predict/sdk/README.md
@@ -44,9 +44,16 @@ const mintTx = await predict.tx.mint(
 );
 // -> sign & execute any of these with your wallet / dapp-kit / signer
 
-// Read: live markets and pool state.
-const marketIds = await predict.read.markets();
-const market = await predict.read.market({ underlying: "BTC", expiryMs: 1767225600000 });
+// Decode the receipt from the execution result (execute with events included):
+const receipt = predict.decode.mint(mintResult);
+receipt.orderId; // PERSIST THIS — needed to redeem/claim later
+receipt.entryProbability; // your fill price (0..1 per $1 payout)
+receipt.netPremium, receipt.fees; // exact cost breakdown
+
+// Read: tradeable markets and pool state.
+const markets = await predict.read.markets();
+// -> [{ id, expiryMs, tickSize, mintPaused }, ...] — pick an expiry from here
+const market = await predict.read.market({ underlying: "BTC", expiryMs: markets[0].expiryMs });
 console.log(market?.nav, market?.tickSize, market?.mintPaused);
 ```
 
@@ -87,9 +94,16 @@ primitives layer, which returns raw `bigint`s (`accountBalance`, `poolStats`, �
   async: they resolve the market object from
   `{ underlying, expiryMs, strike, side }` via the on-chain registry (cached
   per client).
-- **`PredictClient.read`** — `markets()`, `market(desc)` (state + live NAV),
-  `balance(owner)`, `plpBalance(owner)`, `pool()`. All reads run over gRPC
-  `simulateTransaction`; no indexer required.
+- **`PredictClient.read`** — `markets()` (tradeable summaries: id, expiry,
+  tick size, mint-paused), `market(desc)` (state + live NAV), `balance(owner)`,
+  `plpBalance(owner)`, `pool()`, `hasPosition(owner, marketId, orderId)`.
+  All reads run over gRPC `simulateTransaction`; no indexer required.
+- **`PredictClient.decode`** — pure execution-result decoders (no network):
+  `mint`, `redeem`, `claim`, `createManager`, `deposit`, `withdraw`,
+  `plpRequest`, `plpCancel`, `builderCode`, each with a plural form for
+  batched PTBs. Execute transactions with events included and pass the result;
+  receipts come back in SDK units with raw bigints alongside. Decoding uses
+  the events' canonical BCS bytes, so it is transport-independent.
 - **Composable primitives** — every Move entrypoint is also exported as a
   `(cfg, tx, args) => …` function with raw bigint units
   (`mintExactQuantity`, `redeemLive`, `requestSupply`, …) for integrators
@@ -111,11 +125,14 @@ resolution.
 
 ## Notes
 
-- Position enumeration (all open orders for an account) is not on-chain
-  readable and ships with the indexer API integration later; `mint` returns
-  the order id in its transaction result, and `OrderMinted` events carry it.
+- **Your app owns order-id persistence.** Position enumeration is not
+  on-chain readable (indexer integration comes later): capture
+  `decode.mint(result).orderId` at mint time and store it. **After a partial
+  redeem, the old id is retired** — update your store from
+  `decode.redeem(result).replacementOrderId` or the stored id goes stale.
+  Validate stored ids cheaply with `read.hasPosition`.
 - PLP supply/withdraw are queued and fill at the next pool flush; cancels
-  take the queue `index` from the request transaction's events.
+  take the queue `index` — get it from `decode.plpRequest(result).index`.
 - `claimSettled` requires a full close of the order (contract rule).
 
 ## Development

--- a/packages/predict/sdk/README.md
+++ b/packages/predict/sdk/README.md
@@ -1,0 +1,125 @@
+# @mysten/predict
+
+TypeScript SDK for DeepBook Predict — binary markets on Sui. Builds
+ready-to-sign transactions and reads on-chain state over gRPC. The SDK never
+signs and never touches keys: every `tx.*` method returns a `Transaction` for
+your wallet (dapp-kit) or signer to execute.
+
+## Install
+
+Not yet published to npm. Until then, consume it as a git dependency or from a
+local checkout of this repo:
+
+```jsonc
+// package.json
+"dependencies": {
+	"@mysten/predict": "github:MystenLabs/deepbookv3#path:packages/predict/sdk",
+	"@mysten/sui": "^2.16.0" // peer dependency
+}
+```
+
+## Quickstart
+
+```ts
+import { SuiGrpcClient } from "@mysten/sui/grpc";
+import { PredictClient } from "@mysten/predict";
+
+const client = new SuiGrpcClient({
+	network: "testnet",
+	baseUrl: "https://fullnode.testnet.sui.io:443",
+});
+const predict = new PredictClient({ network: "testnet", client });
+
+// One-time: create your Predict account (a shared AccountWrapper).
+const createTx = predict.tx.createManager();
+
+// Fund it: pulls DUSDC from your wallet coins.
+const depositTx = predict.tx.deposit(myAddress, 250); // $250
+
+// Trade: BTC above $105,000 at this hour's expiry, $50 max payout, 2x leverage.
+const mintTx = await predict.tx.mint(
+	myAddress,
+	{ underlying: "BTC", expiryMs: 1767225600000, strike: 105_000, side: "up" },
+	{ quantity: 50, leverage: 2, maxCost: 12.5 },
+);
+// -> sign & execute any of these with your wallet / dapp-kit / signer
+
+// Read: live markets and pool state.
+const marketIds = await predict.read.markets();
+const market = await predict.read.market({ underlying: "BTC", expiryMs: 1767225600000 });
+console.log(market?.nav, market?.tickSize, market?.mintPaused);
+```
+
+## ⚠ Slippage defaults are UNCAPPED
+
+`mint` mirrors the chain's semantics: when you omit `maxCost` and
+`maxProbability`, the mint is **uncapped** — if the price moves between your
+quote and execution, the position can cost up to your full account balance.
+Frontends always have a quote in hand: **pass `maxCost` from your quote.**
+The same applies to `redeem`, which has no slippage floor on the current
+deployment — quote first, close fast.
+
+## Units
+
+Everything human-facing is decimal; everything on-chain is scaled integers.
+The facade converts exactly (string/bigint math — no floats touch money).
+
+| Concept | You pass / receive | On-chain raw |
+| --- | --- | --- |
+| Amounts (deposit, spend, maxCost, balances) | USD decimal number or string (`12.5`, `"12.5"`) | ×1e6 (DUSDC) |
+| `quantity` | **max payout** in USD; positions pay $1 per contract at expiry | ×1e6, in $0.01 lots |
+| `strike` | USD (`105_000`) | ×1e9, must land on the market's tick |
+| `leverage` | number ≥ 1 (default 1) | ×1e9 |
+| `maxProbability` | 0..1 (`0.35` = 35¢ per $1 contract) | ×1e9 |
+| PLP shares (`withdrawPlp`, `plpBalance`) | raw `bigint` shares | 6-decimal coin |
+
+`side: "up"` wins if the settlement price is above the strike; `"down"` below.
+
+## What's in the box
+
+- **`PredictClient.tx`** — `createManager`, `deposit`, `withdraw`, `mint`,
+  `mintAmount`, `redeem`, `claimSettled`, `supplyPlp`, `withdrawPlp`,
+  `cancelSupplyPlp`, `cancelWithdrawPlp`, `setBuilderCode`, `unsetBuilderCode`.
+  Market-resolving builders (`mint`/`mintAmount`/`redeem`/`claimSettled`) are
+  async: they resolve the market object from
+  `{ underlying, expiryMs, strike, side }` via the on-chain registry (cached
+  per client).
+- **`PredictClient.read`** — `markets()`, `market(desc)` (state + live NAV),
+  `balance(owner)`, `plpBalance(owner)`, `pool()`. All reads run over gRPC
+  `simulateTransaction`; no indexer required.
+- **Composable primitives** — every Move entrypoint is also exported as a
+  `(cfg, tx, args) => …` function with raw bigint units
+  (`mintExactQuantity`, `redeemLive`, `requestSupply`, …) for integrators
+  composing their own PTBs, plus the reads (`marketState`,
+  `settlementPrice`, `currentNav`, `poolStats`, …).
+- **Typed errors** — invalid inputs throw `PredictInputError` before the
+  chain sees them; failed simulations throw `PredictMoveError` with the
+  decoded Move abort (`module`, `code`, `abortName`).
+
+## Networks & deployments
+
+**Testnet only today** — `getConfig("mainnet")` throws until a mainnet
+deployment exists. Object ids for the current testnet deployment are baked
+into the SDK (`TESTNET_CONFIG`); they are updated, with a release, whenever a
+new package version is deployed. Move-call targets flow through one
+resolution seam, which will switch to MVR names (`@deepbook/predict`) once
+registered — package upgrades then stop requiring an SDK release for target
+resolution.
+
+## Notes
+
+- Position enumeration (all open orders for an account) is not on-chain
+  readable and ships with the indexer API integration later; `mint` returns
+  the order id in its transaction result, and `OrderMinted` events carry it.
+- PLP supply/withdraw are queued and fill at the next pool flush; cancels
+  take the queue `index` from the request transaction's events.
+- `claimSettled` requires a full close of the order (contract rule).
+
+## Development
+
+```sh
+pnpm install
+pnpm test          # offline unit suite (tx construction, parsing, facade)
+pnpm test:testnet  # live-testnet smoke: reads + deployed-surface arity guards
+pnpm build         # ESM + CJS + d.ts via tsup
+```

--- a/packages/predict/sdk/README.md
+++ b/packages/predict/sdk/README.md
@@ -62,7 +62,10 @@ deployment — quote first, close fast.
 ## Units
 
 Everything human-facing is decimal; everything on-chain is scaled integers.
-The facade converts exactly (string/bigint math — no floats touch money).
+The facade converts **inputs** exactly (string/bigint math — no floats on the
+money path in). Read outputs typed `number` are display values: above 2^53
+raw they lose low-digit precision — for accounting-exact reads use the
+primitives layer, which returns raw `bigint`s (`accountBalance`, `poolStats`, …).
 
 | Concept | You pass / receive | On-chain raw |
 | --- | --- | --- |

--- a/packages/predict/sdk/README.md
+++ b/packages/predict/sdk/README.md
@@ -44,6 +44,16 @@ const mintTx = await predict.tx.mint(
 );
 // -> sign & execute any of these with your wallet / dapp-kit / signer
 
+// Quote before you trade: dry-runs your exact mint, real fees, real account.
+const q = await predict.read.quoteMint(myAddress, market, { quantity: 50 });
+q.entryProbability; // your fill (0..1 per $1 payout)
+q.cost;             // exact all-in debit — pass as maxCost (+ your buffer)
+
+// Anonymous board price (no account needed): both sides of any strike.
+const { up, down } = await predict.read.price({
+	underlying: "BTC", expiryMs, strike: "reference",
+});
+
 // Decode the receipt from the execution result (execute with events included):
 const receipt = predict.decode.mint(mintResult);
 receipt.orderId; // PERSIST THIS — needed to redeem/claim later
@@ -62,9 +72,9 @@ console.log(market?.nav, market?.tickSize, market?.mintPaused);
 `mint` mirrors the chain's semantics: when you omit `maxCost` and
 `maxProbability`, the mint is **uncapped** — if the price moves between your
 quote and execution, the position can cost up to your full account balance.
-Frontends always have a quote in hand: **pass `maxCost` from your quote.**
+**Call `read.quoteMint` and pass its `cost` (plus your buffer) as `maxCost`.**
 The same applies to `redeem`, which has no slippage floor on the current
-deployment — quote first, close fast.
+deployment — `read.quoteRedeem` first, close fast.
 
 ## Units
 
@@ -119,8 +129,13 @@ reference remain fully supported.
   `{ underlying, expiryMs, strike, side }` via the on-chain registry (cached
   per client).
 - **`PredictClient.read`** — `markets()` (tradeable summaries: id, expiry,
-  tick size, mint-paused, reference price), `market(desc)` (state + live NAV), `balance(owner)`,
-  `plpBalance(owner)`, `pool()`, `hasPosition(owner, marketId, orderId)`.
+  tick size, mint-paused, reference price), `market(desc)` (state + live NAV),
+  `price(m)` (anonymous both-sides pricing for any strike),
+  `quoteMint(owner, m, opts)` / `quoteRedeem(owner, m, opts)` (exact dry-run
+  quotes: real fees from the real code path — and they throw the same typed
+  errors the real trade would, so a quote doubles as preflight),
+  `balance(owner)`, `plpBalance(owner)`, `pool()`,
+  `hasPosition(owner, marketId, orderId)`.
   All reads run over gRPC `simulateTransaction`; no indexer required.
 - **`PredictClient.decode`** — pure execution-result decoders (no network):
   `mint`, `redeem`, `claim`, `createManager`, `deposit`, `withdraw`,

--- a/packages/predict/sdk/README.md
+++ b/packages/predict/sdk/README.md
@@ -135,6 +135,7 @@ reference remain fully supported.
   quotes: real fees from the real code path — and they throw the same typed
   errors the real trade would, so a quote doubles as preflight),
   `balance(owner)`, `plpBalance(owner)`, `pool()`,
+  `positions(owner)` (chain-only enumeration of open positions),
   `hasPosition(owner, marketId, orderId)`.
   All reads run over gRPC `simulateTransaction`; no indexer required.
 - **`PredictClient.decode`** — pure execution-result decoders (no network):
@@ -164,12 +165,13 @@ resolution.
 
 ## Notes
 
-- **Your app owns order-id persistence.** Position enumeration is not
-  on-chain readable (indexer integration comes later): capture
-  `decode.mint(result).orderId` at mint time and store it. **After a partial
-  redeem, the old id is retired** — update your store from
-  `decode.redeem(result).replacementOrderId` or the stored id goes stale.
-  Validate stored ids cheaply with `read.hasPosition`.
+- **Positions are enumerable on-chain**: `read.positions(owner)` lists every
+  open position (market + order id) straight from the account's position
+  table — one round trip warm, no indexer. Persisting
+  `decode.mint(result).orderId` and applying
+  `decode.redeem(result).replacementOrderId` is still the fastest hot path,
+  with `read.positions` as the fresh-start/recovery source and
+  `read.hasPosition` as the cheap validator.
 - PLP supply/withdraw are queued and fill at the next pool flush; cancels
   take the queue `index` — get it from `decode.plpRequest(result).index`.
 - `claimSettled` requires a full close of the order (contract rule).

--- a/packages/predict/sdk/package.json
+++ b/packages/predict/sdk/package.json
@@ -16,6 +16,7 @@
         "dist"
     ],
     "scripts": {
+        "prepare": "pnpm run build",
         "build": "tsup src/index.ts --format esm,cjs --dts --clean",
         "test": "vitest run",
         "test:testnet": "PREDICT_SDK_TESTNET=1 vitest run tests/testnet"

--- a/packages/predict/sdk/package.json
+++ b/packages/predict/sdk/package.json
@@ -7,9 +7,9 @@
     "type": "module",
     "exports": {
         ".": {
+            "types": "./dist/index.d.ts",
             "import": "./dist/index.js",
-            "require": "./dist/index.cjs",
-            "types": "./dist/index.d.ts"
+            "require": "./dist/index.cjs"
         }
     },
     "files": [

--- a/packages/predict/sdk/package.json
+++ b/packages/predict/sdk/package.json
@@ -1,0 +1,33 @@
+{
+    "name": "@mysten/predict",
+    "version": "0.0.1",
+    "private": false,
+    "description": "TypeScript SDK for DeepBook Predict",
+    "license": "Apache-2.0",
+    "type": "module",
+    "exports": {
+        ".": {
+            "import": "./dist/index.js",
+            "require": "./dist/index.cjs",
+            "types": "./dist/index.d.ts"
+        }
+    },
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "build": "tsup src/index.ts --format esm,cjs --dts --clean",
+        "test": "vitest run",
+        "test:testnet": "PREDICT_SDK_TESTNET=1 vitest run tests/testnet"
+    },
+    "peerDependencies": {
+        "@mysten/sui": "^2.16.0"
+    },
+    "devDependencies": {
+        "@mysten/sui": "^2.16.0",
+        "@types/node": "^20.17.6",
+        "tsup": "^8.3.5",
+        "typescript": "^5.6.3",
+        "vitest": "^2.1.8"
+    }
+}

--- a/packages/predict/sdk/pnpm-workspace.yaml
+++ b/packages/predict/sdk/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+packages:
+    - .
+
+allowBuilds:
+    esbuild: true

--- a/packages/predict/sdk/src/client.ts
+++ b/packages/predict/sdk/src/client.ts
@@ -17,6 +17,13 @@ import {
 import { PredictInputError } from "./errors.js";
 import type { ReadClient } from "./reads/inspect.js";
 import { simulateWithEvents } from "./reads/inspect.js";
+import {
+	positionsFromTable,
+	resolvePositionsTable,
+	type ObjectReadClient,
+	type OpenPosition,
+	type PositionsHandle,
+} from "./reads/positions.js";
 import { accountBalance, hasPosition } from "./reads/balances.js";
 import {
 	activeMarketIds,
@@ -172,6 +179,10 @@ export class PredictClient {
 	// one resolution per market per client suffices. (mintPaused IS mutable; the
 	// cached copy is never consulted for a tx decision — the chain enforces it.)
 	private readonly marketCache = new Map<string, ResolvedMarket>();
+	// owner → resolved position-store ids. accountUid and the table id are
+	// immutable once created, so cache-forever; a missing table (no Predict
+	// data yet) is NOT cached — it appears after the owner's first trade.
+	private readonly positionsCache = new Map<string, PositionsHandle>();
 
 	constructor(opts: {
 		network: "testnet" | "mainnet";
@@ -250,6 +261,19 @@ export class PredictClient {
 				`quantity ${quantityRaw} raw is not a whole ${POSITION_LOT_SIZE}-unit lot (position_lot_size)`,
 			);
 		}
+	}
+
+	// Position enumeration needs object reads beyond the simulate-only
+	// ReadClient contract; real SuiGrpcClient/SuiJsonRpcClient instances have
+	// them, simulate-only mocks do not — fail with a pointed message.
+	private objectReadClient(): ObjectReadClient {
+		const c = this.client as unknown as ObjectReadClient;
+		if (typeof c.getObject !== "function" || typeof c.listDynamicFields !== "function") {
+			throw new PredictInputError(
+				"read.positions needs a client with getObject + listDynamicFields (e.g. SuiGrpcClient)",
+			);
+		}
+		return c;
 	}
 
 	// Shared construction for tx.mint and read.quoteMint — the quote dry-runs
@@ -472,6 +496,22 @@ export class PredictClient {
 		// close or partial-close replacement — see RedeemReceipt.replacementOrderId).
 		hasPosition: (owner: string, marketId: string, orderId: bigint): Promise<boolean> =>
 			hasPosition(this.client, this.cfg, owner, marketId, orderId),
+
+		// All open positions for an owner, enumerated from the chain (the
+		// account's positions Table): 1 call per page warm, +2 resolution calls
+		// once per owner. Returns [] for owners with no Predict account.
+		positions: async (owner: string): Promise<OpenPosition[]> => {
+			const client = this.objectReadClient();
+			let handle = this.positionsCache.get(owner);
+			if (!handle?.positionsTableId) {
+				const resolved = await resolvePositionsTable(client, this.cfg, owner);
+				if (!resolved) return []; // never onboarded — do not cache
+				if (resolved.positionsTableId) this.positionsCache.set(owner, resolved);
+				handle = resolved;
+			}
+			if (!handle.positionsTableId) return [];
+			return positionsFromTable(client, handle.positionsTableId);
+		},
 
 		// Anonymous board pricing: the chain's probability for both sides of a
 		// strike, from one fresh pricer (no account needed). This is the ↑/↓

--- a/packages/predict/sdk/src/client.ts
+++ b/packages/predict/sdk/src/client.ts
@@ -1,0 +1,358 @@
+import type { SuiGrpcClient } from "@mysten/sui/grpc";
+import { Transaction, coinWithBalance } from "@mysten/sui/transactions";
+import { getConfig, type PredictConfig } from "./config/index.js";
+import { PredictInputError } from "./errors.js";
+import type { ReadClient } from "./reads/inspect.js";
+import { accountBalance } from "./reads/balances.js";
+import {
+	activeMarketIds,
+	currentNav,
+	expiryMarketId,
+	marketState,
+	type MarketState,
+} from "./reads/markets.js";
+import { poolStats } from "./reads/pool.js";
+import { binaryRangeTicks, type Side } from "./ticks.js";
+import { createAccount, depositFunds, withdrawFunds } from "./tx/account.js";
+import { setBuilderCode, unsetBuilderCode } from "./tx/builderCode.js";
+import { deriveAccountWrapperId } from "./tx/common.js";
+import {
+	cancelSupplyRequest,
+	cancelWithdrawRequest,
+	requestSupply,
+	requestWithdraw,
+} from "./tx/plp.js";
+import type { MarketFeeds } from "./tx/trade.js";
+import { mintExactAmount, mintExactQuantity, redeemLive, redeemSettled } from "./tx/trade.js";
+import {
+	leverageToRaw,
+	priceToRaw,
+	probabilityToRaw,
+	rawToUsdc,
+	usdcToRaw,
+	fromRaw,
+} from "./units.js";
+
+// `position_lot_size` — a position quantity must be a whole multiple of this many
+// raw payout units ($0.01 lots). See packages/predict/sources/constants.move:34.
+const POSITION_LOT_SIZE = 10_000n;
+
+/** A live/settled binary market addressed by its human coordinates. */
+export interface MarketDescriptor {
+	underlying: string;
+	expiryMs: number | bigint;
+	strike: number;
+	side: Side;
+}
+
+/** Options for the friendly `mint` (exact payout quantity). */
+export interface MintOptions {
+	quantity: number;
+	leverage?: number;
+	maxCost?: number;
+	maxProbability?: number;
+}
+
+/** Options for `mintAmount` (spend an exact amount, floor the quantity received). */
+export interface MintAmountOptions {
+	spend: number;
+	minQuantity: number;
+	leverage?: number;
+}
+
+/** Options for `redeem` / `claimSettled`: which order and how much to close. */
+export interface CloseOptions {
+	orderId: bigint;
+	quantity: number;
+}
+
+/** A resolved live market: its on-chain state summary for the caller. */
+export interface MarketSummary {
+	id: string;
+	expiryMs: bigint;
+	tickSize: number;
+	mintPaused: boolean;
+	nav: number;
+}
+
+/** Aggregate pool figures, in human units (shares raw, everything else scaled). */
+export interface PoolSummary {
+	plpTotalSupply: bigint;
+	idleUsdc: number;
+	supplyPending: number;
+	withdrawPending: number;
+}
+
+interface ResolvedMarket {
+	id: string;
+	state: MarketState;
+}
+
+/**
+ * The one object an app constructs. Wraps the config, a gRPC client for reads, and
+ * a derived-account model so callers pass owner addresses, decimal amounts, and
+ * human market coordinates — the facade converts to raw units, resolves markets
+ * (cached), and delegates to the tx primitives / reads. Every primitive stays
+ * exported for callers that need to compose their own PTBs.
+ */
+export class PredictClient {
+	readonly cfg: PredictConfig;
+	private readonly client: ReadClient;
+	// underlying:expiryMs → resolved market. Market ids/state are immutable for a
+	// given (underlying, expiry), so one resolution per market per client suffices.
+	private readonly marketCache = new Map<string, ResolvedMarket>();
+
+	constructor(opts: {
+		network: "testnet" | "mainnet";
+		client: SuiGrpcClient | ReadClient;
+		config?: PredictConfig;
+	}) {
+		this.cfg = opts.config ?? getConfig(opts.network);
+		this.client = opts.client;
+	}
+
+	/** The deterministic id of an owner's canonical account wrapper — no chain read. */
+	wrapperIdFor(owner: string): string {
+		return deriveAccountWrapperId(this.cfg, owner);
+	}
+
+	// The four oracle feed ids for a symbol; throws a typed error on an unknown symbol.
+	private feeds(underlying: string): MarketFeeds {
+		const u = this.cfg.underlyings[underlying];
+		if (!u) throw new PredictInputError(`unknown underlying: ${underlying}`);
+		return {
+			pythFeedId: u.pythFeedId,
+			bsSpotFeedId: u.bsSpotFeedId,
+			bsForwardFeedId: u.bsForwardFeedId,
+			bsSviFeedId: u.bsSviFeedId,
+		};
+	}
+
+	// Resolve (and cache) a market's id + state from its human coordinates.
+	private async resolveMarket(m: Pick<MarketDescriptor, "underlying" | "expiryMs">): Promise<ResolvedMarket> {
+		const expiryMs = BigInt(m.expiryMs);
+		const key = `${m.underlying}:${expiryMs}`;
+		const hit = this.marketCache.get(key);
+		if (hit) return hit;
+		const id = await expiryMarketId(this.client, this.cfg, m.underlying, expiryMs);
+		if (!id) throw new PredictInputError(`no market for ${m.underlying} at expiry ${expiryMs}`);
+		const state = await marketState(this.client, this.cfg, id);
+		const resolved: ResolvedMarket = { id, state };
+		this.marketCache.set(key, resolved);
+		return resolved;
+	}
+
+	// Raw payout quantity must land on a lot boundary — the chain rejects otherwise.
+	private assertLot(quantityRaw: bigint): void {
+		if (quantityRaw % POSITION_LOT_SIZE !== 0n) {
+			throw new PredictInputError(
+				`quantity ${quantityRaw} raw is not a whole ${POSITION_LOT_SIZE}-unit lot (position_lot_size)`,
+			);
+		}
+	}
+
+	// === tx builders ===
+	// Each returns a ready-to-sign Transaction. Market-resolving builders are async.
+	readonly tx = {
+		createManager: (): Transaction => {
+			const tx = new Transaction();
+			createAccount(this.cfg, tx);
+			return tx;
+		},
+
+		deposit: (owner: string, amountUsdc: number | string): Transaction => {
+			const tx = new Transaction();
+			const coin = tx.add(
+				coinWithBalance({
+					type: this.cfg.quoteCoinType,
+					balance: usdcToRaw(amountUsdc),
+					useGasCoin: false,
+				}),
+			);
+			depositFunds(this.cfg, tx, { wrapperId: this.wrapperIdFor(owner), coin });
+			return tx;
+		},
+
+		withdraw: (owner: string, amountUsdc: number | string): Transaction => {
+			const tx = new Transaction();
+			const coin = withdrawFunds(this.cfg, tx, {
+				wrapperId: this.wrapperIdFor(owner),
+				amountRaw: usdcToRaw(amountUsdc),
+			});
+			tx.transferObjects([coin], owner);
+			return tx;
+		},
+
+		mint: async (owner: string, m: MarketDescriptor, opts: MintOptions): Promise<Transaction> => {
+			const feeds = this.feeds(m.underlying);
+			const { id, state } = await this.resolveMarket(m);
+			const quantityRaw = usdcToRaw(opts.quantity);
+			this.assertLot(quantityRaw);
+			const { lowerTick, higherTick } = binaryRangeTicks(
+				priceToRaw(m.strike),
+				m.side,
+				state.tickSizeRaw,
+			);
+			const tx = new Transaction();
+			mintExactQuantity(this.cfg, tx, {
+				expiryMarketId: id,
+				wrapperId: this.wrapperIdFor(owner),
+				lowerTick,
+				higherTick,
+				quantityRaw,
+				leverageRaw: leverageToRaw(opts.leverage ?? 1),
+				maxCostRaw: opts.maxCost != null ? usdcToRaw(opts.maxCost) : undefined,
+				maxProbabilityRaw:
+					opts.maxProbability != null ? probabilityToRaw(opts.maxProbability) : undefined,
+				...feeds,
+			});
+			return tx;
+		},
+
+		mintAmount: async (
+			owner: string,
+			m: MarketDescriptor,
+			opts: MintAmountOptions,
+		): Promise<Transaction> => {
+			const feeds = this.feeds(m.underlying);
+			const { id, state } = await this.resolveMarket(m);
+			const minQuantityRaw = usdcToRaw(opts.minQuantity);
+			this.assertLot(minQuantityRaw);
+			const { lowerTick, higherTick } = binaryRangeTicks(
+				priceToRaw(m.strike),
+				m.side,
+				state.tickSizeRaw,
+			);
+			const tx = new Transaction();
+			mintExactAmount(this.cfg, tx, {
+				expiryMarketId: id,
+				wrapperId: this.wrapperIdFor(owner),
+				lowerTick,
+				higherTick,
+				amountRaw: usdcToRaw(opts.spend),
+				minQuantityRaw,
+				leverageRaw: leverageToRaw(opts.leverage ?? 1),
+				...feeds,
+			});
+			return tx;
+		},
+
+		redeem: async (
+			owner: string,
+			m: MarketDescriptor,
+			opts: CloseOptions,
+		): Promise<Transaction> => {
+			const feeds = this.feeds(m.underlying);
+			const { id } = await this.resolveMarket(m);
+			const tx = new Transaction();
+			redeemLive(this.cfg, tx, {
+				expiryMarketId: id,
+				wrapperId: this.wrapperIdFor(owner),
+				orderId: opts.orderId,
+				closeQuantityRaw: usdcToRaw(opts.quantity),
+				...feeds,
+			});
+			return tx;
+		},
+
+		claimSettled: async (
+			owner: string,
+			m: MarketDescriptor,
+			opts: CloseOptions,
+		): Promise<Transaction> => {
+			const feeds = this.feeds(m.underlying);
+			const { id } = await this.resolveMarket(m);
+			const tx = new Transaction();
+			redeemSettled(this.cfg, tx, {
+				expiryMarketId: id,
+				wrapperId: this.wrapperIdFor(owner),
+				orderId: opts.orderId,
+				closeQuantityRaw: usdcToRaw(opts.quantity),
+				pythFeedId: feeds.pythFeedId,
+			});
+			return tx;
+		},
+
+		supplyPlp: (owner: string, amountUsdc: number | string): Transaction => {
+			const tx = new Transaction();
+			requestSupply(this.cfg, tx, {
+				wrapperId: this.wrapperIdFor(owner),
+				amountRaw: usdcToRaw(amountUsdc),
+			});
+			return tx;
+		},
+
+		withdrawPlp: (owner: string, shares: bigint): Transaction => {
+			const tx = new Transaction();
+			requestWithdraw(this.cfg, tx, {
+				wrapperId: this.wrapperIdFor(owner),
+				sharesRaw: shares,
+			});
+			return tx;
+		},
+
+		cancelSupplyPlp: (owner: string, index: bigint): Transaction => {
+			const tx = new Transaction();
+			cancelSupplyRequest(this.cfg, tx, { wrapperId: this.wrapperIdFor(owner), index });
+			return tx;
+		},
+
+		cancelWithdrawPlp: (owner: string, index: bigint): Transaction => {
+			const tx = new Transaction();
+			cancelWithdrawRequest(this.cfg, tx, { wrapperId: this.wrapperIdFor(owner), index });
+			return tx;
+		},
+
+		setBuilderCode: (owner: string, builderCodeId: string): Transaction => {
+			const tx = new Transaction();
+			setBuilderCode(this.cfg, tx, { wrapperId: this.wrapperIdFor(owner), builderCodeId });
+			return tx;
+		},
+
+		unsetBuilderCode: (owner: string): Transaction => {
+			const tx = new Transaction();
+			unsetBuilderCode(this.cfg, tx, { wrapperId: this.wrapperIdFor(owner) });
+			return tx;
+		},
+	};
+
+	// === reads ===
+	readonly read = {
+		markets: (): Promise<string[]> => activeMarketIds(this.client, this.cfg),
+
+		market: async (
+			m: Pick<MarketDescriptor, "underlying" | "expiryMs">,
+		): Promise<MarketSummary | null> => {
+			const expiryMs = BigInt(m.expiryMs);
+			const id = await expiryMarketId(this.client, this.cfg, m.underlying, expiryMs);
+			if (!id) return null;
+			const state = await marketState(this.client, this.cfg, id);
+			this.marketCache.set(`${m.underlying}:${expiryMs}`, { id, state });
+			const navRaw = await currentNav(this.client, this.cfg, id, m.underlying);
+			return {
+				id,
+				expiryMs: state.expiryMs,
+				tickSize: fromRaw(state.tickSizeRaw, 9), // strike/price scale
+				mintPaused: state.mintPaused,
+				nav: rawToUsdc(navRaw),
+			};
+		},
+
+		balance: async (owner: string): Promise<number> =>
+			rawToUsdc(await accountBalance(this.client, this.cfg, owner)),
+
+		// PLP shares held in the owner's account custody (raw u64, 6-decimal PLP coin).
+		plpBalance: (owner: string): Promise<bigint> =>
+			accountBalance(this.client, this.cfg, owner, `${this.cfg.packages.predict}::plp::PLP`),
+
+		pool: async (): Promise<PoolSummary> => {
+			const s = await poolStats(this.client, this.cfg);
+			return {
+				plpTotalSupply: s.plpTotalSupply, // shares raw (6-decimal)
+				idleUsdc: rawToUsdc(s.idleBalance),
+				supplyPending: rawToUsdc(s.supplyRequestsPending), // DUSDC queued
+				withdrawPending: fromRaw(s.withdrawRequestsPending, 6), // PLP shares queued
+			};
+		},
+	};
+}

--- a/packages/predict/sdk/src/client.ts
+++ b/packages/predict/sdk/src/client.ts
@@ -1,14 +1,28 @@
 import type { SuiGrpcClient } from "@mysten/sui/grpc";
 import { Transaction, coinWithBalance } from "@mysten/sui/transactions";
 import { getConfig, type PredictConfig } from "./config/index.js";
+import {
+	decodeAccountsCreated,
+	decodeBuilderCodeSets,
+	decodeClaims,
+	decodeDeposits,
+	decodeMints,
+	decodePlpCancels,
+	decodePlpRequests,
+	decodeRedeems,
+	decodeWithdrawals,
+	exactlyOne,
+	type DecodableTransactionResult,
+} from "./decode.js";
 import { PredictInputError } from "./errors.js";
 import type { ReadClient } from "./reads/inspect.js";
-import { accountBalance } from "./reads/balances.js";
+import { accountBalance, hasPosition } from "./reads/balances.js";
 import {
 	activeMarketIds,
 	currentNav,
 	expiryMarketId,
 	marketState,
+	marketStates,
 	type MarketState,
 } from "./reads/markets.js";
 import { poolStats } from "./reads/pool.js";
@@ -64,6 +78,15 @@ export interface MintAmountOptions {
 export interface CloseOptions {
 	orderId: bigint;
 	quantity: number;
+}
+
+/** One tradeable market as returned by read.markets(). */
+export interface ActiveMarket {
+	id: string;
+	expiryMs: bigint;
+	/** Strike granularity in USD (e.g. 0.01). */
+	tickSize: number;
+	mintPaused: boolean;
 }
 
 /** A resolved live market: its on-chain state summary for the caller. */
@@ -325,7 +348,23 @@ export class PredictClient {
 
 	// === reads ===
 	readonly read = {
-		markets: (): Promise<string[]> => activeMarketIds(this.client, this.cfg),
+		// All tradeable (active) markets with the state a frontend needs to render
+		// and mint: one chain read for ids + one batched PTB for the states.
+		markets: async (): Promise<ActiveMarket[]> => {
+			const ids = await activeMarketIds(this.client, this.cfg);
+			const states = await marketStates(this.client, this.cfg, ids);
+			return ids.map((id, i) => ({
+				id,
+				expiryMs: states[i].expiryMs,
+				tickSize: fromRaw(states[i].tickSizeRaw, 9),
+				mintPaused: states[i].mintPaused,
+			}));
+		},
+
+		// Validate an app-stored order id against the chain (stale after full
+		// close or partial-close replacement — see RedeemReceipt.replacementOrderId).
+		hasPosition: (owner: string, marketId: string, orderId: bigint): Promise<boolean> =>
+			hasPosition(this.client, this.cfg, owner, marketId, orderId),
 
 		market: async (
 			m: Pick<MarketDescriptor, "underlying" | "expiryMs">,
@@ -364,5 +403,33 @@ export class PredictClient {
 				withdrawPending: fromRaw(s.withdrawRequestsPending, 6), // PLP shares queued
 			};
 		},
+	};
+
+	// === execution-result decoders ===
+	// Pure event parsing (no network): pass the executed/simulated transaction
+	// result (with events included) and get a typed receipt back. Singular forms
+	// throw unless exactly one matching event exists; plural forms return all
+	// (an integrator batching N actions in one PTB gets N receipts).
+	readonly decode = {
+		mint: (r: DecodableTransactionResult) => exactlyOne(decodeMints(this.cfg, r), "OrderMinted"),
+		mints: (r: DecodableTransactionResult) => decodeMints(this.cfg, r),
+		redeem: (r: DecodableTransactionResult) =>
+			exactlyOne(decodeRedeems(this.cfg, r), "order-redeemed"),
+		redeems: (r: DecodableTransactionResult) => decodeRedeems(this.cfg, r),
+		claim: (r: DecodableTransactionResult) =>
+			exactlyOne(decodeClaims(this.cfg, r), "SettledOrderRedeemed"),
+		claims: (r: DecodableTransactionResult) => decodeClaims(this.cfg, r),
+		createManager: (r: DecodableTransactionResult) =>
+			exactlyOne(decodeAccountsCreated(this.cfg, r), "AccountCreated"),
+		deposit: (r: DecodableTransactionResult) =>
+			exactlyOne(decodeDeposits(this.cfg, r), "Deposited"),
+		withdraw: (r: DecodableTransactionResult) =>
+			exactlyOne(decodeWithdrawals(this.cfg, r), "Withdrawn"),
+		plpRequest: (r: DecodableTransactionResult) =>
+			exactlyOne(decodePlpRequests(this.cfg, r), "supply/withdraw-requested"),
+		plpCancel: (r: DecodableTransactionResult) =>
+			exactlyOne(decodePlpCancels(this.cfg, r), "RequestCancelled"),
+		builderCode: (r: DecodableTransactionResult) =>
+			exactlyOne(decodeBuilderCodeSets(this.cfg, r), "BuilderCodeSet"),
 	};
 }

--- a/packages/predict/sdk/src/client.ts
+++ b/packages/predict/sdk/src/client.ts
@@ -324,6 +324,9 @@ export class PredictClient {
 			m: Pick<MarketDescriptor, "underlying" | "expiryMs">,
 		): Promise<MarketSummary | null> => {
 			const expiryMs = BigInt(m.expiryMs);
+			// Deliberately re-queries and overwrites the cache instead of reading
+			// through it: this read must return live state (nav, mintPaused), and
+			// refreshing the cache on the way keeps later tx builds consistent.
 			const id = await expiryMarketId(this.client, this.cfg, m.underlying, expiryMs);
 			if (!id) return null;
 			const state = await marketState(this.client, this.cfg, id);

--- a/packages/predict/sdk/src/client.ts
+++ b/packages/predict/sdk/src/client.ts
@@ -16,6 +16,7 @@ import {
 } from "./decode.js";
 import { PredictInputError } from "./errors.js";
 import type { ReadClient } from "./reads/inspect.js";
+import { simulateWithEvents } from "./reads/inspect.js";
 import { accountBalance, hasPosition } from "./reads/balances.js";
 import {
 	activeMarketIds,
@@ -23,6 +24,7 @@ import {
 	expiryMarketId,
 	marketState,
 	marketStates,
+	rangePrices,
 	referenceTick,
 	type MarketState,
 } from "./reads/markets.js";
@@ -43,6 +45,7 @@ import {
 	leverageToRaw,
 	priceToRaw,
 	probabilityToRaw,
+	rawToProbability,
 	rawToUsdc,
 	usdcToRaw,
 	fromRaw,
@@ -114,6 +117,39 @@ export interface PoolSummary {
 	idleUsdc: number;
 	supplyPending: number;
 	withdrawPending: number;
+}
+
+/** Exact pre-trade quote: the dry-run receipt of the mint you are about to send. */
+export interface MintQuote {
+	/** Fill price, 0..1 per $1 payout. */
+	entryProbability: number;
+	/** Net premium into LP backing (quote units). */
+	premium: number;
+	fees: { trading: number; subsidy: number; builder: number; penalty: number };
+	/**
+	 * All-in account debit: premium + (trading − subsidy) + builder + penalty —
+	 * exactly what the chain withdraws; pass this (plus your buffer) as maxCost.
+	 */
+	cost: number;
+	quantity: number;
+	raw: { premium: bigint; cost: bigint; quantity: bigint; entryProbability: bigint };
+	/** True: computed by the real mint code path against real account state. */
+	feesExact: true;
+}
+
+/** Exact pre-close quote: the dry-run receipt of the redeem you are about to send. */
+export interface RedeemQuote {
+	/** NET quote credited to the account. */
+	proceeds: number;
+	/** Gross close value before fees. */
+	gross: number;
+	fees: { trading: number; builder: number; penalty: number };
+	quantityClosed: number;
+	remaining: number;
+	/** True when the position would close as a liquidated tombstone (zero payout). */
+	wouldLiquidate: boolean;
+	raw: { proceeds: bigint; gross: bigint; quantityClosed: bigint };
+	feesExact: true;
 }
 
 interface ResolvedMarket {
@@ -216,6 +252,80 @@ export class PredictClient {
 		}
 	}
 
+	// Shared construction for tx.mint and read.quoteMint — the quote dry-runs
+	// EXACTLY the transaction the trade would send.
+	private async buildMint(
+		owner: string,
+		m: MarketDescriptor,
+		opts: MintOptions,
+	): Promise<Transaction> {
+		const feeds = this.feeds(m.underlying);
+		const { id, state } = await this.resolveMarket(m);
+		const quantityRaw = usdcToRaw(opts.quantity);
+		this.assertLot(quantityRaw);
+		const { lowerTick, higherTick } = await this.strikeTicks(m, id, state);
+		const tx = new Transaction();
+		mintExactQuantity(this.cfg, tx, {
+			expiryMarketId: id,
+			wrapperId: this.wrapperIdFor(owner),
+			lowerTick,
+			higherTick,
+			quantityRaw,
+			leverageRaw: leverageToRaw(opts.leverage ?? 1),
+			maxCostRaw: opts.maxCost != null ? usdcToRaw(opts.maxCost) : undefined,
+			maxProbabilityRaw:
+				opts.maxProbability != null ? probabilityToRaw(opts.maxProbability) : undefined,
+			...feeds,
+		});
+		return tx;
+	}
+
+	// Shared construction for tx.redeem and read.quoteRedeem.
+	private async buildRedeem(
+		owner: string,
+		m: MarketDescriptor,
+		opts: CloseOptions,
+	): Promise<Transaction> {
+		const feeds = this.feeds(m.underlying);
+		const { id } = await this.resolveMarket(m);
+		const closeQuantityRaw = usdcToRaw(opts.quantity);
+		this.assertLot(closeQuantityRaw);
+		const tx = new Transaction();
+		redeemLive(this.cfg, tx, {
+			expiryMarketId: id,
+			wrapperId: this.wrapperIdFor(owner),
+			orderId: opts.orderId,
+			closeQuantityRaw,
+			...feeds,
+		});
+		return tx;
+	}
+
+	// Raw strike for anonymous pricing: numeric strikes validate against the tick
+	// grid; "reference" reads the market's reference tick fresh (unset → typed error).
+	private async strikeRawFor(
+		m: Pick<MarketDescriptor, "underlying" | "expiryMs" | "strike">,
+		marketId: string,
+		state: MarketState,
+	): Promise<bigint> {
+		if (m.strike !== "reference") {
+			const raw = priceToRaw(m.strike);
+			if (raw % state.tickSizeRaw !== 0n) {
+				throw new PredictInputError(
+					`strike ${m.strike} is not on the ${fromRaw(state.tickSizeRaw, 9)} tick grid`,
+				);
+			}
+			return raw;
+		}
+		const tick = await referenceTick(this.client, this.cfg, marketId);
+		if (tick == null) {
+			throw new PredictInputError(
+				`reference price not set yet for ${m.underlying} @ ${m.expiryMs} — retry shortly or pass a numeric strike`,
+			);
+		}
+		return tick * state.tickSizeRaw;
+	}
+
 	// === tx builders ===
 	// Each returns a ready-to-sign Transaction. Market-resolving builders are async.
 	readonly tx = {
@@ -248,27 +358,8 @@ export class PredictClient {
 			return tx;
 		},
 
-		mint: async (owner: string, m: MarketDescriptor, opts: MintOptions): Promise<Transaction> => {
-			const feeds = this.feeds(m.underlying);
-			const { id, state } = await this.resolveMarket(m);
-			const quantityRaw = usdcToRaw(opts.quantity);
-			this.assertLot(quantityRaw);
-			const { lowerTick, higherTick } = await this.strikeTicks(m, id, state);
-			const tx = new Transaction();
-			mintExactQuantity(this.cfg, tx, {
-				expiryMarketId: id,
-				wrapperId: this.wrapperIdFor(owner),
-				lowerTick,
-				higherTick,
-				quantityRaw,
-				leverageRaw: leverageToRaw(opts.leverage ?? 1),
-				maxCostRaw: opts.maxCost != null ? usdcToRaw(opts.maxCost) : undefined,
-				maxProbabilityRaw:
-					opts.maxProbability != null ? probabilityToRaw(opts.maxProbability) : undefined,
-				...feeds,
-			});
-			return tx;
-		},
+		mint: (owner: string, m: MarketDescriptor, opts: MintOptions): Promise<Transaction> =>
+			this.buildMint(owner, m, opts),
 
 		mintAmount: async (
 			owner: string,
@@ -295,25 +386,8 @@ export class PredictClient {
 			return tx;
 		},
 
-		redeem: async (
-			owner: string,
-			m: MarketDescriptor,
-			opts: CloseOptions,
-		): Promise<Transaction> => {
-			const feeds = this.feeds(m.underlying);
-			const { id } = await this.resolveMarket(m);
-			const closeQuantityRaw = usdcToRaw(opts.quantity);
-			this.assertLot(closeQuantityRaw);
-			const tx = new Transaction();
-			redeemLive(this.cfg, tx, {
-				expiryMarketId: id,
-				wrapperId: this.wrapperIdFor(owner),
-				orderId: opts.orderId,
-				closeQuantityRaw,
-				...feeds,
-			});
-			return tx;
-		},
+		redeem: (owner: string, m: MarketDescriptor, opts: CloseOptions): Promise<Transaction> =>
+			this.buildRedeem(owner, m, opts),
 
 		claimSettled: async (
 			owner: string,
@@ -398,6 +472,77 @@ export class PredictClient {
 		// close or partial-close replacement — see RedeemReceipt.replacementOrderId).
 		hasPosition: (owner: string, marketId: string, orderId: bigint): Promise<boolean> =>
 			hasPosition(this.client, this.cfg, owner, marketId, orderId),
+
+		// Anonymous board pricing: the chain's probability for both sides of a
+		// strike, from one fresh pricer (no account needed). This is the ↑/↓
+		// button price before a user has onboarded.
+		price: async (
+			m: Pick<MarketDescriptor, "underlying" | "expiryMs" | "strike">,
+		): Promise<{ up: number; down: number }> => {
+			const feeds = this.feeds(m.underlying);
+			const { id, state } = await this.resolveMarket(m);
+			const strikeRaw = await this.strikeRawFor(m, id, state);
+			const { upRaw, downRaw } = await rangePrices(this.client, this.cfg, id, feeds, strikeRaw);
+			return { up: rawToProbability(upRaw), down: rawToProbability(downRaw) };
+		},
+
+		// Exact pre-trade quote: dry-runs the caller's own mint (same tx as
+		// tx.mint) and decodes the receipt. Requires a funded account; throws
+		// the same typed errors the real trade would — quote doubles as preflight.
+		quoteMint: async (
+			owner: string,
+			m: MarketDescriptor,
+			opts: Pick<MintOptions, "quantity" | "leverage">,
+		): Promise<MintQuote> => {
+			const tx = await this.buildMint(owner, m, opts);
+			const events = await simulateWithEvents(this.client, tx, owner);
+			const r = exactlyOne(decodeMints(this.cfg, { events }), "OrderMinted");
+			const costRaw =
+				r.raw.netPremium +
+				(r.raw.tradingFee - r.raw.feeIncentiveSubsidy) +
+				r.raw.builderFee +
+				r.raw.penaltyFee;
+			return {
+				entryProbability: r.entryProbability,
+				premium: r.netPremium,
+				fees: r.fees,
+				cost: rawToUsdc(costRaw),
+				quantity: r.quantity,
+				raw: {
+					premium: r.raw.netPremium,
+					cost: costRaw,
+					quantity: r.raw.quantity,
+					entryProbability: r.raw.entryProbability,
+				},
+				feesExact: true,
+			};
+		},
+
+		// Exact pre-close quote: dry-runs the caller's own redeem and decodes
+		// the receipt — the informed close against the floor-less deployed redeem.
+		quoteRedeem: async (
+			owner: string,
+			m: MarketDescriptor,
+			opts: CloseOptions,
+		): Promise<RedeemQuote> => {
+			const tx = await this.buildRedeem(owner, m, opts);
+			const events = await simulateWithEvents(this.client, tx, owner);
+			const r = exactlyOne(decodeRedeems(this.cfg, { events }), "order-redeemed");
+			return {
+				proceeds: r.proceeds,
+				gross: r.gross,
+				fees: { trading: r.fees.trading, builder: r.fees.builder, penalty: r.fees.penalty },
+				quantityClosed: r.quantityClosed,
+				remaining: r.remaining,
+				wouldLiquidate: r.liquidated,
+				raw: {
+					proceeds: r.raw.proceeds,
+					gross: r.raw.gross,
+					quantityClosed: r.raw.quantityClosed,
+				},
+				feesExact: true,
+			};
+		},
 
 		market: async (
 			m: Pick<MarketDescriptor, "underlying" | "expiryMs">,

--- a/packages/predict/sdk/src/client.ts
+++ b/packages/predict/sdk/src/client.ts
@@ -23,10 +23,11 @@ import {
 	expiryMarketId,
 	marketState,
 	marketStates,
+	referenceTick,
 	type MarketState,
 } from "./reads/markets.js";
 import { poolStats } from "./reads/pool.js";
-import { binaryRangeTicks, type Side } from "./ticks.js";
+import { POS_INF_TICK, binaryRangeTicks, type Side } from "./ticks.js";
 import { createAccount, depositFunds, withdrawFunds } from "./tx/account.js";
 import { setBuilderCode, unsetBuilderCode } from "./tx/builderCode.js";
 import { deriveAccountWrapperId } from "./tx/common.js";
@@ -55,7 +56,12 @@ const POSITION_LOT_SIZE = 10_000n;
 export interface MarketDescriptor {
 	underlying: string;
 	expiryMs: number | bigint;
-	strike: number;
+	/**
+	 * Strike in USD, or "reference" to trade at the market's on-chain reference
+	 * price (the Polymarket-style anchor: derived from the exact previous-window
+	 * oracle observation, so consecutive windows chain settlement → next strike).
+	 */
+	strike: number | "reference";
 	side: Side;
 }
 
@@ -87,6 +93,8 @@ export interface ActiveMarket {
 	/** Strike granularity in USD (e.g. 0.01). */
 	tickSize: number;
 	mintPaused: boolean;
+	/** The window's anchor strike in USD, or null until the keeper seeds it. */
+	referencePrice: number | null;
 }
 
 /** A resolved live market: its on-chain state summary for the caller. */
@@ -96,6 +104,8 @@ export interface MarketSummary {
 	tickSize: number;
 	mintPaused: boolean;
 	nav: number;
+	/** The window's anchor strike in USD, or null until the keeper seeds it. */
+	referencePrice: number | null;
 }
 
 /** Aggregate pool figures, in human units (shares raw, everything else scaled). */
@@ -167,6 +177,36 @@ export class PredictClient {
 		return resolved;
 	}
 
+	// Reference PRICE in USD from a state (tick index × tick size), or null.
+	private static referencePriceOf(state: MarketState): number | null {
+		return state.referenceTickRaw == null
+			? null
+			: fromRaw(state.referenceTickRaw * state.tickSizeRaw, 9);
+	}
+
+	// Resolve a descriptor's strike to the (lower, higher) tick pair. A numeric
+	// strike converts and validates against the tick grid; "reference" reads the
+	// market's reference tick FRESH (never cached — it is unset early in a
+	// window) and uses it directly: it is on the tick grid by construction.
+	private async strikeTicks(
+		m: MarketDescriptor,
+		marketId: string,
+		state: MarketState,
+	): Promise<{ lowerTick: bigint; higherTick: bigint }> {
+		if (m.strike !== "reference") {
+			return binaryRangeTicks(priceToRaw(m.strike), m.side, state.tickSizeRaw);
+		}
+		const tick = await referenceTick(this.client, this.cfg, marketId);
+		if (tick == null) {
+			throw new PredictInputError(
+				`reference price not set yet for ${m.underlying} @ ${m.expiryMs} — retry shortly or pass a numeric strike`,
+			);
+		}
+		return m.side === "up"
+			? { lowerTick: tick, higherTick: POS_INF_TICK }
+			: { lowerTick: 0n, higherTick: tick };
+	}
+
 	// Raw payout quantity must land on a lot boundary — the chain rejects otherwise.
 	private assertLot(quantityRaw: bigint): void {
 		if (quantityRaw % POSITION_LOT_SIZE !== 0n) {
@@ -213,11 +253,7 @@ export class PredictClient {
 			const { id, state } = await this.resolveMarket(m);
 			const quantityRaw = usdcToRaw(opts.quantity);
 			this.assertLot(quantityRaw);
-			const { lowerTick, higherTick } = binaryRangeTicks(
-				priceToRaw(m.strike),
-				m.side,
-				state.tickSizeRaw,
-			);
+			const { lowerTick, higherTick } = await this.strikeTicks(m, id, state);
 			const tx = new Transaction();
 			mintExactQuantity(this.cfg, tx, {
 				expiryMarketId: id,
@@ -244,11 +280,7 @@ export class PredictClient {
 			// No lot check: min_quantity is a floor the chain compares against an
 			// already-lot-floored minted quantity, so any floor value is legal.
 			const minQuantityRaw = usdcToRaw(opts.minQuantity);
-			const { lowerTick, higherTick } = binaryRangeTicks(
-				priceToRaw(m.strike),
-				m.side,
-				state.tickSizeRaw,
-			);
+			const { lowerTick, higherTick } = await this.strikeTicks(m, id, state);
 			const tx = new Transaction();
 			mintExactAmount(this.cfg, tx, {
 				expiryMarketId: id,
@@ -358,6 +390,7 @@ export class PredictClient {
 				expiryMs: states[i].expiryMs,
 				tickSize: fromRaw(states[i].tickSizeRaw, 9),
 				mintPaused: states[i].mintPaused,
+				referencePrice: PredictClient.referencePriceOf(states[i]),
 			}));
 		},
 
@@ -384,6 +417,7 @@ export class PredictClient {
 				tickSize: fromRaw(state.tickSizeRaw, 9), // strike/price scale
 				mintPaused: state.mintPaused,
 				nav: rawToUsdc(navRaw),
+				referencePrice: PredictClient.referencePriceOf(state),
 			};
 		},
 

--- a/packages/predict/sdk/src/client.ts
+++ b/packages/predict/sdk/src/client.ts
@@ -98,8 +98,10 @@ interface ResolvedMarket {
 export class PredictClient {
 	readonly cfg: PredictConfig;
 	private readonly client: ReadClient;
-	// underlying:expiryMs → resolved market. Market ids/state are immutable for a
-	// given (underlying, expiry), so one resolution per market per client suffices.
+	// underlying:expiryMs → resolved market. The id and tickSizeRaw — the only
+	// state tx building depends on — are immutable per (underlying, expiry), so
+	// one resolution per market per client suffices. (mintPaused IS mutable; the
+	// cached copy is never consulted for a tx decision — the chain enforces it.)
 	private readonly marketCache = new Map<string, ResolvedMarket>();
 
 	constructor(opts: {
@@ -216,8 +218,9 @@ export class PredictClient {
 		): Promise<Transaction> => {
 			const feeds = this.feeds(m.underlying);
 			const { id, state } = await this.resolveMarket(m);
+			// No lot check: min_quantity is a floor the chain compares against an
+			// already-lot-floored minted quantity, so any floor value is legal.
 			const minQuantityRaw = usdcToRaw(opts.minQuantity);
-			this.assertLot(minQuantityRaw);
 			const { lowerTick, higherTick } = binaryRangeTicks(
 				priceToRaw(m.strike),
 				m.side,
@@ -244,12 +247,14 @@ export class PredictClient {
 		): Promise<Transaction> => {
 			const feeds = this.feeds(m.underlying);
 			const { id } = await this.resolveMarket(m);
+			const closeQuantityRaw = usdcToRaw(opts.quantity);
+			this.assertLot(closeQuantityRaw);
 			const tx = new Transaction();
 			redeemLive(this.cfg, tx, {
 				expiryMarketId: id,
 				wrapperId: this.wrapperIdFor(owner),
 				orderId: opts.orderId,
-				closeQuantityRaw: usdcToRaw(opts.quantity),
+				closeQuantityRaw,
 				...feeds,
 			});
 			return tx;
@@ -262,12 +267,14 @@ export class PredictClient {
 		): Promise<Transaction> => {
 			const feeds = this.feeds(m.underlying);
 			const { id } = await this.resolveMarket(m);
+			const closeQuantityRaw = usdcToRaw(opts.quantity);
+			this.assertLot(closeQuantityRaw);
 			const tx = new Transaction();
 			redeemSettled(this.cfg, tx, {
 				expiryMarketId: id,
 				wrapperId: this.wrapperIdFor(owner),
 				orderId: opts.orderId,
-				closeQuantityRaw: usdcToRaw(opts.quantity),
+				closeQuantityRaw,
 				pythFeedId: feeds.pythFeedId,
 			});
 			return tx;

--- a/packages/predict/sdk/src/config/index.ts
+++ b/packages/predict/sdk/src/config/index.ts
@@ -1,0 +1,35 @@
+import { TESTNET_CONFIG } from "./testnet.js";
+import type { PredictConfig } from "./types.js";
+
+export type { PredictConfig, PredictPackages, UnderlyingConfig } from "./types.js";
+export { TESTNET_CONFIG } from "./testnet.js";
+
+/** The shared Clock object — a fixed well-known id on every network. */
+export const CLOCK_ID = "0x6";
+/** The shared AccumulatorRoot object — a fixed well-known id on every network. */
+export const ACCUMULATOR_ROOT_ID = "0xacc";
+
+export function getConfig(network: "testnet" | "mainnet"): PredictConfig {
+	if (network === "mainnet") throw new Error("no mainnet deployment");
+	return TESTNET_CONFIG;
+}
+
+// MVR: when @deepbook/predict is registered, resolve the name here (named-packages
+// plugin); builders never hardcode targets.
+export function predictTarget(
+	cfg: PredictConfig,
+	module: string,
+	fn: string,
+): `${string}::${string}::${string}` {
+	return `${cfg.packages.predict}::${module}::${fn}`;
+}
+
+// MVR: when @deepbook/account is registered, resolve the name here (named-packages
+// plugin); builders never hardcode targets.
+export function accountTarget(
+	cfg: PredictConfig,
+	module: string,
+	fn: string,
+): `${string}::${string}::${string}` {
+	return `${cfg.packages.account}::${module}::${fn}`;
+}

--- a/packages/predict/sdk/src/config/testnet.ts
+++ b/packages/predict/sdk/src/config/testnet.ts
@@ -1,0 +1,33 @@
+import type { PredictConfig } from "./types.js";
+
+/**
+ * Testnet deployment constants. Pure data — every id below is public on-chain
+ * data. Regenerate from the deployment record when a new package version ships.
+ */
+export const TESTNET_CONFIG: PredictConfig = {
+	network: "testnet",
+	packages: {
+		predict: "0xdb3ef5a5129920e59c9b2ae25a77eddb48acd0e1c6307b97073f0e076016446e",
+		account: "0xb9389eac8d59170ffd1427c1a66e5c8306263464fcc6615e825c1f5b3e15da3b",
+		propbook: "0x8eb2adde1c91f8b7c9ba5e9b0a32bfb804510c342939c5f77458fd8143f9755b",
+	},
+	objects: {
+		registry: "0x54afbf245caf42466cedb5756ed7816f34f544afdfa13579a862eccf3afa21ca",
+		protocolConfig: "0x2325224629b4bd96d1f1d7ee937e07f8a06f861018a130bbb26db09cb0394cb6",
+		poolVault: "0xfde98c636eb8a7aba59c3a238cfee6b576b7118d1e5ffa2952876c4b270a3a2a",
+		oracleRegistry: "0xf3deaff68cbd081a35ec21653af6f671d2ad5f012f3b4d817d81752843374136",
+		accountRegistry: "0x3c54d5b8b6bca376fc289121838ad02f8a5b3843242b9ad7e8f8245720e685a2",
+	},
+	quoteCoinType:
+		"0xe95040085976bfd54a1a07225cd46c8a2b4e8e2b6732f140a0fc49850ba73e1a::dusdc::DUSDC",
+	underlyings: {
+		BTC: {
+			symbol: "BTC",
+			propbookUnderlyingId: 1,
+			pythFeedId: "0xc78d7de16217d46d21b92ae475da799448be30b71a758dc6d7bb3ac2f1c35afb",
+			bsSpotFeedId: "0xcdc5fa7364e60fd2504aa96f65b707dc0734e507a919b1a7d7d63164fd67b745",
+			bsForwardFeedId: "0xe72c734ea8d8dcbc9183d9d8f96f51aaa1fb5034d5ed33ac60d67d261e15b48a",
+			bsSviFeedId: "0xdc2f8270676bd05fb28491e8d4a41a495722fda7a454926dd66dbba256a21c69",
+		},
+	},
+};

--- a/packages/predict/sdk/src/config/types.ts
+++ b/packages/predict/sdk/src/config/types.ts
@@ -1,0 +1,31 @@
+/** The three published Move packages a Predict deployment spans. */
+export interface PredictPackages {
+	predict: string;
+	account: string;
+	propbook: string;
+}
+
+/** Per-underlying oracle wiring: the propbook underlying id plus the four feed object ids. */
+export interface UnderlyingConfig {
+	symbol: string;
+	propbookUnderlyingId: number;
+	pythFeedId: string;
+	bsSpotFeedId: string;
+	bsForwardFeedId: string;
+	bsSviFeedId: string;
+}
+
+/** Everything a tx builder or read needs to address a Predict deployment on one network. */
+export interface PredictConfig {
+	network: "testnet" | "mainnet" | "custom";
+	packages: PredictPackages;
+	objects: {
+		registry: string;
+		protocolConfig: string;
+		poolVault: string;
+		oracleRegistry: string;
+		accountRegistry: string;
+	};
+	quoteCoinType: string; // DUSDC on testnet
+	underlyings: Record<string, UnderlyingConfig>; // keyed by symbol, e.g. "BTC"
+}

--- a/packages/predict/sdk/src/decode.ts
+++ b/packages/predict/sdk/src/decode.ts
@@ -234,8 +234,11 @@ export interface RedeemReceipt {
 	 * the remaining quantity — update your stored id or it goes silently stale.
 	 */
 	replacementOrderId: bigint | null;
-	/** Net quote credited to the account (0 for a liquidated tombstone). */
+	/** NET quote credited to the account: gross − trading − builder − penalty
+	 * (verified against the deployed settle path; 0 for a liquidated tombstone). */
 	proceeds: number;
+	/** Gross close value before fees (the event's redeem_amount). */
+	gross: number;
 	liquidated: boolean;
 	fees: { trading: number; builder: number; penalty: number };
 	builderCodeId: string | null;
@@ -243,6 +246,7 @@ export interface RedeemReceipt {
 		quantityClosed: bigint;
 		remaining: bigint;
 		proceeds: bigint;
+		gross: bigint;
 		tradingFee: bigint;
 		builderFee: bigint;
 		penaltyFee: bigint;
@@ -368,7 +372,16 @@ export function decodeRedeems(
 			remaining: fromRaw(BigInt(e.remaining_quantity), 6),
 			replacementOrderId:
 				e.replacement_order_id == null ? null : BigInt(e.replacement_order_id),
-			proceeds: fromRaw(BigInt(e.redeem_amount), 6),
+			// settle_live_redeem_payment credits redeem_amount minus all three
+			// fee components — the event's redeem_amount is GROSS.
+			proceeds: fromRaw(
+				BigInt(e.redeem_amount) -
+					BigInt(e.trading_fee) -
+					BigInt(e.builder_fee) -
+					BigInt(e.penalty_fee),
+				6,
+			),
+			gross: fromRaw(BigInt(e.redeem_amount), 6),
 			liquidated: false,
 			fees: {
 				trading: fromRaw(BigInt(e.trading_fee), 6),
@@ -379,7 +392,12 @@ export function decodeRedeems(
 			raw: {
 				quantityClosed: BigInt(e.quantity_closed),
 				remaining: BigInt(e.remaining_quantity),
-				proceeds: BigInt(e.redeem_amount),
+				proceeds:
+					BigInt(e.redeem_amount) -
+					BigInt(e.trading_fee) -
+					BigInt(e.builder_fee) -
+					BigInt(e.penalty_fee),
+				gross: BigInt(e.redeem_amount),
 				tradingFee: BigInt(e.trading_fee),
 				builderFee: BigInt(e.builder_fee),
 				penaltyFee: BigInt(e.penalty_fee),
@@ -403,6 +421,7 @@ export function decodeRedeems(
 			remaining: 0,
 			replacementOrderId: null,
 			proceeds: 0,
+			gross: 0,
 			liquidated: true,
 			fees: { trading: 0, builder: 0, penalty: 0 },
 			builderCodeId: null,
@@ -410,6 +429,7 @@ export function decodeRedeems(
 				quantityClosed: BigInt(e.quantity_closed),
 				remaining: 0n,
 				proceeds: 0n,
+				gross: 0n,
 				tradingFee: 0n,
 				builderFee: 0n,
 				penaltyFee: 0n,

--- a/packages/predict/sdk/src/decode.ts
+++ b/packages/predict/sdk/src/decode.ts
@@ -1,0 +1,557 @@
+import { bcs } from "@mysten/sui/bcs";
+import { fromBase64, normalizeSuiAddress } from "@mysten/sui/utils";
+import type { PredictConfig } from "./config/index.js";
+import { PredictInputError } from "./errors.js";
+import { fromRaw } from "./units.js";
+
+// ============================================================================
+// Execution-result decoders.
+//
+// Every tx.* builder returns a Transaction; after the app executes it (with
+// events included), the deployed contracts emit typed events carrying the full
+// receipt — order ids, fills, fees, queue indexes, new balances. These pure
+// functions turn that result into typed receipts. No network, no client.
+//
+// Decoding uses each event's BCS bytes, not its `json`: the client typings
+// warn the JSON rendering varies across transports (JSON-RPC/gRPC/GraphQL),
+// while BCS is canonical. Layouts below mirror the DEPLOYED event structs
+// verbatim (git show ec99cfae: packages/predict/sources/events/*.move and
+// packages/account/sources/account_events.move) — field ORDER is load-bearing.
+// Regenerate alongside the abort tables if the deployed package changes.
+// ============================================================================
+
+/** The slice of an executed/simulated transaction result the decoders need. */
+export interface DecodableEvent {
+	/** Full type tag `0xpkg::module::Name` (gRPC `eventType`, legacy `type`). */
+	eventType?: string;
+	type?: string;
+	packageId?: string;
+	module?: string;
+	/** Canonical BCS payload; some transports deliver it base64-encoded. */
+	bcs?: Uint8Array | string;
+}
+
+export interface DecodableTransactionResult {
+	events?: readonly DecodableEvent[] | null;
+}
+
+// --- BCS layouts (verbatim deployed field order) ---------------------------
+
+const OrderMintedBcs = bcs.struct("OrderMinted", {
+	expiry_market_id: bcs.Address,
+	account_id: bcs.Address,
+	order_id: bcs.u256(),
+	position_root_id: bcs.u256(),
+	owner: bcs.Address,
+	lower_tick: bcs.u64(),
+	higher_tick: bcs.u64(),
+	leverage: bcs.u64(),
+	entry_probability: bcs.u64(),
+	quantity: bcs.u64(),
+	net_premium: bcs.u64(),
+	trading_fee: bcs.u64(),
+	fee_incentive_subsidy: bcs.u64(),
+	builder_fee: bcs.u64(),
+	penalty_fee: bcs.u64(),
+	builder_code_id: bcs.option(bcs.Address),
+});
+
+const LiveOrderRedeemedBcs = bcs.struct("LiveOrderRedeemed", {
+	expiry_market_id: bcs.Address,
+	account_id: bcs.Address,
+	order_id: bcs.u256(),
+	position_root_id: bcs.u256(),
+	owner: bcs.Address,
+	quantity_closed: bcs.u64(),
+	remaining_quantity: bcs.u64(),
+	replacement_order_id: bcs.option(bcs.u256()),
+	redeem_amount: bcs.u64(),
+	trading_fee: bcs.u64(),
+	builder_fee: bcs.u64(),
+	penalty_fee: bcs.u64(),
+	builder_code_id: bcs.option(bcs.Address),
+});
+
+const LiquidatedOrderRedeemedBcs = bcs.struct("LiquidatedOrderRedeemed", {
+	expiry_market_id: bcs.Address,
+	account_id: bcs.Address,
+	order_id: bcs.u256(),
+	position_root_id: bcs.u256(),
+	owner: bcs.Address,
+	quantity_closed: bcs.u64(),
+});
+
+const SettledOrderRedeemedBcs = bcs.struct("SettledOrderRedeemed", {
+	expiry_market_id: bcs.Address,
+	account_id: bcs.Address,
+	order_id: bcs.u256(),
+	position_root_id: bcs.u256(),
+	owner: bcs.Address,
+	quantity_closed: bcs.u64(),
+	settlement_price: bcs.u64(),
+	payout_amount: bcs.u64(),
+});
+
+const SupplyRequestedBcs = bcs.struct("SupplyRequested", {
+	pool_vault_id: bcs.Address,
+	account_id: bcs.Address,
+	recipient: bcs.Address,
+	index: bcs.u64(),
+	amount: bcs.u64(),
+});
+const WithdrawRequestedBcs = SupplyRequestedBcs; // identical layout, different name
+
+const RequestCancelledBcs = bcs.struct("RequestCancelled", {
+	pool_vault_id: bcs.Address,
+	account_id: bcs.Address,
+	recipient: bcs.Address,
+	index: bcs.u64(),
+	amount: bcs.u64(),
+	is_supply: bcs.bool(),
+});
+
+const AccountCreatedBcs = bcs.struct("AccountCreated", {
+	account_id: bcs.Address,
+	wrapper_id: bcs.Address,
+	owner: bcs.Address,
+	self_owned: bcs.bool(),
+});
+
+const BalanceChangedBcs = bcs.struct("BalanceChanged", {
+	account_id: bcs.Address,
+	coin_type: bcs.string(),
+	amount: bcs.u64(),
+	new_balance: bcs.u64(),
+}); // shared layout of Deposited / Withdrawn
+
+const BuilderCodeSetBcs = bcs.struct("BuilderCodeSet", {
+	account_id: bcs.Address,
+	owner: bcs.Address,
+	builder_code_id: bcs.option(bcs.Address),
+});
+
+// --- matching + plumbing ----------------------------------------------------
+
+function eventBytes(e: DecodableEvent): Uint8Array | null {
+	if (e.bcs instanceof Uint8Array) return e.bcs;
+	if (typeof e.bcs === "string") return fromBase64(e.bcs);
+	return null;
+}
+
+// Match by defining package + module + struct name. Events are typed by the
+// ORIGINAL package id; for the current v1 deployments that equals the config
+// package id.
+function matches(e: DecodableEvent, pkg: string, module: string, name: string): boolean {
+	const tag = e.eventType ?? e.type;
+	if (tag) {
+		const parts = tag.split("::");
+		if (parts.length !== 3) return false;
+		return (
+			normalizeSuiAddress(parts[0]) === normalizeSuiAddress(pkg) &&
+			parts[1] === module &&
+			parts[2] === name
+		);
+	}
+	return e.module === module && e.packageId != null
+		? normalizeSuiAddress(e.packageId) === normalizeSuiAddress(pkg)
+		: false;
+}
+
+function decodeAll<T>(
+	result: DecodableTransactionResult,
+	pkg: string,
+	module: string,
+	name: string,
+	layout: { parse(bytes: Uint8Array): T },
+): T[] {
+	const out: T[] = [];
+	for (const e of result.events ?? []) {
+		if (!matches(e, pkg, module, name)) continue;
+		const bytes = eventBytes(e);
+		if (!bytes) {
+			throw new PredictInputError(
+				`${module}::${name} event has no BCS payload — execute/simulate with events included`,
+			);
+		}
+		out.push(layout.parse(bytes));
+	}
+	return out;
+}
+
+function exactlyOne<T>(items: T[], what: string): T {
+	if (items.length !== 1) {
+		throw new PredictInputError(`expected exactly one ${what} event, found ${items.length}`);
+	}
+	return items[0];
+}
+
+const optId = (v: string | null | undefined): string | null =>
+	v == null ? null : normalizeSuiAddress(v);
+
+// --- receipts ---------------------------------------------------------------
+
+export interface MintReceipt {
+	marketId: string;
+	accountId: string;
+	owner: string;
+	/** Persist this: required to redeem/claim the position later. */
+	orderId: bigint;
+	/** Stable across partial-close replacements; equals orderId at mint. */
+	positionRootId: bigint;
+	lowerTick: bigint;
+	higherTick: bigint;
+	leverage: number;
+	/** 0..1 range probability quoted at entry (your fill price per $1 payout). */
+	entryProbability: number;
+	/** Max payout actually minted, in quote units (mintAmount: chain-floored). */
+	quantity: number;
+	/** Net premium paid into LP backing, in quote units. */
+	netPremium: number;
+	fees: { trading: number; subsidy: number; builder: number; penalty: number };
+	builderCodeId: string | null;
+	raw: {
+		quantity: bigint;
+		netPremium: bigint;
+		tradingFee: bigint;
+		feeIncentiveSubsidy: bigint;
+		builderFee: bigint;
+		penaltyFee: bigint;
+		leverage: bigint;
+		entryProbability: bigint;
+	};
+}
+
+export interface RedeemReceipt {
+	marketId: string;
+	accountId: string;
+	owner: string;
+	orderId: bigint;
+	positionRootId: bigint;
+	quantityClosed: number;
+	remaining: number;
+	/**
+	 * A partial close RETIRES the old order id and issues this replacement for
+	 * the remaining quantity — update your stored id or it goes silently stale.
+	 */
+	replacementOrderId: bigint | null;
+	/** Net quote credited to the account (0 for a liquidated tombstone). */
+	proceeds: number;
+	liquidated: boolean;
+	fees: { trading: number; builder: number; penalty: number };
+	builderCodeId: string | null;
+	raw: {
+		quantityClosed: bigint;
+		remaining: bigint;
+		proceeds: bigint;
+		tradingFee: bigint;
+		builderFee: bigint;
+		penaltyFee: bigint;
+	};
+}
+
+export interface ClaimReceipt {
+	marketId: string;
+	accountId: string;
+	owner: string;
+	orderId: bigint;
+	positionRootId: bigint;
+	quantityClosed: number;
+	/** Settlement price in USD. */
+	settlementPrice: number;
+	/** Quote units paid out. */
+	payout: number;
+	raw: { quantityClosed: bigint; settlementPrice: bigint; payout: bigint };
+}
+
+export interface CreateManagerReceipt {
+	accountId: string;
+	wrapperId: string;
+	owner: string;
+	selfOwned: boolean;
+}
+
+export interface BalanceChangeReceipt {
+	accountId: string;
+	coinType: string;
+	/** Display value assuming a 6-decimal coin (quote + PLP both are). */
+	amount: number;
+	newBalance: number;
+	raw: { amount: bigint; newBalance: bigint };
+}
+
+export interface PlpRequestReceipt {
+	kind: "supply" | "withdraw";
+	vaultId: string;
+	accountId: string;
+	recipient: string;
+	/** Feed straight into cancelSupplyPlp / cancelWithdrawPlp. */
+	index: bigint;
+	/** Quote units for supply; PLP shares (6-dec) for withdraw. */
+	amount: number;
+	raw: { amount: bigint };
+}
+
+export interface PlpCancelReceipt {
+	vaultId: string;
+	accountId: string;
+	recipient: string;
+	index: bigint;
+	isSupply: boolean;
+	/** Refund returned to the account (quote for supply, PLP for withdraw). */
+	amount: number;
+	raw: { amount: bigint };
+}
+
+export interface BuilderCodeReceipt {
+	accountId: string;
+	owner: string;
+	/** Null after unsetBuilderCode. */
+	builderCodeId: string | null;
+}
+
+// --- decoders (plural = all matching events, in event order) ----------------
+
+export function decodeMints(cfg: PredictConfig, result: DecodableTransactionResult): MintReceipt[] {
+	return decodeAll(result, cfg.packages.predict, "order_events", "OrderMinted", OrderMintedBcs).map(
+		(e) => ({
+			marketId: normalizeSuiAddress(e.expiry_market_id),
+			accountId: normalizeSuiAddress(e.account_id),
+			owner: normalizeSuiAddress(e.owner),
+			orderId: BigInt(e.order_id),
+			positionRootId: BigInt(e.position_root_id),
+			lowerTick: BigInt(e.lower_tick),
+			higherTick: BigInt(e.higher_tick),
+			leverage: fromRaw(BigInt(e.leverage), 9),
+			entryProbability: fromRaw(BigInt(e.entry_probability), 9),
+			quantity: fromRaw(BigInt(e.quantity), 6),
+			netPremium: fromRaw(BigInt(e.net_premium), 6),
+			fees: {
+				trading: fromRaw(BigInt(e.trading_fee), 6),
+				subsidy: fromRaw(BigInt(e.fee_incentive_subsidy), 6),
+				builder: fromRaw(BigInt(e.builder_fee), 6),
+				penalty: fromRaw(BigInt(e.penalty_fee), 6),
+			},
+			builderCodeId: optId(e.builder_code_id),
+			raw: {
+				quantity: BigInt(e.quantity),
+				netPremium: BigInt(e.net_premium),
+				tradingFee: BigInt(e.trading_fee),
+				feeIncentiveSubsidy: BigInt(e.fee_incentive_subsidy),
+				builderFee: BigInt(e.builder_fee),
+				penaltyFee: BigInt(e.penalty_fee),
+				leverage: BigInt(e.leverage),
+				entryProbability: BigInt(e.entry_probability),
+			},
+		}),
+	);
+}
+
+export function decodeRedeems(
+	cfg: PredictConfig,
+	result: DecodableTransactionResult,
+): RedeemReceipt[] {
+	const pkg = cfg.packages.predict;
+	const live = decodeAll(
+		result,
+		pkg,
+		"order_events",
+		"LiveOrderRedeemed",
+		LiveOrderRedeemedBcs,
+	).map(
+		(e): RedeemReceipt => ({
+			marketId: normalizeSuiAddress(e.expiry_market_id),
+			accountId: normalizeSuiAddress(e.account_id),
+			owner: normalizeSuiAddress(e.owner),
+			orderId: BigInt(e.order_id),
+			positionRootId: BigInt(e.position_root_id),
+			quantityClosed: fromRaw(BigInt(e.quantity_closed), 6),
+			remaining: fromRaw(BigInt(e.remaining_quantity), 6),
+			replacementOrderId:
+				e.replacement_order_id == null ? null : BigInt(e.replacement_order_id),
+			proceeds: fromRaw(BigInt(e.redeem_amount), 6),
+			liquidated: false,
+			fees: {
+				trading: fromRaw(BigInt(e.trading_fee), 6),
+				builder: fromRaw(BigInt(e.builder_fee), 6),
+				penalty: fromRaw(BigInt(e.penalty_fee), 6),
+			},
+			builderCodeId: optId(e.builder_code_id),
+			raw: {
+				quantityClosed: BigInt(e.quantity_closed),
+				remaining: BigInt(e.remaining_quantity),
+				proceeds: BigInt(e.redeem_amount),
+				tradingFee: BigInt(e.trading_fee),
+				builderFee: BigInt(e.builder_fee),
+				penaltyFee: BigInt(e.penalty_fee),
+			},
+		}),
+	);
+	const liquidated = decodeAll(
+		result,
+		pkg,
+		"order_events",
+		"LiquidatedOrderRedeemed",
+		LiquidatedOrderRedeemedBcs,
+	).map(
+		(e): RedeemReceipt => ({
+			marketId: normalizeSuiAddress(e.expiry_market_id),
+			accountId: normalizeSuiAddress(e.account_id),
+			owner: normalizeSuiAddress(e.owner),
+			orderId: BigInt(e.order_id),
+			positionRootId: BigInt(e.position_root_id),
+			quantityClosed: fromRaw(BigInt(e.quantity_closed), 6),
+			remaining: 0,
+			replacementOrderId: null,
+			proceeds: 0,
+			liquidated: true,
+			fees: { trading: 0, builder: 0, penalty: 0 },
+			builderCodeId: null,
+			raw: {
+				quantityClosed: BigInt(e.quantity_closed),
+				remaining: 0n,
+				proceeds: 0n,
+				tradingFee: 0n,
+				builderFee: 0n,
+				penaltyFee: 0n,
+			},
+		}),
+	);
+	return [...live, ...liquidated];
+}
+
+export function decodeClaims(
+	cfg: PredictConfig,
+	result: DecodableTransactionResult,
+): ClaimReceipt[] {
+	return decodeAll(
+		result,
+		cfg.packages.predict,
+		"order_events",
+		"SettledOrderRedeemed",
+		SettledOrderRedeemedBcs,
+	).map((e) => ({
+		marketId: normalizeSuiAddress(e.expiry_market_id),
+		accountId: normalizeSuiAddress(e.account_id),
+		owner: normalizeSuiAddress(e.owner),
+		orderId: BigInt(e.order_id),
+		positionRootId: BigInt(e.position_root_id),
+		quantityClosed: fromRaw(BigInt(e.quantity_closed), 6),
+		settlementPrice: fromRaw(BigInt(e.settlement_price), 9),
+		payout: fromRaw(BigInt(e.payout_amount), 6),
+		raw: {
+			quantityClosed: BigInt(e.quantity_closed),
+			settlementPrice: BigInt(e.settlement_price),
+			payout: BigInt(e.payout_amount),
+		},
+	}));
+}
+
+export function decodeAccountsCreated(
+	cfg: PredictConfig,
+	result: DecodableTransactionResult,
+): CreateManagerReceipt[] {
+	return decodeAll(
+		result,
+		cfg.packages.account,
+		"account_events",
+		"AccountCreated",
+		AccountCreatedBcs,
+	).map((e) => ({
+		accountId: normalizeSuiAddress(e.account_id),
+		wrapperId: normalizeSuiAddress(e.wrapper_id),
+		owner: normalizeSuiAddress(e.owner),
+		selfOwned: e.self_owned,
+	}));
+}
+
+function decodeBalanceChanges(
+	cfg: PredictConfig,
+	result: DecodableTransactionResult,
+	name: "Deposited" | "Withdrawn",
+): BalanceChangeReceipt[] {
+	return decodeAll(result, cfg.packages.account, "account_events", name, BalanceChangedBcs).map(
+		(e) => ({
+			accountId: normalizeSuiAddress(e.account_id),
+			coinType: e.coin_type,
+			amount: fromRaw(BigInt(e.amount), 6),
+			newBalance: fromRaw(BigInt(e.new_balance), 6),
+			raw: { amount: BigInt(e.amount), newBalance: BigInt(e.new_balance) },
+		}),
+	);
+}
+
+export const decodeDeposits = (
+	cfg: PredictConfig,
+	result: DecodableTransactionResult,
+): BalanceChangeReceipt[] => decodeBalanceChanges(cfg, result, "Deposited");
+
+export const decodeWithdrawals = (
+	cfg: PredictConfig,
+	result: DecodableTransactionResult,
+): BalanceChangeReceipt[] => decodeBalanceChanges(cfg, result, "Withdrawn");
+
+export function decodePlpRequests(
+	cfg: PredictConfig,
+	result: DecodableTransactionResult,
+): PlpRequestReceipt[] {
+	const pkg = cfg.packages.predict;
+	const make =
+		(kind: "supply" | "withdraw") =>
+		(e: (typeof SupplyRequestedBcs)["$inferType"]): PlpRequestReceipt => ({
+			kind,
+			vaultId: normalizeSuiAddress(e.pool_vault_id),
+			accountId: normalizeSuiAddress(e.account_id),
+			recipient: normalizeSuiAddress(e.recipient),
+			index: BigInt(e.index),
+			amount: fromRaw(BigInt(e.amount), 6),
+			raw: { amount: BigInt(e.amount) },
+		});
+	return [
+		...decodeAll(result, pkg, "vault_events", "SupplyRequested", SupplyRequestedBcs).map(
+			make("supply"),
+		),
+		...decodeAll(result, pkg, "vault_events", "WithdrawRequested", WithdrawRequestedBcs).map(
+			make("withdraw"),
+		),
+	];
+}
+
+export function decodePlpCancels(
+	cfg: PredictConfig,
+	result: DecodableTransactionResult,
+): PlpCancelReceipt[] {
+	return decodeAll(
+		result,
+		cfg.packages.predict,
+		"vault_events",
+		"RequestCancelled",
+		RequestCancelledBcs,
+	).map((e) => ({
+		vaultId: normalizeSuiAddress(e.pool_vault_id),
+		accountId: normalizeSuiAddress(e.account_id),
+		recipient: normalizeSuiAddress(e.recipient),
+		index: BigInt(e.index),
+		isSupply: e.is_supply,
+		amount: fromRaw(BigInt(e.amount), 6),
+		raw: { amount: BigInt(e.amount) },
+	}));
+}
+
+export function decodeBuilderCodeSets(
+	cfg: PredictConfig,
+	result: DecodableTransactionResult,
+): BuilderCodeReceipt[] {
+	return decodeAll(
+		result,
+		cfg.packages.predict,
+		"builder_code_events",
+		"BuilderCodeSet",
+		BuilderCodeSetBcs,
+	).map((e) => ({
+		accountId: normalizeSuiAddress(e.account_id),
+		owner: normalizeSuiAddress(e.owner),
+		builderCodeId: optId(e.builder_code_id),
+	}));
+}
+
+export { exactlyOne };

--- a/packages/predict/sdk/src/errors.ts
+++ b/packages/predict/sdk/src/errors.ts
@@ -35,9 +35,9 @@ export class PredictMoveError extends Error {
 	}
 }
 
-// Abort code → name, per module. Generated from the DEPLOYED sources at branch
-// ec99cfae (packages/predict + packages/account of repos/deepbookv3): grep of
-// `const E<Name>: u64 = <n>;` in each module. Regenerate from that same branch if
+// Abort code → name, per module. Generated from the DEPLOYED sources at commit
+// ec99cfae (this repo's packages/predict + packages/account): grep of
+// `const E<Name>: u64 = <n>;` in each module. Regenerate from that same commit if
 // the deployed package changes — a stale table mislabels a real abort.
 export const ABORT_TABLES: Record<string, Record<number, string>> = {
 	expiry_market: {

--- a/packages/predict/sdk/src/errors.ts
+++ b/packages/predict/sdk/src/errors.ts
@@ -1,0 +1,116 @@
+// Typed errors for the Predict SDK.
+//
+// Two failure kinds cross the SDK boundary:
+//   - PredictInputError — a caller gave us something we rejected before touching
+//     the chain (unknown underlying, malformed argument, …).
+//   - PredictMoveError — a Move `abort` surfaced by a read/simulate. We decode the
+//     on-chain module + code into the human abort name so callers can branch on
+//     `abortName` / `code` instead of string-matching a rendered failure.
+
+/** A caller-supplied argument the SDK rejected before building/sending a tx. */
+export class PredictInputError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "PredictInputError";
+	}
+}
+
+/** A Move `abort` decoded from a simulate/read failure. */
+export class PredictMoveError extends Error {
+	readonly module: string;
+	readonly code: number;
+	/** The `E…` constant name from the abort table, or null if unmapped. */
+	readonly abortName: string | null;
+
+	constructor(module: string, code: number, abortName: string | null) {
+		super(
+			abortName
+				? `Move abort in ${module}: ${abortName} (code ${code})`
+				: `Move abort in ${module}: code ${code}`,
+		);
+		this.name = "PredictMoveError";
+		this.module = module;
+		this.code = code;
+		this.abortName = abortName;
+	}
+}
+
+// Abort code → name, per module. Generated from the DEPLOYED sources at branch
+// ec99cfae (packages/predict + packages/account of repos/deepbookv3): grep of
+// `const E<Name>: u64 = <n>;` in each module. Regenerate from that same branch if
+// the deployed package changes — a stale table mislabels a real abort.
+export const ABORT_TABLES: Record<string, Record<number, string>> = {
+	expiry_market: {
+		0: "EMintPaused",
+		1: "EFullCloseRequired",
+		2: "EMarketNotSettled",
+		3: "EWrongPythFeed",
+		4: "EMintCostAboveMax",
+		5: "EMintProbabilityAboveMax",
+		6: "EMintQuantityBelowMin",
+		7: "EWrongPricer",
+		8: "EReferenceTickObservationMissing",
+		9: "EReferenceTickTimestampMismatch",
+		10: "EMintRedeemSameTimestamp",
+	},
+	plp: {
+		0: "EExpiryMarketNotActive",
+		1: "EExpiryMarketAlreadyValued",
+		2: "EWrongPoolVault",
+		3: "EMissingExpiryValuation",
+		4: "ENotBootstrapped",
+		5: "EPlpPriceBelowCircuitBreaker",
+		6: "EPlpPriceAboveCircuitBreaker",
+		7: "EAlreadyBootstrapped",
+		8: "EPoolNavDust",
+		9: "EBelowMinBootstrapLiquidity",
+		10: "EBelowMinFeeIncentiveSponsorship",
+		11: "EMarketNotSettled",
+	},
+	lp_book: {
+		0: "ERequestNotFound",
+		1: "EBelowMinSupplyRequest",
+		2: "EBelowMinWithdrawRequest",
+		3: "ENotRequestOwner",
+		4: "EInvalidDrainMark",
+	},
+	predict_account: {
+		0: "EPositionAlreadyExists",
+		1: "EPositionNotFound",
+		2: "EInsufficientPosition",
+		3: "EExpirySummaryHasOpenPositions",
+	},
+	account: {
+		0: "EInvalidOwner",
+		1: "EBalanceTooLow",
+		2: "EInvalidAuth",
+	},
+	registry: {
+		0: "EPauseCapNotValid",
+		1: "ELifecycleCapNotValid",
+		2: "ELifecycleCapNotFound",
+	},
+};
+
+// The module name lives inside `ModuleId { … name: Identifier("<module>") }`.
+const MODULE_RE = /name:\s*Identifier\("([^"]+)"\)/;
+// The abort code is the integer following the MoveLocation block, i.e. the last
+// `, <n>)` in the string. The greedy `.*` skips ahead to that final occurrence,
+// so a trailing suffix (e.g. " in command 0") after the code is tolerated.
+const CODE_RE = /MoveAbort\(.*,\s*(\d+)\s*\)/s;
+
+/**
+ * Decode a rendered Move-abort failure string into a {@link PredictMoveError}.
+ * Returns null when `raw` is not a MoveAbort. An abort in an unmapped module or
+ * with an unmapped code still decodes (module/code populated, `abortName: null`).
+ */
+export function decodeMoveAbort(raw: string): PredictMoveError | null {
+	if (typeof raw !== "string" || !raw.includes("MoveAbort")) return null;
+	const moduleMatch = raw.match(MODULE_RE);
+	const codeMatch = raw.match(CODE_RE);
+	if (!moduleMatch || !codeMatch) return null;
+	const module = moduleMatch[1];
+	const code = Number(codeMatch[1]);
+	const abortName = ABORT_TABLES[module]?.[code] ?? null;
+	return new PredictMoveError(module, code, abortName);
+}

--- a/packages/predict/sdk/src/errors.ts
+++ b/packages/predict/sdk/src/errors.ts
@@ -18,11 +18,13 @@ export class PredictInputError extends Error {
 /** A Move `abort` decoded from a simulate/read failure. */
 export class PredictMoveError extends Error {
 	readonly module: string;
-	readonly code: number;
+	/** Exact u64 abort code — bigint because clever-error encodings pack data
+	 * into the high bits, which Number would silently truncate. */
+	readonly code: bigint;
 	/** The `E…` constant name from the abort table, or null if unmapped. */
 	readonly abortName: string | null;
 
-	constructor(module: string, code: number, abortName: string | null) {
+	constructor(module: string, code: bigint, abortName: string | null) {
 		super(
 			abortName
 				? `Move abort in ${module}: ${abortName} (code ${code})`
@@ -110,7 +112,12 @@ export function decodeMoveAbort(raw: string): PredictMoveError | null {
 	const codeMatch = raw.match(CODE_RE);
 	if (!moduleMatch || !codeMatch) return null;
 	const module = moduleMatch[1];
-	const code = Number(codeMatch[1]);
-	const abortName = ABORT_TABLES[module]?.[code] ?? null;
+	const code = BigInt(codeMatch[1]);
+	// Table lookup via Number is safe: enum codes are tiny; a packed code above
+	// 2^53 can't collide into the table because it simply won't be found there.
+	const abortName =
+		code <= BigInt(Number.MAX_SAFE_INTEGER)
+			? (ABORT_TABLES[module]?.[Number(code)] ?? null)
+			: null;
 	return new PredictMoveError(module, code, abortName);
 }

--- a/packages/predict/sdk/src/index.ts
+++ b/packages/predict/sdk/src/index.ts
@@ -77,6 +77,7 @@ export {
 	expiryMarketId,
 	marketState,
 	marketStates,
+	referenceTick,
 	settlementPrice,
 } from "./reads/markets.js";
 export type { MarketState } from "./reads/markets.js";

--- a/packages/predict/sdk/src/index.ts
+++ b/packages/predict/sdk/src/index.ts
@@ -1,1 +1,83 @@
 export const SDK_NAME = "@mysten/predict";
+
+// === Facade ===
+export { PredictClient } from "./client.js";
+export type {
+	MarketDescriptor,
+	MarketSummary,
+	MintOptions,
+	MintAmountOptions,
+	CloseOptions,
+	PoolSummary,
+} from "./client.js";
+
+// === Config + target seam ===
+export {
+	ACCUMULATOR_ROOT_ID,
+	CLOCK_ID,
+	TESTNET_CONFIG,
+	accountTarget,
+	getConfig,
+	predictTarget,
+} from "./config/index.js";
+export type { PredictConfig, PredictPackages, UnderlyingConfig } from "./config/index.js";
+
+// === Units ===
+export {
+	U64_MAX,
+	fromRaw,
+	leverageToRaw,
+	priceToRaw,
+	probabilityToRaw,
+	rawToPrice,
+	rawToProbability,
+	rawToUsdc,
+	toRaw,
+	usdcToRaw,
+} from "./units.js";
+
+// === Ticks ===
+export { POS_INF_TICK, binaryRangeTicks } from "./ticks.js";
+export type { Side } from "./ticks.js";
+
+// === Errors ===
+export {
+	ABORT_TABLES,
+	PredictInputError,
+	PredictMoveError,
+	decodeMoveAbort,
+} from "./errors.js";
+
+// === Transaction primitives ===
+export {
+	loadLivePricer,
+	mintExactAmount,
+	mintExactQuantity,
+	redeemLive,
+	redeemSettled,
+} from "./tx/trade.js";
+export type { MarketFeeds } from "./tx/trade.js";
+export { createAccount, depositFunds, withdrawFunds } from "./tx/account.js";
+export { deriveAccountWrapperId, generateAuth } from "./tx/common.js";
+export {
+	cancelSupplyRequest,
+	cancelWithdrawRequest,
+	requestSupply,
+	requestWithdraw,
+} from "./tx/plp.js";
+export { setBuilderCode, unsetBuilderCode } from "./tx/builderCode.js";
+
+// === Reads ===
+export { inspectReturns } from "./reads/inspect.js";
+export type { ReadClient } from "./reads/inspect.js";
+export { activeMarketIds, currentNav, expiryMarketId, marketState } from "./reads/markets.js";
+export type { MarketState } from "./reads/markets.js";
+export { accountBalance } from "./reads/balances.js";
+export { poolStats } from "./reads/pool.js";
+export type { PoolStats } from "./reads/pool.js";
+export {
+	parseOptionalId,
+	parseOptionalU64,
+	parseU64LE,
+	parseVectorOfIds,
+} from "./reads/parse.js";

--- a/packages/predict/sdk/src/index.ts
+++ b/packages/predict/sdk/src/index.ts
@@ -70,7 +70,13 @@ export { setBuilderCode, unsetBuilderCode } from "./tx/builderCode.js";
 // === Reads ===
 export { inspectReturns } from "./reads/inspect.js";
 export type { ReadClient } from "./reads/inspect.js";
-export { activeMarketIds, currentNav, expiryMarketId, marketState } from "./reads/markets.js";
+export {
+	activeMarketIds,
+	currentNav,
+	expiryMarketId,
+	marketState,
+	settlementPrice,
+} from "./reads/markets.js";
 export type { MarketState } from "./reads/markets.js";
 export { accountBalance } from "./reads/balances.js";
 export { poolStats } from "./reads/pool.js";

--- a/packages/predict/sdk/src/index.ts
+++ b/packages/predict/sdk/src/index.ts
@@ -3,6 +3,7 @@ export const SDK_NAME = "@mysten/predict";
 // === Facade ===
 export { PredictClient } from "./client.js";
 export type {
+	ActiveMarket,
 	MarketDescriptor,
 	MarketSummary,
 	MintOptions,
@@ -75,12 +76,38 @@ export {
 	currentNav,
 	expiryMarketId,
 	marketState,
+	marketStates,
 	settlementPrice,
 } from "./reads/markets.js";
 export type { MarketState } from "./reads/markets.js";
-export { accountBalance } from "./reads/balances.js";
+export { accountBalance, hasPosition } from "./reads/balances.js";
 export { poolStats } from "./reads/pool.js";
 export type { PoolStats } from "./reads/pool.js";
+
+// === Execution-result decoders (pure event parsing, no network) ===
+export {
+	decodeAccountsCreated,
+	decodeBuilderCodeSets,
+	decodeClaims,
+	decodeDeposits,
+	decodeMints,
+	decodePlpCancels,
+	decodePlpRequests,
+	decodeRedeems,
+	decodeWithdrawals,
+} from "./decode.js";
+export type {
+	BalanceChangeReceipt,
+	BuilderCodeReceipt,
+	ClaimReceipt,
+	CreateManagerReceipt,
+	DecodableEvent,
+	DecodableTransactionResult,
+	MintReceipt,
+	PlpCancelReceipt,
+	PlpRequestReceipt,
+	RedeemReceipt,
+} from "./decode.js";
 export {
 	parseOptionalId,
 	parseOptionalU64,

--- a/packages/predict/sdk/src/index.ts
+++ b/packages/predict/sdk/src/index.ts
@@ -3,6 +3,8 @@ export const SDK_NAME = "@mysten/predict";
 // === Facade ===
 export { PredictClient } from "./client.js";
 export type {
+	MintQuote,
+	RedeemQuote,
 	ActiveMarket,
 	MarketDescriptor,
 	MarketSummary,
@@ -69,7 +71,7 @@ export {
 export { setBuilderCode, unsetBuilderCode } from "./tx/builderCode.js";
 
 // === Reads ===
-export { inspectReturns } from "./reads/inspect.js";
+export { inspectReturns, simulateWithEvents } from "./reads/inspect.js";
 export type { ReadClient } from "./reads/inspect.js";
 export {
 	activeMarketIds,
@@ -77,6 +79,7 @@ export {
 	expiryMarketId,
 	marketState,
 	marketStates,
+	rangePrices,
 	referenceTick,
 	settlementPrice,
 } from "./reads/markets.js";

--- a/packages/predict/sdk/src/index.ts
+++ b/packages/predict/sdk/src/index.ts
@@ -85,6 +85,12 @@ export {
 } from "./reads/markets.js";
 export type { MarketState } from "./reads/markets.js";
 export { accountBalance, hasPosition } from "./reads/balances.js";
+export {
+	positions,
+	positionsFromTable,
+	resolvePositionsTable,
+} from "./reads/positions.js";
+export type { ObjectReadClient, OpenPosition, PositionsHandle } from "./reads/positions.js";
 export { poolStats } from "./reads/pool.js";
 export type { PoolStats } from "./reads/pool.js";
 

--- a/packages/predict/sdk/src/index.ts
+++ b/packages/predict/sdk/src/index.ts
@@ -1,0 +1,1 @@
+export const SDK_NAME = "@mysten/predict";

--- a/packages/predict/sdk/src/reads/balances.ts
+++ b/packages/predict/sdk/src/reads/balances.ts
@@ -3,6 +3,7 @@ import {
 	ACCUMULATOR_ROOT_ID,
 	CLOCK_ID,
 	accountTarget,
+	predictTarget,
 	type PredictConfig,
 } from "../config/index.js";
 import { deriveAccountWrapperId } from "../tx/common.js";
@@ -33,4 +34,30 @@ export async function accountBalance(
 	});
 	const cmds = await inspectReturns(client, tx);
 	return parseU64LE(cmds[1][0]);
+}
+
+// Whether the owner's account still holds `orderId` on `marketId`. The cheap
+// on-chain validator for app-stored order ids (stale after a full close or a
+// partial-close replacement — see RedeemReceipt.replacementOrderId). Chains
+// `account::load_account(wrapper)` → `predict_account::has_position(account,
+// market_id, order_id)` — see packages/predict/sources/predict_account.move:86.
+export async function hasPosition(
+	client: ReadClient,
+	cfg: PredictConfig,
+	owner: string,
+	marketId: string,
+	orderId: bigint,
+): Promise<boolean> {
+	const wrapperId = deriveAccountWrapperId(cfg, owner);
+	const tx = new Transaction();
+	const account = tx.moveCall({
+		target: accountTarget(cfg, "account", "load_account"),
+		arguments: [tx.object(wrapperId)],
+	});
+	tx.moveCall({
+		target: predictTarget(cfg, "predict_account", "has_position"),
+		arguments: [account, tx.pure.id(marketId), tx.pure.u256(orderId)],
+	});
+	const cmds = await inspectReturns(client, tx);
+	return (cmds[1][0][0] ?? 0) !== 0; // BCS bool: 1 byte
 }

--- a/packages/predict/sdk/src/reads/balances.ts
+++ b/packages/predict/sdk/src/reads/balances.ts
@@ -1,0 +1,36 @@
+import { Transaction } from "@mysten/sui/transactions";
+import {
+	ACCUMULATOR_ROOT_ID,
+	CLOCK_ID,
+	accountTarget,
+	type PredictConfig,
+} from "../config/index.js";
+import { deriveAccountWrapperId } from "../tx/common.js";
+import { inspectReturns, type ReadClient } from "./inspect.js";
+import { parseU64LE } from "./parse.js";
+
+// An owner's stored account balance for a coin type (defaults to the quote coin,
+// DUSDC on testnet). Chains `account::load_account(wrapper)` →
+// `account::balance<T>(account, root, clock)`; the u64 is command 1's return —
+// see packages/account/sources/account.move:{86,92} and harness runtime.ts:458-466.
+// The wrapper id is derived off-chain (no read needed).
+export async function accountBalance(
+	client: ReadClient,
+	cfg: PredictConfig,
+	owner: string,
+	coinType: string = cfg.quoteCoinType,
+): Promise<bigint> {
+	const wrapperId = deriveAccountWrapperId(cfg, owner);
+	const tx = new Transaction();
+	const account = tx.moveCall({
+		target: accountTarget(cfg, "account", "load_account"),
+		arguments: [tx.object(wrapperId)],
+	});
+	tx.moveCall({
+		target: accountTarget(cfg, "account", "balance"),
+		typeArguments: [coinType],
+		arguments: [account, tx.object(ACCUMULATOR_ROOT_ID), tx.object(CLOCK_ID)],
+	});
+	const cmds = await inspectReturns(client, tx);
+	return parseU64LE(cmds[1][0]);
+}

--- a/packages/predict/sdk/src/reads/inspect.ts
+++ b/packages/predict/sdk/src/reads/inspect.ts
@@ -1,0 +1,42 @@
+import type { SuiGrpcClient } from "@mysten/sui/grpc";
+import type { Transaction } from "@mysten/sui/transactions";
+import { normalizeSuiAddress } from "@mysten/sui/utils";
+
+// The one network seam every read sits on. Structural — any object with a
+// `simulateTransaction` matching the gRPC client's satisfies it, so callers can
+// inject a mock in tests and the SDK never constructs its own transport.
+export type ReadClient = Pick<SuiGrpcClient, "simulateTransaction">;
+
+// Run a read-only PTB through the gRPC `simulateTransaction` (the devInspect
+// replacement) and return each command's BCS return values, indexed
+// [commandIndex][returnValueIndex].
+//
+// `checksEnabled: false` disables validation so we may inspect non-entry public
+// funs — see SimulateTransactionOptions.checksEnabled in
+// node_modules/@mysten/sui/dist/client/types.d.mts:385-396. Per-command outputs
+// live under `commandResults[i].returnValues[j].bcs` — see
+// SimulateTransactionResult / CommandResult / CommandOutput in that same file at
+// lines 309-348. `commandResults` is only populated when `include.commandResults`
+// is set, so we request it explicitly.
+//
+// A sender is required to simulate; callers rarely have one for a pure read, so we
+// default to the zero address. On abort the result's `$kind` is `FailedTransaction`.
+// TODO(Task 9): decode the abort into a typed PredictMoveError; a plain Error for now.
+export async function inspectReturns(
+	client: ReadClient,
+	tx: Transaction,
+	sender: string = normalizeSuiAddress("0x0"),
+): Promise<Uint8Array[][]> {
+	tx.setSender(sender);
+	const result = await client.simulateTransaction<{ commandResults: true }>({
+		transaction: tx,
+		checksEnabled: false,
+		include: { commandResults: true },
+	});
+	if (result.$kind === "FailedTransaction") {
+		throw new Error("simulateTransaction aborted (FailedTransaction)");
+	}
+	const commands = result.commandResults;
+	if (!commands) throw new Error("simulateTransaction returned no commandResults");
+	return commands.map((c) => c.returnValues.map((rv) => rv.bcs));
+}

--- a/packages/predict/sdk/src/reads/inspect.ts
+++ b/packages/predict/sdk/src/reads/inspect.ts
@@ -46,6 +46,36 @@ function abortRawString(error: SimAbortError | undefined): string | undefined {
 // default to the zero address. On abort the result's `$kind` is `FailedTransaction`;
 // we decode the carried abort into a typed PredictMoveError, falling back to a plain
 // Error with the failure message when it isn't a decodable Move abort.
+// Shared failure handling: decode the abort carried by a FailedTransaction
+// into a typed PredictMoveError, else throw a plain Error.
+function throwSimFailure(failed: unknown): never {
+	const status = (failed as { status?: { success: boolean; error?: SimAbortError } })?.status;
+	const error = status && status.success === false ? status.error : undefined;
+	const raw = abortRawString(error);
+	const decoded = raw != null ? decodeMoveAbort(raw) : null;
+	if (decoded) throw decoded;
+	throw new Error(error?.message ?? "simulateTransaction aborted (FailedTransaction)");
+}
+
+// Simulate a full transaction (typically one built by a tx.* builder) and return
+// the events it would emit — the quote path: dry-run the real action, decode the
+// receipt. Sender must be the acting owner so account auth resolves. Throws the
+// same typed errors the real execution would surface.
+export async function simulateWithEvents(
+	client: ReadClient,
+	tx: Transaction,
+	sender: string,
+): Promise<{ eventType?: string; bcs?: Uint8Array | string }[]> {
+	tx.setSender(sender);
+	const result = await client.simulateTransaction<{ events: true }>({
+		transaction: tx,
+		checksEnabled: false,
+		include: { events: true },
+	});
+	if (result.$kind === "FailedTransaction") throwSimFailure(result.FailedTransaction);
+	return (result.Transaction?.events ?? []) as { eventType?: string; bcs?: Uint8Array }[];
+}
+
 export async function inspectReturns(
 	client: ReadClient,
 	tx: Transaction,
@@ -57,16 +87,7 @@ export async function inspectReturns(
 		checksEnabled: false,
 		include: { commandResults: true },
 	});
-	if (result.$kind === "FailedTransaction") {
-		const status = result.FailedTransaction?.status as
-			| { success: boolean; error?: SimAbortError }
-			| undefined;
-		const error = status && status.success === false ? status.error : undefined;
-		const raw = abortRawString(error);
-		const decoded = raw != null ? decodeMoveAbort(raw) : null;
-		if (decoded) throw decoded;
-		throw new Error(error?.message ?? "simulateTransaction aborted (FailedTransaction)");
-	}
+	if (result.$kind === "FailedTransaction") throwSimFailure(result.FailedTransaction);
 	const commands = result.commandResults;
 	if (!commands) throw new Error("simulateTransaction returned no commandResults");
 	return commands.map((c) => c.returnValues.map((rv) => rv.bcs));

--- a/packages/predict/sdk/src/reads/inspect.ts
+++ b/packages/predict/sdk/src/reads/inspect.ts
@@ -1,11 +1,34 @@
 import type { SuiGrpcClient } from "@mysten/sui/grpc";
 import type { Transaction } from "@mysten/sui/transactions";
 import { normalizeSuiAddress } from "@mysten/sui/utils";
+import { decodeMoveAbort } from "../errors.js";
 
 // The one network seam every read sits on. Structural — any object with a
 // `simulateTransaction` matching the gRPC client's satisfies it, so callers can
 // inject a mock in tests and the SDK never constructs its own transport.
 export type ReadClient = Pick<SuiGrpcClient, "simulateTransaction">;
+
+// The abort payload the failed simulate result carries. Read structurally (not via
+// the client's exported ExecutionError type) so mocks and future API-shape drift
+// still satisfy it. Two renderings occur: a display `message` string of the form
+// `MoveAbort(MoveLocation { … name: Identifier("expiry_market") … }, 6)`, and the
+// structured gRPC `MoveAbort` enum arm `{ abortCode, location: { module } }`.
+type SimAbortError = {
+	message?: string;
+	MoveAbort?: { abortCode?: string | number; location?: { module?: string } };
+};
+
+// Normalize either abort rendering to the string decodeMoveAbort understands.
+// Prefer the structured arm (synthesize a canonical MoveAbort string from it) and
+// fall back to the display message.
+function abortRawString(error: SimAbortError | undefined): string | undefined {
+	if (!error) return undefined;
+	const ma = error.MoveAbort;
+	if (ma?.location?.module != null && ma.abortCode != null) {
+		return `MoveAbort(MoveLocation { module: ModuleId { name: Identifier("${ma.location.module}") }, function: 0, instruction: 0 }, ${ma.abortCode})`;
+	}
+	return error.message;
+}
 
 // Run a read-only PTB through the gRPC `simulateTransaction` (the devInspect
 // replacement) and return each command's BCS return values, indexed
@@ -20,8 +43,9 @@ export type ReadClient = Pick<SuiGrpcClient, "simulateTransaction">;
 // is set, so we request it explicitly.
 //
 // A sender is required to simulate; callers rarely have one for a pure read, so we
-// default to the zero address. On abort the result's `$kind` is `FailedTransaction`.
-// TODO(Task 9): decode the abort into a typed PredictMoveError; a plain Error for now.
+// default to the zero address. On abort the result's `$kind` is `FailedTransaction`;
+// we decode the carried abort into a typed PredictMoveError, falling back to a plain
+// Error with the failure message when it isn't a decodable Move abort.
 export async function inspectReturns(
 	client: ReadClient,
 	tx: Transaction,
@@ -34,7 +58,14 @@ export async function inspectReturns(
 		include: { commandResults: true },
 	});
 	if (result.$kind === "FailedTransaction") {
-		throw new Error("simulateTransaction aborted (FailedTransaction)");
+		const status = result.FailedTransaction?.status as
+			| { success: boolean; error?: SimAbortError }
+			| undefined;
+		const error = status && status.success === false ? status.error : undefined;
+		const raw = abortRawString(error);
+		const decoded = raw != null ? decodeMoveAbort(raw) : null;
+		if (decoded) throw decoded;
+		throw new Error(error?.message ?? "simulateTransaction aborted (FailedTransaction)");
 	}
 	const commands = result.commandResults;
 	if (!commands) throw new Error("simulateTransaction returned no commandResults");

--- a/packages/predict/sdk/src/reads/markets.ts
+++ b/packages/predict/sdk/src/reads/markets.ts
@@ -1,0 +1,101 @@
+import { Transaction } from "@mysten/sui/transactions";
+import { predictTarget, type PredictConfig } from "../config/index.js";
+import { loadLivePricer } from "../tx/trade.js";
+import { inspectReturns, type ReadClient } from "./inspect.js";
+import { parseOptionalId, parseU64LE, parseVectorOfIds } from "./parse.js";
+
+// On-chain ids of the pool's active (live, not-yet-settled) expiry markets.
+// `plp::active_expiry_markets(vault)` — see packages/predict/sources/plp/plp.move:182.
+export async function activeMarketIds(client: ReadClient, cfg: PredictConfig): Promise<string[]> {
+	const tx = new Transaction();
+	tx.moveCall({
+		target: predictTarget(cfg, "plp", "active_expiry_markets"),
+		arguments: [tx.object(cfg.objects.poolVault)],
+	});
+	const [cmd0] = await inspectReturns(client, tx);
+	return parseVectorOfIds(cmd0[0]);
+}
+
+// The expiry market id for one underlying at one expiry, or null if none exists.
+// `registry::expiry_market_id(registry, propbook_underlying_id: u32, expiry: u64):
+// Option<ID>` — see packages/predict/sources/registry/registry.move:54.
+export async function expiryMarketId(
+	client: ReadClient,
+	cfg: PredictConfig,
+	underlying: string,
+	expiryMs: bigint,
+): Promise<string | null> {
+	const u = cfg.underlyings[underlying];
+	if (!u) throw new Error(`unknown underlying: ${underlying}`);
+	const tx = new Transaction();
+	tx.moveCall({
+		target: predictTarget(cfg, "registry", "expiry_market_id"),
+		arguments: [
+			tx.object(cfg.objects.registry),
+			tx.pure.u32(u.propbookUnderlyingId),
+			tx.pure.u64(expiryMs),
+		],
+	});
+	const [cmd0] = await inspectReturns(client, tx);
+	return parseOptionalId(cmd0[0]);
+}
+
+export interface MarketState {
+	expiryMs: bigint;
+	tickSizeRaw: bigint;
+	mintPaused: boolean;
+	settlementPriceRaw: bigint;
+}
+
+// A market's four single-arg state reads batched into one PTB (command order fixed
+// below). `expiry_market::{expiry, tick_size, mint_paused, settlement_price}` — see
+// packages/predict/sources/expiry_market.move:{90,146,234,95}.
+export async function marketState(
+	client: ReadClient,
+	cfg: PredictConfig,
+	marketId: string,
+): Promise<MarketState> {
+	const tx = new Transaction();
+	for (const fn of ["expiry", "tick_size", "mint_paused", "settlement_price"]) {
+		tx.moveCall({
+			target: predictTarget(cfg, "expiry_market", fn),
+			arguments: [tx.object(marketId)],
+		});
+	}
+	const cmds = await inspectReturns(client, tx);
+	return {
+		expiryMs: parseU64LE(cmds[0][0]),
+		tickSizeRaw: parseU64LE(cmds[1][0]),
+		mintPaused: (cmds[2][0][0] ?? 0) !== 0, // BCS bool: 1 byte
+		settlementPriceRaw: parseU64LE(cmds[3][0]),
+	};
+}
+
+// A market's current NAV mark (the per-expiry recoverable value the flush prices
+// against). Loads a fresh live pricer, then reads `current_nav(market, &pricer)` —
+// see packages/predict/sources/expiry_market.move:221 and harness runtime.ts:476-481.
+// `Pricer` has copy+drop, so the unconsumed borrow is fine in a read-only inspect.
+export async function currentNav(
+	client: ReadClient,
+	cfg: PredictConfig,
+	marketId: string,
+	underlying: string,
+): Promise<bigint> {
+	const u = cfg.underlyings[underlying];
+	if (!u) throw new Error(`unknown underlying: ${underlying}`);
+	const tx = new Transaction();
+	const pricer = loadLivePricer(cfg, tx, {
+		expiryMarketId: marketId,
+		pythFeedId: u.pythFeedId,
+		bsSpotFeedId: u.bsSpotFeedId,
+		bsForwardFeedId: u.bsForwardFeedId,
+		bsSviFeedId: u.bsSviFeedId,
+	});
+	tx.moveCall({
+		target: predictTarget(cfg, "expiry_market", "current_nav"),
+		arguments: [tx.object(marketId), pricer],
+	});
+	const cmds = await inspectReturns(client, tx);
+	// current_nav is the last command; load_live_pricer precedes it.
+	return parseU64LE(cmds[cmds.length - 1][0]);
+}

--- a/packages/predict/sdk/src/reads/markets.ts
+++ b/packages/predict/sdk/src/reads/markets.ts
@@ -3,7 +3,7 @@ import { predictTarget, type PredictConfig } from "../config/index.js";
 import { PredictMoveError } from "../errors.js";
 import { loadLivePricer } from "../tx/trade.js";
 import { inspectReturns, type ReadClient } from "./inspect.js";
-import { parseOptionalId, parseU64LE, parseVectorOfIds } from "./parse.js";
+import { parseOptionalId, parseOptionalU64, parseU64LE, parseVectorOfIds } from "./parse.js";
 
 // On-chain ids of the pool's active (live, not-yet-settled) expiry markets.
 // `plp::active_expiry_markets(vault)` — see packages/predict/sources/plp/plp.move:182.
@@ -45,35 +45,42 @@ export interface MarketState {
 	expiryMs: bigint;
 	tickSizeRaw: bigint;
 	mintPaused: boolean;
+	/**
+	 * The reference fine-grid tick (Polymarket-style anchor strike: derived
+	 * on-chain from the exact previous-window oracle observation), or null while
+	 * the keeper has not seeded it. Reference PRICE raw = tick * tickSizeRaw.
+	 */
+	referenceTickRaw: bigint | null;
 }
 
-// A market's three single-arg state reads batched into one PTB (command order fixed
-// below). `expiry_market::{expiry, tick_size, mint_paused}` — see
-// packages/predict/sources/expiry_market.move:{90,146,234}. Settlement price is
-// deliberately NOT batched here: on the deployed package it aborts for a live
-// (unsettled) market — use `settlementPrice` below.
+// The per-market state commands, in fixed order. `expiry_market::{expiry,
+// tick_size, mint_paused, reference_tick}` — see
+// packages/predict/sources/expiry_market.move:{90,141,~230,149}. reference_tick
+// returns Option (no abort risk), unlike settlement_price which is deliberately
+// NOT batched here: on the deployed package it aborts for a live (unsettled)
+// market — use `settlementPrice` below.
+const STATE_FNS = ["expiry", "tick_size", "mint_paused", "reference_tick"] as const;
+
+function parseStateAt(cmds: Uint8Array[][], base: number): MarketState {
+	return {
+		expiryMs: parseU64LE(cmds[base][0]),
+		tickSizeRaw: parseU64LE(cmds[base + 1][0]),
+		mintPaused: (cmds[base + 2][0][0] ?? 0) !== 0, // BCS bool: 1 byte
+		referenceTickRaw: parseOptionalU64(cmds[base + 3][0]),
+	};
+}
+
 export async function marketState(
 	client: ReadClient,
 	cfg: PredictConfig,
 	marketId: string,
 ): Promise<MarketState> {
-	const tx = new Transaction();
-	for (const fn of ["expiry", "tick_size", "mint_paused"]) {
-		tx.moveCall({
-			target: predictTarget(cfg, "expiry_market", fn),
-			arguments: [tx.object(marketId)],
-		});
-	}
-	const cmds = await inspectReturns(client, tx);
-	return {
-		expiryMs: parseU64LE(cmds[0][0]),
-		tickSizeRaw: parseU64LE(cmds[1][0]),
-		mintPaused: (cmds[2][0][0] ?? 0) !== 0, // BCS bool: 1 byte
-	};
+	const [state] = await marketStates(client, cfg, [marketId]);
+	return state;
 }
 
-// Batched marketState for N markets in ONE PTB (3 commands per market, same
-// order as marketState). Returns states aligned with `marketIds`.
+// Batched marketState for N markets in ONE PTB (STATE_FNS.length commands per
+// market, same order). Returns states aligned with `marketIds`.
 export async function marketStates(
 	client: ReadClient,
 	cfg: PredictConfig,
@@ -82,7 +89,7 @@ export async function marketStates(
 	if (marketIds.length === 0) return [];
 	const tx = new Transaction();
 	for (const id of marketIds) {
-		for (const fn of ["expiry", "tick_size", "mint_paused"]) {
+		for (const fn of STATE_FNS) {
 			tx.moveCall({
 				target: predictTarget(cfg, "expiry_market", fn),
 				arguments: [tx.object(id)],
@@ -90,11 +97,24 @@ export async function marketStates(
 		}
 	}
 	const cmds = await inspectReturns(client, tx);
-	return marketIds.map((_, i) => ({
-		expiryMs: parseU64LE(cmds[3 * i][0]),
-		tickSizeRaw: parseU64LE(cmds[3 * i + 1][0]),
-		mintPaused: (cmds[3 * i + 2][0][0] ?? 0) !== 0,
-	}));
+	return marketIds.map((_, i) => parseStateAt(cmds, STATE_FNS.length * i));
+}
+
+// Fresh single read of the reference tick — used by mint-at-reference, which
+// must not trust a cached state (the reference is unset early in a window
+// until the keeper seeds it).
+export async function referenceTick(
+	client: ReadClient,
+	cfg: PredictConfig,
+	marketId: string,
+): Promise<bigint | null> {
+	const tx = new Transaction();
+	tx.moveCall({
+		target: predictTarget(cfg, "expiry_market", "reference_tick"),
+		arguments: [tx.object(marketId)],
+	});
+	const [cmd0] = await inspectReturns(client, tx);
+	return parseOptionalU64(cmd0[0]);
 }
 
 // The recorded settlement price, or null while the market is unsettled.

--- a/packages/predict/sdk/src/reads/markets.ts
+++ b/packages/predict/sdk/src/reads/markets.ts
@@ -1,5 +1,6 @@
 import { Transaction } from "@mysten/sui/transactions";
 import { predictTarget, type PredictConfig } from "../config/index.js";
+import { PredictMoveError } from "../errors.js";
 import { loadLivePricer } from "../tx/trade.js";
 import { inspectReturns, type ReadClient } from "./inspect.js";
 import { parseOptionalId, parseU64LE, parseVectorOfIds } from "./parse.js";
@@ -44,19 +45,20 @@ export interface MarketState {
 	expiryMs: bigint;
 	tickSizeRaw: bigint;
 	mintPaused: boolean;
-	settlementPriceRaw: bigint;
 }
 
-// A market's four single-arg state reads batched into one PTB (command order fixed
-// below). `expiry_market::{expiry, tick_size, mint_paused, settlement_price}` — see
-// packages/predict/sources/expiry_market.move:{90,146,234,95}.
+// A market's three single-arg state reads batched into one PTB (command order fixed
+// below). `expiry_market::{expiry, tick_size, mint_paused}` — see
+// packages/predict/sources/expiry_market.move:{90,146,234}. Settlement price is
+// deliberately NOT batched here: on the deployed package it aborts for a live
+// (unsettled) market — use `settlementPrice` below.
 export async function marketState(
 	client: ReadClient,
 	cfg: PredictConfig,
 	marketId: string,
 ): Promise<MarketState> {
 	const tx = new Transaction();
-	for (const fn of ["expiry", "tick_size", "mint_paused", "settlement_price"]) {
+	for (const fn of ["expiry", "tick_size", "mint_paused"]) {
 		tx.moveCall({
 			target: predictTarget(cfg, "expiry_market", fn),
 			arguments: [tx.object(marketId)],
@@ -67,8 +69,39 @@ export async function marketState(
 		expiryMs: parseU64LE(cmds[0][0]),
 		tickSizeRaw: parseU64LE(cmds[1][0]),
 		mintPaused: (cmds[2][0][0] ?? 0) !== 0, // BCS bool: 1 byte
-		settlementPriceRaw: parseU64LE(cmds[3][0]),
 	};
+}
+
+// The recorded settlement price, or null while the market is unsettled.
+//
+// On the deployed package `expiry_market::settlement_price` is public(package) and
+// `destroy_some`s the stored Option — callable here only because simulate runs with
+// checksEnabled:false, and it aborts in std::option (EOPTION_NOT_SET) when the
+// market has not settled; we map exactly that abort (and the public
+// EMarketNotSettled variant, should a future package guard it directly) to null.
+export async function settlementPrice(
+	client: ReadClient,
+	cfg: PredictConfig,
+	marketId: string,
+): Promise<bigint | null> {
+	const tx = new Transaction();
+	tx.moveCall({
+		target: predictTarget(cfg, "expiry_market", "settlement_price"),
+		arguments: [tx.object(marketId)],
+	});
+	try {
+		const [cmd0] = await inspectReturns(client, tx);
+		return parseU64LE(cmd0[0]);
+	} catch (e) {
+		if (
+			e instanceof PredictMoveError &&
+			(e.module === "option" ||
+				(e.module === "expiry_market" && e.abortName === "EMarketNotSettled"))
+		) {
+			return null;
+		}
+		throw e;
+	}
 }
 
 // A market's current NAV mark (the per-expiry recoverable value the flush prices

--- a/packages/predict/sdk/src/reads/markets.ts
+++ b/packages/predict/sdk/src/reads/markets.ts
@@ -72,6 +72,31 @@ export async function marketState(
 	};
 }
 
+// Batched marketState for N markets in ONE PTB (3 commands per market, same
+// order as marketState). Returns states aligned with `marketIds`.
+export async function marketStates(
+	client: ReadClient,
+	cfg: PredictConfig,
+	marketIds: readonly string[],
+): Promise<MarketState[]> {
+	if (marketIds.length === 0) return [];
+	const tx = new Transaction();
+	for (const id of marketIds) {
+		for (const fn of ["expiry", "tick_size", "mint_paused"]) {
+			tx.moveCall({
+				target: predictTarget(cfg, "expiry_market", fn),
+				arguments: [tx.object(id)],
+			});
+		}
+	}
+	const cmds = await inspectReturns(client, tx);
+	return marketIds.map((_, i) => ({
+		expiryMs: parseU64LE(cmds[3 * i][0]),
+		tickSizeRaw: parseU64LE(cmds[3 * i + 1][0]),
+		mintPaused: (cmds[3 * i + 2][0][0] ?? 0) !== 0,
+	}));
+}
+
 // The recorded settlement price, or null while the market is unsettled.
 //
 // On the deployed package `expiry_market::settlement_price` is public(package) and

--- a/packages/predict/sdk/src/reads/markets.ts
+++ b/packages/predict/sdk/src/reads/markets.ts
@@ -1,7 +1,8 @@
 import { Transaction } from "@mysten/sui/transactions";
 import { predictTarget, type PredictConfig } from "../config/index.js";
 import { PredictMoveError } from "../errors.js";
-import { loadLivePricer } from "../tx/trade.js";
+import { U64_MAX } from "../units.js";
+import { loadLivePricer, type MarketFeeds } from "../tx/trade.js";
 import { inspectReturns, type ReadClient } from "./inspect.js";
 import { parseOptionalId, parseOptionalU64, parseU64LE, parseVectorOfIds } from "./parse.js";
 
@@ -98,6 +99,35 @@ export async function marketStates(
 	}
 	const cmds = await inspectReturns(client, tx);
 	return marketIds.map((_, i) => parseStateAt(cmds, STATE_FNS.length * i));
+}
+
+// Anonymous both-sides pricing for one strike: the chain's own probability for
+// (strike, +inf) and (-inf, strike). `pricing::range_price` takes RAW strikes
+// with sentinels neg_inf=0 / pos_inf=u64::MAX (range_codec::strikes_from_ticks);
+// it is public(package) on the deployed package, reachable here only because
+// simulate runs with checksEnabled:false — same coupling as `settlementPrice`,
+// dies when a public quote endpoint lands on-chain. Both sides are read from
+// the SAME pricer in one PTB, so `down` is the chain's number, not 1 − up.
+export async function rangePrices(
+	client: ReadClient,
+	cfg: PredictConfig,
+	marketId: string,
+	feeds: MarketFeeds,
+	strikeRaw: bigint,
+): Promise<{ upRaw: bigint; downRaw: bigint }> {
+	const tx = new Transaction();
+	const pricer = loadLivePricer(cfg, tx, { expiryMarketId: marketId, ...feeds });
+	for (const [lower, higher] of [
+		[strikeRaw, U64_MAX], // UP: (strike, +inf)
+		[0n, strikeRaw], // DOWN: (-inf, strike)
+	] as const) {
+		tx.moveCall({
+			target: predictTarget(cfg, "pricing", "range_price"),
+			arguments: [pricer, tx.pure.u64(lower), tx.pure.u64(higher)],
+		});
+	}
+	const cmds = await inspectReturns(client, tx);
+	return { upRaw: parseU64LE(cmds[1][0]), downRaw: parseU64LE(cmds[2][0]) };
 }
 
 // Fresh single read of the reference tick — used by mint-at-reference, which

--- a/packages/predict/sdk/src/reads/parse.ts
+++ b/packages/predict/sdk/src/reads/parse.ts
@@ -1,0 +1,57 @@
+// BCS decoders for the return values of on-chain reads. Hand-written (not via the
+// `bcs` codec) so the read layer carries no runtime coupling to a schema per read —
+// these shapes (u64 LE, vector<ID>, Option) are stable Move ABI. Ported from the
+// harness's devInspect parsers (`packages/predict/harness/ts/runtime.ts:394-415`).
+// Round-tripped against `@mysten/sui/bcs` in tests/reads.test.ts.
+
+// Read a ULEB128-encoded length prefix, returning [value, nextOffset].
+function readUleb(bytes: Uint8Array, offset: number): [number, number] {
+	let value = 0;
+	let shift = 0;
+	let i = offset;
+	for (;;) {
+		const b = bytes[i++] ?? 0;
+		value |= (b & 0x7f) << shift;
+		if ((b & 0x80) === 0) break;
+		shift += 7;
+	}
+	return [value, i];
+}
+
+// 32 raw bytes → a 0x-prefixed, lowercase, full-length object/address id.
+function toId(bytes: Uint8Array): string {
+	let hex = "";
+	for (const b of bytes) hex += b.toString(16).padStart(2, "0");
+	return `0x${hex}`;
+}
+
+// BCS u64: 8 little-endian bytes → bigint.
+export function parseU64LE(bytes: Uint8Array): bigint {
+	let v = 0n;
+	for (let i = 7; i >= 0; i--) v = (v << 8n) | BigInt(bytes[i] ?? 0);
+	return v;
+}
+
+// BCS vector<ID> / vector<address>: ULEB128 length, then N × 32-byte addresses.
+export function parseVectorOfIds(bytes: Uint8Array): string[] {
+	const [len, start] = readUleb(bytes, 0);
+	const ids: string[] = [];
+	let i = start;
+	for (let k = 0; k < len; k++) {
+		ids.push(toId(bytes.subarray(i, i + 32)));
+		i += 32;
+	}
+	return ids;
+}
+
+// BCS Option<u64>: 1 tag byte (0 = None, 1 = Some), then the u64 LE if Some.
+export function parseOptionalU64(bytes: Uint8Array): bigint | null {
+	if ((bytes[0] ?? 0) === 0) return null;
+	return parseU64LE(bytes.subarray(1));
+}
+
+// BCS Option<ID>: 1 tag byte (0 = None, 1 = Some), then a 32-byte id if Some.
+export function parseOptionalId(bytes: Uint8Array): string | null {
+	if ((bytes[0] ?? 0) === 0) return null;
+	return toId(bytes.subarray(1, 33));
+}

--- a/packages/predict/sdk/src/reads/pool.ts
+++ b/packages/predict/sdk/src/reads/pool.ts
@@ -1,0 +1,37 @@
+import { Transaction } from "@mysten/sui/transactions";
+import { predictTarget, type PredictConfig } from "../config/index.js";
+import { inspectReturns, type ReadClient } from "./inspect.js";
+import { parseU64LE } from "./parse.js";
+
+export interface PoolStats {
+	plpTotalSupply: bigint;
+	idleBalance: bigint;
+	supplyRequestsPending: bigint;
+	withdrawRequestsPending: bigint;
+}
+
+// The pool's four u64 vault stats batched into one PTB (command order fixed below).
+// `plp::{plp_total_supply, idle_balance, supply_requests_pending,
+// withdraw_requests_pending}(vault)` — see
+// packages/predict/sources/plp/plp.move:{167,152,172,177}.
+export async function poolStats(client: ReadClient, cfg: PredictConfig): Promise<PoolStats> {
+	const tx = new Transaction();
+	for (const fn of [
+		"plp_total_supply",
+		"idle_balance",
+		"supply_requests_pending",
+		"withdraw_requests_pending",
+	]) {
+		tx.moveCall({
+			target: predictTarget(cfg, "plp", fn),
+			arguments: [tx.object(cfg.objects.poolVault)],
+		});
+	}
+	const cmds = await inspectReturns(client, tx);
+	return {
+		plpTotalSupply: parseU64LE(cmds[0][0]),
+		idleBalance: parseU64LE(cmds[1][0]),
+		supplyRequestsPending: parseU64LE(cmds[2][0]),
+		withdrawRequestsPending: parseU64LE(cmds[3][0]),
+	};
+}

--- a/packages/predict/sdk/src/reads/positions.ts
+++ b/packages/predict/sdk/src/reads/positions.ts
@@ -1,0 +1,178 @@
+import { bcs } from "@mysten/sui/bcs";
+import type { SuiGrpcClient } from "@mysten/sui/grpc";
+import { deriveDynamicFieldID, normalizeSuiAddress } from "@mysten/sui/utils";
+import { type PredictConfig } from "../config/index.js";
+import { deriveAccountWrapperId } from "../tx/common.js";
+
+// ============================================================================
+// Chain-only position enumeration.
+//
+// Every open position is tracked under the owner's account:
+// `predict_account::PredictData.positions` is a
+// `Table<PositionKey{expiry_market_id, order_id}, Position>` — and Table
+// entries are dynamic fields, so the KEYS (everything redeem/claim need)
+// arrive directly from a dynamic-field listing. No indexer, no simulation.
+//
+// The walk (all parsing is exact BCS via `include: {content: true}`; struct
+// layouts verbatim from the deployed sources at ec99cfae —
+// packages/account/sources/account.move:45-60 and
+// packages/predict/sources/predict_account.move PredictData):
+//   1. wrapper object (id derived client-side)     → account UID
+//   2. derived DataKey<PredictApp> field object     → positions Table id
+//   3. listDynamicFields(table)                    → PositionKey per entry
+// Steps 1-2 resolve ids that are immutable once created — cache them per
+// owner (the facade does) and steady state is ONE call per page of positions.
+// ============================================================================
+
+/** The object-read capabilities this module needs (reads elsewhere in the SDK
+ * only need `simulateTransaction`). A structural pick, so mocks stay easy. */
+export type ObjectReadClient = Pick<SuiGrpcClient, "getObject" | "listDynamicFields">;
+
+const BagBcs = bcs.struct("Bag", { id: bcs.Address, size: bcs.u64() });
+const TableBcs = bcs.struct("Table", { id: bcs.Address, size: bcs.u64() });
+
+// account::AccountWrapper { id, account: Account { account_id, owner,
+// receive_address, balances: Bag, settlements: Bag } }
+const AccountWrapperBcs = bcs.struct("AccountWrapper", {
+	id: bcs.Address,
+	account: bcs.struct("Account", {
+		account_id: bcs.Address,
+		owner: bcs.Address,
+		receive_address: bcs.Address,
+		balances: BagBcs,
+		settlements: BagBcs,
+	}),
+});
+
+// sui::dynamic_field::Field<DataKey<PredictApp>, PredictData>. DataKey is
+// source-empty, but Move inserts a hidden `dummy_field: bool` into empty
+// structs — so the name occupies ONE zero byte between id and value (and the
+// same byte is the derived-field key, below).
+const PredictDataFieldBcs = bcs.struct("Field<DataKey,PredictData>", {
+	id: bcs.Address,
+	name: bcs.bool(), // DataKey's hidden dummy_field
+	value: bcs.struct("PredictData", {
+		positions: TableBcs,
+		expiry_summaries: TableBcs,
+		active_stake: bcs.u64(),
+		inactive_stake: bcs.u64(),
+		stake_epoch: bcs.u64(),
+		builder_code_id: bcs.option(bcs.Address),
+	}),
+});
+
+const PositionKeyBcs = bcs.struct("PositionKey", {
+	expiry_market_id: bcs.Address,
+	order_id: bcs.u256(),
+});
+
+/** One open position — the coordinates redeem/claim/hasPosition take. */
+export interface OpenPosition {
+	marketId: string;
+	orderId: bigint;
+}
+
+/** Resolved-once ids for an owner's position store (cache these). */
+export interface PositionsHandle {
+	accountUid: string;
+	/** Null until the account's Predict data exists (first trade/builder-code). */
+	positionsTableId: string | null;
+	/** Open-position count at resolution time (from the Table's size). */
+	positionCount: bigint;
+}
+
+async function contentOf(
+	client: ObjectReadClient,
+	objectId: string,
+): Promise<Uint8Array | null> {
+	try {
+		const { object } = await client.getObject({ objectId, include: { content: true } });
+		return (object as { content?: Uint8Array }).content ?? null;
+	} catch (e) {
+		// Only a genuinely absent object means "no positions" (never-onboarded
+		// owner, or no Predict data yet). Anything else — transport failures,
+		// rate limits — must surface, not silently read as an empty portfolio.
+		if (/not.?found|does not exist|deleted|NOT_FOUND/i.test(String(e))) return null;
+		throw e;
+	}
+}
+
+/**
+ * Resolve the immutable id chain for an owner's positions: wrapper → account
+ * UID → PredictData → positions Table. Returns null when the owner has never
+ * created a Predict account.
+ */
+export async function resolvePositionsTable(
+	client: ObjectReadClient,
+	cfg: PredictConfig,
+	owner: string,
+): Promise<PositionsHandle | null> {
+	const wrapperContent = await contentOf(client, deriveAccountWrapperId(cfg, owner));
+	if (!wrapperContent) return null;
+	const accountUid = normalizeSuiAddress(
+		AccountWrapperBcs.parse(wrapperContent).account.account_id,
+	);
+
+	// The PredictData field id is derivable — no listing needed for this hop.
+	const dataFieldId = deriveDynamicFieldID(
+		accountUid,
+		`${cfg.packages.account}::account::DataKey<${cfg.packages.predict}::predict_account::PredictApp>`,
+		new Uint8Array([0]), // DataKey's hidden dummy_field: bool = false
+	);
+	const fieldContent = await contentOf(client, dataFieldId);
+	if (!fieldContent) return { accountUid, positionsTableId: null, positionCount: 0n };
+
+	const data = PredictDataFieldBcs.parse(fieldContent).value;
+	return {
+		accountUid,
+		positionsTableId: normalizeSuiAddress(data.positions.id),
+		positionCount: BigInt(data.positions.size),
+	};
+}
+
+/**
+ * List open positions from a resolved positions Table: one call per page,
+ * keys parsed from the dynamic-field NAMES (no per-entry fetches).
+ */
+export async function positionsFromTable(
+	client: ObjectReadClient,
+	positionsTableId: string,
+	opts: { limit?: number; maxPages?: number } = {},
+): Promise<OpenPosition[]> {
+	const limit = opts.limit ?? 1000;
+	const maxPages = opts.maxPages ?? 10;
+	const out: OpenPosition[] = [];
+	let cursor: string | undefined = undefined;
+	for (let page = 0; page < maxPages; page++) {
+		const res: Awaited<ReturnType<ObjectReadClient["listDynamicFields"]>> =
+			await client.listDynamicFields({
+				parentId: positionsTableId,
+				limit,
+				cursor,
+			});
+		for (const entry of res.dynamicFields) {
+			const key = PositionKeyBcs.parse(entry.name.bcs);
+			out.push({
+				marketId: normalizeSuiAddress(key.expiry_market_id),
+				orderId: BigInt(key.order_id),
+			});
+		}
+		if (!res.hasNextPage || !res.cursor) return out;
+		cursor = res.cursor;
+	}
+	throw new Error(
+		`positions listing exceeded ${maxPages} pages (${out.length} so far) — raise maxPages`,
+	);
+}
+
+/** Convenience: resolve + list in one call (uncached; the facade caches). */
+export async function positions(
+	client: ObjectReadClient,
+	cfg: PredictConfig,
+	owner: string,
+	opts: { limit?: number; maxPages?: number } = {},
+): Promise<OpenPosition[]> {
+	const handle = await resolvePositionsTable(client, cfg, owner);
+	if (!handle?.positionsTableId) return [];
+	return positionsFromTable(client, handle.positionsTableId, opts);
+}

--- a/packages/predict/sdk/src/ticks.ts
+++ b/packages/predict/sdk/src/ticks.ts
@@ -1,0 +1,30 @@
+const TICK_BITS = 30n;
+
+/** +inf sentinel tick: the upper bound of an UP range. */
+export const POS_INF_TICK = (1n << TICK_BITS) - 1n;
+
+export type Side = "up" | "down";
+
+// Convert a raw binary-range strike to the `(lower_tick, higher_tick)` pair the
+// `mint` entrypoint takes directly (there is no standalone packed range key).
+// An UP order is `(strike, +inf)` -> lower_tick = strike/tick_size, higher_tick =
+// POS_INF_TICK; a DOWN order is `(-inf, strike)` -> lower_tick = 0 (neg-inf),
+// higher_tick = strike/tick_size.
+export function binaryRangeTicks(
+	strikeRaw: bigint,
+	side: Side,
+	tickSize: bigint,
+): { lowerTick: bigint; higherTick: bigint } {
+	const tick = strikeRaw / tickSize;
+	if (tick * tickSize !== strikeRaw) {
+		throw new Error(`strike ${strikeRaw} is not a whole tick multiple of ${tickSize}`);
+	}
+	if (tick <= 0n || tick >= POS_INF_TICK) {
+		throw new Error(`strike tick ${tick} outside the finite tick domain (1..POS_INF_TICK-1)`);
+	}
+	const isUp = side === "up";
+	return {
+		lowerTick: isUp ? tick : 0n,
+		higherTick: isUp ? POS_INF_TICK : tick,
+	};
+}

--- a/packages/predict/sdk/src/tx/account.ts
+++ b/packages/predict/sdk/src/tx/account.ts
@@ -1,0 +1,72 @@
+import type {
+	Transaction,
+	TransactionObjectArgument,
+	TransactionResult,
+} from "@mysten/sui/transactions";
+import {
+	ACCUMULATOR_ROOT_ID,
+	CLOCK_ID,
+	accountTarget,
+	type PredictConfig,
+} from "../config/index.js";
+import { generateAuth } from "./common.js";
+
+// Create the sender's canonical derived account wrapper and share it. `new` derives the
+// wrapper at a deterministic address (see `deriveAccountWrapperId`); `share` publishes
+// the shared object the trade flows borrow against. See
+// `packages/account/sources/account_registry.move:76` and `account.move:123`.
+export function createAccount(cfg: PredictConfig, tx: Transaction): void {
+	const wrapper = tx.moveCall({
+		target: accountTarget(cfg, "account_registry", "new"),
+		arguments: [tx.object(cfg.objects.accountRegistry)],
+	});
+	tx.moveCall({
+		target: accountTarget(cfg, "account", "share"),
+		arguments: [wrapper],
+	});
+}
+
+// Deposit a caller-provided `coin` into the account's stored balance via the
+// PTB-callable `deposit_funds` (folds settle → authorize → load → deposit). The caller
+// owns coin sourcing. See `packages/account/sources/account.move:196`.
+export function depositFunds(
+	cfg: PredictConfig,
+	tx: Transaction,
+	args: { wrapperId: string; coin: TransactionObjectArgument; coinType?: string },
+): void {
+	const auth = generateAuth(cfg, tx);
+	tx.moveCall({
+		target: accountTarget(cfg, "account", "deposit_funds"),
+		typeArguments: [args.coinType ?? cfg.quoteCoinType],
+		arguments: [
+			tx.object(args.wrapperId),
+			auth,
+			args.coin,
+			tx.object(ACCUMULATOR_ROOT_ID),
+			tx.object(CLOCK_ID),
+		],
+	});
+}
+
+// Withdraw `amountRaw` (raw u64 units) from the account's stored balance via the
+// PTB-callable `withdraw_funds` (folds settle → authorize → load → withdraw), returning
+// the minted `Coin<T>`. `ctx` is implicit in a PTB. See
+// `packages/account/sources/account.move:209`.
+export function withdrawFunds(
+	cfg: PredictConfig,
+	tx: Transaction,
+	args: { wrapperId: string; amountRaw: bigint; coinType?: string },
+): TransactionResult {
+	const auth = generateAuth(cfg, tx);
+	return tx.moveCall({
+		target: accountTarget(cfg, "account", "withdraw_funds"),
+		typeArguments: [args.coinType ?? cfg.quoteCoinType],
+		arguments: [
+			tx.object(args.wrapperId),
+			auth,
+			tx.pure.u64(args.amountRaw),
+			tx.object(ACCUMULATOR_ROOT_ID),
+			tx.object(CLOCK_ID),
+		],
+	});
+}

--- a/packages/predict/sdk/src/tx/builderCode.ts
+++ b/packages/predict/sdk/src/tx/builderCode.ts
@@ -1,0 +1,35 @@
+import type { Transaction } from "@mysten/sui/transactions";
+import { predictTarget, type PredictConfig } from "../config/index.js";
+import { generateAuth } from "./common.js";
+
+// Set the account's sticky builder-code attribution to `builderCodeId`, an existing
+// `BuilderCode` object borrowed as `&BuilderCode`. Command order is auth → set (auth is a
+// hot potato consumed by this call). Lives in the PREDICT package's `predict_account`
+// module, NOT the account package. Deployed sig
+// `git show ec99cfae:packages/predict/sources/predict_account.move:125` — 3 moveCall args
+// (wrapper, auth, code; ctx implicit).
+export function setBuilderCode(
+	cfg: PredictConfig,
+	tx: Transaction,
+	args: { wrapperId: string; builderCodeId: string },
+): void {
+	const auth = generateAuth(cfg, tx);
+	tx.moveCall({
+		target: predictTarget(cfg, "predict_account", "set_builder_code"),
+		arguments: [tx.object(args.wrapperId), auth, tx.object(args.builderCodeId)],
+	});
+}
+
+// Clear the account's sticky builder-code attribution. Command order is auth → unset.
+// Deployed sig `.../predict_account.move:142` — 2 moveCall args (wrapper, auth; ctx implicit).
+export function unsetBuilderCode(
+	cfg: PredictConfig,
+	tx: Transaction,
+	args: { wrapperId: string },
+): void {
+	const auth = generateAuth(cfg, tx);
+	tx.moveCall({
+		target: predictTarget(cfg, "predict_account", "unset_builder_code"),
+		arguments: [tx.object(args.wrapperId), auth],
+	});
+}

--- a/packages/predict/sdk/src/tx/common.ts
+++ b/packages/predict/sdk/src/tx/common.ts
@@ -1,0 +1,30 @@
+import { bcs } from "@mysten/sui/bcs";
+import type { Transaction, TransactionResult } from "@mysten/sui/transactions";
+import { deriveObjectID } from "@mysten/sui/utils";
+import { accountTarget, type PredictConfig } from "../config/index.js";
+
+// Owner authority is a hot-potato `Auth` minted from the tx sender (`ctx` is implicit
+// in a PTB) and consumed by the very next account-loading call (`load_account_mut`
+// inside `deposit_funds` / `withdraw_funds` / `mint` / …). It resolves to owner auth
+// for whoever signs the transaction. See `packages/account/sources/account.move:113`.
+export function generateAuth(cfg: PredictConfig, tx: Transaction): TransactionResult {
+	return tx.moveCall({ target: accountTarget(cfg, "account", "generate_auth"), arguments: [] });
+}
+
+// `AccountWrapperKey(address)` is a one-field positional struct, so its BCS is just the
+// owner's 32-byte address. The wrapper is a derived object of the account registry, so
+// its id is `derive_address(accountRegistry, AccountWrapperKey(owner))`. See
+// `packages/account/sources/account_registry.move:39`.
+const AccountWrapperKeyBcs = bcs.struct("AccountWrapperKey", {
+	pos0: bcs.Address,
+});
+
+// The deterministic id of an owner's canonical account wrapper — no chain read needed.
+export function deriveAccountWrapperId(cfg: PredictConfig, owner: string): string {
+	const key = AccountWrapperKeyBcs.serialize({ pos0: owner }).toBytes();
+	return deriveObjectID(
+		cfg.objects.accountRegistry,
+		`${cfg.packages.account}::account_registry::AccountWrapperKey`,
+		key,
+	);
+}

--- a/packages/predict/sdk/src/tx/plp.ts
+++ b/packages/predict/sdk/src/tx/plp.ts
@@ -1,0 +1,104 @@
+import type { Transaction } from "@mysten/sui/transactions";
+import {
+	ACCUMULATOR_ROOT_ID,
+	CLOCK_ID,
+	predictTarget,
+	type PredictConfig,
+} from "../config/index.js";
+import { generateAuth } from "./common.js";
+
+// Queue a supply request pulling `amountRaw` (raw DUSDC u64) from the account's existing
+// custody balance. `request_supply` auto-settles DUSDC then `account.withdraw`s the payment
+// into queue escrow; the PLP fill is delivered at the next flush, not returned here. Command
+// order is auth → request (auth is a hot potato consumed by this call). Ports harness
+// `requestSupplyFromCustodyTx` (runtime.ts:1260) against deployed sig
+// `git show ec99cfae:.../plp/plp.move:517` — 7 moveCall args (ctx implicit).
+export function requestSupply(
+	cfg: PredictConfig,
+	tx: Transaction,
+	args: { wrapperId: string; amountRaw: bigint },
+): void {
+	const auth = generateAuth(cfg, tx);
+	tx.moveCall({
+		target: predictTarget(cfg, "plp", "request_supply"),
+		arguments: [
+			tx.object(cfg.objects.poolVault),
+			tx.object(args.wrapperId),
+			auth,
+			tx.object(cfg.objects.protocolConfig),
+			tx.pure.u64(args.amountRaw),
+			tx.object(ACCUMULATOR_ROOT_ID),
+			tx.object(CLOCK_ID),
+		],
+	});
+}
+
+// Queue a withdraw request pulling `sharesRaw` (raw PLP u64) from account custody into queue
+// escrow. Auto-settles flush-delivered PLP first; the DUSDC fill lands on the account at the
+// next flush (no `withdraw_settled` entrypoint). Command order is auth → request. Ports
+// harness `requestWithdrawTx` (runtime.ts:1288); deployed sig `.../plp/plp.move:545` — 7 args.
+export function requestWithdraw(
+	cfg: PredictConfig,
+	tx: Transaction,
+	args: { wrapperId: string; sharesRaw: bigint },
+): void {
+	const auth = generateAuth(cfg, tx);
+	tx.moveCall({
+		target: predictTarget(cfg, "plp", "request_withdraw"),
+		arguments: [
+			tx.object(cfg.objects.poolVault),
+			tx.object(args.wrapperId),
+			auth,
+			tx.object(cfg.objects.protocolConfig),
+			tx.pure.u64(args.sharesRaw),
+			tx.object(ACCUMULATOR_ROOT_ID),
+			tx.object(CLOCK_ID),
+		],
+	});
+}
+
+// Cancel a still-pending supply request by queue `index`, refunding its escrowed DUSDC
+// straight back into the requesting account. Command order is auth → cancel. Deployed sig
+// `.../plp/plp.move:571` — same 7-arg shape as request_supply with `index` in the u64 slot.
+export function cancelSupplyRequest(
+	cfg: PredictConfig,
+	tx: Transaction,
+	args: { wrapperId: string; index: bigint },
+): void {
+	const auth = generateAuth(cfg, tx);
+	tx.moveCall({
+		target: predictTarget(cfg, "plp", "cancel_supply_request"),
+		arguments: [
+			tx.object(cfg.objects.poolVault),
+			tx.object(args.wrapperId),
+			auth,
+			tx.object(cfg.objects.protocolConfig),
+			tx.pure.u64(args.index),
+			tx.object(ACCUMULATOR_ROOT_ID),
+			tx.object(CLOCK_ID),
+		],
+	});
+}
+
+// Cancel a still-pending withdraw request by queue `index`, refunding its escrowed PLP
+// straight back into the requesting account. Command order is auth → cancel. Deployed sig
+// `.../plp/plp.move:594` — same 7-arg shape with `index` in the u64 slot.
+export function cancelWithdrawRequest(
+	cfg: PredictConfig,
+	tx: Transaction,
+	args: { wrapperId: string; index: bigint },
+): void {
+	const auth = generateAuth(cfg, tx);
+	tx.moveCall({
+		target: predictTarget(cfg, "plp", "cancel_withdraw_request"),
+		arguments: [
+			tx.object(cfg.objects.poolVault),
+			tx.object(args.wrapperId),
+			auth,
+			tx.object(cfg.objects.protocolConfig),
+			tx.pure.u64(args.index),
+			tx.object(ACCUMULATOR_ROOT_ID),
+			tx.object(CLOCK_ID),
+		],
+	});
+}

--- a/packages/predict/sdk/src/tx/trade.ts
+++ b/packages/predict/sdk/src/tx/trade.ts
@@ -1,0 +1,194 @@
+import type { Transaction, TransactionResult } from "@mysten/sui/transactions";
+import {
+	ACCUMULATOR_ROOT_ID,
+	CLOCK_ID,
+	predictTarget,
+	type PredictConfig,
+} from "../config/index.js";
+import { U64_MAX } from "../units.js";
+import { generateAuth } from "./common.js";
+
+// The four oracle feed object ids a live market's pricer / redeem paths read. Grouped
+// so callers pass one bundle; the deployment's per-underlying ids live in
+// `cfg.underlyings[symbol]` (see `src/config/testnet.ts`).
+export interface MarketFeeds {
+	pythFeedId: string;
+	bsSpotFeedId: string;
+	bsForwardFeedId: string;
+	bsSviFeedId: string;
+}
+
+// Load a fresh `Pricer` from the four live oracle feeds. Every live-flow trade call
+// (`mint_*`, `redeem_live`) borrows this `&Pricer` and it must be loaded first in the
+// PTB. Ports harness `runtime.ts:804` (`load_live_pricer`, 8 args) against the deployed
+// surface (`git show ec99cfae:.../expiry_market.move:167`). `ctx` is not a param here.
+export function loadLivePricer(
+	cfg: PredictConfig,
+	tx: Transaction,
+	args: { expiryMarketId: string } & MarketFeeds,
+): TransactionResult {
+	return tx.moveCall({
+		target: predictTarget(cfg, "expiry_market", "load_live_pricer"),
+		arguments: [
+			tx.object(args.expiryMarketId),
+			tx.object(cfg.objects.protocolConfig),
+			tx.object(cfg.objects.oracleRegistry),
+			tx.object(args.pythFeedId),
+			tx.object(args.bsSpotFeedId),
+			tx.object(args.bsForwardFeedId),
+			tx.object(args.bsSviFeedId),
+			tx.object(CLOCK_ID),
+		],
+	});
+}
+
+// Mint a position of an exact `quantityRaw` at a fixed cost/probability ceiling, returning
+// the new order id (u256). Command order is pricer → auth → mint (auth is a hot potato
+// consumed by this call). Ports harness `runtime.ts:863` (`mint_exact_quantity`, 13 args,
+// deployed sig `expiry_market.move:242`). `maxCostRaw`/`maxProbabilityRaw` default to
+// `U64_MAX` (no slippage cap), matching the harness.
+export function mintExactQuantity(
+	cfg: PredictConfig,
+	tx: Transaction,
+	args: {
+		expiryMarketId: string;
+		wrapperId: string;
+		lowerTick: bigint;
+		higherTick: bigint;
+		quantityRaw: bigint;
+		leverageRaw: bigint;
+		maxCostRaw?: bigint;
+		maxProbabilityRaw?: bigint;
+	} & MarketFeeds,
+): TransactionResult {
+	const pricer = loadLivePricer(cfg, tx, args);
+	const auth = generateAuth(cfg, tx);
+	return tx.moveCall({
+		target: predictTarget(cfg, "expiry_market", "mint_exact_quantity"),
+		arguments: [
+			tx.object(args.expiryMarketId),
+			tx.object(args.wrapperId),
+			auth,
+			tx.object(cfg.objects.protocolConfig),
+			pricer,
+			tx.pure.u64(args.lowerTick),
+			tx.pure.u64(args.higherTick),
+			tx.pure.u64(args.quantityRaw),
+			tx.pure.u64(args.leverageRaw),
+			tx.pure.u64(args.maxCostRaw ?? U64_MAX),
+			tx.pure.u64(args.maxProbabilityRaw ?? U64_MAX),
+			tx.object(ACCUMULATOR_ROOT_ID),
+			tx.object(CLOCK_ID),
+		],
+	});
+}
+
+// Mint by spending an exact `amountRaw` (raw quote units), enforcing a `minQuantityRaw`
+// floor on the position received, returning the new order id (u256). Command order is
+// pricer → auth → mint. Deployed sig `expiry_market.move:293` (`mint_exact_amount`, 12
+// moveCall args — note: no cost/probability ceilings, the floor is `min_quantity`).
+export function mintExactAmount(
+	cfg: PredictConfig,
+	tx: Transaction,
+	args: {
+		expiryMarketId: string;
+		wrapperId: string;
+		lowerTick: bigint;
+		higherTick: bigint;
+		amountRaw: bigint;
+		minQuantityRaw: bigint;
+		leverageRaw: bigint;
+	} & MarketFeeds,
+): TransactionResult {
+	const pricer = loadLivePricer(cfg, tx, args);
+	const auth = generateAuth(cfg, tx);
+	return tx.moveCall({
+		target: predictTarget(cfg, "expiry_market", "mint_exact_amount"),
+		arguments: [
+			tx.object(args.expiryMarketId),
+			tx.object(args.wrapperId),
+			auth,
+			tx.object(cfg.objects.protocolConfig),
+			pricer,
+			tx.pure.u64(args.lowerTick),
+			tx.pure.u64(args.higherTick),
+			tx.pure.u64(args.amountRaw),
+			tx.pure.u64(args.minQuantityRaw),
+			tx.pure.u64(args.leverageRaw),
+			tx.object(ACCUMULATOR_ROOT_ID),
+			tx.object(CLOCK_ID),
+		],
+	});
+}
+
+// Owner-authorized redeem of a live (not-yet-settled) position: close `closeQuantityRaw`
+// of `orderId` at the live pricer's mark, returning (proceeds u256, Option<order id>).
+// Command order is pricer → auth → redeem.
+//
+// DEPLOYED SURFACE (drift guard): the live testnet contract's `redeem_live` takes NO
+// `min_probability`/`min_proceeds` close-side slippage floors — 9 moveCall args, not the
+// 11 the main-shaped harness `runtime.ts:891` passes. Authored from the deployed
+// signature `git show ec99cfae:.../expiry_market.move:350`, NOT from runtime.ts.
+export function redeemLive(
+	cfg: PredictConfig,
+	tx: Transaction,
+	args: {
+		expiryMarketId: string;
+		wrapperId: string;
+		orderId: bigint;
+		closeQuantityRaw: bigint;
+	} & MarketFeeds,
+): TransactionResult {
+	const pricer = loadLivePricer(cfg, tx, args);
+	const auth = generateAuth(cfg, tx);
+	return tx.moveCall({
+		target: predictTarget(cfg, "expiry_market", "redeem_live"),
+		arguments: [
+			tx.object(args.expiryMarketId),
+			tx.object(args.wrapperId),
+			auth,
+			tx.object(cfg.objects.protocolConfig),
+			pricer,
+			tx.pure.u256(args.orderId),
+			tx.pure.u64(args.closeQuantityRaw),
+			tx.object(ACCUMULATOR_ROOT_ID),
+			tx.object(CLOCK_ID),
+		],
+	});
+}
+
+// Permissionless redeem of a settled position: close `closeQuantityRaw` of `orderId`
+// against the settlement pyth price, returning (proceeds u256, Option<order id>).
+//
+// DEPLOYED SURFACE (drift guard): this is the app-auth path — it takes `account_registry`
+// and threads NO `Auth` hot potato, so there is no `generate_auth` call and no live
+// `Pricer`. 10 moveCall args (market, accountRegistry, wrapper, config, oracleRegistry,
+// pyth, order_id, close_quantity, root, clock). Deployed sig
+// `git show ec99cfae:.../expiry_market.move:387`.
+export function redeemSettled(
+	cfg: PredictConfig,
+	tx: Transaction,
+	args: {
+		expiryMarketId: string;
+		wrapperId: string;
+		orderId: bigint;
+		closeQuantityRaw: bigint;
+		pythFeedId: string;
+	},
+): TransactionResult {
+	return tx.moveCall({
+		target: predictTarget(cfg, "expiry_market", "redeem_settled"),
+		arguments: [
+			tx.object(args.expiryMarketId),
+			tx.object(cfg.objects.accountRegistry),
+			tx.object(args.wrapperId),
+			tx.object(cfg.objects.protocolConfig),
+			tx.object(cfg.objects.oracleRegistry),
+			tx.object(args.pythFeedId),
+			tx.pure.u256(args.orderId),
+			tx.pure.u64(args.closeQuantityRaw),
+			tx.object(ACCUMULATOR_ROOT_ID),
+			tx.object(CLOCK_ID),
+		],
+	});
+}

--- a/packages/predict/sdk/src/tx/trade.ts
+++ b/packages/predict/sdk/src/tx/trade.ts
@@ -122,7 +122,8 @@ export function mintExactAmount(
 }
 
 // Owner-authorized redeem of a live (not-yet-settled) position: close `closeQuantityRaw`
-// of `orderId` at the live pricer's mark, returning (proceeds u256, Option<order id>).
+// of `orderId` at the live pricer's mark, returning (closed_order_id u256,
+// Option<replacement order id> — present when a partial close leaves quantity open).
 // Command order is pricer → auth → redeem.
 //
 // DEPLOYED SURFACE (drift guard): the live testnet contract's `redeem_live` takes NO
@@ -158,7 +159,8 @@ export function redeemLive(
 }
 
 // Permissionless redeem of a settled position: close `closeQuantityRaw` of `orderId`
-// against the settlement pyth price, returning (proceeds u256, Option<order id>).
+// against the settlement pyth price, returning (closed_order_id u256,
+// Option<replacement order id>). Requires a full close on the deployed package.
 //
 // DEPLOYED SURFACE (drift guard): this is the app-auth path — it takes `account_registry`
 // and threads NO `Auth` hot potato, so there is no `generate_auth` call and no live

--- a/packages/predict/sdk/src/units.ts
+++ b/packages/predict/sdk/src/units.ts
@@ -1,14 +1,35 @@
 export const U64_MAX = (1n << 64n) - 1n;
 
+// Expand exponential notation to a plain decimal string, exactly (string math).
+// JS Number.toString() emits exponentials below 1e-6 and at/above 1e21, which
+// the plain-decimal regex in toRaw would otherwise reject with a misleading
+// "invalid" error even when the value is exactly representable.
+function expandExponential(s: string): string {
+	const m = /^(\d+)(?:\.(\d+))?[eE]([+-]?\d+)$/.exec(s);
+	if (!m) return s;
+	const [, whole, frac = "", expStr] = m;
+	const digits = whole + frac;
+	const point = whole.length + Number(expStr);
+	if (point <= 0) return "0." + "0".repeat(-point) + digits;
+	if (point >= digits.length) return digits + "0".repeat(point - digits.length);
+	return digits.slice(0, point) + "." + digits.slice(point);
+}
+
 /** Exact decimal→raw conversion via string math. Throws on negatives and excess precision. */
 export function toRaw(value: number | string, decimals: number): bigint {
-	const s = typeof value === "number" ? value.toString() : value.trim();
+	const s = expandExponential(typeof value === "number" ? value.toString() : value.trim());
 	if (!/^\d+(\.\d+)?$/.test(s)) throw new Error(`invalid or negative decimal value: ${s}`);
 	const [whole, frac = ""] = s.split(".");
 	if (frac.length > decimals) throw new Error(`${s} exceeds ${decimals} decimals`);
 	return BigInt(whole) * 10n ** BigInt(decimals) + BigInt(frac.padEnd(decimals, "0") || "0");
 }
 
+/**
+ * Raw→decimal for DISPLAY. Casts through Number, so values above 2^53 raw lose
+ * precision in the low digits — fine for UI, not for accounting. Exact values
+ * stay available as bigints from the primitives layer (`accountBalance`,
+ * `poolStats`, …).
+ */
 export function fromRaw(raw: bigint, decimals: number): number {
 	return Number(raw) / 10 ** decimals;
 }

--- a/packages/predict/sdk/src/units.ts
+++ b/packages/predict/sdk/src/units.ts
@@ -1,0 +1,28 @@
+export const U64_MAX = (1n << 64n) - 1n;
+
+/** Exact decimal→raw conversion via string math. Throws on negatives and excess precision. */
+export function toRaw(value: number | string, decimals: number): bigint {
+	const s = typeof value === "number" ? value.toString() : value.trim();
+	if (!/^\d+(\.\d+)?$/.test(s)) throw new Error(`invalid or negative decimal value: ${s}`);
+	const [whole, frac = ""] = s.split(".");
+	if (frac.length > decimals) throw new Error(`${s} exceeds ${decimals} decimals`);
+	return BigInt(whole) * 10n ** BigInt(decimals) + BigInt(frac.padEnd(decimals, "0") || "0");
+}
+
+export function fromRaw(raw: bigint, decimals: number): number {
+	return Number(raw) / 10 ** decimals;
+}
+
+export const usdcToRaw = (v: number | string) => toRaw(v, 6);
+export const rawToUsdc = (raw: bigint) => fromRaw(raw, 6);
+export const priceToRaw = (v: number | string) => toRaw(v, 9);
+export const rawToPrice = (raw: bigint) => fromRaw(raw, 9);
+export function probabilityToRaw(p: number): bigint {
+	if (p < 0 || p > 1) throw new Error(`probability must be in [0,1], got ${p}`);
+	return toRaw(p, 9);
+}
+export const rawToProbability = (raw: bigint) => fromRaw(raw, 9);
+export function leverageToRaw(l: number): bigint {
+	if (l < 1) throw new Error(`leverage must be >= 1, got ${l}`);
+	return toRaw(l, 9);
+}

--- a/packages/predict/sdk/tests/client.test.ts
+++ b/packages/predict/sdk/tests/client.test.ts
@@ -178,6 +178,27 @@ describe("tx.mint (market resolution + unit conversion)", () => {
 		).rejects.toThrow(/lot/);
 	});
 
+	test("sub-lot close quantity throws /lot/ on redeem and claimSettled", async () => {
+		const pc = new PredictClient({ network: "testnet", client: mockClient().client });
+		const m = { underlying: "BTC", expiryMs: EXPIRY, strike: 105_000, side: "up" } as const;
+		await expect(pc.tx.redeem(OWNER, m, { orderId: 1n, quantity: 0.001 })).rejects.toThrow(
+			/lot/,
+		);
+		await expect(
+			pc.tx.claimSettled(OWNER, m, { orderId: 1n, quantity: 0.001 }),
+		).rejects.toThrow(/lot/);
+	});
+
+	test("mintAmount minQuantity is a floor — sub-lot values are accepted", async () => {
+		const pc = new PredictClient({ network: "testnet", client: mockClient().client });
+		const tx = await pc.tx.mintAmount(
+			OWNER,
+			{ underlying: "BTC", expiryMs: EXPIRY, strike: 105_000, side: "up" },
+			{ spend: 10, minQuantity: 0.015 },
+		);
+		expect(tx).toBeTruthy();
+	});
+
 	test("market resolution is cached: a second mint does not re-resolve", async () => {
 		const { client, counts } = mockClient();
 		const pc = new PredictClient({ network: "testnet", client });

--- a/packages/predict/sdk/tests/client.test.ts
+++ b/packages/predict/sdk/tests/client.test.ts
@@ -48,12 +48,11 @@ function mockClient() {
 			if (fn === "expiry_market_id") {
 				results = [[bcs.option(bcs.Address).serialize(MARKET_ID).toBytes()]];
 			} else if (fn === "expiry") {
-				// marketState PTB: expiry, tick_size, mint_paused, settlement_price
+				// marketState PTB: expiry, tick_size, mint_paused
 				results = [
 					[bcs.u64().serialize(BigInt(EXPIRY)).toBytes()],
 					[bcs.u64().serialize(10_000_000n).toBytes()],
 					[bcs.bool().serialize(false).toBytes()],
-					[bcs.u64().serialize(0n).toBytes()],
 				];
 			} else {
 				// e.g. currentNav's load_live_pricer → current_nav: one u64 per command.

--- a/packages/predict/sdk/tests/client.test.ts
+++ b/packages/predict/sdk/tests/client.test.ts
@@ -1,0 +1,208 @@
+import { bcs } from "@mysten/sui/bcs";
+import type { Transaction } from "@mysten/sui/transactions";
+import { describe, expect, test } from "vitest";
+import { PredictClient } from "../src/client.js";
+import { TESTNET_CONFIG as cfg } from "../src/config/index.js";
+import { PredictInputError } from "../src/errors.js";
+import type { ReadClient } from "../src/reads/inspect.js";
+import { POS_INF_TICK } from "../src/ticks.js";
+
+const OWNER = "0x" + "ab".repeat(32);
+const MARKET_ID = "0x" + "cd".repeat(32);
+const EXPIRY = 1_700_000_000_000;
+
+// The moveCall targets in the order the builder emitted them.
+function targets(tx: Transaction): string[] {
+	return tx.getData().commands.flatMap((c) =>
+		"MoveCall" in c && c.MoveCall
+			? [`${c.MoveCall.package}::${c.MoveCall.module}::${c.MoveCall.function}`]
+			: [],
+	);
+}
+
+function call(tx: Transaction, cmdIdx: number) {
+	return tx.getData().commands[cmdIdx].MoveCall!;
+}
+
+// Resolve the base64 pure bytes an argument points at (undefined if not a pure input).
+function argPureBytes(tx: Transaction, cmdIdx: number, argIdx: number): string | undefined {
+	const arg = call(tx, cmdIdx).arguments[argIdx] as { $kind: string; Input?: number };
+	if (arg.$kind !== "Input" || arg.Input === undefined) return undefined;
+	const input = tx.getData().inputs[arg.Input];
+	return "Pure" in input && input.Pure ? input.Pure.bytes : undefined;
+}
+
+const b64 = (v: bigint) => Buffer.from(bcs.u64().serialize(v).toBytes()).toString("base64");
+
+// A mock ReadClient that dispatches canned return values by the first command's
+// move-call function, and counts how many times each function was simulated.
+function mockClient() {
+	const counts: Record<string, number> = {};
+	const client = {
+		async simulateTransaction(opts: { transaction: Transaction }) {
+			const cmds = opts.transaction.getData().commands;
+			const fn =
+				"MoveCall" in cmds[0] && cmds[0].MoveCall ? cmds[0].MoveCall.function : "?";
+			counts[fn] = (counts[fn] ?? 0) + 1;
+			let results: Uint8Array[][];
+			if (fn === "expiry_market_id") {
+				results = [[bcs.option(bcs.Address).serialize(MARKET_ID).toBytes()]];
+			} else if (fn === "expiry") {
+				// marketState PTB: expiry, tick_size, mint_paused, settlement_price
+				results = [
+					[bcs.u64().serialize(BigInt(EXPIRY)).toBytes()],
+					[bcs.u64().serialize(10_000_000n).toBytes()],
+					[bcs.bool().serialize(false).toBytes()],
+					[bcs.u64().serialize(0n).toBytes()],
+				];
+			} else {
+				// e.g. currentNav's load_live_pricer → current_nav: one u64 per command.
+				results = cmds.map(() => [bcs.u64().serialize(0n).toBytes()]);
+			}
+			return {
+				$kind: "Transaction",
+				Transaction: {},
+				commandResults: results.map((rvs) => ({
+					returnValues: rvs.map((b) => ({ bcs: b })),
+					mutatedReferences: [],
+				})),
+			};
+		},
+	} as unknown as ReadClient;
+	return { client, counts };
+}
+
+// A mock that reports NO market for the descriptor.
+function mockNoMarket() {
+	const client = {
+		async simulateTransaction() {
+			return {
+				$kind: "Transaction",
+				Transaction: {},
+				commandResults: [
+					{
+						returnValues: [{ bcs: bcs.option(bcs.Address).serialize(null).toBytes() }],
+						mutatedReferences: [],
+					},
+				],
+			};
+		},
+	} as unknown as ReadClient;
+	return client;
+}
+
+describe("PredictClient constructor", () => {
+	test("mainnet without config throws (no deployment)", () => {
+		expect(() => new PredictClient({ network: "mainnet", client: mockClient().client })).toThrow();
+	});
+
+	test("testnet resolves the bundled config; wrapperIdFor is deterministic", () => {
+		const pc = new PredictClient({ network: "testnet", client: mockClient().client });
+		const id = pc.wrapperIdFor(OWNER);
+		expect(id).toMatch(/^0x[0-9a-f]{64}$/);
+		expect(pc.wrapperIdFor(OWNER)).toBe(id);
+	});
+});
+
+describe("tx.deposit / tx.withdraw", () => {
+	test("deposit sources a coin via CoinWithBalance intent and calls deposit_funds; 12.5 → 12_500_000", () => {
+		const pc = new PredictClient({ network: "testnet", client: mockClient().client });
+		const tx = pc.tx.deposit(OWNER, "12.5");
+		// a CoinWithBalance $Intent command is present
+		const hasIntent = tx
+			.getData()
+			.commands.some((c) => "$Intent" in c && c.$Intent?.name === "CoinWithBalance");
+		expect(hasIntent).toBe(true);
+		expect(targets(tx)).toContain(`${cfg.packages.account}::account::deposit_funds`);
+	});
+
+	test("withdraw transfers the returned coin to the owner (TransferObjects present)", () => {
+		const pc = new PredictClient({ network: "testnet", client: mockClient().client });
+		const tx = pc.tx.withdraw(OWNER, "5");
+		expect(targets(tx)).toContain(`${cfg.packages.account}::account::withdraw_funds`);
+		const hasTransfer = tx.getData().commands.some((c) => "TransferObjects" in c && c.TransferObjects);
+		expect(hasTransfer).toBe(true);
+	});
+});
+
+describe("tx.mint (market resolution + unit conversion)", () => {
+	test("converts quantity, leverage, ticks against a resolved market", async () => {
+		const { client } = mockClient();
+		const pc = new PredictClient({ network: "testnet", client });
+		const tx = await pc.tx.mint(
+			OWNER,
+			{ underlying: "BTC", expiryMs: EXPIRY, strike: 105_000, side: "up" },
+			{ quantity: 50, leverage: 2 },
+		);
+		expect(targets(tx)).toEqual([
+			`${cfg.packages.predict}::expiry_market::load_live_pricer`,
+			`${cfg.packages.account}::account::generate_auth`,
+			`${cfg.packages.predict}::expiry_market::mint_exact_quantity`,
+		]);
+		// mint args: [market, wrapper, auth, config, pricer, lower, higher, quantity, leverage, ...]
+		expect(argPureBytes(tx, 2, 5)).toBe(b64(10_500_000n)); // lower tick = strike/tickSize
+		expect(argPureBytes(tx, 2, 6)).toBe(b64(POS_INF_TICK)); // higher tick (up)
+		expect(argPureBytes(tx, 2, 7)).toBe(b64(50_000_000n)); // quantity 50 → 1e6
+		expect(argPureBytes(tx, 2, 8)).toBe(b64(2_000_000_000n)); // leverage 2 → 1e9
+	});
+
+	test("unknown market → PredictInputError /no market/", async () => {
+		const pc = new PredictClient({ network: "testnet", client: mockNoMarket() });
+		await expect(
+			pc.tx.mint(
+				OWNER,
+				{ underlying: "BTC", expiryMs: EXPIRY, strike: 105_000, side: "up" },
+				{ quantity: 50 },
+			),
+		).rejects.toThrow(/no market/);
+	});
+
+	test("unknown underlying → PredictInputError", async () => {
+		const pc = new PredictClient({ network: "testnet", client: mockClient().client });
+		await expect(
+			pc.tx.mint(
+				OWNER,
+				{ underlying: "DOGE", expiryMs: EXPIRY, strike: 1, side: "up" },
+				{ quantity: 50 },
+			),
+		).rejects.toBeInstanceOf(PredictInputError);
+	});
+
+	test("sub-lot quantity throws /lot/", async () => {
+		const pc = new PredictClient({ network: "testnet", client: mockClient().client });
+		await expect(
+			pc.tx.mint(
+				OWNER,
+				{ underlying: "BTC", expiryMs: EXPIRY, strike: 105_000, side: "up" },
+				{ quantity: 0.001 },
+			),
+		).rejects.toThrow(/lot/);
+	});
+
+	test("market resolution is cached: a second mint does not re-resolve", async () => {
+		const { client, counts } = mockClient();
+		const pc = new PredictClient({ network: "testnet", client });
+		const m = { underlying: "BTC", expiryMs: EXPIRY, strike: 105_000, side: "up" } as const;
+		await pc.tx.mint(OWNER, m, { quantity: 50 });
+		await pc.tx.mint(OWNER, m, { quantity: 50 });
+		expect(counts.expiry_market_id).toBe(1);
+	});
+});
+
+describe("read facade", () => {
+	test("market returns id + converted fields, or null when absent", async () => {
+		const { client } = mockClient();
+		const pc = new PredictClient({ network: "testnet", client });
+		const m = await pc.read.market({ underlying: "BTC", expiryMs: EXPIRY });
+		expect(m).not.toBeNull();
+		expect(m!.id).toBe(MARKET_ID);
+		expect(m!.expiryMs).toBe(BigInt(EXPIRY));
+		expect(m!.mintPaused).toBe(false);
+
+		const none = await new PredictClient({ network: "testnet", client: mockNoMarket() }).read.market({
+			underlying: "BTC",
+			expiryMs: 1,
+		});
+		expect(none).toBeNull();
+	});
+});

--- a/packages/predict/sdk/tests/client.test.ts
+++ b/packages/predict/sdk/tests/client.test.ts
@@ -34,6 +34,84 @@ function argPureBytes(tx: Transaction, cmdIdx: number, argIdx: number): string |
 
 const b64 = (v: bigint) => Buffer.from(bcs.u64().serialize(v).toBytes()).toString("base64");
 
+// Canned trade events for quote dry-runs (layouts mirror src/decode.ts).
+const MINTED_EVENT = {
+	eventType: `${cfg.packages.predict}::order_events::OrderMinted`,
+	bcs: bcs
+		.struct("OrderMinted", {
+			expiry_market_id: bcs.Address,
+			account_id: bcs.Address,
+			order_id: bcs.u256(),
+			position_root_id: bcs.u256(),
+			owner: bcs.Address,
+			lower_tick: bcs.u64(),
+			higher_tick: bcs.u64(),
+			leverage: bcs.u64(),
+			entry_probability: bcs.u64(),
+			quantity: bcs.u64(),
+			net_premium: bcs.u64(),
+			trading_fee: bcs.u64(),
+			fee_incentive_subsidy: bcs.u64(),
+			builder_fee: bcs.u64(),
+			penalty_fee: bcs.u64(),
+			builder_code_id: bcs.option(bcs.Address),
+		})
+		.serialize({
+			expiry_market_id: MARKET_ID,
+			account_id: MARKET_ID,
+			order_id: 7n,
+			position_root_id: 7n,
+			owner: OWNER,
+			lower_tick: 10_500_000n,
+			higher_tick: (1n << 30n) - 1n,
+			leverage: 1_000_000_000n,
+			entry_probability: 340_000_000n, // 0.34
+			quantity: 50_000_000n, // $50
+			net_premium: 17_000_000n, // $17
+			trading_fee: 100_000n, // $0.10
+			fee_incentive_subsidy: 20_000n, // $0.02 sponsor-paid
+			builder_fee: 30_000n, // $0.03
+			penalty_fee: 5_000n, // $0.005
+			builder_code_id: null,
+		})
+		.toBytes(),
+};
+const REDEEMED_EVENT = {
+	eventType: `${cfg.packages.predict}::order_events::LiveOrderRedeemed`,
+	bcs: bcs
+		.struct("LiveOrderRedeemed", {
+			expiry_market_id: bcs.Address,
+			account_id: bcs.Address,
+			order_id: bcs.u256(),
+			position_root_id: bcs.u256(),
+			owner: bcs.Address,
+			quantity_closed: bcs.u64(),
+			remaining_quantity: bcs.u64(),
+			replacement_order_id: bcs.option(bcs.u256()),
+			redeem_amount: bcs.u64(),
+			trading_fee: bcs.u64(),
+			builder_fee: bcs.u64(),
+			penalty_fee: bcs.u64(),
+			builder_code_id: bcs.option(bcs.Address),
+		})
+		.serialize({
+			expiry_market_id: MARKET_ID,
+			account_id: MARKET_ID,
+			order_id: 7n,
+			position_root_id: 7n,
+			owner: OWNER,
+			quantity_closed: 20_000_000n,
+			remaining_quantity: 30_000_000n,
+			replacement_order_id: 8n,
+			redeem_amount: 6_000_000n, // gross $6
+			trading_fee: 50_000n,
+			builder_fee: 0n,
+			penalty_fee: 0n,
+			builder_code_id: null,
+		})
+		.toBytes(),
+};
+
 // A mock ReadClient that dispatches canned return values by the first command's
 // move-call function, and counts how many times each function was simulated.
 function mockClient() {
@@ -41,11 +119,28 @@ function mockClient() {
 	const client = {
 		async simulateTransaction(opts: { transaction: Transaction }) {
 			const cmds = opts.transaction.getData().commands;
-			const fn =
-				"MoveCall" in cmds[0] && cmds[0].MoveCall ? cmds[0].MoveCall.function : "?";
+			const fns = cmds.map((c) =>
+				"MoveCall" in c && c.MoveCall ? c.MoveCall.function : "?",
+			);
+			const fn = fns[0];
 			counts[fn] = (counts[fn] ?? 0) + 1;
+			// Quote dry-runs: a simulated trade returns its emitted events.
+			if (fns.includes("mint_exact_quantity")) {
+				counts.quote_mint_sim = (counts.quote_mint_sim ?? 0) + 1;
+				return { $kind: "Transaction", Transaction: { events: [MINTED_EVENT] } };
+			}
+			if (fns.includes("redeem_live")) {
+				return { $kind: "Transaction", Transaction: { events: [REDEEMED_EVENT] } };
+			}
 			let results: Uint8Array[][];
-			if (fn === "active_expiry_markets") {
+			if (fns[1] === "range_price") {
+				// price PTB: load_live_pricer → up range → down range
+				results = [
+					[new Uint8Array(0)],
+					[bcs.u64().serialize(340_000_000n).toBytes()], // up 0.34
+					[bcs.u64().serialize(660_000_000n).toBytes()], // down 0.66
+				];
+			} else if (fn === "active_expiry_markets") {
 				results = [[bcs.vector(bcs.Address).serialize([MARKET_ID]).toBytes()]];
 			} else if (fn === "expiry_market_id") {
 				results = [[bcs.option(bcs.Address).serialize(MARKET_ID).toBytes()]];
@@ -288,6 +383,51 @@ describe("tx.mint (market resolution + unit conversion)", () => {
 				{ quantity: 50 },
 			),
 		).rejects.toThrow(/reference price not set/);
+	});
+
+	test("read.price returns both sides from the chain's range_price", async () => {
+		const pc = new PredictClient({ network: "testnet", client: mockClient().client });
+		const p = await pc.read.price({ underlying: "BTC", expiryMs: EXPIRY, strike: 105_000 });
+		expect(p).toEqual({ up: 0.34, down: 0.66 });
+	});
+
+	test("read.price rejects off-grid strikes", async () => {
+		const pc = new PredictClient({ network: "testnet", client: mockClient().client });
+		await expect(
+			pc.read.price({ underlying: "BTC", expiryMs: EXPIRY, strike: 105_000.005 }),
+		).rejects.toThrow(/tick grid/);
+	});
+
+	test("read.quoteMint dry-runs the mint and computes the all-in cost", async () => {
+		const { client, counts } = mockClient();
+		const pc = new PredictClient({ network: "testnet", client });
+		const q = await pc.read.quoteMint(
+			OWNER,
+			{ underlying: "BTC", expiryMs: EXPIRY, strike: 105_000, side: "up" },
+			{ quantity: 50 },
+		);
+		expect(counts.quote_mint_sim).toBe(1);
+		expect(q.entryProbability).toBeCloseTo(0.34);
+		expect(q.premium).toBe(17);
+		// cost = premium + (trading − subsidy) + builder + penalty
+		expect(q.raw.cost).toBe(17_000_000n + 80_000n + 30_000n + 5_000n);
+		expect(q.cost).toBeCloseTo(17.115);
+		expect(q.quantity).toBe(50);
+		expect(q.feesExact).toBe(true);
+	});
+
+	test("read.quoteRedeem dry-runs the close and returns NET proceeds", async () => {
+		const pc = new PredictClient({ network: "testnet", client: mockClient().client });
+		const q = await pc.read.quoteRedeem(
+			OWNER,
+			{ underlying: "BTC", expiryMs: EXPIRY, strike: 105_000, side: "up" },
+			{ orderId: 7n, quantity: 0.02 },
+		);
+		expect(q.gross).toBe(6);
+		expect(q.proceeds).toBe(5.95);
+		expect(q.wouldLiquidate).toBe(false);
+		expect(q.remaining).toBe(30);
+		expect(q.feesExact).toBe(true);
 	});
 
 	test("market resolution is cached: a second mint does not re-resolve", async () => {

--- a/packages/predict/sdk/tests/client.test.ts
+++ b/packages/predict/sdk/tests/client.test.ts
@@ -45,7 +45,9 @@ function mockClient() {
 				"MoveCall" in cmds[0] && cmds[0].MoveCall ? cmds[0].MoveCall.function : "?";
 			counts[fn] = (counts[fn] ?? 0) + 1;
 			let results: Uint8Array[][];
-			if (fn === "expiry_market_id") {
+			if (fn === "active_expiry_markets") {
+				results = [[bcs.vector(bcs.Address).serialize([MARKET_ID]).toBytes()]];
+			} else if (fn === "expiry_market_id") {
 				results = [[bcs.option(bcs.Address).serialize(MARKET_ID).toBytes()]];
 			} else if (fn === "expiry") {
 				// marketState PTB: expiry, tick_size, mint_paused
@@ -197,6 +199,19 @@ describe("tx.mint (market resolution + unit conversion)", () => {
 			{ spend: 10, minQuantity: 0.015 },
 		);
 		expect(tx).toBeTruthy();
+	});
+
+	test("read.markets returns tradeable summaries", async () => {
+		const pc = new PredictClient({ network: "testnet", client: mockClient().client });
+		const markets = await pc.read.markets();
+		expect(markets).toEqual([
+			{
+				id: MARKET_ID,
+				expiryMs: BigInt(EXPIRY),
+				tickSize: 0.01,
+				mintPaused: false,
+			},
+		]);
 	});
 
 	test("market resolution is cached: a second mint does not re-resolve", async () => {

--- a/packages/predict/sdk/tests/client.test.ts
+++ b/packages/predict/sdk/tests/client.test.ts
@@ -50,12 +50,16 @@ function mockClient() {
 			} else if (fn === "expiry_market_id") {
 				results = [[bcs.option(bcs.Address).serialize(MARKET_ID).toBytes()]];
 			} else if (fn === "expiry") {
-				// marketState PTB: expiry, tick_size, mint_paused
+				// marketState PTB: expiry, tick_size, mint_paused, reference_tick
 				results = [
 					[bcs.u64().serialize(BigInt(EXPIRY)).toBytes()],
 					[bcs.u64().serialize(10_000_000n).toBytes()],
 					[bcs.bool().serialize(false).toBytes()],
+					[bcs.option(bcs.u64()).serialize(10_500_000n).toBytes()],
 				];
+			} else if (fn === "reference_tick") {
+				// mint-at-reference fresh read: tick 10_500_000 (= $105,000 @ $0.01)
+				results = [[bcs.option(bcs.u64()).serialize(10_500_000n).toBytes()]];
 			} else {
 				// e.g. currentNav's load_live_pricer → current_nav: one u64 per command.
 				results = cmds.map(() => [bcs.u64().serialize(0n).toBytes()]);
@@ -210,8 +214,80 @@ describe("tx.mint (market resolution + unit conversion)", () => {
 				expiryMs: BigInt(EXPIRY),
 				tickSize: 0.01,
 				mintPaused: false,
+				referencePrice: 105_000, // tick 10_500_000 × $0.01
 			},
 		]);
+	});
+
+	test("mint at the reference strike uses the on-chain reference tick directly", async () => {
+		const { client, counts } = mockClient();
+		const pc = new PredictClient({ network: "testnet", client });
+		const tx = await pc.tx.mint(
+			OWNER,
+			{ underlying: "BTC", expiryMs: EXPIRY, strike: "reference", side: "up" },
+			{ quantity: 50 },
+		);
+		// The fresh reference read must have happened (never served from cache).
+		expect(counts.reference_tick).toBe(1);
+		// lowerTick input = the reference tick itself; higherTick = +inf sentinel.
+		const inputs = tx.getData().inputs;
+		const pureB64 = inputs
+			.filter((i) => "Pure" in i && i.Pure)
+			.map((i) => (i as { Pure: { bytes: string } }).Pure.bytes);
+		expect(pureB64).toContain(b64(10_500_000n)); // reference tick
+		expect(pureB64).toContain(b64((1n << 30n) - 1n)); // POS_INF_TICK
+	});
+
+	test("mint at reference: DOWN side puts the tick on the higher bound", async () => {
+		const pc = new PredictClient({ network: "testnet", client: mockClient().client });
+		const tx = await pc.tx.mint(
+			OWNER,
+			{ underlying: "BTC", expiryMs: EXPIRY, strike: "reference", side: "down" },
+			{ quantity: 50 },
+		);
+		const pureB64 = tx
+			.getData()
+			.inputs.filter((i) => "Pure" in i && i.Pure)
+			.map((i) => (i as { Pure: { bytes: string } }).Pure.bytes);
+		expect(pureB64).toContain(b64(0n)); // -inf sentinel on the lower bound
+		expect(pureB64).toContain(b64(10_500_000n)); // reference tick on the higher
+	});
+
+	test("mint at reference: unset reference → PredictInputError", async () => {
+		const base = mockClient().client as unknown as {
+			simulateTransaction: (o: { transaction: Transaction }) => Promise<unknown>;
+		};
+		// Wrap the mock: reference_tick returns None; everything else passes through.
+		const client = {
+			async simulateTransaction(opts: { transaction: Transaction }) {
+				const cmds = opts.transaction.getData().commands;
+				const fn =
+					"MoveCall" in cmds[0] && cmds[0].MoveCall ? cmds[0].MoveCall.function : "?";
+				if (fn === "reference_tick") {
+					return {
+						$kind: "Transaction",
+						Transaction: {},
+						commandResults: [
+							{
+								returnValues: [
+									{ bcs: bcs.option(bcs.u64()).serialize(null).toBytes() },
+								],
+								mutatedReferences: [],
+							},
+						],
+					};
+				}
+				return base.simulateTransaction(opts);
+			},
+		} as never;
+		const pc = new PredictClient({ network: "testnet", client });
+		await expect(
+			pc.tx.mint(
+				OWNER,
+				{ underlying: "BTC", expiryMs: EXPIRY, strike: "reference", side: "up" },
+				{ quantity: 50 },
+			),
+		).rejects.toThrow(/reference price not set/);
 	});
 
 	test("market resolution is cached: a second mint does not re-resolve", async () => {

--- a/packages/predict/sdk/tests/config.test.ts
+++ b/packages/predict/sdk/tests/config.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "vitest";
+
+import {
+	ACCUMULATOR_ROOT_ID,
+	CLOCK_ID,
+	TESTNET_CONFIG,
+	accountTarget,
+	getConfig,
+	predictTarget,
+} from "../src/config/index.js";
+
+const ID_RE = /^0x[0-9a-f]{1,64}$/;
+
+test("all package IDs are well-formed", () => {
+	expect(TESTNET_CONFIG.packages.predict).toMatch(ID_RE);
+	expect(TESTNET_CONFIG.packages.account).toMatch(ID_RE);
+	expect(TESTNET_CONFIG.packages.propbook).toMatch(ID_RE);
+});
+
+test("all shared object IDs are well-formed", () => {
+	for (const id of Object.values(TESTNET_CONFIG.objects)) {
+		expect(id).toMatch(ID_RE);
+	}
+});
+
+test("quoteCoinType is a DUSDC coin type", () => {
+	expect(TESTNET_CONFIG.quoteCoinType).toMatch(/^0x[0-9a-f]+::dusdc::DUSDC$/);
+});
+
+test("BTC underlying is present and well-formed", () => {
+	const btc = TESTNET_CONFIG.underlyings.BTC;
+	expect(btc.symbol).toBe("BTC");
+	expect(Number.isInteger(btc.propbookUnderlyingId)).toBe(true);
+	expect(btc.pythFeedId).toMatch(ID_RE);
+	expect(btc.bsSpotFeedId).toMatch(ID_RE);
+	expect(btc.bsForwardFeedId).toMatch(ID_RE);
+	expect(btc.bsSviFeedId).toMatch(ID_RE);
+});
+
+test("predictTarget concatenates from the predict package", () => {
+	expect(predictTarget(TESTNET_CONFIG, "plp", "request_supply")).toBe(
+		`${TESTNET_CONFIG.packages.predict}::plp::request_supply`,
+	);
+});
+
+test("accountTarget concatenates from the account package", () => {
+	expect(accountTarget(TESTNET_CONFIG, "account", "open")).toBe(
+		`${TESTNET_CONFIG.packages.account}::account::open`,
+	);
+});
+
+test("getConfig returns the testnet config", () => {
+	expect(getConfig("testnet")).toBe(TESTNET_CONFIG);
+});
+
+test("getConfig throws for mainnet", () => {
+	expect(() => getConfig("mainnet")).toThrow(/no mainnet deployment/);
+});
+
+test("well-known object id constants", () => {
+	expect(CLOCK_ID).toBe("0x6");
+	expect(ACCUMULATOR_ROOT_ID).toBe("0xacc");
+});

--- a/packages/predict/sdk/tests/decode.test.ts
+++ b/packages/predict/sdk/tests/decode.test.ts
@@ -1,0 +1,356 @@
+import { bcs } from "@mysten/sui/bcs";
+import { toBase64 } from "@mysten/sui/utils";
+import { describe, expect, test } from "vitest";
+import { TESTNET_CONFIG as cfg } from "../src/config/index.js";
+import {
+	decodeAccountsCreated,
+	decodeClaims,
+	decodeDeposits,
+	decodeMints,
+	decodePlpCancels,
+	decodePlpRequests,
+	decodeRedeems,
+	type DecodableEvent,
+} from "../src/decode.js";
+import { PredictClient } from "../src/client.js";
+import { PredictInputError } from "../src/errors.js";
+
+// Fixtures serialize with layouts mirroring the deployed structs. NOTE: this
+// round-trips the SDK's own layouts (field order vs chain is anchored by the
+// verbatim-source comments in decode.ts and validated live for AccountCreated
+// in the testnet smoke).
+
+const MARKET = "0x" + "11".repeat(32);
+const ACCOUNT = "0x" + "22".repeat(32);
+const OWNER = "0x" + "33".repeat(32);
+const VAULT = "0x" + "44".repeat(32);
+const CODE = "0x" + "55".repeat(32);
+
+const OrderMintedBcs = bcs.struct("OrderMinted", {
+	expiry_market_id: bcs.Address,
+	account_id: bcs.Address,
+	order_id: bcs.u256(),
+	position_root_id: bcs.u256(),
+	owner: bcs.Address,
+	lower_tick: bcs.u64(),
+	higher_tick: bcs.u64(),
+	leverage: bcs.u64(),
+	entry_probability: bcs.u64(),
+	quantity: bcs.u64(),
+	net_premium: bcs.u64(),
+	trading_fee: bcs.u64(),
+	fee_incentive_subsidy: bcs.u64(),
+	builder_fee: bcs.u64(),
+	penalty_fee: bcs.u64(),
+	builder_code_id: bcs.option(bcs.Address),
+});
+
+function mintedEvent(orderId: bigint, overrides: Record<string, unknown> = {}): DecodableEvent {
+	return {
+		eventType: `${cfg.packages.predict}::order_events::OrderMinted`,
+		bcs: OrderMintedBcs.serialize({
+			expiry_market_id: MARKET,
+			account_id: ACCOUNT,
+			order_id: orderId,
+			position_root_id: orderId,
+			owner: OWNER,
+			lower_tick: 10_500_000n,
+			higher_tick: (1n << 30n) - 1n,
+			leverage: 2_000_000_000n,
+			entry_probability: 300_000_000n,
+			quantity: 50_000_000n,
+			net_premium: 12_500_000n,
+			trading_fee: 100_000n,
+			fee_incentive_subsidy: 20_000n,
+			builder_fee: 30_000n,
+			penalty_fee: 5_000n,
+			builder_code_id: CODE,
+			...overrides,
+		}).toBytes(),
+	};
+}
+
+describe("decodeMints", () => {
+	test("full receipt with human + raw units", () => {
+		const [r] = decodeMints(cfg, { events: [mintedEvent(7n)] });
+		expect(r.orderId).toBe(7n);
+		expect(r.positionRootId).toBe(7n);
+		expect(r.marketId).toBe(MARKET);
+		expect(r.quantity).toBe(50); // $50 payout
+		expect(r.netPremium).toBe(12.5);
+		expect(r.entryProbability).toBeCloseTo(0.3);
+		expect(r.leverage).toBe(2);
+		expect(r.fees).toEqual({ trading: 0.1, subsidy: 0.02, builder: 0.03, penalty: 0.005 });
+		expect(r.builderCodeId).toBe(CODE);
+		expect(r.raw.quantity).toBe(50_000_000n);
+		expect(r.raw.netPremium).toBe(12_500_000n);
+	});
+
+	test("batched PTB: N mints → N receipts, in order", () => {
+		const receipts = decodeMints(cfg, { events: [mintedEvent(1n), mintedEvent(2n)] });
+		expect(receipts.map((r) => r.orderId)).toEqual([1n, 2n]);
+	});
+
+	test("accepts base64-encoded bcs payloads", () => {
+		const e = mintedEvent(9n);
+		const [r] = decodeMints(cfg, {
+			events: [{ ...e, bcs: toBase64(e.bcs as Uint8Array) }],
+		});
+		expect(r.orderId).toBe(9n);
+	});
+
+	test("None builder code → null", () => {
+		const [r] = decodeMints(cfg, { events: [mintedEvent(1n, { builder_code_id: null })] });
+		expect(r.builderCodeId).toBeNull();
+	});
+
+	test("foreign events are ignored", () => {
+		const wrongPkg = {
+			...mintedEvent(1n),
+			eventType: `0x${"aa".repeat(32)}::order_events::OrderMinted`,
+		};
+		const wrongName = {
+			...mintedEvent(1n),
+			eventType: `${cfg.packages.predict}::order_events::SomethingElse`,
+		};
+		expect(decodeMints(cfg, { events: [wrongPkg, wrongName] })).toEqual([]);
+	});
+
+	test("facade singular: throws unless exactly one", () => {
+		const pc = new PredictClient({
+			network: "testnet",
+			client: { simulateTransaction: async () => ({}) } as never,
+		});
+		expect(() => pc.decode.mint({ events: [] })).toThrow(PredictInputError);
+		expect(() => pc.decode.mint({ events: [mintedEvent(1n), mintedEvent(2n)] })).toThrow(
+			/found 2/,
+		);
+		expect(pc.decode.mint({ events: [mintedEvent(3n)] }).orderId).toBe(3n);
+	});
+});
+
+describe("decodeRedeems", () => {
+	const LiveOrderRedeemedBcs = bcs.struct("LiveOrderRedeemed", {
+		expiry_market_id: bcs.Address,
+		account_id: bcs.Address,
+		order_id: bcs.u256(),
+		position_root_id: bcs.u256(),
+		owner: bcs.Address,
+		quantity_closed: bcs.u64(),
+		remaining_quantity: bcs.u64(),
+		replacement_order_id: bcs.option(bcs.u256()),
+		redeem_amount: bcs.u64(),
+		trading_fee: bcs.u64(),
+		builder_fee: bcs.u64(),
+		penalty_fee: bcs.u64(),
+		builder_code_id: bcs.option(bcs.Address),
+	});
+
+	function liveRedeem(replacement: bigint | null): DecodableEvent {
+		return {
+			eventType: `${cfg.packages.predict}::order_events::LiveOrderRedeemed`,
+			bcs: LiveOrderRedeemedBcs.serialize({
+				expiry_market_id: MARKET,
+				account_id: ACCOUNT,
+				order_id: 7n,
+				position_root_id: 7n,
+				owner: OWNER,
+				quantity_closed: 20_000_000n,
+				remaining_quantity: replacement == null ? 0n : 30_000_000n,
+				replacement_order_id: replacement,
+				redeem_amount: 6_000_000n,
+				trading_fee: 50_000n,
+				builder_fee: 0n,
+				penalty_fee: 0n,
+				builder_code_id: null,
+			}).toBytes(),
+		};
+	}
+
+	test("partial close surfaces the replacement order id", () => {
+		const [r] = decodeRedeems(cfg, { events: [liveRedeem(8n)] });
+		expect(r.replacementOrderId).toBe(8n);
+		expect(r.remaining).toBe(30);
+		expect(r.proceeds).toBe(6);
+		expect(r.liquidated).toBe(false);
+	});
+
+	test("full close → replacement null", () => {
+		const [r] = decodeRedeems(cfg, { events: [liveRedeem(null)] });
+		expect(r.replacementOrderId).toBeNull();
+		expect(r.remaining).toBe(0);
+	});
+
+	test("liquidated tombstone → zero payout, liquidated flag", () => {
+		const LiquidatedBcs = bcs.struct("LiquidatedOrderRedeemed", {
+			expiry_market_id: bcs.Address,
+			account_id: bcs.Address,
+			order_id: bcs.u256(),
+			position_root_id: bcs.u256(),
+			owner: bcs.Address,
+			quantity_closed: bcs.u64(),
+		});
+		const [r] = decodeRedeems(cfg, {
+			events: [
+				{
+					eventType: `${cfg.packages.predict}::order_events::LiquidatedOrderRedeemed`,
+					bcs: LiquidatedBcs.serialize({
+						expiry_market_id: MARKET,
+						account_id: ACCOUNT,
+						order_id: 7n,
+						position_root_id: 7n,
+						owner: OWNER,
+						quantity_closed: 50_000_000n,
+					}).toBytes(),
+				},
+			],
+		});
+		expect(r.liquidated).toBe(true);
+		expect(r.proceeds).toBe(0);
+		expect(r.quantityClosed).toBe(50);
+	});
+});
+
+describe("other decoders", () => {
+	test("claim receipt", () => {
+		const SettledBcs = bcs.struct("SettledOrderRedeemed", {
+			expiry_market_id: bcs.Address,
+			account_id: bcs.Address,
+			order_id: bcs.u256(),
+			position_root_id: bcs.u256(),
+			owner: bcs.Address,
+			quantity_closed: bcs.u64(),
+			settlement_price: bcs.u64(),
+			payout_amount: bcs.u64(),
+		});
+		const [r] = decodeClaims(cfg, {
+			events: [
+				{
+					eventType: `${cfg.packages.predict}::order_events::SettledOrderRedeemed`,
+					bcs: SettledBcs.serialize({
+						expiry_market_id: MARKET,
+						account_id: ACCOUNT,
+						order_id: 7n,
+						position_root_id: 7n,
+						owner: OWNER,
+						quantity_closed: 50_000_000n,
+						settlement_price: 106_000_000_000_000n,
+						payout_amount: 50_000_000n,
+					}).toBytes(),
+				},
+			],
+		});
+		expect(r.settlementPrice).toBe(106_000);
+		expect(r.payout).toBe(50);
+	});
+
+	test("createManager receipt", () => {
+		const AccountCreatedBcs = bcs.struct("AccountCreated", {
+			account_id: bcs.Address,
+			wrapper_id: bcs.Address,
+			owner: bcs.Address,
+			self_owned: bcs.bool(),
+		});
+		const [r] = decodeAccountsCreated(cfg, {
+			events: [
+				{
+					eventType: `${cfg.packages.account}::account_events::AccountCreated`,
+					bcs: AccountCreatedBcs.serialize({
+						account_id: ACCOUNT,
+						wrapper_id: VAULT,
+						owner: OWNER,
+						self_owned: true,
+					}).toBytes(),
+				},
+			],
+		});
+		expect(r).toEqual({ accountId: ACCOUNT, wrapperId: VAULT, owner: OWNER, selfOwned: true });
+	});
+
+	test("deposit receipt carries new balance", () => {
+		const DepositedBcs = bcs.struct("Deposited", {
+			account_id: bcs.Address,
+			coin_type: bcs.string(),
+			amount: bcs.u64(),
+			new_balance: bcs.u64(),
+		});
+		const [r] = decodeDeposits(cfg, {
+			events: [
+				{
+					eventType: `${cfg.packages.account}::account_events::Deposited`,
+					bcs: DepositedBcs.serialize({
+						account_id: ACCOUNT,
+						coin_type: cfg.quoteCoinType.slice(2),
+						amount: 250_000_000n,
+						new_balance: 1_000_000_000n,
+					}).toBytes(),
+				},
+			],
+		});
+		expect(r.amount).toBe(250);
+		expect(r.newBalance).toBe(1000);
+	});
+
+	test("plp request receipt yields the cancel index", () => {
+		const SupplyRequestedBcs = bcs.struct("SupplyRequested", {
+			pool_vault_id: bcs.Address,
+			account_id: bcs.Address,
+			recipient: bcs.Address,
+			index: bcs.u64(),
+			amount: bcs.u64(),
+		});
+		const [r] = decodePlpRequests(cfg, {
+			events: [
+				{
+					eventType: `${cfg.packages.predict}::vault_events::SupplyRequested`,
+					bcs: SupplyRequestedBcs.serialize({
+						pool_vault_id: VAULT,
+						account_id: ACCOUNT,
+						recipient: OWNER,
+						index: 42n,
+						amount: 100_000_000n,
+					}).toBytes(),
+				},
+			],
+		});
+		expect(r.kind).toBe("supply");
+		expect(r.index).toBe(42n);
+		expect(r.amount).toBe(100);
+	});
+
+	test("plp cancel receipt", () => {
+		const RequestCancelledBcs = bcs.struct("RequestCancelled", {
+			pool_vault_id: bcs.Address,
+			account_id: bcs.Address,
+			recipient: bcs.Address,
+			index: bcs.u64(),
+			amount: bcs.u64(),
+			is_supply: bcs.bool(),
+		});
+		const [r] = decodePlpCancels(cfg, {
+			events: [
+				{
+					eventType: `${cfg.packages.predict}::vault_events::RequestCancelled`,
+					bcs: RequestCancelledBcs.serialize({
+						pool_vault_id: VAULT,
+						account_id: ACCOUNT,
+						recipient: OWNER,
+						index: 42n,
+						amount: 100_000_000n,
+						is_supply: true,
+					}).toBytes(),
+				},
+			],
+		});
+		expect(r.index).toBe(42n);
+		expect(r.isSupply).toBe(true);
+	});
+
+	test("missing bcs payload → descriptive error", () => {
+		expect(() =>
+			decodeMints(cfg, {
+				events: [{ eventType: `${cfg.packages.predict}::order_events::OrderMinted` }],
+			}),
+		).toThrow(/events included/);
+	});
+});

--- a/packages/predict/sdk/tests/decode.test.ts
+++ b/packages/predict/sdk/tests/decode.test.ts
@@ -167,11 +167,14 @@ describe("decodeRedeems", () => {
 		};
 	}
 
-	test("partial close surfaces the replacement order id", () => {
+	test("partial close surfaces the replacement order id and NET proceeds", () => {
 		const [r] = decodeRedeems(cfg, { events: [liveRedeem(8n)] });
 		expect(r.replacementOrderId).toBe(8n);
 		expect(r.remaining).toBe(30);
-		expect(r.proceeds).toBe(6);
+		// redeem_amount 6.0 is GROSS; net = gross − trading (0.05) − builder − penalty
+		expect(r.gross).toBe(6);
+		expect(r.proceeds).toBe(5.95);
+		expect(r.raw.proceeds).toBe(5_950_000n);
 		expect(r.liquidated).toBe(false);
 	});
 

--- a/packages/predict/sdk/tests/errors.test.ts
+++ b/packages/predict/sdk/tests/errors.test.ts
@@ -19,7 +19,7 @@ describe("decodeMoveAbort", () => {
 		expect(e).toBeInstanceOf(PredictMoveError);
 		expect(e).toMatchObject({
 			module: "expiry_market",
-			code: 6,
+			code: 6n,
 			abortName: "EMintQuantityBelowMin",
 		});
 	});
@@ -27,13 +27,19 @@ describe("decodeMoveAbort", () => {
 	test("known module, unknown code → abortName null", () => {
 		const e = decodeMoveAbort(ABORT_STR.replace(/, 6\)$/, ", 99)"));
 		expect(e?.module).toBe("expiry_market");
-		expect(e?.code).toBe(99);
+		expect(e?.code).toBe(99n);
 		expect(e?.abortName).toBeNull();
 	});
 
 	test("unknown module → abortName null", () => {
 		const e = decodeMoveAbort(ABORT_STR.replace("expiry_market", "nonsense_mod"));
 		expect(e?.module).toBe("nonsense_mod");
+		expect(e?.abortName).toBeNull();
+	});
+
+	test("u64 abort codes above 2^53 decode exactly (clever-error packing)", () => {
+		const e = decodeMoveAbort(ABORT_STR.replace(/, 6\)$/, ", 9223372036854775814)"));
+		expect(e?.code).toBe(9223372036854775814n);
 		expect(e?.abortName).toBeNull();
 	});
 
@@ -45,7 +51,7 @@ describe("decodeMoveAbort", () => {
 
 	test("tolerates a trailing suffix after the abort code (e.g. ' in command 0')", () => {
 		const e = decodeMoveAbort(`${ABORT_STR} in command 0`);
-		expect(e).toMatchObject({ module: "expiry_market", code: 6 });
+		expect(e).toMatchObject({ module: "expiry_market", code: 6n });
 	});
 
 	test("message includes module and abort name when known", () => {

--- a/packages/predict/sdk/tests/errors.test.ts
+++ b/packages/predict/sdk/tests/errors.test.ts
@@ -1,0 +1,123 @@
+import { Transaction } from "@mysten/sui/transactions";
+import { describe, expect, test } from "vitest";
+import {
+	ABORT_TABLES,
+	PredictInputError,
+	PredictMoveError,
+	decodeMoveAbort,
+} from "../src/errors.js";
+import type { ReadClient } from "../src/reads/inspect.js";
+import { inspectReturns } from "../src/reads/inspect.js";
+
+// A representative failure string as the gRPC/JSON-RPC layer renders a MoveAbort.
+const ABORT_STR =
+	'MoveAbort(MoveLocation { module: ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000abc, name: Identifier("expiry_market") }, function: 12, instruction: 34 }, 6)';
+
+describe("decodeMoveAbort", () => {
+	test("decodes a real abort string to module/code/name", () => {
+		const e = decodeMoveAbort(ABORT_STR);
+		expect(e).toBeInstanceOf(PredictMoveError);
+		expect(e).toMatchObject({
+			module: "expiry_market",
+			code: 6,
+			abortName: "EMintQuantityBelowMin",
+		});
+	});
+
+	test("known module, unknown code → abortName null", () => {
+		const e = decodeMoveAbort(ABORT_STR.replace(/, 6\)$/, ", 99)"));
+		expect(e?.module).toBe("expiry_market");
+		expect(e?.code).toBe(99);
+		expect(e?.abortName).toBeNull();
+	});
+
+	test("unknown module → abortName null", () => {
+		const e = decodeMoveAbort(ABORT_STR.replace("expiry_market", "nonsense_mod"));
+		expect(e?.module).toBe("nonsense_mod");
+		expect(e?.abortName).toBeNull();
+	});
+
+	test("non-abort string → null", () => {
+		expect(decodeMoveAbort("some random error")).toBeNull();
+		expect(decodeMoveAbort("InsufficientGas")).toBeNull();
+		expect(decodeMoveAbort("")).toBeNull();
+	});
+
+	test("tolerates a trailing suffix after the abort code (e.g. ' in command 0')", () => {
+		const e = decodeMoveAbort(`${ABORT_STR} in command 0`);
+		expect(e).toMatchObject({ module: "expiry_market", code: 6 });
+	});
+
+	test("message includes module and abort name when known", () => {
+		const msg = decodeMoveAbort(ABORT_STR)!.message;
+		expect(msg).toContain("expiry_market");
+		expect(msg).toContain("EMintQuantityBelowMin");
+	});
+
+	test("message includes the raw code when the abort is unnamed", () => {
+		const msg = decodeMoveAbort(ABORT_STR.replace(/, 6\)$/, ", 99)"))!.message;
+		expect(msg).toContain("expiry_market");
+		expect(msg).toContain("99");
+	});
+});
+
+describe("ABORT_TABLES", () => {
+	test("carry the six covered modules with their seed values", () => {
+		expect(ABORT_TABLES.expiry_market[6]).toBe("EMintQuantityBelowMin");
+		expect(ABORT_TABLES.expiry_market[0]).toBe("EMintPaused");
+		expect(ABORT_TABLES.plp[5]).toBe("EPlpPriceBelowCircuitBreaker");
+		expect(ABORT_TABLES.plp[6]).toBe("EPlpPriceAboveCircuitBreaker");
+		expect(ABORT_TABLES.lp_book[0]).toBe("ERequestNotFound");
+		expect(ABORT_TABLES.predict_account[1]).toBe("EPositionNotFound");
+		expect(ABORT_TABLES.account[0]).toBe("EInvalidOwner");
+		expect(ABORT_TABLES.registry[0]).toBe("EPauseCapNotValid");
+	});
+});
+
+describe("PredictInputError", () => {
+	test("is an Error subclass carrying its message", () => {
+		const e = new PredictInputError("bad input");
+		expect(e).toBeInstanceOf(Error);
+		expect(e.message).toBe("bad input");
+	});
+});
+
+describe("inspectReturns decodes aborts on FailedTransaction", () => {
+	function failingClient(error: unknown): ReadClient {
+		return {
+			async simulateTransaction() {
+				return {
+					$kind: "FailedTransaction",
+					FailedTransaction: { status: { success: false, error } },
+					commandResults: undefined,
+				};
+			},
+		} as unknown as ReadClient;
+	}
+
+	test("throws PredictMoveError from the display `message` string", async () => {
+		const client = failingClient({ message: ABORT_STR });
+		const err = await inspectReturns(client, new Transaction()).catch((e) => e);
+		expect(err).toBeInstanceOf(PredictMoveError);
+		expect(err.abortName).toBe("EMintQuantityBelowMin");
+	});
+
+	test("throws PredictMoveError from the structured gRPC MoveAbort arm", async () => {
+		const client = failingClient({
+			$kind: "MoveAbort",
+			message: "transaction aborted",
+			MoveAbort: { abortCode: "6", location: { module: "expiry_market" } },
+		});
+		const err = await inspectReturns(client, new Transaction()).catch((e) => e);
+		expect(err).toBeInstanceOf(PredictMoveError);
+		expect(err.abortName).toBe("EMintQuantityBelowMin");
+	});
+
+	test("falls back to a plain Error when the abort cannot be decoded", async () => {
+		const client = failingClient({ message: "InsufficientGas" });
+		const err = await inspectReturns(client, new Transaction()).catch((e) => e);
+		expect(err).toBeInstanceOf(Error);
+		expect(err).not.toBeInstanceOf(PredictMoveError);
+		expect(err.message).toContain("InsufficientGas");
+	});
+});

--- a/packages/predict/sdk/tests/positions.test.ts
+++ b/packages/predict/sdk/tests/positions.test.ts
@@ -1,0 +1,181 @@
+import { bcs } from "@mysten/sui/bcs";
+import { deriveDynamicFieldID, normalizeSuiAddress } from "@mysten/sui/utils";
+import { describe, expect, test } from "vitest";
+import { PredictClient } from "../src/client.js";
+import { TESTNET_CONFIG as cfg } from "../src/config/index.js";
+import { PredictInputError } from "../src/errors.js";
+import {
+	positionsFromTable,
+	resolvePositionsTable,
+	type ObjectReadClient,
+} from "../src/reads/positions.js";
+import { deriveAccountWrapperId } from "../src/tx/common.js";
+
+const OWNER = "0x" + "ab".repeat(32);
+const ACCOUNT_UID = "0x" + "22".repeat(32);
+const TABLE_ID = "0x" + "33".repeat(32);
+const MARKET = "0x" + "44".repeat(32);
+
+// Fixtures serialize with the same layouts as src (field order anchored to the
+// deployed structs; the live smoke validates against the real chain).
+const BagBcs = bcs.struct("Bag", { id: bcs.Address, size: bcs.u64() });
+const wrapperContent = bcs
+	.struct("AccountWrapper", {
+		id: bcs.Address,
+		account: bcs.struct("Account", {
+			account_id: bcs.Address,
+			owner: bcs.Address,
+			receive_address: bcs.Address,
+			balances: BagBcs,
+			settlements: BagBcs,
+		}),
+	})
+	.serialize({
+		id: deriveAccountWrapperId(cfg, OWNER),
+		account: {
+			account_id: ACCOUNT_UID,
+			owner: OWNER,
+			receive_address: OWNER,
+			balances: { id: "0x1", size: 0n },
+			settlements: { id: "0x2", size: 0n },
+		},
+	})
+	.toBytes();
+
+const dataFieldContent = bcs
+	.struct("Field", {
+		id: bcs.Address,
+		name: bcs.bool(), // DataKey's hidden dummy_field
+		value: bcs.struct("PredictData", {
+			positions: bcs.struct("T1", { id: bcs.Address, size: bcs.u64() }),
+			expiry_summaries: bcs.struct("T2", { id: bcs.Address, size: bcs.u64() }),
+			active_stake: bcs.u64(),
+			inactive_stake: bcs.u64(),
+			stake_epoch: bcs.u64(),
+			builder_code_id: bcs.option(bcs.Address),
+		}),
+	})
+	.serialize({
+		id: "0x5",
+		name: false,
+		value: {
+			positions: { id: TABLE_ID, size: 2n },
+			expiry_summaries: { id: "0x6", size: 1n },
+			active_stake: 0n,
+			inactive_stake: 0n,
+			stake_epoch: 1n,
+			builder_code_id: null,
+		},
+	})
+	.toBytes();
+
+const keyBcs = (orderId: bigint) =>
+	bcs
+		.struct("PositionKey", { expiry_market_id: bcs.Address, order_id: bcs.u256() })
+		.serialize({ expiry_market_id: MARKET, order_id: orderId })
+		.toBytes();
+
+const DATA_FIELD_ID = deriveDynamicFieldID(
+	ACCOUNT_UID,
+	`${cfg.packages.account}::account::DataKey<${cfg.packages.predict}::predict_account::PredictApp>`,
+	new Uint8Array([0]),
+);
+
+function mockClient(opts: { pages?: number } = {}) {
+	const pages = opts.pages ?? 1;
+	const calls = { getObject: 0, listDynamicFields: 0 };
+	const client = {
+		async getObject({ objectId }: { objectId: string }) {
+			calls.getObject++;
+			if (normalizeSuiAddress(objectId) === normalizeSuiAddress(deriveAccountWrapperId(cfg, OWNER))) {
+				return { object: { content: wrapperContent } };
+			}
+			if (normalizeSuiAddress(objectId) === normalizeSuiAddress(DATA_FIELD_ID)) {
+				return { object: { content: dataFieldContent } };
+			}
+			throw new Error(`object not found: ${objectId}`);
+		},
+		async listDynamicFields({ cursor }: { parentId: string; cursor?: string }) {
+			calls.listDynamicFields++;
+			const page = cursor ? Number(cursor) : 0;
+			const base = BigInt(page * 2);
+			return {
+				hasNextPage: page + 1 < pages,
+				cursor: page + 1 < pages ? String(page + 1) : null,
+				dynamicFields: [
+					{ fieldId: "0x7", type: "", valueType: "", name: { type: "", bcs: keyBcs(base + 1n) } },
+					{ fieldId: "0x8", type: "", valueType: "", name: { type: "", bcs: keyBcs(base + 2n) } },
+				],
+			};
+		},
+	} as unknown as ObjectReadClient;
+	return { client, calls };
+}
+
+describe("position enumeration", () => {
+	test("resolvePositionsTable walks wrapper → derived data field → table id", async () => {
+		const { client, calls } = mockClient();
+		const handle = await resolvePositionsTable(client, cfg, OWNER);
+		expect(handle).toEqual({
+			accountUid: ACCOUNT_UID,
+			positionsTableId: TABLE_ID,
+			positionCount: 2n,
+		});
+		expect(calls.getObject).toBe(2); // wrapper + derived field — no listing needed
+	});
+
+	test("never-onboarded owner → null handle, [] from the facade", async () => {
+		const client = {
+			async getObject() {
+				throw new Error("Object 0xabc not found");
+			},
+			async listDynamicFields() {
+				throw new Error("unreachable");
+			},
+		} as unknown as ObjectReadClient;
+		expect(await resolvePositionsTable(client, cfg, OWNER)).toBeNull();
+		const pc = new PredictClient({ network: "testnet", client: client as never });
+		expect(await pc.read.positions(OWNER)).toEqual([]);
+	});
+
+	test("keys parse from dynamic-field names — no per-entry fetches", async () => {
+		const { client, calls } = mockClient();
+		const out = await positionsFromTable(client, TABLE_ID);
+		expect(out).toEqual([
+			{ marketId: MARKET, orderId: 1n },
+			{ marketId: MARKET, orderId: 2n },
+		]);
+		expect(calls.getObject).toBe(0);
+		expect(calls.listDynamicFields).toBe(1);
+	});
+
+	test("pagination follows cursors and maxPages guards runaways", async () => {
+		const three = mockClient({ pages: 3 });
+		const out = await positionsFromTable(three.client, TABLE_ID);
+		expect(out.length).toBe(6);
+		expect(three.calls.listDynamicFields).toBe(3);
+		const many = mockClient({ pages: 99 });
+		await expect(positionsFromTable(many.client, TABLE_ID, { maxPages: 2 })).rejects.toThrow(
+			/maxPages/,
+		);
+	});
+
+	test("facade caches the resolution: second call is one listing only", async () => {
+		const { client, calls } = mockClient();
+		const pc = new PredictClient({ network: "testnet", client: client as never });
+		await pc.read.positions(OWNER);
+		const afterFirst = { ...calls };
+		await pc.read.positions(OWNER);
+		expect(calls.getObject).toBe(afterFirst.getObject); // no re-resolution
+		expect(calls.listDynamicFields).toBe(afterFirst.listDynamicFields + 1);
+	});
+
+	test("simulate-only client → pointed capability error", async () => {
+		const pc = new PredictClient({
+			network: "testnet",
+			client: { simulateTransaction: async () => ({}) } as never,
+		});
+		await expect(pc.read.positions(OWNER)).rejects.toThrow(PredictInputError);
+		await expect(pc.read.positions(OWNER)).rejects.toThrow(/getObject/);
+	});
+});

--- a/packages/predict/sdk/tests/reads.test.ts
+++ b/packages/predict/sdk/tests/reads.test.ts
@@ -9,6 +9,7 @@ import type { ReadClient } from "../src/reads/inspect.js";
 import { inspectReturns } from "../src/reads/inspect.js";
 import {
 	activeMarketIds,
+	rangePrices,
 	currentNav,
 	expiryMarketId,
 	marketState,
@@ -162,6 +163,37 @@ describe("markets reads", () => {
 			mintPaused: true,
 			referenceTickRaw: 10_500_000n,
 		});
+	});
+
+	test("rangePrices: one pricer, both sides, sentinel bounds", async () => {
+		const { client, captured } = mockClient([
+			[new Uint8Array(0)], // load_live_pricer (reference return unused)
+			[bcs.u64().serialize(340_000_000n).toBytes()], // up
+			[bcs.u64().serialize(660_000_000n).toBytes()], // down
+		]);
+		const feeds = {
+			pythFeedId: cfg.underlyings.BTC.pythFeedId,
+			bsSpotFeedId: cfg.underlyings.BTC.bsSpotFeedId,
+			bsForwardFeedId: cfg.underlyings.BTC.bsForwardFeedId,
+			bsSviFeedId: cfg.underlyings.BTC.bsSviFeedId,
+		};
+		const r = await rangePrices(client, cfg, ADDR_A, feeds, 105_000_000_000_000n);
+		expect(r).toEqual({ upRaw: 340_000_000n, downRaw: 660_000_000n });
+		expect(targets(captured.tx!)).toEqual([
+			`${cfg.packages.predict}::expiry_market::load_live_pricer`,
+			`${cfg.packages.predict}::pricing::range_price`,
+			`${cfg.packages.predict}::pricing::range_price`,
+		]);
+		// sentinel bounds: UP = (strike, u64::MAX), DOWN = (0, strike)
+		const pure = captured
+			.tx!.getData()
+			.inputs.filter((i) => "Pure" in i && i.Pure)
+			.map((i) => (i as { Pure: { bytes: string } }).Pure.bytes);
+		const b64u64 = (v: bigint) =>
+			Buffer.from(bcs.u64().serialize(v).toBytes()).toString("base64");
+		expect(pure).toContain(b64u64((1n << 64n) - 1n));
+		expect(pure).toContain(b64u64(0n));
+		expect(pure).toContain(b64u64(105_000_000_000_000n));
 	});
 
 	test("referenceTick: Some → tick, None → null", async () => {

--- a/packages/predict/sdk/tests/reads.test.ts
+++ b/packages/predict/sdk/tests/reads.test.ts
@@ -4,7 +4,7 @@ import { normalizeSuiAddress } from "@mysten/sui/utils";
 import { describe, expect, test } from "vitest";
 import { TESTNET_CONFIG as cfg } from "../src/config/index.js";
 import { PredictMoveError } from "../src/errors.js";
-import { accountBalance } from "../src/reads/balances.js";
+import { accountBalance, hasPosition } from "../src/reads/balances.js";
 import type { ReadClient } from "../src/reads/inspect.js";
 import { inspectReturns } from "../src/reads/inspect.js";
 import {
@@ -12,6 +12,7 @@ import {
 	currentNav,
 	expiryMarketId,
 	marketState,
+	marketStates,
 	settlementPrice,
 } from "../src/reads/markets.js";
 import {
@@ -157,6 +158,48 @@ describe("markets reads", () => {
 			tickSizeRaw: 10_000_000n,
 			mintPaused: true,
 		});
+	});
+
+	test("marketStates: batched N markets in one PTB, parsed by index", async () => {
+		const { client, captured } = mockClient([
+			[bcs.u64().serialize(1_000n).toBytes()], // m0 expiry
+			[bcs.u64().serialize(10_000_000n).toBytes()], // m0 tick
+			[bcs.bool().serialize(false).toBytes()], // m0 paused
+			[bcs.u64().serialize(2_000n).toBytes()], // m1 expiry
+			[bcs.u64().serialize(20_000_000n).toBytes()], // m1 tick
+			[bcs.bool().serialize(true).toBytes()], // m1 paused
+		]);
+		const states = await marketStates(client, cfg, [ADDR_A, ADDR_B]);
+		expect(targets(captured.tx!).length).toBe(6);
+		expect(states).toEqual([
+			{ expiryMs: 1_000n, tickSizeRaw: 10_000_000n, mintPaused: false },
+			{ expiryMs: 2_000n, tickSizeRaw: 20_000_000n, mintPaused: true },
+		]);
+	});
+
+	test("marketStates: empty input → no network call", async () => {
+		let called = 0;
+		const client = {
+			simulateTransaction: async () => {
+				called++;
+				throw new Error("unreachable");
+			},
+		} as unknown as ReadClient;
+		expect(await marketStates(client, cfg, [])).toEqual([]);
+		expect(called).toBe(0);
+	});
+
+	test("hasPosition: load_account → has_position, parses bool", async () => {
+		const { client, captured } = mockClient([
+			[new Uint8Array(0)], // load_account returns a reference — no value needed
+			[bcs.bool().serialize(true).toBytes()],
+		]);
+		const ok = await hasPosition(client, cfg, ADDR_A, ADDR_B, 7n);
+		expect(targets(captured.tx!)).toEqual([
+			`${cfg.packages.account}::account::load_account`,
+			`${cfg.packages.predict}::predict_account::has_position`,
+		]);
+		expect(ok).toBe(true);
 	});
 
 	test("settlementPrice: settled market → u64", async () => {

--- a/packages/predict/sdk/tests/reads.test.ts
+++ b/packages/predict/sdk/tests/reads.test.ts
@@ -13,6 +13,7 @@ import {
 	expiryMarketId,
 	marketState,
 	marketStates,
+	referenceTick,
 	settlementPrice,
 } from "../src/reads/markets.js";
 import {
@@ -141,23 +142,36 @@ describe("markets reads", () => {
 		await expect(expiryMarketId(client, cfg, "DOGE", 1n)).rejects.toThrow(/DOGE/);
 	});
 
-	test("marketState: one PTB with 3 reads, dispatched per command index", async () => {
+	test("marketState: one PTB with 4 reads, dispatched per command index", async () => {
 		const { client, captured } = mockClient([
 			[bcs.u64().serialize(1_700_000_000_000n).toBytes()], // expiry
 			[bcs.u64().serialize(10_000_000n).toBytes()], // tick_size
 			[bcs.bool().serialize(true).toBytes()], // mint_paused
+			[bcs.option(bcs.u64()).serialize(10_500_000n).toBytes()], // reference_tick
 		]);
 		const s = await marketState(client, cfg, "0xdeadbeef");
 		expect(targets(captured.tx!)).toEqual([
 			`${cfg.packages.predict}::expiry_market::expiry`,
 			`${cfg.packages.predict}::expiry_market::tick_size`,
 			`${cfg.packages.predict}::expiry_market::mint_paused`,
+			`${cfg.packages.predict}::expiry_market::reference_tick`,
 		]);
 		expect(s).toEqual({
 			expiryMs: 1_700_000_000_000n,
 			tickSizeRaw: 10_000_000n,
 			mintPaused: true,
+			referenceTickRaw: 10_500_000n,
 		});
+	});
+
+	test("referenceTick: Some → tick, None → null", async () => {
+		const some = mockClient([[bcs.option(bcs.u64()).serialize(42n).toBytes()]]);
+		expect(await referenceTick(some.client, cfg, "0xdeadbeef")).toBe(42n);
+		expect(targets(some.captured.tx!)).toEqual([
+			`${cfg.packages.predict}::expiry_market::reference_tick`,
+		]);
+		const none = mockClient([[bcs.option(bcs.u64()).serialize(null).toBytes()]]);
+		expect(await referenceTick(none.client, cfg, "0xdeadbeef")).toBeNull();
 	});
 
 	test("marketStates: batched N markets in one PTB, parsed by index", async () => {
@@ -165,15 +179,17 @@ describe("markets reads", () => {
 			[bcs.u64().serialize(1_000n).toBytes()], // m0 expiry
 			[bcs.u64().serialize(10_000_000n).toBytes()], // m0 tick
 			[bcs.bool().serialize(false).toBytes()], // m0 paused
+			[bcs.option(bcs.u64()).serialize(7n).toBytes()], // m0 reference
 			[bcs.u64().serialize(2_000n).toBytes()], // m1 expiry
 			[bcs.u64().serialize(20_000_000n).toBytes()], // m1 tick
 			[bcs.bool().serialize(true).toBytes()], // m1 paused
+			[bcs.option(bcs.u64()).serialize(null).toBytes()], // m1 reference (unset)
 		]);
 		const states = await marketStates(client, cfg, [ADDR_A, ADDR_B]);
-		expect(targets(captured.tx!).length).toBe(6);
+		expect(targets(captured.tx!).length).toBe(8);
 		expect(states).toEqual([
-			{ expiryMs: 1_000n, tickSizeRaw: 10_000_000n, mintPaused: false },
-			{ expiryMs: 2_000n, tickSizeRaw: 20_000_000n, mintPaused: true },
+			{ expiryMs: 1_000n, tickSizeRaw: 10_000_000n, mintPaused: false, referenceTickRaw: 7n },
+			{ expiryMs: 2_000n, tickSizeRaw: 20_000_000n, mintPaused: true, referenceTickRaw: null },
 		]);
 	});
 

--- a/packages/predict/sdk/tests/reads.test.ts
+++ b/packages/predict/sdk/tests/reads.test.ts
@@ -1,0 +1,231 @@
+import { bcs } from "@mysten/sui/bcs";
+import { Transaction } from "@mysten/sui/transactions";
+import { normalizeSuiAddress } from "@mysten/sui/utils";
+import { describe, expect, test } from "vitest";
+import { TESTNET_CONFIG as cfg } from "../src/config/index.js";
+import { accountBalance } from "../src/reads/balances.js";
+import type { ReadClient } from "../src/reads/inspect.js";
+import { inspectReturns } from "../src/reads/inspect.js";
+import {
+	activeMarketIds,
+	currentNav,
+	expiryMarketId,
+	marketState,
+} from "../src/reads/markets.js";
+import {
+	parseOptionalId,
+	parseOptionalU64,
+	parseU64LE,
+	parseVectorOfIds,
+} from "../src/reads/parse.js";
+import { poolStats } from "../src/reads/pool.js";
+
+// The moveCall targets in the order the read built its PTB.
+function targets(tx: Transaction): string[] {
+	return tx.getData().commands.flatMap((c) =>
+		"MoveCall" in c && c.MoveCall
+			? [`${c.MoveCall.package}::${c.MoveCall.module}::${c.MoveCall.function}`]
+			: [],
+	);
+}
+
+// A mock ReadClient: returns a canned SimulateTransactionResult-shaped value and
+// captures the Transaction it was called with, plus the options. Result shape per
+// node_modules/@mysten/sui/dist/client/types.d.mts:309-348 (commandResults[].returnValues[].bcs).
+function mockClient(commandReturns: Uint8Array[][], kind: "Transaction" | "FailedTransaction" = "Transaction") {
+	const captured: { tx?: Transaction; opts?: Record<string, unknown> } = {};
+	const client = {
+		async simulateTransaction(opts: { transaction: Transaction } & Record<string, unknown>) {
+			captured.tx = opts.transaction;
+			captured.opts = opts;
+			return {
+				$kind: kind,
+				Transaction: {},
+				FailedTransaction: {},
+				commandResults: commandReturns.map((rvs) => ({
+					returnValues: rvs.map((b) => ({ bcs: b })),
+					mutatedReferences: [],
+				})),
+			};
+		},
+	} as unknown as ReadClient;
+	return { client, captured };
+}
+
+const ADDR_A = normalizeSuiAddress("0x1");
+const ADDR_B = normalizeSuiAddress("0xabc");
+
+describe("parsers (pure, round-trip via bcs)", () => {
+	test("parseU64LE round-trips a bcs u64", () => {
+		expect(parseU64LE(bcs.u64().serialize(42n).toBytes())).toBe(42n);
+		expect(parseU64LE(bcs.u64().serialize(0n).toBytes())).toBe(0n);
+		const big = (1n << 64n) - 1n;
+		expect(parseU64LE(bcs.u64().serialize(big).toBytes())).toBe(big);
+	});
+
+	test("parseVectorOfIds round-trips a bcs vector<address>", () => {
+		expect(parseVectorOfIds(bcs.vector(bcs.Address).serialize([]).toBytes())).toEqual([]);
+		expect(
+			parseVectorOfIds(bcs.vector(bcs.Address).serialize([ADDR_A, ADDR_B]).toBytes()),
+		).toEqual([ADDR_A, ADDR_B]);
+	});
+
+	test("parseOptionalU64 handles Some and None via bcs.option(bcs.u64())", () => {
+		expect(parseOptionalU64(bcs.option(bcs.u64()).serialize(7n).toBytes())).toBe(7n);
+		expect(parseOptionalU64(bcs.option(bcs.u64()).serialize(null).toBytes())).toBeNull();
+	});
+
+	test("parseOptionalId handles Some and None via bcs.option(bcs.Address)", () => {
+		expect(parseOptionalId(bcs.option(bcs.Address).serialize(ADDR_B).toBytes())).toBe(ADDR_B);
+		expect(parseOptionalId(bcs.option(bcs.Address).serialize(null).toBytes())).toBeNull();
+	});
+});
+
+describe("inspectReturns (the network seam)", () => {
+	test("sets sender, checksEnabled:false, include.commandResults; returns per-command bcs", async () => {
+		const { client, captured } = mockClient([
+			[bcs.u64().serialize(5n).toBytes()],
+			[bcs.u64().serialize(6n).toBytes()],
+		]);
+		const tx = new Transaction();
+		const out = await inspectReturns(client, tx);
+		expect(captured.opts?.checksEnabled).toBe(false);
+		expect((captured.opts?.include as { commandResults?: boolean }).commandResults).toBe(true);
+		expect(captured.tx?.getData().sender).toBe(normalizeSuiAddress("0x0"));
+		expect(out).toHaveLength(2);
+		expect(parseU64LE(out[0][0])).toBe(5n);
+		expect(parseU64LE(out[1][0])).toBe(6n);
+	});
+
+	test("honors an explicit sender", async () => {
+		const { client, captured } = mockClient([[bcs.u64().serialize(1n).toBytes()]]);
+		await inspectReturns(client, new Transaction(), ADDR_B);
+		expect(captured.tx?.getData().sender).toBe(ADDR_B);
+	});
+
+	test("throws on FailedTransaction (abort)", async () => {
+		const { client } = mockClient([], "FailedTransaction");
+		await expect(inspectReturns(client, new Transaction())).rejects.toThrow();
+	});
+});
+
+describe("markets reads", () => {
+	test("activeMarketIds: plp::active_expiry_markets(vault), parses vector<ID>", async () => {
+		const { client, captured } = mockClient([
+			[bcs.vector(bcs.Address).serialize([ADDR_A, ADDR_B]).toBytes()],
+		]);
+		const ids = await activeMarketIds(client, cfg);
+		expect(targets(captured.tx!)).toEqual([`${cfg.packages.predict}::plp::active_expiry_markets`]);
+		expect(ids).toEqual([ADDR_A, ADDR_B]);
+	});
+
+	test("expiryMarketId: registry::expiry_market_id, Some → id", async () => {
+		const { client, captured } = mockClient([
+			[bcs.option(bcs.Address).serialize(ADDR_B).toBytes()],
+		]);
+		const id = await expiryMarketId(client, cfg, "BTC", 1_700_000_000_000n);
+		expect(targets(captured.tx!)).toEqual([`${cfg.packages.predict}::registry::expiry_market_id`]);
+		expect(id).toBe(ADDR_B);
+	});
+
+	test("expiryMarketId: None → null", async () => {
+		const { client } = mockClient([[bcs.option(bcs.Address).serialize(null).toBytes()]]);
+		expect(await expiryMarketId(client, cfg, "BTC", 1n)).toBeNull();
+	});
+
+	test("expiryMarketId: unknown underlying throws", async () => {
+		const { client } = mockClient([]);
+		await expect(expiryMarketId(client, cfg, "DOGE", 1n)).rejects.toThrow(/DOGE/);
+	});
+
+	test("marketState: one PTB with 4 reads, dispatched per command index", async () => {
+		const { client, captured } = mockClient([
+			[bcs.u64().serialize(1_700_000_000_000n).toBytes()], // expiry
+			[bcs.u64().serialize(10_000_000n).toBytes()], // tick_size
+			[bcs.bool().serialize(true).toBytes()], // mint_paused
+			[bcs.u64().serialize(65_000_000_000_000n).toBytes()], // settlement_price
+		]);
+		const s = await marketState(client, cfg, "0xdeadbeef");
+		expect(targets(captured.tx!)).toEqual([
+			`${cfg.packages.predict}::expiry_market::expiry`,
+			`${cfg.packages.predict}::expiry_market::tick_size`,
+			`${cfg.packages.predict}::expiry_market::mint_paused`,
+			`${cfg.packages.predict}::expiry_market::settlement_price`,
+		]);
+		expect(s).toEqual({
+			expiryMs: 1_700_000_000_000n,
+			tickSizeRaw: 10_000_000n,
+			mintPaused: true,
+			settlementPriceRaw: 65_000_000_000_000n,
+		});
+	});
+
+	test("currentNav: load_live_pricer → current_nav, parses last command's u64", async () => {
+		const { client, captured } = mockClient([
+			[new Uint8Array([0])], // load_live_pricer's Pricer bytes (opaque here)
+			[bcs.u64().serialize(999n).toBytes()], // current_nav
+		]);
+		const nav = await currentNav(client, cfg, "0xabc123", "BTC");
+		expect(targets(captured.tx!)).toEqual([
+			`${cfg.packages.predict}::expiry_market::load_live_pricer`,
+			`${cfg.packages.predict}::expiry_market::current_nav`,
+		]);
+		expect(nav).toBe(999n);
+	});
+
+	test("currentNav: unknown underlying throws", async () => {
+		const { client } = mockClient([]);
+		await expect(currentNav(client, cfg, "0xabc123", "DOGE")).rejects.toThrow(/DOGE/);
+	});
+});
+
+describe("balances read", () => {
+	test("accountBalance: load_account → balance<T>, parses command 1's u64", async () => {
+		const { client, captured } = mockClient([
+			[], // load_account returns a &Account reference (no bcs return value)
+			[bcs.u64().serialize(123_456n).toBytes()], // balance
+		]);
+		const bal = await accountBalance(client, cfg, ADDR_A);
+		expect(targets(captured.tx!)).toEqual([
+			`${cfg.packages.account}::account::load_account`,
+			`${cfg.packages.account}::account::balance`,
+		]);
+		expect(bal).toBe(123_456n);
+		// default coin type is the quote coin
+		const balCmd = captured.tx!.getData().commands[1];
+		expect(
+			"MoveCall" in balCmd && balCmd.MoveCall?.typeArguments,
+		).toEqual([cfg.quoteCoinType]);
+	});
+
+	test("accountBalance: honors an explicit coin type", async () => {
+		const { client, captured } = mockClient([[], [bcs.u64().serialize(1n).toBytes()]]);
+		await accountBalance(client, cfg, ADDR_A, "0x2::sui::SUI");
+		const balCmd = captured.tx!.getData().commands[1];
+		expect("MoveCall" in balCmd && balCmd.MoveCall?.typeArguments).toEqual(["0x2::sui::SUI"]);
+	});
+});
+
+describe("pool read", () => {
+	test("poolStats: one PTB, 4 plp reads, dispatched per command index", async () => {
+		const { client, captured } = mockClient([
+			[bcs.u64().serialize(1_000n).toBytes()], // plp_total_supply
+			[bcs.u64().serialize(2_000n).toBytes()], // idle_balance
+			[bcs.u64().serialize(3_000n).toBytes()], // supply_requests_pending
+			[bcs.u64().serialize(4_000n).toBytes()], // withdraw_requests_pending
+		]);
+		const stats = await poolStats(client, cfg);
+		expect(targets(captured.tx!)).toEqual([
+			`${cfg.packages.predict}::plp::plp_total_supply`,
+			`${cfg.packages.predict}::plp::idle_balance`,
+			`${cfg.packages.predict}::plp::supply_requests_pending`,
+			`${cfg.packages.predict}::plp::withdraw_requests_pending`,
+		]);
+		expect(stats).toEqual({
+			plpTotalSupply: 1_000n,
+			idleBalance: 2_000n,
+			supplyRequestsPending: 3_000n,
+			withdrawRequestsPending: 4_000n,
+		});
+	});
+});

--- a/packages/predict/sdk/tests/reads.test.ts
+++ b/packages/predict/sdk/tests/reads.test.ts
@@ -175,7 +175,7 @@ describe("markets reads", () => {
 		// abort in std::option. The read maps exactly that abort to null.
 		const client = {
 			simulateTransaction: async () => {
-				throw new PredictMoveError("option", 262145, null);
+				throw new PredictMoveError("option", 262145n, null);
 			},
 		} as unknown as ReadClient;
 		expect(await settlementPrice(client, cfg, "0xdeadbeef")).toBeNull();
@@ -184,7 +184,7 @@ describe("markets reads", () => {
 	test("settlementPrice: unrelated aborts propagate", async () => {
 		const client = {
 			simulateTransaction: async () => {
-				throw new PredictMoveError("expiry_market", 3, "EWrongPythFeed");
+				throw new PredictMoveError("expiry_market", 3n, "EWrongPythFeed");
 			},
 		} as unknown as ReadClient;
 		await expect(settlementPrice(client, cfg, "0xdeadbeef")).rejects.toThrow(

--- a/packages/predict/sdk/tests/reads.test.ts
+++ b/packages/predict/sdk/tests/reads.test.ts
@@ -3,6 +3,7 @@ import { Transaction } from "@mysten/sui/transactions";
 import { normalizeSuiAddress } from "@mysten/sui/utils";
 import { describe, expect, test } from "vitest";
 import { TESTNET_CONFIG as cfg } from "../src/config/index.js";
+import { PredictMoveError } from "../src/errors.js";
 import { accountBalance } from "../src/reads/balances.js";
 import type { ReadClient } from "../src/reads/inspect.js";
 import { inspectReturns } from "../src/reads/inspect.js";
@@ -11,6 +12,7 @@ import {
 	currentNav,
 	expiryMarketId,
 	marketState,
+	settlementPrice,
 } from "../src/reads/markets.js";
 import {
 	parseOptionalId,
@@ -138,26 +140,56 @@ describe("markets reads", () => {
 		await expect(expiryMarketId(client, cfg, "DOGE", 1n)).rejects.toThrow(/DOGE/);
 	});
 
-	test("marketState: one PTB with 4 reads, dispatched per command index", async () => {
+	test("marketState: one PTB with 3 reads, dispatched per command index", async () => {
 		const { client, captured } = mockClient([
 			[bcs.u64().serialize(1_700_000_000_000n).toBytes()], // expiry
 			[bcs.u64().serialize(10_000_000n).toBytes()], // tick_size
 			[bcs.bool().serialize(true).toBytes()], // mint_paused
-			[bcs.u64().serialize(65_000_000_000_000n).toBytes()], // settlement_price
 		]);
 		const s = await marketState(client, cfg, "0xdeadbeef");
 		expect(targets(captured.tx!)).toEqual([
 			`${cfg.packages.predict}::expiry_market::expiry`,
 			`${cfg.packages.predict}::expiry_market::tick_size`,
 			`${cfg.packages.predict}::expiry_market::mint_paused`,
-			`${cfg.packages.predict}::expiry_market::settlement_price`,
 		]);
 		expect(s).toEqual({
 			expiryMs: 1_700_000_000_000n,
 			tickSizeRaw: 10_000_000n,
 			mintPaused: true,
-			settlementPriceRaw: 65_000_000_000_000n,
 		});
+	});
+
+	test("settlementPrice: settled market → u64", async () => {
+		const { client, captured } = mockClient([
+			[bcs.u64().serialize(65_000_000_000_000n).toBytes()],
+		]);
+		const p = await settlementPrice(client, cfg, "0xdeadbeef");
+		expect(targets(captured.tx!)).toEqual([
+			`${cfg.packages.predict}::expiry_market::settlement_price`,
+		]);
+		expect(p).toBe(65_000_000_000_000n);
+	});
+
+	test("settlementPrice: unsettled market's option abort → null", async () => {
+		// The deployed getter destroy_some()s the stored Option; unsettled markets
+		// abort in std::option. The read maps exactly that abort to null.
+		const client = {
+			simulateTransaction: async () => {
+				throw new PredictMoveError("option", 262145, null);
+			},
+		} as unknown as ReadClient;
+		expect(await settlementPrice(client, cfg, "0xdeadbeef")).toBeNull();
+	});
+
+	test("settlementPrice: unrelated aborts propagate", async () => {
+		const client = {
+			simulateTransaction: async () => {
+				throw new PredictMoveError("expiry_market", 3, "EWrongPythFeed");
+			},
+		} as unknown as ReadClient;
+		await expect(settlementPrice(client, cfg, "0xdeadbeef")).rejects.toThrow(
+			PredictMoveError,
+		);
 	});
 
 	test("currentNav: load_live_pricer → current_nav, parses last command's u64", async () => {

--- a/packages/predict/sdk/tests/smoke.test.ts
+++ b/packages/predict/sdk/tests/smoke.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from "vitest";
+
+import { SDK_NAME } from "../src/index.js";
+
+test("package exports", () => expect(SDK_NAME).toBe("@mysten/predict"));

--- a/packages/predict/sdk/tests/testnet/smoke.test.ts
+++ b/packages/predict/sdk/tests/testnet/smoke.test.ts
@@ -189,6 +189,31 @@ describe("testnet smoke (live deployment)", () => {
 		).rejects.toThrow(/Object|Move abort|aborted|not found|no market/i);
 	});
 
+	test("read.positions: never-onboarded owner resolves to [] against the live chain", async () => {
+		// Validates the wrapper-derivation + not-found path with real node errors.
+		expect(await predict.read.positions(SMOKE_SENDER)).toEqual([]);
+	});
+
+	test("read.positions: real owner enumerates from the live account table (opt-in)", async () => {
+		// Set PREDICT_SDK_SMOKE_OWNER to a funded testnet owner to validate the
+		// full BCS walk (wrapper → PredictData → positions table) against real
+		// objects. Kept out of the repo: no fixture addresses in public code.
+		const owner = process.env.PREDICT_SDK_SMOKE_OWNER;
+		if (!owner) return;
+		const out = await predict.read.positions(owner);
+		expect(Array.isArray(out)).toBe(true);
+		for (const p of out) {
+			expect(p.marketId).toMatch(/^0x[0-9a-f]{64}$/);
+			expect(p.orderId > 0n).toBe(true);
+			// Cross-validate a sample against the on-chain membership check.
+		}
+		if (out.length > 0) {
+			expect(await predict.read.hasPosition(owner, out[0].marketId, out[0].orderId)).toBe(
+				true,
+			);
+		}
+	});
+
 	test("createManager simulates clean AND its real event decodes", async () => {
 		const tx = predict.tx.createManager();
 		tx.setSender(SMOKE_SENDER);

--- a/packages/predict/sdk/tests/testnet/smoke.test.ts
+++ b/packages/predict/sdk/tests/testnet/smoke.test.ts
@@ -153,6 +153,42 @@ describe("testnet smoke (live deployment)", () => {
 		expectSemanticOrSuccess(await simulate(tx), "redeem_live");
 	});
 
+	test("read.price: live both-sides pricing for a grid strike", async () => {
+		if (liveMarkets.length === 0) return;
+		const m = liveMarkets[0];
+		// A deep-ITM-for-UP strike: 1000 ticks above zero — any grid point works,
+		// the assertion is on plumbing + probability domain, not on moneyness.
+		const strike = m.tickSize * 1_000;
+		const p = await predict.read.price({
+			underlying: "BTC",
+			expiryMs: m.expiryMs,
+			strike,
+		});
+		expect(p.up).toBeGreaterThanOrEqual(0);
+		expect(p.up).toBeLessThanOrEqual(1);
+		expect(p.down).toBeGreaterThanOrEqual(0);
+		expect(p.down).toBeLessThanOrEqual(1);
+		// Complementary within chain rounding.
+		expect(Math.abs(p.up + p.down - 1)).toBeLessThan(0.05);
+	});
+
+	test("read.quoteMint: unfunded owner fails as a typed semantic abort (preflight)", async () => {
+		if (liveMarkets.length === 0) return;
+		const m = liveMarkets[0];
+		// SMOKE_SENDER never onboarded, so its derived wrapper doesn't exist:
+		// the dry-run fails at input resolution ("Object 0x… " from the node) —
+		// while a funded-but-broke owner would surface a typed Move abort. Either
+		// way the quote fails EXACTLY like the real trade would (preflight), and
+		// this proves the build → simulate-with-events → error path live.
+		await expect(
+			predict.read.quoteMint(
+				SMOKE_SENDER,
+				{ underlying: "BTC", expiryMs: m.expiryMs, strike: m.tickSize * 1_000, side: "up" },
+				{ quantity: 1 },
+			),
+		).rejects.toThrow(/Object|Move abort|aborted|not found|no market/i);
+	});
+
 	test("createManager simulates clean AND its real event decodes", async () => {
 		const tx = predict.tx.createManager();
 		tx.setSender(SMOKE_SENDER);

--- a/packages/predict/sdk/tests/testnet/smoke.test.ts
+++ b/packages/predict/sdk/tests/testnet/smoke.test.ts
@@ -1,0 +1,171 @@
+// Live-testnet smoke suite — the SDK's first contact with the real deployment.
+// Network-gated: runs only under `pnpm test:testnet` (PREDICT_SDK_TESTNET=1).
+//
+// What this proves that the offline suite cannot:
+//  1. The real gRPC SimulateTransactionResult shape matches what reads/inspect.ts
+//     codes against (commandResults[i].returnValues[j].bcs).
+//  2. Every config object id resolves on chain (a read returning data uses the
+//     registry, pool vault, feeds, protocol config, and the DUSDC coin type).
+//  3. The arity guard: our mint/redeem builders execute against the DEPLOYED
+//     entrypoints far enough that any failure is a semantic Move abort — never a
+//     VM verification / argument-arity error. This detects deployed-surface
+//     signature drift (argument count/type). It cannot detect swaps between
+//     same-typed arguments; those are pinned by the offline slot tests.
+import { SuiGrpcClient } from "@mysten/sui/grpc";
+import { Transaction } from "@mysten/sui/transactions";
+import { describe, expect, test } from "vitest";
+import {
+	PredictClient,
+	PredictMoveError,
+	TESTNET_CONFIG,
+	accountTarget,
+	marketState,
+	mintExactQuantity,
+	redeemLive,
+} from "../../src/index.js";
+
+const TESTNET_GRPC_URL = "https://fullnode.testnet.sui.io:443";
+
+// A fixed, arbitrary sender for dry-runs. Deliberately not the zero address so
+// `account_registry::new` derives a wrapper id no real user owns.
+const SMOKE_SENDER = "0x51de1e01c51dc51dc51dc51dc51dc51dc51dc51dc51dc51dc51dc51dc51dc51d";
+
+const cfg = TESTNET_CONFIG;
+const client = new SuiGrpcClient({ network: "testnet", baseUrl: TESTNET_GRPC_URL });
+const predict = new PredictClient({ network: "testnet", client });
+
+// Shared across tests (vitest runs a file's tests sequentially by default).
+let liveMarketIds: string[] = [];
+
+// Build a PTB that creates a FRESH AccountWrapper and threads it straight into a
+// trade builder, then shares it. The facade derives wrapper ids for existing
+// accounts, which a throwaway sender does not have — simulation would then fail at
+// input resolution, before the VM ever checks the call's arity. Creating the
+// wrapper in-PTB guarantees execution reaches the deployed Move entrypoint.
+// `tx.object()` passes a result handle through unchanged, so the primitives accept
+// it at runtime; the cast bridges their string-typed wrapperId.
+function freshWrapperTx(): { tx: Transaction; wrapper: string } {
+	const tx = new Transaction();
+	const wrapper = tx.moveCall({
+		target: accountTarget(cfg, "account_registry", "new"),
+		arguments: [tx.object(cfg.objects.accountRegistry)],
+	});
+	return { tx, wrapper: wrapper as unknown as string };
+}
+
+function shareWrapper(tx: Transaction, wrapper: string): void {
+	tx.moveCall({
+		target: accountTarget(cfg, "account", "share"),
+		arguments: [tx.object(wrapper)],
+	});
+}
+
+// Simulate and classify the failure. Returns null on success, the error otherwise.
+async function simulate(tx: Transaction): Promise<unknown> {
+	tx.setSender(SMOKE_SENDER);
+	try {
+		const result = await client.simulateTransaction({
+			transaction: tx,
+			checksEnabled: false,
+		});
+		return result.$kind === "FailedTransaction" ? result.FailedTransaction : null;
+	} catch (e) {
+		return e;
+	}
+}
+
+// The guard: a failure is acceptable only if it is a semantic Move abort (or a
+// typed PredictMoveError our own plumbing decoded). Arity/type drift surfaces as
+// VMVerificationOrDeserializationError / CommandArgumentError instead — fail loud.
+function expectSemanticOrSuccess(outcome: unknown, label: string): void {
+	if (outcome === null) return; // full success is also proof of matching arity
+	const text =
+		outcome instanceof PredictMoveError
+			? `MoveAbort:${outcome.module}:${outcome.code}`
+			: JSON.stringify(outcome, (_, v) => (typeof v === "bigint" ? v.toString() : v));
+	expect(text, `${label}: expected semantic Move abort, got: ${text}`).not.toMatch(
+		/VMVerificationOrDeserialization|CommandArgumentError|InvalidPublicFunctionReturnType|arity|number of arguments/i,
+	);
+	expect(text, `${label}: expected a Move abort, got: ${text}`).toMatch(/MoveAbort/i);
+}
+
+describe("testnet smoke (live deployment)", () => {
+	test("read.markets() — simulate plumbing + result shape end-to-end", async () => {
+		liveMarketIds = await predict.read.markets();
+		expect(Array.isArray(liveMarketIds)).toBe(true);
+		for (const id of liveMarketIds) expect(id).toMatch(/^0x[0-9a-f]{64}$/);
+	});
+
+	test("read.pool() — pool objects resolve, pool is bootstrapped", async () => {
+		const pool = await predict.read.pool();
+		expect(pool.plpTotalSupply > 0n).toBe(true);
+		expect(pool.idleUsdc).toBeGreaterThanOrEqual(0);
+		expect(pool.supplyPending).toBeGreaterThanOrEqual(0);
+		expect(pool.withdrawPending).toBeGreaterThanOrEqual(0);
+	});
+
+	test("marketState + registry mapping agree for a live market", async () => {
+		if (liveMarketIds.length === 0) return; // no live expiry right now — skip
+		const id = liveMarketIds[0];
+		const state = await marketState(client, cfg, id);
+		expect(state.tickSizeRaw > 0n).toBe(true);
+		expect(typeof state.mintPaused).toBe("boolean");
+		expect(state.expiryMs > 0n).toBe(true);
+		// BTC is the only registered underlying on testnet, so the registry must map
+		// (BTC, this expiry) back to this exact market object.
+		const summary = await predict.read.market({ underlying: "BTC", expiryMs: state.expiryMs });
+		expect(summary?.id).toBe(id);
+		expect(summary!.nav).toBeGreaterThanOrEqual(0);
+		expect(summary!.tickSize).toBeGreaterThan(0);
+	});
+
+	test("arity guard: mint_exact_quantity matches the deployed surface", async () => {
+		if (liveMarketIds.length === 0) return;
+		const id = liveMarketIds[0];
+		const state = await marketState(client, cfg, id);
+		const { tx, wrapper } = freshWrapperTx();
+		mintExactQuantity(cfg, tx, {
+			expiryMarketId: id,
+			wrapperId: wrapper,
+			// tick 1_000 is deep in the finite domain for any sane tick size
+			lowerTick: 1_000n,
+			higherTick: 1_001n,
+			quantityRaw: 1_000_000n, // $1 payout, 100 lots
+			leverageRaw: 1_000_000_000n, // 1x
+			...predictFeeds(),
+		});
+		shareWrapper(tx, wrapper);
+		expectSemanticOrSuccess(await simulate(tx), `mint on ${id} (tick ${state.tickSizeRaw})`);
+	});
+
+	test("arity guard: redeem_live matches the deployed surface", async () => {
+		if (liveMarketIds.length === 0) return;
+		const { tx, wrapper } = freshWrapperTx();
+		redeemLive(cfg, tx, {
+			expiryMarketId: liveMarketIds[0],
+			wrapperId: wrapper,
+			orderId: 1n, // no such order for a fresh account — semantic abort expected
+			closeQuantityRaw: 10_000n,
+			...predictFeeds(),
+		});
+		shareWrapper(tx, wrapper);
+		expectSemanticOrSuccess(await simulate(tx), "redeem_live");
+	});
+
+	test("arity guard: createManager simulates clean (account package)", async () => {
+		const tx = predict.tx.createManager();
+		const outcome = await simulate(tx);
+		// A fresh sender has no wrapper yet, so pure create+share must fully succeed.
+		expect(outcome).toBeNull();
+	});
+});
+
+function predictFeeds() {
+	const u = cfg.underlyings.BTC;
+	return {
+		pythFeedId: u.pythFeedId,
+		bsSpotFeedId: u.bsSpotFeedId,
+		bsForwardFeedId: u.bsForwardFeedId,
+		bsSviFeedId: u.bsSviFeedId,
+	};
+}

--- a/packages/predict/sdk/tests/testnet/smoke.test.ts
+++ b/packages/predict/sdk/tests/testnet/smoke.test.ts
@@ -97,6 +97,8 @@ describe("testnet smoke (live deployment)", () => {
 			expect(m.expiryMs > 0n).toBe(true);
 			expect(m.tickSize).toBeGreaterThan(0);
 			expect(typeof m.mintPaused).toBe("boolean");
+			// Option parse validated live: unset → null, seeded → a positive USD price.
+			if (m.referencePrice !== null) expect(m.referencePrice).toBeGreaterThan(0);
 		}
 	});
 

--- a/packages/predict/sdk/tests/testnet/smoke.test.ts
+++ b/packages/predict/sdk/tests/testnet/smoke.test.ts
@@ -19,7 +19,6 @@ import {
 	PredictMoveError,
 	TESTNET_CONFIG,
 	accountTarget,
-	marketState,
 	mintExactQuantity,
 	redeemLive,
 } from "../../src/index.js";
@@ -35,7 +34,7 @@ const client = new SuiGrpcClient({ network: "testnet", baseUrl: TESTNET_GRPC_URL
 const predict = new PredictClient({ network: "testnet", client });
 
 // Shared across tests (vitest runs a file's tests sequentially by default).
-let liveMarketIds: string[] = [];
+let liveMarkets: Awaited<ReturnType<typeof predict.read.markets>> = [];
 
 // Build a PTB that creates a FRESH AccountWrapper and threads it straight into a
 // trade builder, then shares it. The facade derives wrapper ids for existing
@@ -90,10 +89,15 @@ function expectSemanticOrSuccess(outcome: unknown, label: string): void {
 }
 
 describe("testnet smoke (live deployment)", () => {
-	test("read.markets() — simulate plumbing + result shape end-to-end", async () => {
-		liveMarketIds = await predict.read.markets();
-		expect(Array.isArray(liveMarketIds)).toBe(true);
-		for (const id of liveMarketIds) expect(id).toMatch(/^0x[0-9a-f]{64}$/);
+	test("read.markets() — tradeable summaries, simulate plumbing end-to-end", async () => {
+		liveMarkets = await predict.read.markets();
+		expect(Array.isArray(liveMarkets)).toBe(true);
+		for (const m of liveMarkets) {
+			expect(m.id).toMatch(/^0x[0-9a-f]{64}$/);
+			expect(m.expiryMs > 0n).toBe(true);
+			expect(m.tickSize).toBeGreaterThan(0);
+			expect(typeof m.mintPaused).toBe("boolean");
+		}
 	});
 
 	test("read.pool() — pool objects resolve, pool is bootstrapped", async () => {
@@ -104,25 +108,20 @@ describe("testnet smoke (live deployment)", () => {
 		expect(pool.withdrawPending).toBeGreaterThanOrEqual(0);
 	});
 
-	test("marketState + registry mapping agree for a live market", async () => {
-		if (liveMarketIds.length === 0) return; // no live expiry right now — skip
-		const id = liveMarketIds[0];
-		const state = await marketState(client, cfg, id);
-		expect(state.tickSizeRaw > 0n).toBe(true);
-		expect(typeof state.mintPaused).toBe("boolean");
-		expect(state.expiryMs > 0n).toBe(true);
+	test("registry mapping agrees with the summary for a live market", async () => {
+		if (liveMarkets.length === 0) return; // no live expiry right now — skip
+		const m = liveMarkets[0];
 		// BTC is the only registered underlying on testnet, so the registry must map
 		// (BTC, this expiry) back to this exact market object.
-		const summary = await predict.read.market({ underlying: "BTC", expiryMs: state.expiryMs });
-		expect(summary?.id).toBe(id);
+		const summary = await predict.read.market({ underlying: "BTC", expiryMs: m.expiryMs });
+		expect(summary?.id).toBe(m.id);
 		expect(summary!.nav).toBeGreaterThanOrEqual(0);
-		expect(summary!.tickSize).toBeGreaterThan(0);
+		expect(summary!.tickSize).toBe(m.tickSize);
 	});
 
 	test("arity guard: mint_exact_quantity matches the deployed surface", async () => {
-		if (liveMarketIds.length === 0) return;
-		const id = liveMarketIds[0];
-		const state = await marketState(client, cfg, id);
+		if (liveMarkets.length === 0) return;
+		const id = liveMarkets[0].id;
 		const { tx, wrapper } = freshWrapperTx();
 		mintExactQuantity(cfg, tx, {
 			expiryMarketId: id,
@@ -135,14 +134,14 @@ describe("testnet smoke (live deployment)", () => {
 			...predictFeeds(),
 		});
 		shareWrapper(tx, wrapper);
-		expectSemanticOrSuccess(await simulate(tx), `mint on ${id} (tick ${state.tickSizeRaw})`);
+		expectSemanticOrSuccess(await simulate(tx), `mint on ${id}`);
 	});
 
 	test("arity guard: redeem_live matches the deployed surface", async () => {
-		if (liveMarketIds.length === 0) return;
+		if (liveMarkets.length === 0) return;
 		const { tx, wrapper } = freshWrapperTx();
 		redeemLive(cfg, tx, {
-			expiryMarketId: liveMarketIds[0],
+			expiryMarketId: liveMarkets[0].id,
 			wrapperId: wrapper,
 			orderId: 1n, // no such order for a fresh account — semantic abort expected
 			closeQuantityRaw: 10_000n,
@@ -152,11 +151,24 @@ describe("testnet smoke (live deployment)", () => {
 		expectSemanticOrSuccess(await simulate(tx), "redeem_live");
 	});
 
-	test("arity guard: createManager simulates clean (account package)", async () => {
+	test("createManager simulates clean AND its real event decodes", async () => {
 		const tx = predict.tx.createManager();
-		const outcome = await simulate(tx);
-		// A fresh sender has no wrapper yet, so pure create+share must fully succeed.
-		expect(outcome).toBeNull();
+		tx.setSender(SMOKE_SENDER);
+		// include events: this validates decode.createManager against a REAL
+		// emitted event (BCS layout, type matching, byte handling) — the live
+		// anchor for the decoder layer's field-order assumptions.
+		const result = await client.simulateTransaction({
+			transaction: tx,
+			checksEnabled: false,
+			include: { events: true },
+		});
+		expect(result.$kind).toBe("Transaction"); // fresh sender: create+share succeeds
+		const receipt = predict.decode.createManager({
+			events: result.Transaction?.events ?? [],
+		});
+		expect(receipt.owner).toBe(SMOKE_SENDER);
+		// The decoded on-chain wrapper id must equal the client-side derivation.
+		expect(receipt.wrapperId).toBe(predict.wrapperIdFor(SMOKE_SENDER));
 	});
 });
 

--- a/packages/predict/sdk/tests/ticks.test.ts
+++ b/packages/predict/sdk/tests/ticks.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "vitest";
+
+import { POS_INF_TICK, binaryRangeTicks } from "../src/ticks.js";
+import { priceToRaw } from "../src/units.js";
+
+const TICK_SIZE = 10_000_000n;
+
+test("POS_INF_TICK sentinel", () => {
+	expect(POS_INF_TICK).toBe((1n << 30n) - 1n);
+});
+
+test("UP order encodes (strike, +inf)", () => {
+	expect(binaryRangeTicks(priceToRaw(105_000), "up", TICK_SIZE)).toEqual({
+		lowerTick: 10_500_000n,
+		higherTick: POS_INF_TICK,
+	});
+});
+
+test("DOWN order encodes (-inf, strike)", () => {
+	expect(binaryRangeTicks(priceToRaw(105_000), "down", TICK_SIZE)).toEqual({
+		lowerTick: 0n,
+		higherTick: 10_500_000n,
+	});
+});
+
+test("misaligned strike throws", () => {
+	expect(() => binaryRangeTicks(priceToRaw(105_000) + 1n, "up", TICK_SIZE)).toThrow(
+		/tick multiple/,
+	);
+});
+
+test("out-of-domain tick throws", () => {
+	// tick 0 (neg-inf sentinel)
+	expect(() => binaryRangeTicks(0n, "up", TICK_SIZE)).toThrow(/finite tick domain/);
+	// tick >= POS_INF_TICK
+	expect(() => binaryRangeTicks(POS_INF_TICK * TICK_SIZE, "up", TICK_SIZE)).toThrow(
+		/finite tick domain/,
+	);
+});

--- a/packages/predict/sdk/tests/tx-account.test.ts
+++ b/packages/predict/sdk/tests/tx-account.test.ts
@@ -1,0 +1,55 @@
+import { Transaction } from "@mysten/sui/transactions";
+import { expect, test } from "vitest";
+import { TESTNET_CONFIG as cfg } from "../src/config/index.js";
+import { createAccount, depositFunds, withdrawFunds } from "../src/tx/account.js";
+import { deriveAccountWrapperId } from "../src/tx/common.js";
+
+function targets(tx: Transaction): string[] {
+	return tx.getData().commands.flatMap((c) =>
+		"MoveCall" in c && c.MoveCall
+			? [`${c.MoveCall.package}::${c.MoveCall.module}::${c.MoveCall.function}`]
+			: [],
+	);
+}
+
+test("createAccount = registry.new → share", () => {
+	const tx = new Transaction();
+	createAccount(cfg, tx);
+	expect(targets(tx)).toEqual([
+		`${cfg.packages.account}::account_registry::new`,
+		`${cfg.packages.account}::account::share`,
+	]);
+});
+
+test("depositFunds: auth then deposit_funds<DUSDC>", () => {
+	const tx = new Transaction();
+	const coin = tx.object("0xc0");
+	depositFunds(cfg, tx, { wrapperId: "0x123", coin });
+	const t = targets(tx);
+	expect(t[0]).toBe(`${cfg.packages.account}::account::generate_auth`);
+	expect(t[1]).toBe(`${cfg.packages.account}::account::deposit_funds`);
+	expect(tx.getData().commands[1].MoveCall!.typeArguments).toEqual([cfg.quoteCoinType]);
+});
+
+test("depositFunds honors coinType override", () => {
+	const tx = new Transaction();
+	const coin = tx.object("0xc0");
+	depositFunds(cfg, tx, { wrapperId: "0x123", coin, coinType: "0x2::sui::SUI" });
+	expect(tx.getData().commands[1].MoveCall!.typeArguments).toEqual(["0x2::sui::SUI"]);
+});
+
+test("withdrawFunds: auth then withdraw_funds<DUSDC> with amount", () => {
+	const tx = new Transaction();
+	withdrawFunds(cfg, tx, { wrapperId: "0x123", amountRaw: 5_000_000n });
+	const t = targets(tx);
+	expect(t[0]).toBe(`${cfg.packages.account}::account::generate_auth`);
+	expect(t[1]).toBe(`${cfg.packages.account}::account::withdraw_funds`);
+	const call = tx.getData().commands[1].MoveCall!;
+	expect(call.typeArguments).toEqual([cfg.quoteCoinType]);
+});
+
+test("wrapper id derivation is deterministic", () => {
+	const a = deriveAccountWrapperId(cfg, "0x" + "ab".repeat(32));
+	expect(a).toMatch(/^0x[0-9a-f]{64}$/);
+	expect(deriveAccountWrapperId(cfg, "0x" + "ab".repeat(32))).toBe(a);
+});

--- a/packages/predict/sdk/tests/tx-plp.test.ts
+++ b/packages/predict/sdk/tests/tx-plp.test.ts
@@ -1,0 +1,176 @@
+import { bcs } from "@mysten/sui/bcs";
+import { Transaction } from "@mysten/sui/transactions";
+import { normalizeSuiObjectId } from "@mysten/sui/utils";
+import { expect, test } from "vitest";
+import { TESTNET_CONFIG as cfg } from "../src/config/index.js";
+import {
+	setBuilderCode,
+	unsetBuilderCode,
+} from "../src/tx/builderCode.js";
+import {
+	cancelSupplyRequest,
+	cancelWithdrawRequest,
+	requestSupply,
+	requestWithdraw,
+} from "../src/tx/plp.js";
+
+function targets(tx: Transaction): string[] {
+	return tx.getData().commands.flatMap((c) =>
+		"MoveCall" in c && c.MoveCall
+			? [`${c.MoveCall.package}::${c.MoveCall.module}::${c.MoveCall.function}`]
+			: [],
+	);
+}
+
+function call(tx: Transaction, cmdIdx: number) {
+	return tx.getData().commands[cmdIdx].MoveCall!;
+}
+
+// Resolve the object id an argument points at, or undefined if it is not an
+// object input (e.g. it's a pure value or a command result).
+function argObjectId(tx: Transaction, cmdIdx: number, argIdx: number): string | undefined {
+	const arg = call(tx, cmdIdx).arguments[argIdx] as { $kind: string; Input?: number };
+	if (arg.$kind !== "Input" || arg.Input === undefined) return undefined;
+	const input = tx.getData().inputs[arg.Input];
+	if ("Object" in input && input.Object) {
+		const o = input.Object;
+		if ("ImmOrOwnedObject" in o && o.ImmOrOwnedObject) return o.ImmOrOwnedObject.objectId;
+		if ("SharedObject" in o && o.SharedObject) return o.SharedObject.objectId;
+	}
+	if ("UnresolvedObject" in input && input.UnresolvedObject) return input.UnresolvedObject.objectId;
+	return undefined;
+}
+
+// True when the argument at (cmdIdx, argIdx) is an object input pointing at `expected`,
+// comparing in normalized 32-byte form (moveCall pads short ids like "0xdef").
+function expectObject(tx: Transaction, cmdIdx: number, argIdx: number, expected: string) {
+	expect(argObjectId(tx, cmdIdx, argIdx)).toBe(normalizeSuiObjectId(expected));
+}
+
+// Resolve the base64 pure bytes an argument points at, or undefined if the
+// argument is not a pure input.
+function argPureBytes(tx: Transaction, cmdIdx: number, argIdx: number): string | undefined {
+	const arg = call(tx, cmdIdx).arguments[argIdx] as { $kind: string; Input?: number };
+	if (arg.$kind !== "Input" || arg.Input === undefined) return undefined;
+	const input = tx.getData().inputs[arg.Input];
+	return "Pure" in input && input.Pure ? input.Pure.bytes : undefined;
+}
+
+const AUTH = `${cfg.packages.account}::account::generate_auth`;
+
+test("requestSupply: auth → request_supply, 7 args, exact slot kinds/values", () => {
+	const tx = new Transaction();
+	requestSupply(cfg, tx, { wrapperId: "0xdef", amountRaw: 5_000_000n });
+	expect(targets(tx)).toEqual([
+		AUTH,
+		`${cfg.packages.predict}::plp::request_supply`,
+	]);
+	const c = call(tx, 1);
+	// deployed sig: (vault, wrapper, auth, config, amount u64, root, clock, ctx)
+	// → 7 moveCall args (ctx is implicit)
+	expect(c.arguments).toHaveLength(7);
+	// slot 0: vault = cfg.objects.poolVault
+	expectObject(tx, 1, 0, cfg.objects.poolVault);
+	// slot 1: wrapper
+	expectObject(tx, 1, 1, "0xdef");
+	// slot 2: auth (Result from generate_auth immediately before this call)
+	expect(c.arguments[2].$kind).toBe("Result");
+	// slot 3: config = cfg.objects.protocolConfig
+	expectObject(tx, 1, 3, cfg.objects.protocolConfig);
+	// slot 4: pure u64 amount
+	expect(argPureBytes(tx, 1, 4)).toBe(
+		Buffer.from(bcs.u64().serialize(5_000_000n).toBytes()).toString("base64"),
+	);
+	// slot 5: root = 0xacc, slot 6: clock = 0x6
+	expectObject(tx, 1, 5, "0xacc");
+	expectObject(tx, 1, 6, "0x6");
+});
+
+test("requestWithdraw: auth → request_withdraw, 7 args, shares in u64 slot", () => {
+	const tx = new Transaction();
+	requestWithdraw(cfg, tx, { wrapperId: "0xdef", sharesRaw: 1_234n });
+	expect(targets(tx)).toEqual([
+		AUTH,
+		`${cfg.packages.predict}::plp::request_withdraw`,
+	]);
+	const c = call(tx, 1);
+	expect(c.arguments).toHaveLength(7);
+	expectObject(tx, 1, 0, cfg.objects.poolVault);
+	expectObject(tx, 1, 1, "0xdef");
+	expect(c.arguments[2].$kind).toBe("Result");
+	expectObject(tx, 1, 3, cfg.objects.protocolConfig);
+	expect(argPureBytes(tx, 1, 4)).toBe(
+		Buffer.from(bcs.u64().serialize(1_234n).toBytes()).toString("base64"),
+	);
+	expectObject(tx, 1, 5, "0xacc");
+	expectObject(tx, 1, 6, "0x6");
+});
+
+test("cancelSupplyRequest: auth → cancel_supply_request, 7 args, index in u64 slot", () => {
+	const tx = new Transaction();
+	cancelSupplyRequest(cfg, tx, { wrapperId: "0xdef", index: 3n });
+	expect(targets(tx)).toEqual([
+		AUTH,
+		`${cfg.packages.predict}::plp::cancel_supply_request`,
+	]);
+	const c = call(tx, 1);
+	expect(c.arguments).toHaveLength(7);
+	expectObject(tx, 1, 0, cfg.objects.poolVault);
+	expectObject(tx, 1, 1, "0xdef");
+	expect(c.arguments[2].$kind).toBe("Result");
+	expectObject(tx, 1, 3, cfg.objects.protocolConfig);
+	expect(argPureBytes(tx, 1, 4)).toBe(
+		Buffer.from(bcs.u64().serialize(3n).toBytes()).toString("base64"),
+	);
+	expectObject(tx, 1, 5, "0xacc");
+	expectObject(tx, 1, 6, "0x6");
+});
+
+test("cancelWithdrawRequest: auth → cancel_withdraw_request, 7 args, index in u64 slot", () => {
+	const tx = new Transaction();
+	cancelWithdrawRequest(cfg, tx, { wrapperId: "0xdef", index: 7n });
+	expect(targets(tx)).toEqual([
+		AUTH,
+		`${cfg.packages.predict}::plp::cancel_withdraw_request`,
+	]);
+	const c = call(tx, 1);
+	expect(c.arguments).toHaveLength(7);
+	expectObject(tx, 1, 0, cfg.objects.poolVault);
+	expectObject(tx, 1, 1, "0xdef");
+	expect(c.arguments[2].$kind).toBe("Result");
+	expectObject(tx, 1, 3, cfg.objects.protocolConfig);
+	expect(argPureBytes(tx, 1, 4)).toBe(
+		Buffer.from(bcs.u64().serialize(7n).toBytes()).toString("base64"),
+	);
+	expectObject(tx, 1, 5, "0xacc");
+	expectObject(tx, 1, 6, "0x6");
+});
+
+test("setBuilderCode: auth → set_builder_code (predict pkg), 3 args", () => {
+	const tx = new Transaction();
+	setBuilderCode(cfg, tx, { wrapperId: "0xdef", builderCodeId: "0xbc0de" });
+	expect(targets(tx)).toEqual([
+		AUTH,
+		`${cfg.packages.predict}::predict_account::set_builder_code`,
+	]);
+	const c = call(tx, 1);
+	// deployed sig: (wrapper, auth, code: &BuilderCode, ctx) → 3 moveCall args
+	expect(c.arguments).toHaveLength(3);
+	expectObject(tx, 1, 0, "0xdef"); // wrapper
+	expect(c.arguments[1].$kind).toBe("Result"); // auth
+	expectObject(tx, 1, 2, "0xbc0de"); // builder code object
+});
+
+test("unsetBuilderCode: auth → unset_builder_code (predict pkg), 2 args", () => {
+	const tx = new Transaction();
+	unsetBuilderCode(cfg, tx, { wrapperId: "0xdef" });
+	expect(targets(tx)).toEqual([
+		AUTH,
+		`${cfg.packages.predict}::predict_account::unset_builder_code`,
+	]);
+	const c = call(tx, 1);
+	// deployed sig: (wrapper, auth, ctx) → 2 moveCall args
+	expect(c.arguments).toHaveLength(2);
+	expectObject(tx, 1, 0, "0xdef"); // wrapper
+	expect(c.arguments[1].$kind).toBe("Result"); // auth
+});

--- a/packages/predict/sdk/tests/tx-trade.test.ts
+++ b/packages/predict/sdk/tests/tx-trade.test.ts
@@ -1,0 +1,169 @@
+import { bcs } from "@mysten/sui/bcs";
+import { Transaction } from "@mysten/sui/transactions";
+import { expect, test } from "vitest";
+import { TESTNET_CONFIG as cfg } from "../src/config/index.js";
+import { U64_MAX } from "../src/units.js";
+import {
+	loadLivePricer,
+	mintExactAmount,
+	mintExactQuantity,
+	redeemLive,
+	redeemSettled,
+} from "../src/tx/trade.js";
+
+const btc = cfg.underlyings.BTC;
+const feeds = {
+	pythFeedId: btc.pythFeedId,
+	bsSpotFeedId: btc.bsSpotFeedId,
+	bsForwardFeedId: btc.bsForwardFeedId,
+	bsSviFeedId: btc.bsSviFeedId,
+};
+
+function targets(tx: Transaction): string[] {
+	return tx.getData().commands.flatMap((c) =>
+		"MoveCall" in c && c.MoveCall
+			? [`${c.MoveCall.package}::${c.MoveCall.module}::${c.MoveCall.function}`]
+			: [],
+	);
+}
+
+function call(tx: Transaction, cmdIdx: number) {
+	return tx.getData().commands[cmdIdx].MoveCall!;
+}
+
+// Resolve the base64 pure bytes an argument points at, or undefined if the
+// argument is not a pure input (e.g. it's an object or a command result).
+function argPureBytes(tx: Transaction, cmdIdx: number, argIdx: number): string | undefined {
+	const arg = call(tx, cmdIdx).arguments[argIdx] as { $kind: string; Input?: number };
+	if (arg.$kind !== "Input" || arg.Input === undefined) return undefined;
+	const input = tx.getData().inputs[arg.Input];
+	return "Pure" in input && input.Pure ? input.Pure.bytes : undefined;
+}
+
+const U64_MAX_B64 = Buffer.from(bcs.u64().serialize(U64_MAX).toBytes()).toString("base64");
+
+test("loadLivePricer: 8 args to expiry_market::load_live_pricer", () => {
+	const tx = new Transaction();
+	loadLivePricer(cfg, tx, { expiryMarketId: "0xabc", ...feeds });
+	expect(targets(tx)).toEqual([`${cfg.packages.predict}::expiry_market::load_live_pricer`]);
+	expect(call(tx, 0).arguments).toHaveLength(8);
+});
+
+test("mintExactQuantity: pricer → auth → mint, 13 args", () => {
+	const tx = new Transaction();
+	mintExactQuantity(cfg, tx, {
+		expiryMarketId: "0xabc",
+		wrapperId: "0xdef",
+		lowerTick: 10n,
+		higherTick: 20n,
+		quantityRaw: 1_000_000n,
+		leverageRaw: 1_000_000_000n,
+		...feeds,
+	});
+	expect(targets(tx)).toEqual([
+		`${cfg.packages.predict}::expiry_market::load_live_pricer`,
+		`${cfg.packages.account}::account::generate_auth`,
+		`${cfg.packages.predict}::expiry_market::mint_exact_quantity`,
+	]);
+	const mint = call(tx, 2);
+	expect(mint.arguments).toHaveLength(13);
+	// arg order: [market, wrapper, auth(Result), config, pricer(Result), lower, higher,
+	//             quantity, leverage, maxCost, maxProbability, root, clock]
+	expect(mint.arguments[2].$kind).toBe("Result"); // auth
+	expect(mint.arguments[4].$kind).toBe("Result"); // pricer
+	// defaults: maxCost (idx 9) and maxProbability (idx 10) = U64_MAX
+	expect(argPureBytes(tx, 2, 9)).toBe(U64_MAX_B64);
+	expect(argPureBytes(tx, 2, 10)).toBe(U64_MAX_B64);
+});
+
+test("mintExactQuantity: explicit maxCost/maxProbability override defaults", () => {
+	const tx = new Transaction();
+	mintExactQuantity(cfg, tx, {
+		expiryMarketId: "0xabc",
+		wrapperId: "0xdef",
+		lowerTick: 10n,
+		higherTick: 20n,
+		quantityRaw: 1_000_000n,
+		leverageRaw: 1_000_000_000n,
+		maxCostRaw: 5_000_000n,
+		maxProbabilityRaw: 900_000_000n,
+		...feeds,
+	});
+	expect(argPureBytes(tx, 2, 9)).toBe(
+		Buffer.from(bcs.u64().serialize(5_000_000n).toBytes()).toString("base64"),
+	);
+	expect(argPureBytes(tx, 2, 10)).toBe(
+		Buffer.from(bcs.u64().serialize(900_000_000n).toBytes()).toString("base64"),
+	);
+	expect(argPureBytes(tx, 2, 9)).not.toBe(U64_MAX_B64);
+});
+
+test("mintExactAmount: pricer → auth → mint, 12 args", () => {
+	const tx = new Transaction();
+	mintExactAmount(cfg, tx, {
+		expiryMarketId: "0xabc",
+		wrapperId: "0xdef",
+		lowerTick: 10n,
+		higherTick: 20n,
+		amountRaw: 5_000_000n,
+		minQuantityRaw: 1_000_000n,
+		leverageRaw: 1_000_000_000n,
+		...feeds,
+	});
+	expect(targets(tx)).toEqual([
+		`${cfg.packages.predict}::expiry_market::load_live_pricer`,
+		`${cfg.packages.account}::account::generate_auth`,
+		`${cfg.packages.predict}::expiry_market::mint_exact_amount`,
+	]);
+	const mint = call(tx, 2);
+	expect(mint.arguments).toHaveLength(12);
+	expect(mint.arguments[2].$kind).toBe("Result"); // auth
+	expect(mint.arguments[4].$kind).toBe("Result"); // pricer
+});
+
+test("redeemLive: pricer → auth → redeem, 9 args, NO slippage-floor pair", () => {
+	const tx = new Transaction();
+	redeemLive(cfg, tx, {
+		expiryMarketId: "0xabc",
+		wrapperId: "0xdef",
+		orderId: 42n,
+		closeQuantityRaw: 500_000n,
+		...feeds,
+	});
+	expect(targets(tx)).toEqual([
+		`${cfg.packages.predict}::expiry_market::load_live_pricer`,
+		`${cfg.packages.account}::account::generate_auth`,
+		`${cfg.packages.predict}::expiry_market::redeem_live`,
+	]);
+	const redeem = call(tx, 2);
+	// deployed: market, wrapper, auth, config, pricer, order_id u256, close_quantity u64,
+	//           root, clock  →  9 moveCall args (drift guard: main has 11 with two floors)
+	expect(redeem.arguments).toHaveLength(9);
+	expect(redeem.arguments[2].$kind).toBe("Result"); // auth
+	expect(redeem.arguments[4].$kind).toBe("Result"); // pricer
+	// after close_quantity (idx 6) come root and clock objects — NOT a pure u64 floor pair
+	expect(argPureBytes(tx, 2, 7)).toBeUndefined(); // root object, not pure
+	expect(argPureBytes(tx, 2, 8)).toBeUndefined(); // clock object, not pure
+});
+
+test("redeemSettled: 10 args, app-auth (no generate_auth in tx)", () => {
+	const tx = new Transaction();
+	redeemSettled(cfg, tx, {
+		expiryMarketId: "0xabc",
+		wrapperId: "0xdef",
+		orderId: 42n,
+		closeQuantityRaw: 500_000n,
+		pythFeedId: btc.pythFeedId,
+	});
+	expect(targets(tx)).toEqual([
+		`${cfg.packages.predict}::expiry_market::redeem_settled`,
+	]);
+	// no auth command anywhere
+	expect(targets(tx)).not.toContain(`${cfg.packages.account}::account::generate_auth`);
+	const redeem = call(tx, 0);
+	// market, accountRegistry, wrapper, config, oracleRegistry, pyth, order_id u256,
+	// close_quantity u64, root, clock  →  10 moveCall args
+	expect(redeem.arguments).toHaveLength(10);
+	// all object/pure inputs (no command results) — app-auth path threads no Auth
+	for (const a of redeem.arguments) expect(a.$kind).toBe("Input");
+});

--- a/packages/predict/sdk/tests/units.test.ts
+++ b/packages/predict/sdk/tests/units.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "vitest";
+
+import {
+	U64_MAX,
+	leverageToRaw,
+	priceToRaw,
+	probabilityToRaw,
+	rawToUsdc,
+	toRaw,
+	usdcToRaw,
+} from "../src/units.js";
+
+test("toRaw exact decimal string math (no float)", () => {
+	expect(toRaw("12.5", 6)).toBe(12_500_000n);
+	expect(toRaw(0.1, 6)).toBe(100_000n);
+	expect(toRaw("105000", 9)).toBe(105_000_000_000_000n);
+	expect(() => toRaw("1.1234567", 6)).toThrow(/decimals/);
+	expect(() => toRaw("-1", 6)).toThrow(/negative/);
+});
+test("wrappers", () => {
+	expect(usdcToRaw(100)).toBe(100_000_000n);
+	expect(rawToUsdc(12_500_000n)).toBe(12.5);
+	expect(priceToRaw(105_000)).toBe(105_000_000_000_000n);
+	expect(probabilityToRaw(0.3)).toBe(300_000_000n);
+	expect(() => probabilityToRaw(1.5)).toThrow(/probability/);
+	expect(leverageToRaw(2)).toBe(2_000_000_000n);
+	expect(() => leverageToRaw(0.5)).toThrow(/leverage/);
+	expect(U64_MAX).toBe(18446744073709551615n);
+});

--- a/packages/predict/sdk/tests/units.test.ts
+++ b/packages/predict/sdk/tests/units.test.ts
@@ -17,6 +17,17 @@ test("toRaw exact decimal string math (no float)", () => {
 	expect(() => toRaw("1.1234567", 6)).toThrow(/decimals/);
 	expect(() => toRaw("-1", 6)).toThrow(/negative/);
 });
+test("exponential-notation number inputs convert exactly", () => {
+	// Number.toString() goes exponential below 1e-6 and at/above 1e21; these are
+	// exactly representable and must not be rejected as "invalid".
+	expect(probabilityToRaw(1e-7)).toBe(100n);
+	expect(priceToRaw(1e-9)).toBe(1n);
+	expect(toRaw(2.5e-7, 9)).toBe(250n);
+	expect(toRaw(1e21, 6)).toBe(1_000_000_000_000_000_000_000_000_000n);
+	// Still exact: sub-representable magnitudes throw rather than round.
+	expect(() => toRaw(1e-10, 9)).toThrow(/decimals/);
+});
+
 test("wrappers", () => {
 	expect(usdcToRaw(100)).toBe(100_000_000n);
 	expect(rawToUsdc(12_500_000n)).toBe(12.5);

--- a/packages/predict/sdk/tsconfig.json
+++ b/packages/predict/sdk/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "strict": true,
+        "declaration": true,
+        "skipLibCheck": true,
+        "outDir": "dist",
+        "rootDir": "src",
+        "types": ["node"]
+    },
+    "include": ["src"]
+}

--- a/packages/predict/sdk/vitest.config.ts
+++ b/packages/predict/sdk/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    test: {
+        include: ["tests/**/*.test.ts"],
+        exclude: process.env.PREDICT_SDK_TESTNET ? [] : ["tests/testnet/**"],
+    },
+});


### PR DESCRIPTION
## What

A consumer-facing TypeScript SDK for Predict at `packages/predict/sdk/` — transaction building + on-chain reads for trading frontends and integrators. Purely additive (no existing files touched).

Two hand-written layers:
- **`PredictClient` facade** — human units in/out (decimal USD, probabilities 0..1, leverage ≥1), market descriptors (`{underlying, expiryMs, strike, side}`) resolved via the on-chain registry and cached, coin plumbing via `coinWithBalance`, pre-flight validation with typed `PredictInputError`.
- **Composable primitives** — one `(cfg, tx, args) => …` function per Move entrypoint with raw bigint units, for integrators composing their own PTBs. The facade is built strictly on these.

Reads run over gRPC `simulateTransaction({checksEnabled:false})` (no JSON-RPC, no indexer dependency): active markets, market state, live NAV, settlement price, account/PLP balances, pool stats. Move aborts decode into typed `PredictMoveError` via tables generated from the deployed sources.

## Deployed-surface targeting (important)

The SDK targets the **live testnet deployment** (built from `ec99cfae`, branch `predict-testnet-6-24`), whose consumer entrypoints have drifted from `main`:
- `redeem_live` on the deployed package has no `min_probability`/`min_proceeds` floors (9 args, not 11).
- `redeem_settled` is the single app-auth form taking `&AccountRegistry` (no owner-auth variant).
- `settlement_price` is `public(package)` and aborts for unsettled markets — exposed as a dedicated `settlementPrice` read returning `null` while unsettled.

`git show ec99cfae:…` is the signature authority for the builders; when the next deployment realigns with main, the builders + config update in that deployment's PR.

## Testing

- **Offline (76 tests):** per-builder PTB assertions (targets, argument count and slot-by-slot order, BCS bytes for defaults), unit-conversion round-trips, BCS parser round-trips, facade conversion/caching/validation with mocked reads.
- **Live testnet smoke (6 tests, `pnpm test:testnet`):** reads return real data end-to-end, and **arity guards** dry-run `mint_exact_quantity` / `redeem_live` against the deployed contracts (fresh in-PTB `AccountWrapper` threaded into the builders) asserting any failure is a semantic Move abort — the standing drift detector for future deployments.

## Deliberately deferred

- npm publish (package is npm-shaped; consume via git until the org/token/workflow setup happens).
- MVR targets — all moveCall targets flow through one resolution seam (`predictTarget`/`accountTarget`); switching to `@deepbook/predict` MVR names later is a config-only change.
- Position enumeration (`read.positions()`) — needs the indexer; order ids come from mint results / `OrderMinted` events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)