### PR TITLE
server: migrate full-node reads from JSON-RPC to gRPC

### DIFF
--- a/.claude/rules/indexer.md
+++ b/.claude/rules/indexer.md
@@ -17,3 +17,25 @@ Deliberately minimal after the 2026-07-06 rules cleanup: this file covers only t
 - `/margin_manager_states` returns ALL rows (no pagination) — memory/timeout risk against large tables.
 - The server creates 3 separate connection pools (reader / writer / margin poller) against the same Postgres — monitor total connections when diagnosing pool exhaustion.
 - Pre-push: `cargo fmt -p deepbook-server` (CI fails on formatting) and `cargo build -p deepbook-server`.
+
+## Full-node reads are gRPC, not JSON-RPC
+
+Sui deactivated JSON-RPC on 2026-07-31. The server reads the chain over `sui.rpc.v2` gRPC (`sui-rpc` crate); `crates/server/src/grpc.rs` owns every call. The indexer never talked to a node — it ingests checkpoints from the remote store — so it was never affected. Three gotchas, each of which fails *silently or misleadingly*:
+
+- **`read_mask` defaults are lossy.** `GetObject` defaults to `object_id,version,digest`, so `owner` comes back **empty unless you ask for it** — and `owner` is the only reason we fetch the object (it carries `initial_shared_version`). Likewise `SimulateTransaction` only populates `command_outputs` when the mask requests it. A forgotten mask reads as "not a shared object" / "no results", not as an error.
+- **`checks: DISABLED` does NOT skip gas-object resolution.** The node still tries to load the gas coin, so a placeholder like `ObjectInput::owned(Address::ZERO, ..)` fails with `Could not find the referenced object 0x0`. `TransactionBuilder::try_build()` *requires* a gas coin, so build with one and then `transaction.gas_payment.objects.clear()` before simulating. That empty-gas-list posture is what actually reproduces `dev_inspect`.
+- **`Owner.version` is overloaded** — `initial_shared_version` when `kind == SHARED`, `start_version` when `CONSENSUS_ADDRESS`. Check the kind before trusting it.
+
+`sui-sdk-types` 0.3.x made `StructTag`'s fields private: use `StructTag::new(..)` and the `.address()` / `.module()` / `.name()` accessors.
+
+## Running the indexer snapshot tests locally
+
+They spin up a temporary Postgres, which needs the **server** binary — `libpq` alone is not enough, and `initdb` fails with `program "postgres" is needed by initdb but was not found`. All 35 tests then fail for a reason that has nothing to do with your change. Fix:
+
+```
+brew install postgresql@16
+export PATH="/opt/homebrew/opt/postgresql@16/bin:$PATH"
+cargo test -p deepbook-indexer
+```
+
+These snapshot tests are the real regression net for `traits.rs` event-type matching — every handler decodes real checkpoint events through it, so run them after touching event matching or the `sui-sdk-types` pin.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,12 +1198,6 @@ dependencies = [
 
 [[package]]
 name = "bnum"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f781dba93de3a5ef6dc5b17c9958b208f6f3f021623b360fb605ea51ce443f10"
-
-[[package]]
-name = "bnum"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "119771309b95163ec7aaf79810da82f7cd0599c19722d48b9c03894dca833966"
@@ -1355,12 +1349,6 @@ dependencies = [
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cexpr"
@@ -1574,16 +1562,6 @@ checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "combine"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-dependencies = [
- "bytes",
- "memchr",
 ]
 
 [[package]]
@@ -2194,9 +2172,9 @@ dependencies = [
  "sui-indexer-alt-framework",
  "sui-indexer-alt-metrics",
  "sui-pg-db",
- "sui-sdk-types 0.0.7",
+ "sui-sdk-types 0.3.1",
  "sui-storage",
- "sui-transaction-builder 0.0.7",
+ "sui-transaction-builder 0.3.1",
  "sui-types",
  "telemetry-subscribers",
  "tokio",
@@ -2241,14 +2219,15 @@ dependencies = [
  "subtle",
  "sui-futures",
  "sui-indexer-alt-metrics",
- "sui-json-rpc-types",
  "sui-pg-db",
- "sui-sdk",
- "sui-types",
+ "sui-rpc 0.3.1",
+ "sui-sdk-types 0.3.1",
+ "sui-transaction-builder 0.3.1",
  "telemetry-subscribers",
  "thiserror 1.0.69",
  "tokio",
  "tokio-util 0.7.18",
+ "tonic 0.14.5",
  "tower-http 0.5.2",
  "tracing",
  "url",
@@ -2305,17 +2284,6 @@ name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive-syn-parse"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79116f119dd1dba1abf1f3405f03b9b0e79a27a3883864bfebded8a3dc768cd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3702,7 +3670,6 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "log",
  "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
@@ -4100,50 +4067,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jni"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
-dependencies = [
- "cesu8",
- "cfg-if",
- "combine",
- "jni-sys 0.3.1",
- "log",
- "thiserror 1.0.69",
- "walkdir",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
-dependencies = [
- "jni-sys 0.4.1",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
-dependencies = [
- "jni-sys-macros",
-]
-
-[[package]]
-name = "jni-sys-macros"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
-dependencies = [
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4184,161 +4107,6 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "jsonrpsee"
-version = "0.24.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e281ae70cc3b98dac15fced3366a880949e65fc66e345ce857a5682d152f3e62"
-dependencies = [
- "jsonrpsee-core",
- "jsonrpsee-http-client",
- "jsonrpsee-proc-macros",
- "jsonrpsee-server",
- "jsonrpsee-types",
- "jsonrpsee-ws-client",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-client-transport"
-version = "0.24.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4280b709ac3bb5e16cf3bad5056a0ec8df55fa89edfe996361219aadc2c7ea"
-dependencies = [
- "base64 0.22.1",
- "futures-util",
- "http",
- "jsonrpsee-core",
- "pin-project",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
- "soketto",
- "thiserror 1.0.69",
- "tokio",
- "tokio-rustls",
- "tokio-util 0.7.18",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "jsonrpsee-core"
-version = "0.24.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348ee569eaed52926b5e740aae20863762b16596476e943c9e415a6479021622"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-timer",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "jsonrpsee-types",
- "parking_lot",
- "pin-project",
- "rand 0.8.5",
- "rustc-hash 2.1.2",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-http-client"
-version = "0.24.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50c389d6e6a52eb7c3548a6600c90cf74d9b71cb5912209833f00a5479e9a01"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "http-body",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "rustls",
- "rustls-platform-verifier",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tower 0.4.13",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "jsonrpsee-proc-macros"
-version = "0.24.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7398cddf5013cca4702862a2692b66c48a3bd6cf6ec681a47453c93d63cf8de5"
-dependencies = [
- "heck 0.5.0",
- "proc-macro-crate 3.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "jsonrpsee-server"
-version = "0.24.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21429bcdda37dcf2d43b68621b994adede0e28061f816b038b0f18c70c143d51"
-dependencies = [
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "pin-project",
- "route-recognizer",
- "serde",
- "serde_json",
- "soketto",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
- "tokio-util 0.7.18",
- "tower 0.4.13",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-types"
-version = "0.24.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f05e0028e55b15dbd2107163b3c744cd3bb4474f193f95d9708acbf5677e44"
-dependencies = [
- "http",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "jsonrpsee-ws-client"
-version = "0.24.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78fc744f17e7926d57f478cf9ca6e1ee5d8332bf0514860b1a3cdf1742e614cc"
-dependencies = [
- "http",
- "jsonrpsee-client-transport",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "url",
 ]
 
 [[package]]
@@ -5347,7 +5115,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6d4752e6230d8ef7adf7bd5d8c4b1f6561c1014c5ba9a37445ccefe18aa1db"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -5676,7 +5444,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5960,7 +5728,7 @@ version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -6410,15 +6178,6 @@ checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
 dependencies = [
  "thiserror 1.0.69",
  "toml 0.5.11",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
-dependencies = [
- "toml_edit",
 ]
 
 [[package]]
@@ -7194,12 +6953,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "route-recognizer"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
-
-[[package]]
 name = "rsa"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7335,33 +7088,6 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
-
-[[package]]
-name = "rustls-platform-verifier"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
-dependencies = [
- "core-foundation",
- "core-foundation-sys",
- "jni",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
- "security-framework-sys",
- "webpki-root-certs 0.26.11",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustls-platform-verifier-android"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -8052,22 +7778,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "soketto"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e859df029d160cb88608f5d7df7fb4753fd20fdfb4de5644f3d8b8440841721"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures",
- "http",
- "httparse",
- "log",
- "rand 0.8.5",
- "sha1",
-]
-
-[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8550,7 +8260,7 @@ dependencies = [
  "ark-snark",
  "ark-std",
  "base64ct",
- "bnum 0.13.0",
+ "bnum",
  "ed25519-dalek",
  "itertools 0.14.0",
  "k256 0.13.4",
@@ -8676,7 +8386,7 @@ dependencies = [
  "sui-indexer-alt-framework-store-traits",
  "sui-indexer-alt-metrics",
  "sui-pg-db",
- "sui-rpc",
+ "sui-rpc 0.2.2",
  "sui-rpc-api",
  "sui-sdk-types 0.2.2",
  "sui-storage",
@@ -8734,26 +8444,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sui-types",
-]
-
-[[package]]
-name = "sui-json-rpc-api"
-version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui.git?branch=testnet#3c0f387ebb40b8be292d3b7bd3f5bee8ad226d33"
-dependencies = [
- "anyhow",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=db643fd05a1b1c4cd52de3939766b53e12ce137e)",
- "jsonrpsee",
- "mysten-metrics",
- "once_cell",
- "prometheus",
- "sui-json",
- "sui-json-rpc-types",
- "sui-open-rpc",
- "sui-open-rpc-macros",
- "sui-types",
- "tap",
- "tracing",
 ]
 
 [[package]]
@@ -8837,31 +8527,6 @@ dependencies = [
  "serde",
  "sui-types",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "sui-open-rpc"
-version = "1.68.1"
-source = "git+https://github.com/MystenLabs/sui.git?branch=testnet#3c0f387ebb40b8be292d3b7bd3f5bee8ad226d33"
-dependencies = [
- "bcs",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "versions",
-]
-
-[[package]]
-name = "sui-open-rpc-macros"
-version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui.git?branch=testnet#3c0f387ebb40b8be292d3b7bd3f5bee8ad226d33"
-dependencies = [
- "derive-syn-parse",
- "itertools 0.13.0",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unescape",
 ]
 
 [[package]]
@@ -8975,6 +8640,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "sui-rpc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00a313a63f07ada0be04c03e9d6e8c1d176e5a469ee6e3b6f973dee525667311"
+dependencies = [
+ "base64 0.22.1",
+ "bcs",
+ "bytes",
+ "futures",
+ "http",
+ "http-body",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
+ "serde",
+ "serde_json",
+ "sui-sdk-types 0.3.1",
+ "tap",
+ "tokio",
+ "tonic 0.14.5",
+ "tonic-prost",
+ "tower 0.5.3",
+]
+
+[[package]]
 name = "sui-rpc-api"
 version = "0.1.0"
 source = "git+https://github.com/MystenLabs/sui.git?branch=testnet#3c0f387ebb40b8be292d3b7bd3f5bee8ad226d33"
@@ -9010,7 +8699,7 @@ dependencies = [
  "sui-name-service",
  "sui-package-resolver",
  "sui-protocol-config",
- "sui-rpc",
+ "sui-rpc 0.2.2",
  "sui-sdk-types 0.2.2",
  "sui-transaction-builder 0.0.0",
  "sui-types",
@@ -9031,57 +8720,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "sui-sdk"
-version = "1.68.1"
-source = "git+https://github.com/MystenLabs/sui.git?branch=testnet#3c0f387ebb40b8be292d3b7bd3f5bee8ad226d33"
-dependencies = [
- "anyhow",
- "async-trait",
- "base64 0.21.7",
- "bcs",
- "clap",
- "colored",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=db643fd05a1b1c4cd52de3939766b53e12ce137e)",
- "futures",
- "futures-core",
- "jsonrpsee",
- "move-core-types",
- "mysten-common",
- "reqwest",
- "serde",
- "serde_json",
- "serde_with",
- "shared-crypto",
- "sui-config",
- "sui-crypto",
- "sui-json",
- "sui-json-rpc-api",
- "sui-json-rpc-types",
- "sui-keys",
- "sui-rpc",
- "sui-rpc-api",
- "sui-sdk-types 0.2.2",
- "sui-transaction-builder 0.0.0",
- "sui-types",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "sui-sdk-types"
-version = "0.0.7"
-source = "git+https://github.com/mystenlabs/sui-rust-sdk?rev=048124e484f14b9bf2a402227c9bc255c7621bc1#048124e484f14b9bf2a402227c9bc255c7621bc1"
+version = "0.2.2"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=7b020c71d12616c9674b34874f526ac3aa6e5e64#7b020c71d12616c9674b34874f526ac3aa6e5e64"
 dependencies = [
  "base64ct",
  "bcs",
  "blake2",
- "bnum 0.12.1",
+ "bnum",
  "bs58 0.5.1",
  "bytes",
  "bytestring",
- "itertools 0.13.0",
- "roaring 0.10.12",
+ "itertools 0.14.0",
+ "roaring 0.11.3",
  "serde",
  "serde_derive",
  "serde_json",
@@ -9091,13 +8742,14 @@ dependencies = [
 
 [[package]]
 name = "sui-sdk-types"
-version = "0.2.2"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=7b020c71d12616c9674b34874f526ac3aa6e5e64#7b020c71d12616c9674b34874f526ac3aa6e5e64"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23f800c4c3539246ba94a825f6afe7faab0bc8fc4dda56c6cfa493ea2a32ecbd"
 dependencies = [
  "base64ct",
  "bcs",
  "blake2",
- "bnum 0.13.0",
+ "bnum",
  "bs58 0.5.1",
  "bytes",
  "bytestring",
@@ -9189,15 +8841,16 @@ dependencies = [
 
 [[package]]
 name = "sui-transaction-builder"
-version = "0.0.7"
-source = "git+https://github.com/mystenlabs/sui-rust-sdk?rev=048124e484f14b9bf2a402227c9bc255c7621bc1#048124e484f14b9bf2a402227c9bc255c7621bc1"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58530d23db8328c97b4cd2dec73af501f76fc7b3d538629ca32ec011efdc3cf8"
 dependencies = [
- "base64ct",
+ "async-trait",
  "bcs",
+ "futures",
  "serde",
- "serde_json",
- "serde_with",
- "sui-sdk-types 0.0.7",
+ "sui-rpc 0.3.1",
+ "sui-sdk-types 0.3.1",
  "thiserror 2.0.18",
 ]
 
@@ -9267,7 +8920,7 @@ dependencies = [
  "sui-enum-compat-util",
  "sui-macros",
  "sui-protocol-config",
- "sui-rpc",
+ "sui-rpc 0.2.2",
  "sui-sdk-types 0.2.2",
  "tap",
  "thiserror 1.0.69",
@@ -9742,7 +9395,6 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
- "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -9766,7 +9418,7 @@ dependencies = [
  "indexmap 2.13.0",
  "serde_core",
  "serde_spanned",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
  "winnow 0.7.15",
@@ -9779,27 +9431,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.25.8+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
-dependencies = [
- "indexmap 2.13.0",
- "toml_datetime 1.1.0+spec-1.1.0",
- "toml_parser",
- "winnow 1.0.1",
 ]
 
 [[package]]
@@ -10340,12 +9971,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
-name = "unescape"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccb97dac3243214f8d8507998906ca3e2e0b900bf9bf4870477f125b82e68f6e"
-
-[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10501,16 +10126,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "versions"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee97e1d97bd593fb513912a07691b742361b3dd64ad56f2c694ea2dbfe0665d3"
-dependencies = [
- "itertools 0.10.5",
- "nom",
-]
 
 [[package]]
 name = "vfs"
@@ -10717,24 +10332,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-root-certs"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
-dependencies = [
- "webpki-root-certs 1.0.6",
-]
-
-[[package]]
-name = "webpki-root-certs"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10867,15 +10464,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -10917,21 +10505,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -10984,12 +10557,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -11008,12 +10575,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -11029,12 +10590,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -11068,12 +10623,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -11089,12 +10638,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -11116,12 +10659,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -11137,12 +10674,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -11176,9 +10707,6 @@ name = "winnow"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "wit-bindgen"

--- a/crates/indexer/Cargo.toml
+++ b/crates/indexer/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 [dependencies]
 tokio.workspace = true
 sui-indexer-alt-framework = { git = "https://github.com/MystenLabs/sui.git", branch = "testnet" }
-sui-sdk-types = { git = "https://github.com/mystenlabs/sui-rust-sdk", features = ["serde"], rev = "048124e484f14b9bf2a402227c9bc255c7621bc1" }
-sui-transaction-builder = { git = "https://github.com/mystenlabs/sui-rust-sdk", rev = "048124e484f14b9bf2a402227c9bc255c7621bc1" }
+sui-sdk-types = { version = "0.3.1", features = ["serde"] }
+sui-transaction-builder = "0.3.1"
 clap = { workspace = true, features = ["env"] }
 diesel = { workspace = true, features = ["postgres", "uuid", "chrono", "serde_json", "numeric"] }
 diesel-async = { workspace = true, features = ["bb8", "postgres"] }

--- a/crates/indexer/src/traits.rs
+++ b/crates/indexer/src/traits.rs
@@ -36,9 +36,9 @@ pub trait MoveStruct: Serialize {
         // NOTE: We intentionally ignore type_params.len() because events may have phantom/generic type parameters
         // that don't affect the actual event structure (e.g., DeepBurned<BaseAsset, QuoteAsset>)
         all_struct_types.iter().any(|struct_type| {
-            event_type.address == AccountAddress::new(*struct_type.address.inner())
-                && event_type.module.as_str() == struct_type.module.as_str()
-                && event_type.name.as_str() == struct_type.name.as_str()
+            event_type.address == AccountAddress::new(*struct_type.address().inner())
+                && event_type.module.as_str() == struct_type.module().as_str()
+                && event_type.name.as_str() == struct_type.name().as_str()
         })
     }
 
@@ -51,22 +51,22 @@ pub trait MoveStruct: Serialize {
         let mut struct_types = Vec::new();
 
         for address in acceptable_addresses {
-            let struct_tag = StructTag {
-                address: (*address.inner()).into(),
-                module: Identifier::from_str(Self::MODULE).unwrap(),
-                name: Identifier::from_str(Self::NAME).unwrap(),
-                type_params: Self::TYPE_PARAMS
+            let struct_tag = StructTag::new(
+                (*address.inner()).into(),
+                Identifier::from_str(Self::MODULE).unwrap(),
+                Identifier::from_str(Self::NAME).unwrap(),
+                Self::TYPE_PARAMS
                     .iter()
                     .map(|param| {
-                        sui_sdk_types::TypeTag::Struct(Box::new(StructTag {
-                            address: (*address.inner()).into(),
-                            module: Identifier::from_str(Self::MODULE).unwrap(),
-                            name: Identifier::from_str(param).unwrap(),
-                            type_params: Vec::new(),
-                        }))
+                        sui_sdk_types::TypeTag::Struct(Box::new(StructTag::new(
+                            (*address.inner()).into(),
+                            Identifier::from_str(Self::MODULE).unwrap(),
+                            Identifier::from_str(param).unwrap(),
+                            Vec::new(),
+                        )))
                     })
                     .collect(),
-            };
+            );
             struct_types.push(struct_tag);
         }
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -20,14 +20,15 @@ serde_json.workspace = true
 url.workspace = true
 prometheus.workspace = true
 sui-futures.workspace = true
-sui-types.workspace = true
 sui-indexer-alt-metrics.workspace = true
 telemetry-subscribers.workspace = true
 axum = { version = "0.7", features = ["json"] }
-sui-json-rpc-types = { git = "https://github.com/MystenLabs/sui.git", branch = "testnet" }
 sui-pg-db.workspace = true
 tower-http = { version = "0.5", features = ["cors"] }
-sui-sdk = { git = "https://github.com/MystenLabs/sui.git", branch = "testnet" }
+sui-rpc = "0.3.1"
+sui-sdk-types = "0.3.1"
+sui-transaction-builder = "0.3.1"
+tonic = "0.14"
 bigdecimal = "0.4.9"
 chrono = "0.4.42"
 thiserror = "1.0"

--- a/crates/server/src/error.rs
+++ b/crates/server/src/error.rs
@@ -84,14 +84,8 @@ impl From<anyhow::Error> for DeepBookError {
     }
 }
 
-impl From<sui_sdk::error::Error> for DeepBookError {
-    fn from(err: sui_sdk::error::Error) -> Self {
+impl From<tonic::Status> for DeepBookError {
+    fn from(err: tonic::Status) -> Self {
         Self::Rpc(err.to_string())
-    }
-}
-
-impl From<sui_types::base_types::ObjectIDParseError> for DeepBookError {
-    fn from(err: sui_types::base_types::ObjectIDParseError) -> Self {
-        Self::BadRequest(err.to_string())
     }
 }

--- a/crates/server/src/grpc.rs
+++ b/crates/server/src/grpc.rs
@@ -1,0 +1,171 @@
+//! Sui full-node reads over gRPC (`sui.rpc.v2`).
+//!
+//! Replaces the JSON-RPC `read_api()` calls this server used until Sui deactivated JSON-RPC.
+//! Three primitives cover every read we make: the latest checkpoint, a shared object's
+//! `initial_shared_version`, and a read-only PTB's per-command return values.
+
+use crate::error::DeepBookError;
+use sui_rpc::field::{FieldMask, FieldMaskUtil};
+use sui_rpc::proto::sui::rpc::v2::simulate_transaction_request::TransactionChecks;
+use sui_rpc::proto::sui::rpc::v2::{
+    owner::OwnerKind, GetObjectRequest, GetServiceInfoRequest, SimulateTransactionRequest,
+};
+use sui_rpc::Client;
+use sui_sdk_types::{Address, Digest, Transaction, TypeTag};
+use sui_transaction_builder::{Function, ObjectInput, TransactionBuilder};
+
+/// Reads are unsigned and unpaid: nobody is charged, so the values are arbitrary. They exist
+/// only because `TransactionBuilder::try_build` refuses to produce a transaction without them.
+const READ_GAS_BUDGET: u64 = 50_000_000;
+const READ_GAS_PRICE: u64 = 1000;
+
+const SUI_CLOCK_OBJECT_ID: &str =
+    "0x0000000000000000000000000000000000000000000000000000000000000006";
+
+/// Height of the most recently executed checkpoint.
+pub async fn latest_checkpoint(client: &Client) -> Result<u64, DeepBookError> {
+    client
+        .clone()
+        .ledger_client()
+        .get_service_info(GetServiceInfoRequest::default())
+        .await?
+        .into_inner()
+        .checkpoint_height
+        .ok_or_else(|| DeepBookError::rpc("Node returned no checkpoint height"))
+}
+
+/// The version a shared object was first shared at, needed to reference it as a PTB input.
+///
+/// `read_mask` is not optional in spirit: `GetObject` defaults to `object_id,version,digest`, so
+/// without it `owner` comes back empty and this looks like "not a shared object".
+pub async fn initial_shared_version(
+    client: &Client,
+    object_id: &str,
+) -> Result<u64, DeepBookError> {
+    let object = client
+        .clone()
+        .ledger_client()
+        .get_object(
+            GetObjectRequest::default()
+                .with_object_id(object_id)
+                .with_read_mask(FieldMask::from_paths(["owner"])),
+        )
+        .await?
+        .into_inner()
+        .object
+        .ok_or_else(|| DeepBookError::rpc(format!("Object {object_id} not found")))?;
+
+    let owner = object
+        .owner
+        .ok_or_else(|| DeepBookError::rpc(format!("Object {object_id} has no owner")))?;
+
+    // `Owner.version` means `initial_shared_version` only for SHARED; for CONSENSUS_ADDRESS the
+    // same field carries `start_version`, so the kind check is load-bearing, not defensive.
+    if owner.kind() != OwnerKind::Shared {
+        return Err(DeepBookError::rpc(format!(
+            "Object {object_id} is not a shared object"
+        )));
+    }
+    owner
+        .version
+        .ok_or_else(|| DeepBookError::rpc(format!("Shared object {object_id} has no version")))
+}
+
+/// Start a read-only PTB: sender `0x0`, no signature, no real gas — the `dev_inspect` posture.
+pub fn read_only_tx() -> TransactionBuilder {
+    let mut tx = TransactionBuilder::new();
+    tx.set_sender(Address::ZERO);
+    tx.set_gas_budget(READ_GAS_BUDGET);
+    tx.set_gas_price(READ_GAS_PRICE);
+    tx.add_gas_objects([ObjectInput::owned(Address::ZERO, 1, Digest::ZERO)]);
+    tx
+}
+
+/// Reference a shared object immutably, the only way these read PTBs ever take one.
+pub fn shared_input(
+    object_id: &str,
+    initial_shared_version: u64,
+) -> Result<ObjectInput, DeepBookError> {
+    let address: Address = object_id
+        .parse()
+        .map_err(|e| DeepBookError::bad_request(format!("Invalid object ID {object_id}: {e}")))?;
+    Ok(ObjectInput::shared(
+        address,
+        initial_shared_version,
+        false, // immutable
+    ))
+}
+
+/// The `0x6` Clock, always shared at version 1.
+pub fn clock_input() -> ObjectInput {
+    let clock: Address = SUI_CLOCK_OBJECT_ID
+        .parse()
+        .expect("clock object ID is a valid address literal");
+    ObjectInput::shared(clock, 1, false)
+}
+
+/// Resolve a Move function to call, with its type arguments.
+pub fn function(
+    package: &str,
+    module: &str,
+    name: &str,
+    type_args: Vec<TypeTag>,
+) -> Result<Function, DeepBookError> {
+    let package: Address = package
+        .parse()
+        .map_err(|e| DeepBookError::bad_request(format!("Invalid package ID {package}: {e}")))?;
+    let module = module
+        .parse()
+        .map_err(|e| DeepBookError::bad_request(format!("Invalid module {module}: {e}")))?;
+    let name = name
+        .parse()
+        .map_err(|e| DeepBookError::bad_request(format!("Invalid function {name}: {e}")))?;
+    Ok(Function::new(package, module, name).with_type_args(type_args))
+}
+
+/// Simulate a read-only PTB and return each command's BCS return values, indexed
+/// `[command_index][return_value_index]` — the same bytes `dev_inspect` used to hand back.
+pub async fn simulate_returns(
+    client: &Client,
+    builder: TransactionBuilder,
+) -> Result<Vec<Vec<Vec<u8>>>, DeepBookError> {
+    let mut transaction: Transaction = builder
+        .try_build()
+        .map_err(|e| DeepBookError::rpc(format!("Failed to build read transaction: {e}")))?;
+
+    // `try_build` demands a gas coin, but address 0x0 owns none and the node resolves gas inputs
+    // even when checks are disabled — a placeholder coin fails with "could not find object 0x0".
+    // Sending no gas objects is what actually reproduces dev_inspect.
+    transaction.gas_payment.objects.clear();
+
+    let response = client
+        .clone()
+        .execution_client()
+        .simulate_transaction(
+            SimulateTransactionRequest::default()
+                .with_transaction(transaction)
+                // Without this mask `command_outputs` comes back empty rather than erroring.
+                .with_read_mask(FieldMask::from_paths(["command_outputs"]))
+                // Disabled checks let us call non-entry public view functions with no gas and no
+                // real sender, exactly as dev_inspect did.
+                .with_checks(TransactionChecks::Disabled),
+        )
+        .await?
+        .into_inner();
+
+    if response.command_outputs.is_empty() {
+        return Err(DeepBookError::rpc("No results from simulate_transaction"));
+    }
+
+    Ok(response
+        .command_outputs
+        .into_iter()
+        .map(|command| {
+            command
+                .return_values
+                .into_iter()
+                .filter_map(|output| output.value.and_then(|bcs| bcs.value).map(|b| b.to_vec()))
+                .collect()
+        })
+        .collect())
+}

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod admin;
 pub mod error;
+pub mod grpc;
 pub mod margin_metrics;
 mod metrics;
 mod reader;

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -22,6 +22,7 @@ struct Args {
         default_value = "postgres://postgres:postgrespw@localhost:5432/deepbook"
     )]
     database_url: Url,
+    /// Full node gRPC endpoint (`sui.rpc.v2`). Same host/port as the old JSON-RPC URL.
     #[clap(env, long, default_value = "https://fullnode.mainnet.sui.io:443")]
     rpc_url: Url,
     #[clap(

--- a/crates/server/src/margin_metrics/poller.rs
+++ b/crates/server/src/margin_metrics/poller.rs
@@ -8,9 +8,8 @@ use diesel_async::RunQueryDsl;
 use std::sync::Arc;
 use std::time::Duration;
 use sui_pg_db::Db;
-use sui_sdk::SuiClientBuilder;
+use sui_rpc::Client;
 use tokio_util::sync::CancellationToken;
-use url::Url;
 
 #[derive(Debug, Clone)]
 struct MarginPoolInfo {
@@ -21,7 +20,7 @@ struct MarginPoolInfo {
 
 pub struct MarginPoller {
     db: Db,
-    rpc_url: Url,
+    sui_client: Client,
     margin_package_id: String,
     metrics: Arc<MarginMetrics>,
     poll_interval: Duration,
@@ -31,7 +30,7 @@ pub struct MarginPoller {
 impl MarginPoller {
     pub fn new(
         db: Db,
-        rpc_url: Url,
+        sui_client: Client,
         margin_package_id: String,
         metrics: Arc<MarginMetrics>,
         poll_interval_secs: u64,
@@ -39,7 +38,7 @@ impl MarginPoller {
     ) -> Self {
         Self {
             db,
-            rpc_url,
+            sui_client,
             margin_package_id,
             metrics,
             poll_interval: Duration::from_secs(poll_interval_secs),
@@ -79,10 +78,7 @@ impl MarginPoller {
         }
 
         // 2. Create RPC client
-        let sui_client = SuiClientBuilder::default()
-            .build(self.rpc_url.as_str())
-            .await?;
-        let rpc_client = MarginRpcClient::new(sui_client, &self.margin_package_id)?;
+        let rpc_client = MarginRpcClient::new(self.sui_client.clone(), &self.margin_package_id);
 
         // 3. Query each pool and update metrics
         for pool_info in &pools {

--- a/crates/server/src/margin_metrics/rpc_client.rs
+++ b/crates/server/src/margin_metrics/rpc_client.rs
@@ -1,17 +1,10 @@
+use crate::grpc;
 use anyhow::{anyhow, Result};
 use std::str::FromStr;
-use sui_sdk::SuiClient;
-use sui_types::{
-    base_types::{ObjectID, SequenceNumber, SuiAddress},
-    programmable_transaction_builder::ProgrammableTransactionBuilder,
-    transaction::{Argument, CallArg, Command, ObjectArg, ProgrammableMoveCall, TransactionKind},
-    type_input::TypeInput,
-    TypeTag,
-};
+use sui_rpc::Client;
+use sui_sdk_types::TypeTag;
 
 const MARGIN_POOL_MODULE: &str = "margin_pool";
-const SUI_CLOCK_OBJECT_ID: &str =
-    "0x0000000000000000000000000000000000000000000000000000000000000006";
 
 /// Normalize asset type by ensuring the address has a 0x prefix.
 /// The DB stores types like "abc123::module::Type" but TypeTag parser needs "0xabc123::module::Type"
@@ -38,45 +31,22 @@ pub struct MarginPoolState {
 }
 
 pub struct MarginRpcClient {
-    sui_client: SuiClient,
-    margin_package_id: ObjectID,
+    sui_client: Client,
+    margin_package_id: String,
 }
 
 impl MarginRpcClient {
-    pub fn new(sui_client: SuiClient, margin_package_id: &str) -> Result<Self> {
-        let package_id = ObjectID::from_hex_literal(margin_package_id)
-            .map_err(|e| anyhow!("Invalid margin package ID: {}", e))?;
-        Ok(Self {
+    pub fn new(sui_client: Client, margin_package_id: &str) -> Self {
+        Self {
             sui_client,
-            margin_package_id: package_id,
-        })
+            margin_package_id: margin_package_id.to_string(),
+        }
     }
 
     pub async fn get_pool_state(&self, pool_id: &str, asset_type: &str) -> Result<MarginPoolState> {
-        let pool_object_id = ObjectID::from_hex_literal(pool_id)
-            .map_err(|e| anyhow!("Invalid pool ID '{}': {}", pool_id, e))?;
-
         // Get the pool object to find its initial_shared_version
-        let pool_object = self
-            .sui_client
-            .read_api()
-            .get_object_with_options(
-                pool_object_id,
-                sui_json_rpc_types::SuiObjectDataOptions::full_content().with_owner(),
-            )
-            .await?;
-
-        let pool_data = pool_object
-            .data
-            .as_ref()
-            .ok_or_else(|| anyhow!("Pool {} not found", pool_id))?;
-
-        let initial_shared_version = match &pool_data.owner {
-            Some(sui_types::object::Owner::Shared {
-                initial_shared_version,
-            }) => *initial_shared_version,
-            _ => return Err(anyhow!("Pool {} is not a shared object", pool_id)),
-        };
+        let initial_shared_version =
+            grpc::initial_shared_version(&self.sui_client, pool_id).await?;
 
         // Parse the asset type for type arguments
         // The asset_type from DB may be missing the 0x prefix, so normalize it
@@ -86,11 +56,11 @@ impl MarginRpcClient {
 
         // Query all the view functions in a single PTB
         let state = self
-            .query_pool_state(pool_object_id, initial_shared_version, &type_tag)
+            .query_pool_state(pool_id, initial_shared_version, &type_tag)
             .await?;
 
         Ok(MarginPoolState {
-            pool_id: pool_object_id.to_hex_literal(),
+            pool_id: pool_id.to_string(),
             asset_type: normalized_asset_type,
             total_supply: state.0,
             total_borrow: state.1,
@@ -105,126 +75,55 @@ impl MarginRpcClient {
 
     async fn query_pool_state(
         &self,
-        pool_id: ObjectID,
-        initial_shared_version: SequenceNumber,
+        pool_id: &str,
+        initial_shared_version: u64,
         type_tag: &TypeTag,
     ) -> Result<(u64, u64, u64, u64, u64, u64, u64, u64)> {
-        let mut ptb = ProgrammableTransactionBuilder::new();
+        let mut ptb = grpc::read_only_tx();
 
         // Input 0: Pool object
-        let pool_input = CallArg::Object(ObjectArg::SharedObject {
-            id: pool_id,
-            initial_shared_version,
-            mutability: sui_types::transaction::SharedObjectMutability::Immutable,
-        });
-        ptb.input(pool_input)?;
-
+        let pool = ptb.object(grpc::shared_input(pool_id, initial_shared_version)?);
         // Input 1: Clock object (for get_available_withdrawal)
-        let clock_id = ObjectID::from_hex_literal(SUI_CLOCK_OBJECT_ID)?;
-        let clock_input = CallArg::Object(ObjectArg::SharedObject {
-            id: clock_id,
-            initial_shared_version: SequenceNumber::from_u64(1),
-            mutability: sui_types::transaction::SharedObjectMutability::Immutable,
-        });
-        ptb.input(clock_input)?;
+        let clock = ptb.object(grpc::clock_input());
 
-        let type_input = TypeInput::from(type_tag.clone());
-        let type_args = vec![type_input];
+        let type_args = vec![type_tag.clone()];
+        let call = |name: &str| {
+            grpc::function(
+                &self.margin_package_id,
+                MARGIN_POOL_MODULE,
+                name,
+                type_args.clone(),
+            )
+        };
 
         // Command 0: total_supply<Asset>(pool)
-        ptb.command(Command::MoveCall(Box::new(ProgrammableMoveCall {
-            package: self.margin_package_id,
-            module: MARGIN_POOL_MODULE.to_string(),
-            function: "total_supply".to_string(),
-            type_arguments: type_args.clone(),
-            arguments: vec![Argument::Input(0)],
-        })));
-
+        ptb.move_call(call("total_supply")?, vec![pool]);
         // Command 1: total_borrow<Asset>(pool)
-        ptb.command(Command::MoveCall(Box::new(ProgrammableMoveCall {
-            package: self.margin_package_id,
-            module: MARGIN_POOL_MODULE.to_string(),
-            function: "total_borrow".to_string(),
-            type_arguments: type_args.clone(),
-            arguments: vec![Argument::Input(0)],
-        })));
-
+        ptb.move_call(call("total_borrow")?, vec![pool]);
         // Command 2: vault_balance<Asset>(pool)
-        ptb.command(Command::MoveCall(Box::new(ProgrammableMoveCall {
-            package: self.margin_package_id,
-            module: MARGIN_POOL_MODULE.to_string(),
-            function: "vault_balance".to_string(),
-            type_arguments: type_args.clone(),
-            arguments: vec![Argument::Input(0)],
-        })));
-
+        ptb.move_call(call("vault_balance")?, vec![pool]);
         // Command 3: supply_cap<Asset>(pool)
-        ptb.command(Command::MoveCall(Box::new(ProgrammableMoveCall {
-            package: self.margin_package_id,
-            module: MARGIN_POOL_MODULE.to_string(),
-            function: "supply_cap".to_string(),
-            type_arguments: type_args.clone(),
-            arguments: vec![Argument::Input(0)],
-        })));
-
+        ptb.move_call(call("supply_cap")?, vec![pool]);
         // Command 4: interest_rate<Asset>(pool)
-        ptb.command(Command::MoveCall(Box::new(ProgrammableMoveCall {
-            package: self.margin_package_id,
-            module: MARGIN_POOL_MODULE.to_string(),
-            function: "interest_rate".to_string(),
-            type_arguments: type_args.clone(),
-            arguments: vec![Argument::Input(0)],
-        })));
-
+        ptb.move_call(call("interest_rate")?, vec![pool]);
         // Command 5: get_available_withdrawal<Asset>(pool, clock)
-        ptb.command(Command::MoveCall(Box::new(ProgrammableMoveCall {
-            package: self.margin_package_id,
-            module: MARGIN_POOL_MODULE.to_string(),
-            function: "get_available_withdrawal".to_string(),
-            type_arguments: type_args.clone(),
-            arguments: vec![Argument::Input(0), Argument::Input(1)],
-        })));
-
+        ptb.move_call(call("get_available_withdrawal")?, vec![pool, clock]);
         // Command 6: supply_ratio<Asset>(pool)
-        ptb.command(Command::MoveCall(Box::new(ProgrammableMoveCall {
-            package: self.margin_package_id,
-            module: MARGIN_POOL_MODULE.to_string(),
-            function: "supply_ratio".to_string(),
-            type_arguments: type_args.clone(),
-            arguments: vec![Argument::Input(0)],
-        })));
-
+        ptb.move_call(call("supply_ratio")?, vec![pool]);
         // Command 7: borrow_ratio<Asset>(pool)
-        ptb.command(Command::MoveCall(Box::new(ProgrammableMoveCall {
-            package: self.margin_package_id,
-            module: MARGIN_POOL_MODULE.to_string(),
-            function: "borrow_ratio".to_string(),
-            type_arguments: type_args,
-            arguments: vec![Argument::Input(0)],
-        })));
+        ptb.move_call(call("borrow_ratio")?, vec![pool]);
 
-        let builder = ptb.finish();
-        let tx = TransactionKind::ProgrammableTransaction(builder);
-
-        let result = self
-            .sui_client
-            .read_api()
-            .dev_inspect_transaction_block(SuiAddress::default(), tx, None, None, None)
-            .await?;
-
-        let results = result
-            .results
-            .ok_or_else(|| anyhow!("No results from dev_inspect_transaction_block"))?;
+        let results = grpc::simulate_returns(&self.sui_client, ptb).await?;
 
         // Extract each u64 result
-        let total_supply = self.extract_u64(&results, 0, "total_supply")?;
-        let total_borrow = self.extract_u64(&results, 1, "total_borrow")?;
-        let vault_balance = self.extract_u64(&results, 2, "vault_balance")?;
-        let supply_cap = self.extract_u64(&results, 3, "supply_cap")?;
-        let interest_rate = self.extract_u64(&results, 4, "interest_rate")?;
-        let available_withdrawal = self.extract_u64(&results, 5, "get_available_withdrawal")?;
-        let supply_share_price = self.extract_u64(&results, 6, "supply_ratio")?;
-        let borrow_share_price = self.extract_u64(&results, 7, "borrow_ratio")?;
+        let total_supply = extract_u64(&results, 0, "total_supply")?;
+        let total_borrow = extract_u64(&results, 1, "total_borrow")?;
+        let vault_balance = extract_u64(&results, 2, "vault_balance")?;
+        let supply_cap = extract_u64(&results, 3, "supply_cap")?;
+        let interest_rate = extract_u64(&results, 4, "interest_rate")?;
+        let available_withdrawal = extract_u64(&results, 5, "get_available_withdrawal")?;
+        let supply_share_price = extract_u64(&results, 6, "supply_ratio")?;
+        let borrow_share_price = extract_u64(&results, 7, "borrow_ratio")?;
 
         Ok((
             total_supply,
@@ -237,25 +136,14 @@ impl MarginRpcClient {
             borrow_share_price,
         ))
     }
+}
 
-    fn extract_u64(
-        &self,
-        results: &[sui_json_rpc_types::SuiExecutionResult],
-        index: usize,
-        func_name: &str,
-    ) -> Result<u64> {
-        let result = results
-            .get(index)
-            .ok_or_else(|| anyhow!("Missing result for {}", func_name))?;
+fn extract_u64(results: &[Vec<Vec<u8>>], index: usize, func_name: &str) -> Result<u64> {
+    let bytes = results
+        .get(index)
+        .ok_or_else(|| anyhow!("Missing result for {}", func_name))?
+        .first()
+        .ok_or_else(|| anyhow!("No return value for {}", func_name))?;
 
-        let bytes = result
-            .return_values
-            .first()
-            .ok_or_else(|| anyhow!("No return value for {}", func_name))?;
-
-        let value: u64 = bcs::from_bytes(&bytes.0)
-            .map_err(|e| anyhow!("Failed to deserialize {} result: {}", func_name, e))?;
-
-        Ok(value)
-    }
+    bcs::from_bytes(bytes).map_err(|e| anyhow!("Failed to deserialize {} result: {}", func_name, e))
 }

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -33,7 +33,6 @@ use std::{collections::HashMap, net::SocketAddr};
 use sui_pg_db::DbArgs;
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
-use tokio::sync::OnceCell;
 use tower_http::cors::{AllowMethods, Any, CorsLayer};
 use url::Url;
 
@@ -49,15 +48,8 @@ use std::str::FromStr;
 use std::sync::Arc;
 use sui_futures::service::Service;
 use sui_indexer_alt_metrics::{MetricsArgs, MetricsService};
-use sui_json_rpc_types::{SuiObjectData, SuiObjectDataOptions, SuiObjectResponse};
-use sui_sdk::SuiClientBuilder;
-use sui_types::{
-    base_types::{ObjectID, SuiAddress},
-    programmable_transaction_builder::ProgrammableTransactionBuilder,
-    transaction::{Argument, CallArg, Command, ObjectArg, ProgrammableMoveCall, TransactionKind},
-    type_input::TypeInput,
-    TypeTag,
-};
+use sui_rpc::Client;
+use sui_sdk_types::TypeTag;
 use tokio::join;
 
 diesel::define_sql_function! {
@@ -148,8 +140,7 @@ pub struct AppState {
     reader: Reader,
     writer: Writer,
     metrics: Arc<RpcMetrics>,
-    rpc_url: Url,
-    sui_client: Arc<OnceCell<sui_sdk::SuiClient>>,
+    sui_client: Client,
     deepbook_package_id: String,
     deep_token_package_id: String,
     deep_treasury_id: String,
@@ -205,8 +196,7 @@ impl AppState {
             reader,
             writer,
             metrics,
-            rpc_url,
-            sui_client: Arc::new(OnceCell::new()),
+            sui_client: Client::new(rpc_url.as_str())?,
             deepbook_package_id,
             deep_token_package_id,
             deep_treasury_id,
@@ -216,17 +206,10 @@ impl AppState {
         })
     }
 
-    /// Returns a reference to the shared SuiClient instance.
-    /// Lazily initializes the client on first access and caches it for subsequent calls
-    pub async fn sui_client(&self) -> Result<&sui_sdk::SuiClient, DeepBookError> {
-        self.sui_client
-            .get_or_try_init(|| async {
-                SuiClientBuilder::default()
-                    .build(self.rpc_url.as_str())
-                    .await
-            })
-            .await
-            .map_err(DeepBookError::from)
+    /// The shared full-node gRPC client. Cloning is cheap (it shares one channel), which is how
+    /// callers get the `&mut` receiver tonic's generated clients want.
+    pub fn sui_client(&self) -> &Client {
+        &self.sui_client
     }
     pub(crate) fn metrics(&self) -> &RpcMetrics {
         &self.metrics
@@ -309,7 +292,7 @@ pub async fn run_server(
         let margin_db = sui_pg_db::Db::for_write(database_url, db_arg).await?;
         let margin_poller = crate::margin_metrics::MarginPoller::new(
             margin_db,
-            rpc_url.clone(),
+            state.sui_client().clone(),
             margin_pkg_id,
             margin_metrics,
             margin_poll_interval_secs,
@@ -459,11 +442,8 @@ async fn status(
     // Get watermarks from the database
     let watermarks = state.reader.get_watermarks().await?;
 
-    // Get the latest checkpoint from Sui RPC
-    let sui_client = state.sui_client().await?;
-    let latest_checkpoint = sui_client
-        .read_api()
-        .get_latest_checkpoint_sequence_number()
+    // Get the latest checkpoint from the full node
+    let latest_checkpoint = crate::grpc::latest_checkpoint(state.sui_client())
         .await
         .map_err(|e| DeepBookError::rpc(format!("Failed to get latest checkpoint: {}", e)))?;
 
@@ -1561,121 +1541,46 @@ async fn orderbook(
     let base_decimals = base_decimals as u8;
     let quote_decimals = quote_decimals as u8;
 
-    let pool_address = ObjectID::from_hex_literal(&pool_id)?;
+    let client = state.sui_client();
+    let initial_shared_version = crate::grpc::initial_shared_version(client, &pool_id)
+        .await
+        .map_err(|e| DeepBookError::rpc(format!("Pool '{}': {}", pool_name, e)))?;
 
-    let sui_client = state.sui_client().await?;
-    let mut ptb = ProgrammableTransactionBuilder::new();
-
-    let pool_object: SuiObjectResponse = sui_client
-        .read_api()
-        .get_object_with_options(
-            pool_address,
-            SuiObjectDataOptions::full_content().with_owner(),
-        )
-        .await?;
-    let pool_data: &SuiObjectData = pool_object.data.as_ref().ok_or(DeepBookError::rpc(
-        format!("Missing data in pool object response for '{}'", pool_name),
-    ))?;
-
-    let initial_shared_version = match &pool_data.owner {
-        Some(sui_types::object::Owner::Shared {
-            initial_shared_version,
-        }) => *initial_shared_version,
-        _ => {
-            return Err(DeepBookError::rpc(format!(
-                "Pool '{}' is not a shared object or owner info missing",
-                pool_name
-            )));
-        }
-    };
-
-    let pool_input = CallArg::Object(ObjectArg::SharedObject {
-        id: pool_data.object_id,
-        initial_shared_version,
-        mutability: sui_types::transaction::SharedObjectMutability::Immutable,
-    });
-    ptb.input(pool_input)?;
-
-    let input_argument = CallArg::Pure(
-        bcs::to_bytes(&ticks_from_mid)
-            .map_err(|_| DeepBookError::internal("Failed to serialize ticks_from_mid"))?,
-    );
-    ptb.input(input_argument)?;
-
-    let sui_clock_object_id = ObjectID::from_hex_literal(
-        "0x0000000000000000000000000000000000000000000000000000000000000006",
-    )?;
-    let clock_input = CallArg::Object(ObjectArg::SharedObject {
-        id: sui_clock_object_id,
-        initial_shared_version: sui_types::base_types::SequenceNumber::from_u64(1),
-        mutability: sui_types::transaction::SharedObjectMutability::Immutable,
-    });
-    ptb.input(clock_input)?;
+    let mut ptb = crate::grpc::read_only_tx();
+    let pool = ptb.object(crate::grpc::shared_input(&pool_id, initial_shared_version)?);
+    let ticks = ptb.pure(&ticks_from_mid);
+    let clock = ptb.object(crate::grpc::clock_input());
 
     let base_coin_type = parse_type_input(&base_asset_id)?;
     let quote_coin_type = parse_type_input(&quote_asset_id)?;
 
-    let package = ObjectID::from_hex_literal(&state.deepbook_package_id)
-        .map_err(|e| DeepBookError::bad_request(format!("Invalid pool ID: {}", e)))?;
-    let module = LEVEL2_MODULE.to_string();
-    let function = LEVEL2_FUNCTION.to_string();
+    ptb.move_call(
+        crate::grpc::function(
+            &state.deepbook_package_id,
+            LEVEL2_MODULE,
+            LEVEL2_FUNCTION,
+            vec![base_coin_type, quote_coin_type],
+        )?,
+        vec![pool, ticks, clock],
+    );
 
-    ptb.command(Command::MoveCall(Box::new(ProgrammableMoveCall {
-        package,
-        module,
-        function,
-        type_arguments: vec![base_coin_type, quote_coin_type],
-        arguments: vec![Argument::Input(0), Argument::Input(1), Argument::Input(2)],
-    })));
+    let results = crate::grpc::simulate_returns(client, ptb).await?;
 
-    let builder = ptb.finish();
-    let tx = TransactionKind::ProgrammableTransaction(builder);
-
-    let result = sui_client
-        .read_api()
-        .dev_inspect_transaction_block(SuiAddress::default(), tx, None, None, None)
-        .await?;
-
-    let mut binding = result.results.ok_or(DeepBookError::rpc(
-        "No results from dev_inspect_transaction_block",
-    ))?;
-    let bid_prices = &binding
-        .first_mut()
-        .ok_or(DeepBookError::rpc("No return values for bid prices"))?
-        .return_values
-        .first_mut()
-        .ok_or(DeepBookError::rpc("No bid price data found"))?
-        .0;
-    let bid_parsed_prices: Vec<u64> = bcs::from_bytes(bid_prices)
-        .map_err(|_| DeepBookError::deserialization("Failed to deserialize bid prices"))?;
-    let bid_quantities = &binding
-        .first_mut()
-        .ok_or(DeepBookError::rpc("No return values for bid quantities"))?
-        .return_values
-        .get(1)
-        .ok_or(DeepBookError::rpc("No bid quantity data found"))?
-        .0;
-    let bid_parsed_quantities: Vec<u64> = bcs::from_bytes(bid_quantities)
-        .map_err(|_| DeepBookError::deserialization("Failed to deserialize bid quantities"))?;
-
-    let ask_prices = &binding
-        .first_mut()
-        .ok_or(DeepBookError::rpc("No return values for ask prices"))?
-        .return_values
-        .get(2)
-        .ok_or(DeepBookError::rpc("No ask price data found"))?
-        .0;
-    let ask_parsed_prices: Vec<u64> = bcs::from_bytes(ask_prices)
-        .map_err(|_| DeepBookError::deserialization("Failed to deserialize ask prices"))?;
-    let ask_quantities = &binding
-        .first_mut()
-        .ok_or(DeepBookError::rpc("No return values for ask quantities"))?
-        .return_values
-        .get(3)
-        .ok_or(DeepBookError::rpc("No ask quantity data found"))?
-        .0;
-    let ask_parsed_quantities: Vec<u64> = bcs::from_bytes(ask_quantities)
-        .map_err(|_| DeepBookError::deserialization("Failed to deserialize ask quantities"))?;
+    // One command returning four vectors: bid prices, bid quantities, ask prices, ask quantities.
+    let level2 = results
+        .first()
+        .ok_or(DeepBookError::rpc("No return values for level2 ticks"))?;
+    let decode = |index: usize, what: &str| -> Result<Vec<u64>, DeepBookError> {
+        let bytes = level2
+            .get(index)
+            .ok_or_else(|| DeepBookError::rpc(format!("No {} data found", what)))?;
+        bcs::from_bytes(bytes)
+            .map_err(|_| DeepBookError::deserialization(format!("Failed to deserialize {}", what)))
+    };
+    let bid_parsed_prices = decode(0, "bid prices")?;
+    let bid_parsed_quantities = decode(1, "bid quantities")?;
+    let ask_parsed_prices = decode(2, "ask prices")?;
+    let ask_parsed_quantities = decode(3, "ask quantities")?;
 
     let mut result = HashMap::new();
 
@@ -1720,69 +1625,32 @@ async fn orderbook(
 
 /// DEEP total supply
 async fn deep_supply(State(state): State<Arc<AppState>>) -> Result<Json<u64>, DeepBookError> {
-    let sui_client = state.sui_client().await?;
-    let mut ptb = ProgrammableTransactionBuilder::new();
+    let client = state.sui_client();
+    let initial_shared_version =
+        crate::grpc::initial_shared_version(client, &state.deep_treasury_id).await?;
 
-    let deep_treasury_object_id = ObjectID::from_hex_literal(&state.deep_treasury_id)?;
-    let deep_treasury_object: SuiObjectResponse = sui_client
-        .read_api()
-        .get_object_with_options(
-            deep_treasury_object_id,
-            SuiObjectDataOptions::full_content().with_owner(),
-        )
-        .await?;
-    let deep_treasury_data: &SuiObjectData = deep_treasury_object
-        .data
-        .as_ref()
-        .ok_or(DeepBookError::rpc("Incorrect Treasury ID"))?;
-
-    let initial_shared_version = match &deep_treasury_data.owner {
-        Some(sui_types::object::Owner::Shared {
-            initial_shared_version,
-        }) => *initial_shared_version,
-        _ => {
-            return Err(DeepBookError::rpc("Treasury is not a shared object"));
-        }
-    };
-    let deep_treasury_input = CallArg::Object(ObjectArg::SharedObject {
-        id: deep_treasury_data.object_id,
+    let mut ptb = crate::grpc::read_only_tx();
+    let treasury = ptb.object(crate::grpc::shared_input(
+        &state.deep_treasury_id,
         initial_shared_version,
-        mutability: sui_types::transaction::SharedObjectMutability::Immutable,
-    });
-    ptb.input(deep_treasury_input)?;
+    )?);
+    ptb.move_call(
+        crate::grpc::function(
+            &state.deep_token_package_id,
+            DEEP_SUPPLY_MODULE,
+            DEEP_SUPPLY_FUNCTION,
+            vec![],
+        )?,
+        vec![treasury],
+    );
 
-    let package = ObjectID::from_hex_literal(&state.deep_token_package_id)
-        .map_err(|e| DeepBookError::bad_request(format!("Invalid deep token package ID: {}", e)))?;
-    let module = DEEP_SUPPLY_MODULE.to_string();
-    let function = DEEP_SUPPLY_FUNCTION.to_string();
+    let results = crate::grpc::simulate_returns(client, ptb).await?;
 
-    ptb.command(Command::MoveCall(Box::new(ProgrammableMoveCall {
-        package,
-        module,
-        function,
-        type_arguments: vec![],
-        arguments: vec![Argument::Input(0)],
-    })));
-
-    let builder = ptb.finish();
-    let tx = TransactionKind::ProgrammableTransaction(builder);
-
-    let result = sui_client
-        .read_api()
-        .dev_inspect_transaction_block(SuiAddress::default(), tx, None, None, None)
-        .await?;
-
-    let mut binding = result.results.ok_or(DeepBookError::rpc(
-        "No results from dev_inspect_transaction_block",
-    ))?;
-
-    let total_supply = &binding
-        .first_mut()
+    let total_supply = results
+        .first()
         .ok_or(DeepBookError::rpc("No return values for total supply"))?
-        .return_values
-        .first_mut()
-        .ok_or(DeepBookError::rpc("No total supply data found"))?
-        .0;
+        .first()
+        .ok_or(DeepBookError::rpc("No total supply data found"))?;
 
     let total_supply_value: u64 = bcs::from_bytes(total_supply)
         .map_err(|_| DeepBookError::deserialization("Failed to deserialize total supply"))?;
@@ -1803,65 +1671,41 @@ async fn fees(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<HashMap<String, PoolFees>>, DeepBookError> {
     let pools: Vec<Pools> = state.reader.get_pools().await?;
-    let sui_client = state.sui_client().await?;
-    let package = ObjectID::from_hex_literal(&state.deepbook_package_id)
-        .map_err(|e| DeepBookError::bad_request(format!("Invalid package ID: {}", e)))?;
+    let client = state.sui_client();
 
-    // Fetch all pool objects to get initial_shared_version
-    let pool_object_futures = pools.iter().map(|pool| {
-        let pool_id = pool.pool_id.clone();
-        async move {
-            let pool_address = ObjectID::from_hex_literal(&pool_id)?;
-            let pool_object: SuiObjectResponse = sui_client
-                .read_api()
-                .get_object_with_options(
-                    pool_address,
-                    SuiObjectDataOptions::full_content().with_owner(),
-                )
-                .await?;
-            Ok::<_, DeepBookError>(pool_object)
-        }
-    });
-    let pool_objects: Vec<Result<SuiObjectResponse, DeepBookError>> =
-        join_all(pool_object_futures).await;
+    // Fetch all pool objects in parallel to get initial_shared_version
+    let versions: Vec<Result<u64, DeepBookError>> = join_all(
+        pools
+            .iter()
+            .map(|pool| crate::grpc::initial_shared_version(client, &pool.pool_id)),
+    )
+    .await;
 
-    let mut ptb = ProgrammableTransactionBuilder::new();
+    let mut ptb = crate::grpc::read_only_tx();
     let mut valid_pools: Vec<&Pools> = Vec::new();
 
-    for (pool, pool_object_result) in pools.iter().zip(pool_objects.into_iter()) {
-        let pool_object = match pool_object_result {
-            Ok(obj) => obj,
-            Err(_) => continue,
-        };
-        let pool_data = match pool_object.data.as_ref() {
-            Some(data) => data,
-            None => continue,
-        };
-        let initial_shared_version = match &pool_data.owner {
-            Some(sui_types::object::Owner::Shared {
-                initial_shared_version,
-            }) => *initial_shared_version,
-            _ => continue,
+    for (pool, version) in pools.iter().zip(versions.into_iter()) {
+        let Ok(initial_shared_version) = version else {
+            continue;
         };
 
-        let input_idx = valid_pools.len() as u16;
-        let pool_input = CallArg::Object(ObjectArg::SharedObject {
-            id: pool_data.object_id,
+        let pool_input = ptb.object(crate::grpc::shared_input(
+            &pool.pool_id,
             initial_shared_version,
-            mutability: sui_types::transaction::SharedObjectMutability::Immutable,
-        });
-        ptb.input(pool_input)?;
+        )?);
 
         let base_coin_type = parse_type_input(&pool.base_asset_id)?;
         let quote_coin_type = parse_type_input(&pool.quote_asset_id)?;
 
-        ptb.command(Command::MoveCall(Box::new(ProgrammableMoveCall {
-            package,
-            module: FEES_MODULE.to_string(),
-            function: FEES_FUNCTION.to_string(),
-            type_arguments: vec![base_coin_type, quote_coin_type],
-            arguments: vec![Argument::Input(input_idx)],
-        })));
+        ptb.move_call(
+            crate::grpc::function(
+                &state.deepbook_package_id,
+                FEES_MODULE,
+                FEES_FUNCTION,
+                vec![base_coin_type, quote_coin_type],
+            )?,
+            vec![pool_input],
+        );
 
         valid_pools.push(pool);
     }
@@ -1870,46 +1714,32 @@ async fn fees(
         return Ok(Json(HashMap::new()));
     }
 
-    let builder = ptb.finish();
-    let tx = TransactionKind::ProgrammableTransaction(builder);
-
-    let result = sui_client
-        .read_api()
-        .dev_inspect_transaction_block(SuiAddress::default(), tx, None, None, None)
-        .await?;
-
-    let results = result.results.ok_or(DeepBookError::rpc(
-        "No results from dev_inspect_transaction_block",
-    ))?;
+    let results = crate::grpc::simulate_returns(client, ptb).await?;
 
     let mut fees = HashMap::new();
     for (i, pool) in valid_pools.iter().enumerate() {
-        let return_values = &results
+        let return_values = results
             .get(i)
-            .ok_or(DeepBookError::rpc("Missing result for pool"))?
-            .return_values;
+            .ok_or(DeepBookError::rpc("Missing result for pool"))?;
 
         let taker_fee: u64 = bcs::from_bytes(
-            &return_values
+            return_values
                 .first()
-                .ok_or(DeepBookError::rpc("Missing taker_fee"))?
-                .0,
+                .ok_or(DeepBookError::rpc("Missing taker_fee"))?,
         )
         .map_err(|_| DeepBookError::deserialization("Failed to deserialize taker_fee"))?;
 
         let maker_fee: u64 = bcs::from_bytes(
-            &return_values
+            return_values
                 .get(1)
-                .ok_or(DeepBookError::rpc("Missing maker_fee"))?
-                .0,
+                .ok_or(DeepBookError::rpc("Missing maker_fee"))?,
         )
         .map_err(|_| DeepBookError::deserialization("Failed to deserialize maker_fee"))?;
 
         let stake_required: u64 = bcs::from_bytes(
-            &return_values
+            return_values
                 .get(2)
-                .ok_or(DeepBookError::rpc("Missing stake_required"))?
-                .0,
+                .ok_or(DeepBookError::rpc("Missing stake_required"))?,
         )
         .map_err(|_| DeepBookError::deserialization("Failed to deserialize stake_required"))?;
 
@@ -1947,37 +1777,16 @@ async fn margin_supply(
         return Ok(Json(HashMap::new()));
     }
 
-    let sui_client = state.sui_client().await?;
-    let package = ObjectID::from_hex_literal(margin_package_id)
-        .map_err(|e| DeepBookError::bad_request(format!("Invalid margin package ID: {}", e)))?;
+    let client = state.sui_client();
 
     let mut result: HashMap<String, u64> = HashMap::new();
 
     for (pool_id, asset_type) in pools {
-        let pool_object_id = ObjectID::from_hex_literal(&pool_id).map_err(|e| {
-            DeepBookError::bad_request(format!("Invalid pool ID '{}': {}", pool_id, e))
-        })?;
-
         // Get the pool object to find its initial_shared_version
-        let pool_object: SuiObjectResponse = sui_client
-            .read_api()
-            .get_object_with_options(
-                pool_object_id,
-                SuiObjectDataOptions::full_content().with_owner(),
-            )
-            .await?;
-
-        let pool_data: &SuiObjectData = pool_object.data.as_ref().ok_or(DeepBookError::rpc(
-            format!("Missing data in pool object response for '{}'", pool_id),
-        ))?;
-
-        let initial_shared_version = match &pool_data.owner {
-            Some(sui_types::object::Owner::Shared {
-                initial_shared_version,
-            }) => *initial_shared_version,
-            _ => {
-                continue;
-            }
+        let Ok(initial_shared_version) =
+            crate::grpc::initial_shared_version(client, &pool_id).await
+        else {
+            continue;
         };
 
         // Normalize asset type (ensure 0x prefix)
@@ -1992,46 +1801,30 @@ async fn margin_supply(
             Ok(t) => t,
             Err(_) => continue,
         };
-        let type_input = TypeInput::from(type_tag);
 
         // Build PTB for total_supply call
-        let mut ptb = ProgrammableTransactionBuilder::new();
+        let mut ptb = crate::grpc::read_only_tx();
+        let pool_input = ptb.object(crate::grpc::shared_input(&pool_id, initial_shared_version)?);
+        ptb.move_call(
+            crate::grpc::function(
+                margin_package_id,
+                MARGIN_POOL_MODULE,
+                "total_supply",
+                vec![type_tag],
+            )?,
+            vec![pool_input],
+        );
 
-        let pool_input = CallArg::Object(ObjectArg::SharedObject {
-            id: pool_data.object_id,
-            initial_shared_version,
-            mutability: sui_types::transaction::SharedObjectMutability::Immutable,
-        });
-        ptb.input(pool_input)?;
-
-        ptb.command(Command::MoveCall(Box::new(ProgrammableMoveCall {
-            package,
-            module: MARGIN_POOL_MODULE.to_string(),
-            function: "total_supply".to_string(),
-            type_arguments: vec![type_input],
-            arguments: vec![Argument::Input(0)],
-        })));
-
-        let builder = ptb.finish();
-        let tx = TransactionKind::ProgrammableTransaction(builder);
-
-        let inspect_result = sui_client
-            .read_api()
-            .dev_inspect_transaction_block(SuiAddress::default(), tx, None, None, None)
-            .await?;
-
-        if let Some(mut results) = inspect_result.results {
-            if let Some(first_result) = results.first_mut() {
-                if let Some(return_value) = first_result.return_values.first() {
-                    if let Ok(total_supply) = bcs::from_bytes::<u64>(&return_value.0) {
-                        // Extract asset name from asset_type (e.g., "0x2::sui::SUI" -> "SUI")
-                        let asset_name = asset_type
-                            .rsplit("::")
-                            .next()
-                            .unwrap_or(&asset_type)
-                            .to_string();
-                        result.insert(asset_name, total_supply);
-                    }
+        if let Ok(results) = crate::grpc::simulate_returns(client, ptb).await {
+            if let Some(return_value) = results.first().and_then(|c| c.first()) {
+                if let Ok(total_supply) = bcs::from_bytes::<u64>(return_value) {
+                    // Extract asset name from asset_type (e.g., "0x2::sui::SUI" -> "SUI")
+                    let asset_name = asset_type
+                        .rsplit("::")
+                        .next()
+                        .unwrap_or(&asset_type)
+                        .to_string();
+                    result.insert(asset_name, total_supply);
                 }
             }
         }
@@ -2077,9 +1870,9 @@ async fn book_params_updated(
     Ok(Json(state.reader.get_book_params_updated(pool_id).await?))
 }
 
-fn parse_type_input(type_str: &str) -> Result<TypeInput, DeepBookError> {
-    let type_tag = TypeTag::from_str(type_str)?;
-    Ok(TypeInput::from(type_tag))
+fn parse_type_input(type_str: &str) -> Result<TypeTag, DeepBookError> {
+    TypeTag::from_str(type_str)
+        .map_err(|e| DeepBookError::bad_request(format!("Invalid type '{}': {}", type_str, e)))
 }
 
 trait ParameterUtil {


### PR DESCRIPTION
## Why

**Sui is turning JSON-RPC off on 2026-07-31. Our server reads the chain over JSON-RPC. On that date those reads stop working.**

That's the whole reason for this PR. Concretely, if we do nothing, on July 31 these five endpoints start failing and the margin metrics poller stops writing data:

| Surface | What breaks |
|---|---|
| `/orderbook/:pool` | live L2 book (a Move view call) |
| `/deep_supply` | DEEP total supply |
| `/fees` | per-pool taker/maker fee + stake required |
| `/margin_supply` | per-margin-pool total supply |
| `/status` | checkpoint-lag health check |
| margin poller | Prometheus gauges + `margin_pool_snapshots` rows |

Everything else we serve comes from Postgres and was never at risk.

**Two things that make this smaller than it sounds:**

1. **The indexer needs no change.** It never talked to a node over JSON-RPC — it ingests checkpoints from the remote store (`checkpoints.mainnet.sui.io`), which the sunset doesn't touch. All 12 JSON-RPC call sites were in `crates/server`. Spot and margin are the same binary, so both are covered here.
2. **The reads map 1:1 onto gRPC.** No behavior had to be redesigned:

| JSON-RPC (today) | gRPC (this PR) |
|---|---|
| `getLatestCheckpointSequenceNumber` | `LedgerService.GetServiceInfo` → `checkpoint_height` |
| `getObject` (only ever to read a shared object's `initial_shared_version`) | `LedgerService.GetObject` |
| `devInspectTransactionBlock` (run Move view fns) | `TransactionExecutionService.SimulateTransaction` |

`SimulateTransaction` hands back the same per-command BCS return values `devInspect` did, so all the existing decode logic is untouched.

**Why gRPC and not GraphQL** (Sui offers both as replacements): Sui's own guidance puts backend services doing low-latency point lookups on gRPC, and it's where this repo already went — most of `scripts/` uses `SuiGrpcClient`, and the Predict SDK already runs Move view functions through gRPC `simulateTransaction`. This server was the last JSON-RPC holdout in the hot path.

## Summary
- Move every full-node read in `crates/server` from JSON-RPC (`sui-sdk`) to `sui.rpc.v2` gRPC (`sui-rpc`).
- Add `crates/server/src/grpc.rs` — three primitives cover every read we make: `latest_checkpoint`, `initial_shared_version`, and `simulate_returns`.
- Port the five call sites plus the margin metrics poller onto it.
- Drop `sui-sdk`, `sui-json-rpc-types`, and `sui-types` from the server; build PTBs with `sui-transaction-builder`. Net **-605 lines**.
- Bump `crates/indexer` off its Aug-2025 `sui-rust-sdk` git pin (which only ships the old `v2beta2` protos) to crates.io `0.3.1`, so the workspace carries a single `sui-sdk-types`.

## Key decisions
- **No API changes.** Routes, response shapes, field names, types, and error mapping are all unchanged — only the transport underneath moved. Verified by diffing real responses against prod (below).
- **1:1 behavioral port, no opportunistic cleanups.** So that any post-deploy regression is unambiguously a transport bug. The pre-existing `/margin_supply` N+1 and the tuple-of-8 in `rpc_client.rs` are deliberately left alone (see follow-ups).
- **No deploy config change.** `--rpc-url` / `$RPC_URL` keeps its current value — the same host and port serve gRPC. Only the help text changed.
- **Three gotchas, each of which fails silently or misleadingly** (all documented in `.claude/rules/indexer.md`):
  - `read_mask` defaults are lossy. `GetObject` defaults to `object_id,version,digest`, so `owner` — the only reason we fetch the object, since it carries `initial_shared_version` — comes back **empty unless explicitly requested**. Same for `command_outputs` on `SimulateTransaction`. A forgotten mask reads as "not a shared object" / "no results", not as an error.
  - `checks: DISABLED` does **not** skip gas-object resolution. A placeholder `0x0` gas coin is rejected with `Could not find the referenced object 0x0`. `try_build()` requires a gas coin, so we build with one and then clear `gas_payment.objects`; that empty-gas posture is what actually reproduces `devInspect`.
  - `Owner.version` is overloaded — `initial_shared_version` for `SHARED`, `start_version` for `CONSENSUS_ADDRESS` — so the kind check is load-bearing, not defensive.
- `sui-sdk-types` 0.3.x made `StructTag`'s fields private, which forced a rewrite of the event-type matching in `indexer/src/traits.rs` that **every** handler depends on. The 35 snapshot tests are the regression net for that.

## Test plan

**End-to-end run of the actual `deepbook-server` binary** (local Postgres seeded with prod's DEEP_SUI pool + USDSUI margin pool, `--rpc-url https://fullnode.mainnet.sui.io:443`), every response compared against the live prod API, which is still on JSON-RPC:

| Endpoint | This PR | Prod (JSON-RPC) |
|---|---|---|
| `/deep_supply` | `9968631400260264` | identical |
| `/fees` (DEEP_SUI) | `taker 0.0, maker 0.0, stake 0.0`, same `pool_id` | identical |
| `/margin_supply` | `{"USDSUI":1050465684}` | identical |
| `/orderbook?level=1` | `bids [["0.02485","280"]] asks [["0.02486","400"]]` | identical, 3/3 paired samples |
| `/status` | `latest_onchain_checkpoint: 298206755` | tracks the node's `x-sui-checkpoint-height` |

- [x] Margin poller (the batched 8-call PTB): `margin_rpc_poll_errors_total 0`, gauges populated, and a `margin_pool_snapshots` row written with `total_supply=1050465684` / `supply_cap=1000000000000` — matching on-chain. (`supply_cap` and `available_withdrawal` independently corroborate the pool's on-chain creation event, which confirms the Clock input and type-arg/asset-type normalization.)
- [x] `cargo build --workspace` clean — 0 errors, 0 warnings; `cargo fmt --all --check` clean; no new clippy warnings.
- [x] `cargo test -p deepbook-indexer` — **35/35 snapshot tests pass** (needs a real Postgres server binary, not just `libpq`; see `.claude/rules/indexer.md`).
- [x] Provider support confirmed — every provider on Sui's list serves gRPC on Mainnet, including the Sui Foundation public endpoint that `--rpc-url` defaults to (QuickNode, BlockPi, Ankr, ZAN, Inodra, NodeInfra, Triton One, Alchemy, Dwellir, Blockvision, GetBlock, 01.ro, Natsai).

## Follow-ups (not in this PR)
- ⚠️ **`scripts/utils/utils.ts` still uses `SuiJsonRpcClient`** (`dryRunTransactionBlock`, `getObject`, `getLatestSuiSystemState`) on the mainnet multisig admin path. **This also breaks on 2026-07-31** and needs its own PR.
- Predict harness + simulations runtimes still use `SuiJsonRpcClient` + `devInspectTransactionBlock`. Localnet-only, so not on the sunset clock, but they break whenever the local `sui` binary drops JSON-RPC.
- `/margin_supply` is an N+1 (2 sequential round-trips per pool) and duplicates `margin_metrics/rpc_client.rs`; the batched-PTB pattern already in that file fixes it.
- The margin poller counts a no-op poll as a success: if the `assets` table has no row for a pool's asset type, the pool is filtered out and `margin_rpc_poll_success_total` still increments, so the metric can look healthy while nothing is being polled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
