### PR TITLE
Predict: consumer quote + read surface (quote_mint, settlement readability, public pricing)

### DIFF
--- a/packages/predict/predeploy/open-items.md
+++ b/packages/predict/predeploy/open-items.md
@@ -6,6 +6,20 @@ gates, audit findings, stress-test follow-ups, and required decisions.
 Resolved items should be removed from this file. Historical raw audit output may
 remain in ignored agent scratchpads, but this file is the tracked manifest.
 
+## Consumer-Surface Work
+
+### order_state: on-chain position-valuation read (DBU-513)
+
+**Severity:** Feature ask, isolated review required.
+
+Split from the consumer quote surface (DBU-512, landed as `quote_mint` +
+settlement readability + public pricing getters): `order_state(market, pricer,
+order_id)` returning the exact holder value (leverage/floor-share aware),
+`is_liquidated`, and `is_liquidatable_now`. Requires factoring the read-only
+valuation half out of `strike_exposure::close_and_quote_live_order` — the same
+pure/mutating split `quote_mint_terms` vs `allocate_mint_order` now uses on the
+mint side. Tracked in Linear DBU-513.
+
 ## Deploy Gates
 
 ### S-4: Block Scholes updates are forgeable while the verifier is a stub

--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -96,6 +96,12 @@ public fun settlement_price(market: &ExpiryMarket): u64 {
     market.settlement_price.destroy_some()
 }
 
