### PR TITLE
deepbook: bump testnet core to v20

### DIFF
--- a/.claude/rules/scripts.md
+++ b/.claude/rules/scripts.md
@@ -44,12 +44,69 @@ await prepareMultisigTx(tx, "mainnet");
 This handles gas object setup, epoch-based expiration, and outputs to `tx/tx-data.txt`.
 
 ### Direct Execution (testnet/devnet)
+There is **no** `signAndExecute` helper in `utils.ts` (this file used to claim one — it never
+existed). Build the client yourself and execute. On testnet this MUST be gRPC (see below):
 ```typescript
-import { signAndExecute } from "../utils/utils";
-const res = await signAndExecute(tx, "testnet");
+import { SuiGrpcClient } from "@mysten/sui/grpc";
+import { getSigner } from "../utils/utils.js";
+
+const client = new SuiGrpcClient({ baseUrl: "https://fullnode.testnet.sui.io", network: "testnet" });
+const res = await client.signAndExecuteTransaction({ transaction: tx, signer: getSigner() });
 ```
+Result shape is `res.Transaction.{digest,status.success}` — NOT the JSON-RPC `res.effects.status.status`.
+`client.simulateTransaction({ transaction })` is the dry-run equivalent and returns the same shape.
 
 ## Common Issues
+
+### Testnet JSON-RPC Is Off — Use gRPC
+`https://fullnode.testnet.sui.io` **404s on JSON-RPC**. This breaks `getClient("testnet")`
+(it builds a `SuiJsonRpcClient`) and therefore every testnet script that uses it — the failure
+surfaces as `SuiHTTPStatusError: Unexpected status code: 404` from `getLatestSuiSystemState`
+during `tx.build()`, which reads like an SDK bug but is the endpoint being gone.
+The same host serves gRPC fine — use `SuiGrpcClient` (see Direct Execution above).
+`getClient` has not been migrated (it is shared with the mainnet multisig path), so testnet
+scripts must construct their own gRPC client for now.
+
+Knock-on effect when debugging: JSON-RPC reads (`suix_getOwnedObjects`, `sui_getObject`) return
+nothing on testnet. Use the GraphQL endpoint `https://graphql.testnet.sui.io/graphql` instead
+(NOT `sui-testnet.mystenlabs.com`, which does not resolve), or the `sui client` CLI.
+
+### Upgrading deepbook core: `CURRENT_VERSION` is a two-part change
+`sui client upgrade` reads `[published.<env>]` from `Published.toml` and rewrites `published-at`,
+`version`, and `toolchain-version` on success — commit that file (precedent: #957, #1111).
+`Move.toml` stays `deepbook = "0x0"`.
+
+Publishing is only half the job. Every gated entrypoint asserts
+`allowed_versions.contains(current_version())` (`registry.move`; each `Pool` also caches its own
+copy), so a package whose `constants::CURRENT_VERSION` is not in the Registry's set aborts with
+`EPackageVersionNotEnabled` on essentially every call — the upgrade lands and is dead on arrival.
+Full sequence:
+1. `sui client upgrade -c <UpgradeCap>` (testnet cap + admin cap IDs are in `config/constants.ts`).
+2. `registry::enable_version(registry, N, admin_cap)` for the new `CURRENT_VERSION`.
+3. `pool::update_pool_allowed_versions(pool, registry)` for **every** pool — pools cache
+   `allowed_versions` and never re-read the Registry, so an unrefreshed pool still rejects the
+   new version. Permissionless, no admin cap.
+
+`enable_version`, `update_allowed_versions`, and `update_pool_allowed_versions` are all explicitly
+gate-exempt ("This function does not have version restrictions"), so there is no chicken-and-egg
+deadlock — you can call them from the newly-published package immediately.
+
+Gotchas:
+- `enable_version` asserts the version is **not** already present (`EVersionAlreadyEnabled`), so
+  only pass missing versions. Read the live set first: `Registry.inner` is a `Versioned` whose UID
+  is *not* a top-level object (GraphQL `object(address:)` returns null) — read it with
+  `sui client dynamic-field <Registry.inner.id>` and decode the `Field<u64, RegistryInner>` BCS
+  (`allowed_versions` is the first field; same for `PoolInner`).
+- Keep testnet's set equal to mainnet's. Enable the version the *previous* package reports too, or
+  you brick the still-referenced old package. As of 2026-07, both are `{1,2,3,4,5,6,8}`.
+- **7 was never a `CURRENT_VERSION`** — the constant went 6 → 8 (`1ba89515` → `43c3416d`).
+  `ee85e213` ("bump core to v7") was a *package* version, not the gate constant. Don't "fill the
+  gap" by enabling 7; mainnet skips it on purpose.
+- `scripts/transactions/updateAllPoolAllowedVersions.ts` is **mainnet-only** (hardcoded
+  `env = "mainnet"` + mainnet package/registry/indexer). For testnet use
+  `enableTestnetVersionsAndPools.ts`, which enumerates pools via GraphQL (there is no testnet
+  `pool_created` indexer) and chunks them across txs — a single PTB over all ~117 pools is both a
+  size and shared-object-congestion risk.
 
 ### TransactionExpiration Enum Error
 SDK v2.1.0+ uses `ValidDuring` (enum value 2) by default. Older multisig tools may not recognize it.

--- a/packages/deepbook/Published.toml
+++ b/packages/deepbook/Published.toml
@@ -10,8 +10,8 @@ version = 8
 
 [published.testnet]
 chain-id = "4c78adac"
-published-at = "0x74cd5657843c627f3d80f713b71e9f895bbbeb470956d8a8e1185badf6cc77c8"
+published-at = "0xd874d2417a55bfa6479bffa06ad950fea144ef93a94cc6c49f32b03e386bbb24"
 original-id = "0xfb28c4cbc6865bd1c897d26aecbe1f8792d1509a20ffec692c800660cbec6982"
-version = 19
-toolchain-version = "1.69.2"
+version = 20
+toolchain-version = "1.75.1"
 build-config = { flavor = "sui", edition = "2024" }

--- a/scripts/transactions/enableTestnetVersionsAndPools.ts
+++ b/scripts/transactions/enableTestnetVersionsAndPools.ts
@@ -1,0 +1,141 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+import { Transaction } from '@mysten/sui/transactions';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+import { getSigner } from '../utils/utils.js';
+import { adminCapID, adminCapOwner } from '../config/constants.js';
+
+// JSON-RPC is switched off on the testnet fullnode (it 404s), so `utils.getClient` cannot be
+// used here — talk to the same host over gRPC instead.
+const GRPC_URL = 'https://fullnode.testnet.sui.io';
+
+// deepbook testnet, package v20 (Published.toml [published.testnet].published-at).
+const DEEPBOOK_PACKAGE_ID = '0xd874d2417a55bfa6479bffa06ad950fea144ef93a94cc6c49f32b03e386bbb24';
+const REGISTRY_ID = '0x7c256edbda983a2cd6f946655f4bf3f00a41043993781f8674a7046e8c0e11d1';
+const ORIGINAL_PACKAGE_ID = '0xfb28c4cbc6865bd1c897d26aecbe1f8792d1509a20ffec692c800660cbec6982';
+const GRAPHQL_URL = 'https://graphql.testnet.sui.io/graphql';
+
+// Testnet Registry.allowed_versions was {1,2,3,4,5}; mainnet is {1,2,3,4,5,6,8}.
+// 6 = constants::CURRENT_VERSION of the previously deployed package, 8 = the current one.
+// 7 was never a CURRENT_VERSION (the constant went 6 -> 8), which is why mainnet skips it.
+const VERSIONS_TO_ENABLE = [6, 8];
+
+// One tx per chunk of pools: each pool is a separate shared object, so a single
+// giant PTB both risks the tx size limit and serializes on congestion.
+const POOLS_PER_TX = 25;
+
+const DRY_RUN = process.env.DRY_RUN === '1';
+
+// Split `Pool<Base, Quote>` into [Base, Quote] while respecting nested <>.
+const splitTypeArgs = (typeStr: string): [string, string] => {
+	const open = typeStr.indexOf('<');
+	const close = typeStr.lastIndexOf('>');
+	if (open < 0 || close < 0) throw new Error(`no type args in ${typeStr}`);
+	const inner = typeStr.slice(open + 1, close);
+	let depth = 0;
+	let splitIdx = -1;
+	for (let i = 0; i < inner.length; i++) {
+		const c = inner[i];
+		if (c === '<') depth++;
+		else if (c === '>') depth--;
+		else if (c === ',' && depth === 0) {
+			splitIdx = i;
+			break;
+		}
+	}
+	if (splitIdx < 0) throw new Error(`could not split type args in ${typeStr}`);
+	return [inner.slice(0, splitIdx).trim(), inner.slice(splitIdx + 1).trim()];
+};
+
+// Enumerate every Pool object of the original package. The pool_created indexer
+// endpoint used by updateAllPoolAllowedVersions.ts is mainnet-only.
+const fetchPools = async (): Promise<{ id: string; base: string; quote: string }[]> => {
+	const pools: { id: string; base: string; quote: string }[] = [];
+	let after: string | null = null;
+	do {
+		const query = `{ objects(filter: {type: "${ORIGINAL_PACKAGE_ID}::pool::Pool"}, first: 50${
+			after ? `, after: "${after}"` : ''
+		}) { pageInfo { hasNextPage endCursor } nodes { address asMoveObject { contents { type { repr } } } } } }`;
+		const resp = await fetch(GRAPHQL_URL, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ query }),
+		});
+		if (!resp.ok) throw new Error(`graphql ${resp.status} ${resp.statusText}`);
+		const body = (await resp.json()) as any;
+		if (body.errors) throw new Error(`graphql errors: ${JSON.stringify(body.errors)}`);
+		const page = body.data.objects;
+		for (const n of page.nodes) {
+			const [base, quote] = splitTypeArgs(n.asMoveObject.contents.type.repr);
+			pools.push({ id: n.address, base, quote });
+		}
+		after = page.pageInfo.hasNextPage ? page.pageInfo.endCursor : null;
+	} while (after);
+	return pools;
+};
+
+(async () => {
+	const env = 'testnet';
+	const client = new SuiGrpcClient({ baseUrl: GRPC_URL, network: env });
+	const signer = getSigner();
+	const sender = signer.getPublicKey().toSuiAddress();
+
+	if (sender !== adminCapOwner[env]) {
+		throw new Error(
+			`signer ${sender} is not the testnet adminCapOwner ${adminCapOwner[env]} — it cannot use DeepbookAdminCap ${adminCapID[env]}`,
+		);
+	}
+
+	const pools = await fetchPools();
+	console.log(`enabling versions [${VERSIONS_TO_ENABLE}] and refreshing ${pools.length} pools`);
+
+	const execute = async (label: string, tx: Transaction) => {
+		tx.setSender(sender);
+
+		const res: any = DRY_RUN
+			? await client.simulateTransaction({ transaction: tx })
+			: await client.signAndExecuteTransaction({ transaction: tx, signer });
+
+		const result = res.Transaction ?? res.transaction ?? res;
+		const status = result?.status ?? result?.effects?.status;
+		const digest: string | undefined = result?.digest ?? res?.digest;
+
+		if (!status?.success) {
+			console.dir(status ?? res, { depth: null });
+			throw new Error(`${label} failed`);
+		}
+		if (digest && !DRY_RUN) await client.waitForTransaction({ digest });
+		console.log(`${DRY_RUN ? '[dry-run] ' : ''}${label}: success${digest ? ` (${digest})` : ''}`);
+	};
+
+	// 1. Enable the versions on the Registry. `enable_version` asserts the version is not
+	// already present (EVersionAlreadyEnabled), so only pass versions that are missing.
+	const versionTx = new Transaction();
+	for (const version of VERSIONS_TO_ENABLE) {
+		versionTx.moveCall({
+			target: `${DEEPBOOK_PACKAGE_ID}::registry::enable_version`,
+			arguments: [
+				versionTx.object(REGISTRY_ID),
+				versionTx.pure.u64(version),
+				versionTx.object(adminCapID[env]),
+			],
+		});
+	}
+	await execute(`enable_version ${VERSIONS_TO_ENABLE}`, versionTx);
+
+	// 2. Refresh each pool's cached allowed_versions from the Registry. Pools cache the set
+	// and never re-read it, so a pool that is not refreshed still rejects the new version.
+	// `update_pool_allowed_versions` is permissionless and gate-exempt (pool.move:1070).
+	for (let i = 0; i < pools.length; i += POOLS_PER_TX) {
+		const chunk = pools.slice(i, i + POOLS_PER_TX);
+		const tx = new Transaction();
+		for (const pool of chunk) {
+			tx.moveCall({
+				target: `${DEEPBOOK_PACKAGE_ID}::pool::update_pool_allowed_versions`,
+				arguments: [tx.object(pool.id), tx.object(REGISTRY_ID)],
+				typeArguments: [pool.base, pool.quote],
+			});
+		}
+		await execute(`pools ${i + 1}-${i + chunk.length} of ${pools.length}`, tx);
+	}
+})();

