### PR TITLE
margin: enable version 6 in enableMarginVersion script

### DIFF
--- a/scripts/transactions/enableMarginVersion.ts
+++ b/scripts/transactions/enableMarginVersion.ts
@@ -9,7 +9,7 @@ import { SuiGrpcClient } from "@mysten/sui/grpc";
 (async () => {
   // Update constant for env
   const env = "mainnet";
-  const versionToEnable = 2;
+  const versionToEnable = 6;
 
   const client = new SuiGrpcClient({
     baseUrl: "https://sui-mainnet.mystenlabs.com",


### PR DESCRIPTION
## Summary
- Bump `versionToEnable` from `2` to `6` in `scripts/transactions/enableMarginVersion.ts`

## Why
- The margin admin needs to enable margin version 6 on mainnet; the script previously targeted the stale version 2

## Key decisions
- None — single-constant change to the existing multisig enable-version script

## Test plan
- [ ] Run `pnpm tsx transactions/enableMarginVersion.ts` (with `GAS_OBJECT` set) and confirm the multisig tx to `enableVersion(6)` is produced in `tx/tx-data.txt`
- [ ] Execute the multisig tx on mainnet and verify version 6 appears in the MarginRegistry's `allowed_versions`