+/// The recorded settlement price, or none while the market is unsettled — the
+/// non-aborting read for consumers that must not branch on an abort.
+public fun try_settlement_price(market: &ExpiryMarket): Option<u64> {
+    market.settlement_price
+}
+
 /// Return DUSDC currently held by this expiry.
 public fun cash_balance(market: &ExpiryMarket): u64 {
     market.cash.balance()
@@ -198,6 +204,147 @@ public fun load_live_pricer(
         market.expiry,
         clock,
     )
+}
+
+/// A fee-complete mint quote: exactly what `mint_exact_quantity` would charge,
+/// computed by the same code paths, with no state touched.
+public struct MintQuote has copy, drop {
+    /// 1e9-scaled range probability quoted at entry (the per-contract price).
+    entry_probability: u64,
+    /// Net premium into LP backing, in DUSDC base units.
+    net_premium: u64,
+    /// Full trading fee, including the near-expiry window ramp, after any
+    /// stake discount (account-aware variant) and before the sponsor subsidy.
+    trading_fee: u64,
+    /// Portion of `trading_fee` the expiry's fee incentives would cover.
+    fee_incentive_subsidy: u64,
+    /// Builder cut (zero in the anonymous variant or without a sticky code).
+    builder_fee: u64,
+    /// EWMA congestion surcharge at the CURRENT smoothed estimate (a peek —
+    /// the trade itself first folds its own gas observation in, so the
+    /// executed penalty can differ marginally).
+    penalty_fee: u64,
+    /// All-in account debit: net_premium + (trading_fee − subsidy) + builder
+    /// + penalty. The value `max_cost` bounds.
+    all_in_cost: u64,
+}
+
+public fun quote_entry_probability(quote: &MintQuote): u64 { quote.entry_probability }
+
+public fun quote_net_premium(quote: &MintQuote): u64 { quote.net_premium }
+
+public fun quote_trading_fee(quote: &MintQuote): u64 { quote.trading_fee }
+
+public fun quote_fee_incentive_subsidy(quote: &MintQuote): u64 { quote.fee_incentive_subsidy }
+
+public fun quote_builder_fee(quote: &MintQuote): u64 { quote.builder_fee }
+
+public fun quote_penalty_fee(quote: &MintQuote): u64 { quote.penalty_fee }
+
+public fun quote_all_in_cost(quote: &MintQuote): u64 { quote.all_in_cost }
+
+/// Quote a live mint anonymously: no stake discount, no builder fee. Runs the
+/// same gates the mint runs (live-mint allowed, tick admission,
+/// probability/leverage policy), so a quote aborts exactly when the trade
+/// would — a successful quote is a preflight. Read-only by construction
+/// (`&ExpiryMarket`).
+public fun quote_mint(
+    market: &ExpiryMarket,
+    config: &ProtocolConfig,
+    pricer: &Pricer,
+    lower_tick: u64,
+    higher_tick: u64,
+    quantity: u64,
+    leverage: u64,
+    clock: &Clock,
+    ctx: &TxContext,
+): MintQuote {
+    market.quote_mint_internal(
+        config,
+        pricer,
+        lower_tick,
+        higher_tick,
+        quantity,
+        leverage,
+        0,
+        &option::none(),
+        clock,
+        ctx,
+    )
+}
+
+/// Quote a live mint as a specific account would be charged: applies the
+/// account's rolled stake discount and sticky builder code. Needs no auth and
+/// no funded balance — quoting is free.
+public fun quote_mint_for_account(
+    market: &ExpiryMarket,
+    wrapper: &AccountWrapper,
+    config: &ProtocolConfig,
+    pricer: &Pricer,
+    lower_tick: u64,
+    higher_tick: u64,
+    quantity: u64,
+    leverage: u64,
+    clock: &Clock,
+    ctx: &TxContext,
+): MintQuote {
+    let account = wrapper.load_account();
+    let active_stake = predict_account::rolled_active_stake(account, ctx);
+    let builder_code_id = predict_account::builder_code_id(account);
+    market.quote_mint_internal(
+        config,
+        pricer,
+        lower_tick,
+        higher_tick,
+        quantity,
+        leverage,
+        active_stake,
+        &builder_code_id,
+        clock,
+        ctx,
+    )
+}
+
+fun quote_mint_internal(
+    market: &ExpiryMarket,
+    config: &ProtocolConfig,
+    pricer: &Pricer,
+    lower_tick: u64,
+    higher_tick: u64,
+    quantity: u64,
+    leverage: u64,
+    active_stake: u64,
+    builder_code_id: &Option<ID>,
+    clock: &Clock,
+    ctx: &TxContext,
+): MintQuote {
+    market.assert_live_mint_allowed(config, pricer);
+    let (entry_probability, net_premium, _floor_shares) = market
+        .strike_exposure
+        .quote_mint_terms(
+            pricer,
+            lower_tick,
+            higher_tick,
+            quantity,
+            leverage,
+        );
+    let raw_fee_amount = market.strike_exposure.trading_fee(entry_probability, quantity, clock);
+    let trading_fee = config.stake_config().fee_amount_after_discount(raw_fee_amount, active_stake);
+    // Peek only: `ewma_penalty` (the trade path) folds this tx's gas
+    // observation in via `ewma.update` first; a read must not mutate.
+    let penalty_fee = market.ewma.penalty_fee(config.ewma_config(), quantity, ctx);
+    let fee_incentive_subsidy = market.fee_incentive_subsidy_amount(trading_fee);
+    let builder_fee = builder_fee_amount(builder_code_id, trading_fee, quantity);
+    let all_in_cost = net_premium + (trading_fee - fee_incentive_subsidy) + builder_fee + penalty_fee;
+    MintQuote {
+        entry_probability,
+        net_premium,
+        trading_fee,
+        fee_incentive_subsidy,
+        builder_fee,
+        penalty_fee,
+        all_in_cost,
+    }
 }
 
 /// Return this expiry market's exact live NAV: free cash minus the exact
@@ -717,11 +864,12 @@ public(package) fun create_and_share(
     expiry_market_id
 }
 