--- a/scripts/transactions/enableTestnetVersionsAndPools.ts
+++ b/scripts/transactions/enableTestnetVersionsAndPools.ts
@@ -47,24 +47,51 @@ const splitTypeArgs = (typeStr: string): [string, string] => {
 	return [inner.slice(0, splitIdx).trim(), inner.slice(splitIdx + 1).trim()];
 };
 
+const gql = async <T>(query: string): Promise<T> => {
+	const resp = await fetch(GRAPHQL_URL, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ query }),
+	});
+	if (!resp.ok) throw new Error(`graphql ${resp.status} ${resp.statusText}`);
+	const body = (await resp.json()) as any;
+	if (body.errors) throw new Error(`graphql errors: ${JSON.stringify(body.errors)}`);
+	return body.data as T;
+};
+
+// Read the Registry's live allowed_versions. `Registry.inner` is a `Versioned` whose UID is NOT a
+// top-level object (GraphQL `object(address:)` on it returns null), so the set lives in a dynamic
+// field hanging off it. The field object itself IS addressable, so: list the fields over gRPC to
+// get its id, then read the parsed contents over GraphQL.
+const fetchAllowedVersions = async (client: SuiGrpcClient): Promise<number[]> => {
+	const reg = await gql<any>(
+		`{ object(address: "${REGISTRY_ID}") { asMoveObject { contents { json } } } }`,
+	);
+	const innerId: string = reg.object.asMoveObject.contents.json.inner.id;
+
+	const { dynamicFields } = await client.core.listDynamicFields({ parentId: innerId });
+	const field = dynamicFields.find((f: any) => f.valueType?.endsWith('::registry::RegistryInner'));
+	if (!field) throw new Error(`no RegistryInner dynamic field on ${innerId}`);
+
+	const data = await gql<any>(
+		`{ object(address: "${field.fieldId}") { asMoveObject { contents { json } } } }`,
+	);
+	const contents: string[] = data.object.asMoveObject.contents.json.value.allowed_versions.contents;
+	return contents.map(Number).sort((a, b) => a - b);
+};
+
 // Enumerate every Pool object of the original package. The pool_created indexer
 // endpoint used by updateAllPoolAllowedVersions.ts is mainnet-only.
 const fetchPools = async (): Promise<{ id: string; base: string; quote: string }[]> => {
 	const pools: { id: string; base: string; quote: string }[] = [];
 	let after: string | null = null;
 	do {
-		const query = `{ objects(filter: {type: "${ORIGINAL_PACKAGE_ID}::pool::Pool"}, first: 50${
-			after ? `, after: "${after}"` : ''
-		}) { pageInfo { hasNextPage endCursor } nodes { address asMoveObject { contents { type { repr } } } } } }`;
-		const resp = await fetch(GRAPHQL_URL, {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ query }),
-		});
-		if (!resp.ok) throw new Error(`graphql ${resp.status} ${resp.statusText}`);
-		const body = (await resp.json()) as any;
-		if (body.errors) throw new Error(`graphql errors: ${JSON.stringify(body.errors)}`);
-		const page = body.data.objects;
+		const data: any = await gql<any>(
+			`{ objects(filter: {type: "${ORIGINAL_PACKAGE_ID}::pool::Pool"}, first: 50${
+				after ? `, after: "${after}"` : ''
+			}) { pageInfo { hasNextPage endCursor } nodes { address asMoveObject { contents { type { repr } } } } } }`,
+		);
+		const page: any = data.objects;
 		for (const n of page.nodes) {
 			const [base, quote] = splitTypeArgs(n.asMoveObject.contents.type.repr);
 			pools.push({ id: n.address, base, quote });
@@ -86,8 +113,19 @@ const fetchPools = async (): Promise<{ id: string; base: string; quote: string }
 		);
 	}
 
