### PR TITLE
docker: bump builder to rust 1.92 (fixes image build on main)

### DIFF
--- a/docker/deepbook-indexer/Dockerfile
+++ b/docker/deepbook-indexer/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.90.0 AS builder
+FROM rust:1.92.0 AS builder
 
 ARG PROFILE=release
 ARG GIT_REVISION

--- a/docker/deepbook-sandbox/Dockerfile
+++ b/docker/deepbook-sandbox/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.90.0 AS builder
+FROM rust:1.92.0 AS builder
 
 ARG PROFILE=release
 ARG GIT_REVISION

--- a/docker/deepbook-server/Dockerfile
+++ b/docker/deepbook-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.90.0 AS builder
+FROM rust:1.92.0 AS builder
 
 ARG PROFILE=release
 ARG GIT_REVISION


### PR DESCRIPTION
## Summary
- Bump `FROM rust:1.90.0` → `rust:1.92.0` in the three builder images that compile the Rust crates: `deepbook-indexer`, `deepbook-server`, `deepbook-sandbox`.

## Why
**Image builds on `main` are currently failing, and this unblocks them.**

#1113 (the JSON-RPC → gRPC migration) added `sui-transaction-builder 0.3.1`. That crate calls `BTreeMap::extract_if`, which is **still unstable on Rust 1.90** — the version all three builder images pin. So every image build on `main` now dies with:

```
error[E0658]: use of unstable library feature `btree_extract_if`
  --> sui-transaction-builder-0.3.1/src/intent/coin_with_balance.rs:342:45
error: could not compile `sui-transaction-builder` (lib) due to 1 previous error
```

This is why the testnet Pulumi update failed for both `deepbook-indexer` and `deepbook-server`.

It slipped through because the repo has no `rust-toolchain.toml`: local dev toolchains are newer than 1.90 (mine is 1.93), so the crate compiled fine locally and the version gap only showed up inside the image. The three new deps (`sui-rpc`, `sui-sdk-types`, `sui-transaction-builder`) are all edition 2024 and track recent Rust closely.

Nothing about the migration itself is wrong — it just needs a builder toolchain new enough for its dependencies.

## Key decisions
- **1.92.0, not latest.** It's the lowest version I actually verified end-to-end; I didn't want to pin a version I hadn't built. (1.91 may well work — `extract_if` looks to have stabilized there — but I didn't test it, so I'm not pinning it.)
- **All three images bumped, not just the two that failed.** `deepbook-sandbox` also runs `cargo build` against the same crates, so it would have broken on the next build.
- Worth considering as a follow-up: a `rust-toolchain.toml` so local builds and image builds can't silently diverge like this again. Left out here to keep the fix surgical.

## Test plan
- [x] **Reproduced the failure**: `cargo +1.90 build -p deepbook-server` fails with the exact `E0658 btree_extract_if` error from the Pulumi log.
- [x] **Fix verified**: `cargo +1.92 build -p deepbook-server -p deepbook-indexer` → 0 errors.
- [x] **Matched the Docker build exactly**: `cargo +1.92 build --profile release --bin deepbook-server --bin deepbook-indexer` → `Finished release profile [optimized]`, 0 errors.
- [x] Confirmed the `rust:1.92.0` tag exists on Docker Hub (so the bump can't fail on a missing base image).
- [ ] Reviewer: re-run the testnet Pulumi update to confirm the images build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)