-// === Private Functions ===
-
-fun is_settled(market: &ExpiryMarket): bool {
+/// Whether terminal settlement has been recorded for this expiry.
+public fun is_settled(market: &ExpiryMarket): bool {
     market.settlement_price.is_some()
 }
+
+// === Private Functions ===
 
 /// Cache terminal payout liability in strike exposure if it has not already been cached.
 fun materialize_settled_liability(market: &mut ExpiryMarket): u64 {

--- a/packages/predict/sources/predict_account.move
+++ b/packages/predict/sources/predict_account.move
@@ -122,6 +122,19 @@ public fun inactive_stake(account: &Account): u64 {
     data(account).inactive_stake
 }
 
+/// Non-mutating counterpart of `roll_active_stake`: the active stake a
+/// discount-bearing interaction would see this epoch, including the inactive
+/// stake an actual roll would activate. Same u64 the mutating roll returns.
+public fun rolled_active_stake(account: &Account, ctx: &TxContext): u64 {
+    if (!account.has_data<PredictApp>()) return 0;
+    let d = data(account);
+    if (d.stake_epoch != ctx.epoch()) {
+        d.active_stake + d.inactive_stake
+    } else {
+        d.active_stake
+    }
+}
+
 /// Return the sticky builder-code ID, if set.
 public fun builder_code_id(account: &Account): Option<ID> {
     if (!account.has_data<PredictApp>()) return option::none();

--- a/packages/predict/sources/pricing/pricing.move
+++ b/packages/predict/sources/pricing/pricing.move
@@ -116,12 +116,13 @@ public(package) fun load_live_pricer(
 }
 
 /// Return the current UP tail price for one strike.
-public(package) fun up_price(pricer: &Pricer, strike: u64): u64 {
+public fun up_price(pricer: &Pricer, strike: u64): u64 {
     compute_up_price(&pricer.svi, pricer.forward, strike)
 }
 
-/// Return the current raw probability for a live range.
-public(package) fun range_price(pricer: &Pricer, lower: u64, higher: u64): u64 {
+/// Return the current raw probability for a live range. Raw-strike bounds with
+/// the open-range sentinels `neg_inf!()`/`pos_inf!()` (see `range_codec`).
+public fun range_price(pricer: &Pricer, lower: u64, higher: u64): u64 {
     compute_range_price(&pricer.svi, pricer.forward, lower, higher)
 }
 

--- a/packages/predict/sources/strike_exposure/strike_exposure.move
+++ b/packages/predict/sources/strike_exposure/strike_exposure.move
@@ -256,22 +256,13 @@ public(package) fun allocate_mint_order(
     quantity: u64,
     leverage: u64,
 ): MintQuote {
-    exposure.assert_admitted_mint_ticks(lower_tick, higher_tick);
-    let (lower, higher) = range_codec::strikes_from_ticks(
+    let (entry_probability, net_premium, floor_shares) = exposure.quote_mint_terms(
+        pricer,
         lower_tick,
         higher_tick,
-        exposure.tick_size,
+        quantity,
+        leverage,
     );
-    let entry_probability = pricer.range_price(lower, higher);
-    let admission = exposure
-        .config
-        .assert_mint_admission(
-            entry_probability,
-            quantity,
-            leverage,
-        );
-    let net_premium = admission.net_premium();
-    let floor_shares = admission.floor_shares();
 
     let sequence = exposure.next_order_sequence;
     let allocated_order = order::new_from_ticks(
@@ -300,6 +291,35 @@ public(package) fun set_reference_tick(exposure: &mut StrikeExposure, tick: u64)
     };
     exposure.reference_tick = option::some(tick);
     true
+}
+
+/// Read-only mint valuation: `(entry_probability, net_premium, floor_shares)`
+/// for a candidate order, running the same admission gates the mint runs. The
+/// single source of mint pricing — `allocate_mint_order` composes this with the
+/// book mutations, so a quote and the trade it precedes cannot disagree.
+public(package) fun quote_mint_terms(
+    exposure: &StrikeExposure,
+    pricer: &Pricer,
+    lower_tick: u64,
+    higher_tick: u64,
+    quantity: u64,
+    leverage: u64,
+): (u64, u64, u64) {
+    exposure.assert_admitted_mint_ticks(lower_tick, higher_tick);
+    let (lower, higher) = range_codec::strikes_from_ticks(
+        lower_tick,
+        higher_tick,
+        exposure.tick_size,
+    );
+    let entry_probability = pricer.range_price(lower, higher);
+    let admission = exposure
+        .config
+        .assert_mint_admission(
+            entry_probability,
+            quantity,
+            leverage,
+        );
+    (entry_probability, admission.net_premium(), admission.floor_shares())
 }
 
 /// Quote immutable mint entry probability without mutating the exposure book.

--- a/packages/predict/tests/flows/quote_mint_tests.move
+++ b/packages/predict/tests/flows/quote_mint_tests.move
@@ -1,0 +1,206 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Quote/trade parity for `quote_mint`: the quote must equal what the mint
+/// actually charges, pinned from BOTH sides of the `max_cost` boundary — a mint
+/// bounded at exactly `quote.all_in_cost` succeeds and withdraws exactly that
+/// amount; one unit below aborts. Probability parity uses `max_probability` the
+/// same way. Gate parity: a paused market aborts the quote with the mint's own
+/// code. The account-aware variant equals the anonymous quote for an account
+/// with no stake and no builder code.
+#[test_only]
+module deepbook_predict::quote_mint_tests;
+
+use deepbook_predict::{constants, expiry_market, flow_test_helpers as helpers, test_constants};
+use dusdc::dusdc::DUSDC;
+use std::unit_test::assert_eq;
+
+const LEVERAGE_ONE_X: u64 = 1_000_000_000;
+/// Independently derived in mint_redeem_guard_tests for the same fixture mint:
+/// ATM digital Φ(0) premium 500_000_000 + min-fee-bound fee 5_000_000.
+const ALL_IN_MINT_COST: u64 = 505_000_000;
+const ATM_ENTRY_PROBABILITY: u64 = 500_000_000;
+
+#[test]
+fun quote_matches_charged_all_in_cost_exactly() {
+    let (mut fx, expiry_id, trader) = helpers::setup_live_market(
+        test_constants::default_expiry_ms(),
+        test_constants::default_live_price(),
+    );
+    fx.scenario_mut().next_tx(test_constants::alice());
+    let mut market = fx.take_market_bundle(expiry_id);
+    let mut account = fx.take_account_bundle(&trader);
+
+    let quote = fx.quote_mint_bundle(
+        &market,
+        helpers::strike_tick(),
+        constants::pos_inf_tick!(),
+        test_constants::mint_quantity(),
+        LEVERAGE_ONE_X,
+    );
+    // Pinned against the independently derived constant…
+    assert_eq!(quote.quote_all_in_cost(), ALL_IN_MINT_COST);
+    assert_eq!(quote.quote_entry_probability(), ATM_ENTRY_PROBABILITY);
+    assert_eq!(
+        quote.quote_net_premium() + quote.quote_trading_fee()
+            - quote.quote_fee_incentive_subsidy()
+            + quote.quote_builder_fee() + quote.quote_penalty_fee(),
+        quote.quote_all_in_cost(),
+    );
+
+    // …and against the trade itself: max_cost bound at exactly the quote
+    // succeeds, and the account is debited exactly the quoted amount.
+    let balance_before = fx.account_balance_bundle<DUSDC>(&account);
+    let order = fx.mint_exact_quantity_bundle(
+        &mut market,
+        &mut account,
+        helpers::strike_tick(),
+        constants::pos_inf_tick!(),
+        test_constants::mint_quantity(),
+        LEVERAGE_ONE_X,
+        quote.quote_all_in_cost(),
+        quote.quote_entry_probability(),
+    );
+    assert!(helpers::has_position_bundle(&account, expiry_id, order));
+    assert_eq!(
+        fx.account_balance_bundle<DUSDC>(&account),
+        balance_before - quote.quote_all_in_cost(),
+    );
+
+    helpers::return_market_bundle(market);
+    helpers::return_account_bundle(account);
+    fx.finish();
+}
+
+#[test, expected_failure(abort_code = expiry_market::EMintCostAboveMax)]
+fun mint_one_below_quoted_cost_aborts() {
+    let (mut fx, expiry_id, trader) = helpers::setup_live_market(
+        test_constants::default_expiry_ms(),
+        test_constants::default_live_price(),
+    );
+    fx.scenario_mut().next_tx(test_constants::alice());
+    let mut market = fx.take_market_bundle(expiry_id);
+    let mut account = fx.take_account_bundle(&trader);
+
+    let quote = fx.quote_mint_bundle(
+        &market,
+        helpers::strike_tick(),
+        constants::pos_inf_tick!(),
+        test_constants::mint_quantity(),
+        LEVERAGE_ONE_X,
+    );
+    fx.mint_exact_quantity_bundle(
+        &mut market,
+        &mut account,
+        helpers::strike_tick(),
+        constants::pos_inf_tick!(),
+        test_constants::mint_quantity(),
+        LEVERAGE_ONE_X,
+        quote.quote_all_in_cost() - 1,
+        std::u64::max_value!(),
+    );
+
+    abort 999
+}
+
+#[test, expected_failure(abort_code = expiry_market::EMintProbabilityAboveMax)]
+fun mint_one_below_quoted_probability_aborts() {
+    let (mut fx, expiry_id, trader) = helpers::setup_live_market(
+        test_constants::default_expiry_ms(),
+        test_constants::default_live_price(),
+    );
+    fx.scenario_mut().next_tx(test_constants::alice());
+    let mut market = fx.take_market_bundle(expiry_id);
+    let mut account = fx.take_account_bundle(&trader);
+
+    let quote = fx.quote_mint_bundle(
+        &market,
+        helpers::strike_tick(),
+        constants::pos_inf_tick!(),
+        test_constants::mint_quantity(),
+        LEVERAGE_ONE_X,
+    );
+    fx.mint_exact_quantity_bundle(
+        &mut market,
+        &mut account,
+        helpers::strike_tick(),
+        constants::pos_inf_tick!(),
+        test_constants::mint_quantity(),
+        LEVERAGE_ONE_X,
+        std::u64::max_value!(),
+        quote.quote_entry_probability() - 1,
+    );
+
+    abort 999
+}
+
+#[test, expected_failure(abort_code = expiry_market::EMintPaused)]
+fun quote_on_paused_market_aborts_like_the_mint() {
+    let (mut fx, expiry_id, _trader) = helpers::setup_live_market(
+        test_constants::default_expiry_ms(),
+        test_constants::default_live_price(),
+    );
+    fx.scenario_mut().next_tx(test_constants::alice());
+    let mut market = fx.take_market_bundle(expiry_id);
+    fx.set_expiry_mint_paused_bundle(&mut market, true);
+
+    fx.quote_mint_bundle(
+        &market,
+        helpers::strike_tick(),
+        constants::pos_inf_tick!(),
+        test_constants::mint_quantity(),
+        LEVERAGE_ONE_X,
+    );
+
+    abort 999
+}
+
+#[test]
+fun account_quote_equals_anonymous_without_stake_or_builder() {
+    let (mut fx, expiry_id, trader) = helpers::setup_live_market(
+        test_constants::default_expiry_ms(),
+        test_constants::default_live_price(),
+    );
+    fx.scenario_mut().next_tx(test_constants::alice());
+    let market = fx.take_market_bundle(expiry_id);
+    let account = fx.take_account_bundle(&trader);
+
+    let anonymous = fx.quote_mint_bundle(
+        &market,
+        helpers::strike_tick(),
+        constants::pos_inf_tick!(),
+        test_constants::mint_quantity(),
+        LEVERAGE_ONE_X,
+    );
+    let for_account = fx.quote_mint_for_account_bundle(
+        &market,
+        &account,
+        helpers::strike_tick(),
+        constants::pos_inf_tick!(),
+        test_constants::mint_quantity(),
+        LEVERAGE_ONE_X,
+    );
+    assert_eq!(for_account.quote_all_in_cost(), anonymous.quote_all_in_cost());
+    assert_eq!(for_account.quote_trading_fee(), anonymous.quote_trading_fee());
+    assert_eq!(for_account.quote_builder_fee(), 0);
+
+    helpers::return_market_bundle(market);
+    helpers::return_account_bundle(account);
+    fx.finish();
+}
+
+#[test]
+fun settlement_readability_on_live_market() {
+    let (mut fx, expiry_id, _trader) = helpers::setup_live_market(
+        test_constants::default_expiry_ms(),
+        test_constants::default_live_price(),
+    );
+    fx.scenario_mut().next_tx(test_constants::alice());
+    let market = fx.take_market_bundle(expiry_id);
+
+    assert!(!market.market_ref().is_settled());
+    assert!(market.market_ref().try_settlement_price().is_none());
+
+    helpers::return_market_bundle(market);
+    fx.finish();
+}

--- a/packages/predict/tests/helper/flow_test_helpers.move
+++ b/packages/predict/tests/helper/flow_test_helpers.move
@@ -31,7 +31,7 @@ use deepbook_predict::{
     admin::AdminCap,
     block_scholes_feed::{Self as bs_feed, BlockScholesFeed},
     constants,
-    expiry_market::ExpiryMarket,
+    expiry_market::{ExpiryMarket, MintQuote},
     market_lifecycle_cap::MarketLifecycleCap,
     market_manager,
     plp::{Self, PoolVault, PoolValuation},
@@ -434,6 +434,11 @@ public fun take_market_bundle_with_pyth(
 }
 
 /// Return the shared objects taken by `take_market_bundle`.
+/// Immutable view of the bundle's market (read-only assertions in tests).
+public fun market_ref(bundle: &MarketBundle): &ExpiryMarket {
+    &bundle.market
+}
+
 public fun return_market_bundle(bundle: MarketBundle) {
     let MarketBundle { pyth, bs, oracle_registry, vault, market, config } = bundle;
     return_shared(market);
@@ -1472,6 +1477,56 @@ public fun current_nav_bundle(self: &Fixture, market: &MarketBundle): u64 {
         &market.pyth,
         &market.bs,
     )
+}
+
+/// Anonymous mint quote through a market bundle (fresh pricer, fixture clock).
+public fun quote_mint_bundle(
+    self: &mut Fixture,
+    market: &MarketBundle,
+    lower_tick: u64,
+    higher_tick: u64,
+    quantity: u64,
+    leverage: u64,
+): MintQuote {
+    let pricer = self.load_pricer_bundle(market);
+    market
+        .market
+        .quote_mint(
+            &market.config,
+            &pricer,
+            lower_tick,
+            higher_tick,
+            quantity,
+            leverage,
+            &self.clock,
+            self.scenario.ctx(),
+        )
+}
+
+/// Account-aware mint quote through the bundles (stake discount + builder code).
+public fun quote_mint_for_account_bundle(
+    self: &mut Fixture,
+    market: &MarketBundle,
+    account: &AccountBundle,
+    lower_tick: u64,
+    higher_tick: u64,
+    quantity: u64,
+    leverage: u64,
+): MintQuote {
+    let pricer = self.load_pricer_bundle(market);
+    market
+        .market
+        .quote_mint_for_account(
+            &account.wrapper,
+            &market.config,
+            &pricer,
+            lower_tick,
+            higher_tick,
+            quantity,
+            leverage,
+            &self.clock,
+            self.scenario.ctx(),
+        )
 }
 
 public fun load_pricer(


### PR DESCRIPTION
## What

The read-only consumer surface for Predict (Linear DBU-512): exact pre-trade quotes and non-aborting settlement reads, so consumers (the `@mysten/predict` SDK, the official app, on-chain composers) stop needing private-function devInspect tricks or funded-account dry runs.

### `quote_mint` / `quote_mint_for_account` → `MintQuote`

Fee-complete: entry probability, net premium, trading fee (expiry-window ramp + stake discount), sponsor subsidy, builder fee, EWMA penalty, and the all-in cost `max_cost` bounds. Two properties engineered in:

- **Parity by construction**: the valuation half of `allocate_mint_order` is factored into read-only `strike_exposure::quote_mint_terms`, and the mint now composes it — quote and trade share one pricing source. Pinned executably from both sides: a mint bounded at *exactly* `quote.all_in_cost` succeeds and debits exactly that amount; one unit below aborts (`EMintCostAboveMax`); same pair for entry probability.
- **Quote = preflight**: quotes run the mint's own gates (live-mint allowed, tick admission, probability/leverage policy), so a quote aborts precisely when the trade would (pinned: paused market → `EMintPaused`).

Supporting pieces: `predict_account::rolled_active_stake` (non-mutating counterpart of `roll_active_stake` — same u64, no epoch-roll write) for the account-aware variant, and quotes peek congestion via `ewma::penalty_fee` **without** `ewma::update` (documented skew: the trade folds its own gas observation in first). `&ExpiryMarket` in every quote signature makes read-only a compiler guarantee.

### Settlement readability

`is_settled` → public; new `try_settlement_price(): Option<u64>`. The existing `settlement_price` still `destroy_some()`s (aborts while live) — kept for compat; consumers no longer need to branch on a `std::option` abort code.

### Pricing getters

`pricing::range_price` / `up_price` → `public` (raw probability primitives for anonymous board pricing).

### Split out

`order_state` (exact holder valuation incl. leverage/floor-shares + liquidation flags) → Linear DBU-513, recorded in `predeploy/open-items.md`; its close-path valuation factoring deserves isolated review.

## Tests

6 new in `tests/flows/quote_mint_tests.move` (two-sided cost/probability boundary parity anchored to the independently derived `505_000_000` fixture constant, gate parity, account≡anonymous without stake/builder, settlement readability). Full predict suite: **373/373** — the `allocate_mint_order` refactor is regression-clean.

Note: `prettier-move` unavailable locally (root workspace pnpm incompatibility, known issue) — formatting matched to surrounding style manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)