+	// `enable_version` aborts with EVersionAlreadyEnabled (registry code 5) on a version that is
+	// already in the set, which would take the whole run down — including the pool refresh, which
+	// is idempotent and worth re-running on its own (e.g. after new pools are created).
+	const allowed = await fetchAllowedVersions(client);
+	const missing = VERSIONS_TO_ENABLE.filter((v) => !allowed.includes(v));
+	console.log(`registry allowed_versions: [${allowed}]`);
+
 	const pools = await fetchPools();
-	console.log(`enabling versions [${VERSIONS_TO_ENABLE}] and refreshing ${pools.length} pools`);
+	console.log(
+		missing.length
+			? `enabling [${missing}] and refreshing ${pools.length} pools`
+			: `versions [${VERSIONS_TO_ENABLE}] already enabled — refreshing ${pools.length} pools only`,
+	);
 
 	const execute = async (label: string, tx: Transaction) => {
 		tx.setSender(sender);
@@ -108,20 +146,21 @@ const fetchPools = async (): Promise<{ id: string; base: string; quote: string }
 		console.log(`${DRY_RUN ? '[dry-run] ' : ''}${label}: success${digest ? ` (${digest})` : ''}`);
 	};
 
-	// 1. Enable the versions on the Registry. `enable_version` asserts the version is not
-	// already present (EVersionAlreadyEnabled), so only pass versions that are missing.
-	const versionTx = new Transaction();
-	for (const version of VERSIONS_TO_ENABLE) {
-		versionTx.moveCall({
-			target: `${DEEPBOOK_PACKAGE_ID}::registry::enable_version`,
-			arguments: [
-				versionTx.object(REGISTRY_ID),
-				versionTx.pure.u64(version),
-				versionTx.object(adminCapID[env]),
-			],
-		});
+	// 1. Enable any missing versions on the Registry.
+	if (missing.length) {
+		const versionTx = new Transaction();
+		for (const version of missing) {
+			versionTx.moveCall({
+				target: `${DEEPBOOK_PACKAGE_ID}::registry::enable_version`,
+				arguments: [
+					versionTx.object(REGISTRY_ID),
+					versionTx.pure.u64(version),
+					versionTx.object(adminCapID[env]),
+				],
+			});
+		}
+		await execute(`enable_version ${missing}`, versionTx);
 	}
-	await execute(`enable_version ${VERSIONS_TO_ENABLE}`, versionTx);
 
 	// 2. Refresh each pool's cached allowed_versions from the Registry. Pools cache the set
 	// and never re-read it, so a pool that is not refreshed still rejects the new version.


### PR DESCRIPTION
## Summary
- Bump `packages/deepbook` `[published.testnet]` to the upgraded package: `published-at` → `0xd874d2417a55bfa6479bffa06ad950fea144ef93a94cc6c49f32b03e386bbb24`, `version` 19 → 20, `toolchain-version` 1.69.2 → 1.75.1.
- Add `scripts/transactions/enableTestnetVersionsAndPools.ts` — enables the required versions on the testnet Registry and refreshes every pool's cached `allowed_versions`. Idempotent and dry-runnable (`DRY_RUN=1`). **Already executed against testnet** (see Test plan).
- Document the core-upgrade runbook and the testnet JSON-RPC → gRPC break in `.claude/rules/scripts.md`, and drop that file's reference to a `signAndExecute()` helper that never existed.
- No Move source changes. `constants::CURRENT_VERSION` stays at 8, matching mainnet.

## Why
- Testnet was serving package v19. This lands the current `packages/deepbook` source on testnet and makes it actually callable.
- **Publishing alone was not enough.** Every gated entrypoint asserts `allowed_versions.contains(current_version())`, and the testnet Registry allowed only `{1,2,3,4,5}`. A v20 package reporting `current_version() == 8` aborts with `EPackageVersionNotEnabled` on essentially every call — landed but dead on arrival. #957 published testnet v19 and #958 bumped `CURRENT_VERSION` 6 → 8 in a *separate* PR, and no `enable_version` was ever run on testnet, so nothing ≥ 6 had ever been enabled there.
- The existing `updateAllPoolAllowedVersions.ts` is hardcoded to mainnet, so there was no way to do the testnet pool refresh at all.
- The old toolchain (sui 1.74.0) could no longer reach testnet: `Network protocol version is ProtocolVersion(129), but the maximum supported version by the binary is 127`. Hence the `toolchain-version` bump to 1.75.1.

## Key decisions
- **Enabled 6 and 8, not 7.** Version 7 was never a `CURRENT_VERSION` — the constant went 6 → 8 (`1ba89515` → `43c3416d`); `ee85e213` ("bump core to v7") was a *package* version, not the gate constant. Mainnet's set skips 7 for exactly this reason. 6 is what the old v19 package reports and 8 is what v20 reports, so both must be enabled. Testnet now equals mainnet: `{1,2,3,4,5,6,8}`.
- **Pools must be refreshed individually.** `Pool` caches `allowed_versions` and never re-reads the Registry, so enabling on the Registry alone leaves every pool rejecting the new version. `enable_version` / `update_pool_allowed_versions` are both explicitly gate-exempt, so there is no chicken-and-egg deadlock — they are callable from the newly-published package immediately. The pool refresh is permissionless (no admin cap).
- **The script is idempotent.** It reads the live `allowed_versions` and only enables what is missing. A naive re-run aborts on `EVersionAlreadyEnabled` (registry code 5) at the first command, which would also take down the pool refresh — a step that is safe to re-run on its own after new pools are created.
- **gRPC, not JSON-RPC.** `https://fullnode.testnet.sui.io` now 404s on JSON-RPC, which breaks `utils.getClient("testnet")` for *every* testnet script in `scripts/`. This PR does not migrate `getClient` itself — it is shared with the mainnet multisig path and deserves its own PR. Left as a follow-up.
- Pools are enumerated via GraphQL (there is no testnet `pool_created` indexer) and chunked 25/tx; a single PTB over all 117 pools risks both the tx size limit and shared-object congestion.

## Test plan
- [x] `sui client upgrade` succeeded with UpgradeCap `0x479467ad…764ffb` (policy 0, compatible).
- [x] New package `0xd874d241…6bbb24` verified on chain at `version: 20`; UpgradeCap advanced to match.
- [x] `DRY_RUN=1 pnpm tsx transactions/enableTestnetVersionsAndPools.ts` — all txs simulate clean.
- [x] Executed: `enable_version 6,8` + 117 pools refreshed in 5 batches, all success.
- [x] Verified on chain (decoded from chain state, not script output): Registry `allowed_versions` = `{1,2,3,4,5,6,8}`, matching mainnet.
- [x] Verified DEEP/SUI, DEEP/DBUSDC, DBTC/DBUSDC each cached `{1,2,3,4,5,6,8}` — v8 accepted.
- [x] Re-run after execution correctly skips the version step and refreshes pools only (idempotency).
- [x] `npx tsc --noEmit` clean.
- [ ] Follow-up PR: migrate `utils.getClient` off JSON-RPC so the other testnet scripts work again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)