### PR TITLE
predict: taper max leverage as expiry approaches

### DIFF
--- a/packages/predict/sources/config/config_constants.move
+++ b/packages/predict/sources/config/config_constants.move
@@ -30,6 +30,7 @@ const EInvalidBackingBufferLambda: u64 = 19;
 const EInvalidMaxAdmissionLeverage: u64 = 20;
 const EInvalidCadenceWindowSize: u64 = 21;
 const EMarketTickSizeTooLarge: u64 = 22;
+const EInvalidLeverageTaperWindowMs: u64 = 23;
 
 // === Fees ===
 
@@ -101,6 +102,26 @@ public(package) fun assert_max_admission_leverage(value: u64) {
 /// `p * (1 + k) / (p + k)`. `0.2` makes low probabilities meaningfully stricter
 /// while still approaching the configured cap smoothly as probability rises.
 public(package) macro fun admission_leverage_curve_k(): u64 { 200_000_000 }
+
+/// Window before expiry over which admissible leverage tapers linearly from the
+/// probability-derived cap down to 1x (no leverage) at expiry. Shrinking leverage
+/// as expiry nears bounds LP exposure to single-tick probability jumps (gamma)
+/// that can leap an order past its knockout before liquidation fires. `0` disables
+/// the taper; one hour by default.
+public(package) macro fun default_leverage_taper_window_ms(): u64 {
+    deepbook_predict::constants::one_hour_ms!()
+}
+public(package) macro fun min_leverage_taper_window_ms(): u64 { 0 }
+public(package) macro fun max_leverage_taper_window_ms(): u64 {
+    deepbook_predict::constants::one_year_ms!()
+}
+
+public(package) fun assert_leverage_taper_window_ms(value: u64) {
+    assert!(
+        value >= min_leverage_taper_window_ms!() && value <= max_leverage_taper_window_ms!(),
+        EInvalidLeverageTaperWindowMs,
+    );
+}
 
 public(package) macro fun default_backing_buffer_lambda(): u64 { 250_000_000 }
 public(package) macro fun min_backing_buffer_lambda(): u64 { 50_000_000 }

--- a/packages/predict/sources/config/protocol_config.move
+++ b/packages/predict/sources/config/protocol_config.move
@@ -96,6 +96,16 @@ public fun set_template_expiry_fee_max_multiplier(
     config.strike_exposure_template_config.set_expiry_fee_max_multiplier(value);
 }
 
+/// Set the near-expiry leverage-taper window snapshotted by future expiry markets.
+public fun set_template_leverage_taper_window_ms(
+    config: &mut ProtocolConfig,
+    _admin_cap: &AdminCap,
+    value: u64,
+) {
+    config.assert_version();
+    config.strike_exposure_template_config.set_leverage_taper_window_ms(value);
+}
+
 /// Set the liquidation LTV snapshotted by future expiry markets.
 public fun set_template_liquidation_ltv(
     config: &mut ProtocolConfig,

--- a/packages/predict/sources/config/strike_exposure_config.move
+++ b/packages/predict/sources/config/strike_exposure_config.move
@@ -48,6 +48,9 @@ public struct StrikeExposureConfig has store {
     expiry_fee_window_ms: u64,
     /// Fee multiplier reached at expiry, in FLOAT_SCALING; 1x disables the ramp.
     expiry_fee_max_multiplier: u64,
+    /// Window before expiry over which admissible leverage tapers linearly to 1x
+    /// (no leverage) at expiry, in ms. `0` disables the taper.
+    leverage_taper_window_ms: u64,
 }
 
 /// Mint admission outcome: the net premium charged for the order and the static
@@ -95,6 +98,10 @@ public(package) fun expiry_fee_max_multiplier(config: &StrikeExposureConfig): u6
     config.expiry_fee_max_multiplier
 }
 
+public(package) fun leverage_taper_window_ms(config: &StrikeExposureConfig): u64 {
+    config.leverage_taper_window_ms
+}
+
 /// Return the raw trade fee for a live probability and quantity.
 ///
 /// Precondition: `timestamp_ms < expiry_ms`. Live-pricing callers enforce this
@@ -116,6 +123,7 @@ public(package) fun assert_mint_probability_and_leverage_policy(
     config: &StrikeExposureConfig,
     entry_probability: u64,
     leverage: u64,
+    time_to_expiry_ms: u64,
 ) {
     assert!(
         entry_probability >= config.min_entry_probability
@@ -123,10 +131,11 @@ public(package) fun assert_mint_probability_and_leverage_policy(
         EEntryProbabilityOutOfBounds,
     );
 
-    // Leverage is continuous, with the protocol cap scaled down for low prices.
+    // Leverage is continuous, with the protocol cap scaled down for low prices and
+    // as expiry approaches.
     assert!(leverage >= math::float_scaling!(), EInvalidLeverage);
     assert!(
-        leverage <= config.admitted_leverage_cap(entry_probability),
+        leverage <= config.admitted_leverage_cap(entry_probability, time_to_expiry_ms),
         ELeverageAboveAdmissionCap,
     );
 }
@@ -135,17 +144,23 @@ public(package) fun assert_mint_probability_and_leverage_policy(
 /// `MintAdmission` carrying the net premium and the static floor `F`.
 ///
 /// `floor_shares` is the static dollar floor `F = financed_amount = entry_value -
-/// net_premium`. Leverage must be at least 1x and no greater than the
-/// probability-sensitive admission cap. The actual live liquidation threshold
-/// remains the market's fixed `liquidation_ltv`; admission only decides whether
-/// the protocol originates the requested leverage.
+/// net_premium`. Leverage must be at least 1x and no greater than the admission
+/// cap, which scales down for low probabilities and as expiry approaches
+/// (`time_to_expiry_ms`). The actual live liquidation threshold remains the
+/// market's fixed `liquidation_ltv`; admission only decides whether the protocol
+/// originates the requested leverage.
 public(package) fun assert_mint_admission(
     config: &StrikeExposureConfig,
     entry_probability: u64,
     quantity: u64,
     leverage: u64,
+    time_to_expiry_ms: u64,
 ): MintAdmission {
-    config.assert_mint_probability_and_leverage_policy(entry_probability, leverage);
+    config.assert_mint_probability_and_leverage_policy(
+        entry_probability,
+        leverage,
+        time_to_expiry_ms,
+    );
 
     let entry_value = math::mul(entry_probability, quantity);
     let net_premium = math::div(entry_value, leverage);
@@ -196,6 +211,7 @@ public(package) fun new(): StrikeExposureConfig {
         max_entry_probability: config_constants::default_max_entry_probability!(),
         expiry_fee_window_ms: config_constants::default_expiry_fee_window_ms!(),
         expiry_fee_max_multiplier: config_constants::default_expiry_fee_max_multiplier!(),
+        leverage_taper_window_ms: config_constants::default_leverage_taper_window_ms!(),
     }
 }
 
@@ -211,6 +227,7 @@ public(package) fun snapshot(config: &StrikeExposureConfig): StrikeExposureConfi
         max_entry_probability: config.max_entry_probability,
         expiry_fee_window_ms: config.expiry_fee_window_ms,
         expiry_fee_max_multiplier: config.expiry_fee_max_multiplier,
+        leverage_taper_window_ms: config.leverage_taper_window_ms,
     }
 }
 
@@ -261,6 +278,11 @@ public(package) fun set_expiry_fee_max_multiplier(config: &mut StrikeExposureCon
     config.expiry_fee_max_multiplier = value;
 }
 
+public(package) fun set_leverage_taper_window_ms(config: &mut StrikeExposureConfig, value: u64) {
+    config_constants::assert_leverage_taper_window_ms(value);
+    config.leverage_taper_window_ms = value;
+}
+
 /// Return the 1e9-scaled per-unit trade fee.
 ///
 /// Precondition: `timestamp_ms < expiry_ms`; callers must enforce pre-expiry
@@ -287,15 +309,37 @@ fun raw_bernoulli_fee_rate(config: &StrikeExposureConfig, probability: u64): u64
     math::mul(config.base_fee, bernoulli_factor)
 }
 
-fun admitted_leverage_cap(config: &StrikeExposureConfig, entry_probability: u64): u64 {
+fun admitted_leverage_cap(
+    config: &StrikeExposureConfig,
+    entry_probability: u64,
+    time_to_expiry_ms: u64,
+): u64 {
     let k = config_constants::admission_leverage_curve_k!();
     let risk_curve = math::mul_div_down(
         entry_probability,
         math::float_scaling!() + k,
         entry_probability + k,
     );
-    math::float_scaling!()
-        + math::mul(config.max_admission_leverage - math::float_scaling!(), risk_curve)
+    // Scale the leverage-above-1x by both the low-price risk curve and the
+    // near-expiry taper, so the cap collapses to 1x at either the price tails or
+    // at expiry.
+    let excess_leverage = math::mul(
+        math::mul(config.max_admission_leverage - math::float_scaling!(), risk_curve),
+        config.leverage_taper_multiplier(time_to_expiry_ms),
+    );
+    math::float_scaling!() + excess_leverage
+}
+
+/// Linear taper on admissible leverage-above-1x as expiry approaches: full
+/// (`float_scaling`) outside the window, ramping down to `0` at expiry so the cap
+/// collapses to 1x. A `0` window disables the taper.
+///
+/// Precondition: `time_to_expiry_ms` is derived under caller-enforced pre-expiry
+/// liveness, mirroring `expiry_fee_multiplier`.
+fun leverage_taper_multiplier(config: &StrikeExposureConfig, time_to_expiry_ms: u64): u64 {
+    let window = config.leverage_taper_window_ms;
+    if (window == 0 || time_to_expiry_ms >= window) return math::float_scaling!();
+    math::div(time_to_expiry_ms, window)
 }
 
 /// Linear ramp that scales the trade fee up as expiry approaches.

--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -297,7 +297,7 @@ public fun quote_mint(
     market.assert_live_mint_allowed(config, pricer);
     let terms = market
         .strike_exposure
-        .quote_mint_terms(pricer, lower_tick, higher_tick, quantity, leverage);
+        .quote_mint_terms(pricer, lower_tick, higher_tick, quantity, leverage, clock);
     let builder_code_id: Option<ID> = option::none();
     let penalty_fee = market.ewma.penalty_fee(config.ewma_config(), quantity, ctx);
     market.compute_mint_quote(config, &terms, 0, &builder_code_id, penalty_fee, clock)
@@ -325,7 +325,7 @@ public fun quote_mint_for_account(
     let account = wrapper.load_account();
     let terms = market
         .strike_exposure
-        .quote_mint_terms(pricer, lower_tick, higher_tick, quantity, leverage);
+        .quote_mint_terms(pricer, lower_tick, higher_tick, quantity, leverage, clock);
     let builder_code_id = predict_account::builder_code_id(account);
     let penalty_fee = market.ewma.penalty_fee(config.ewma_config(), quantity, ctx);
     market.compute_mint_quote(
@@ -470,6 +470,7 @@ public fun mint_exact_amount(
         higher_tick,
         amount,
         leverage,
+        clock,
     );
     assert!(quantity >= min_quantity, EMintQuantityBelowMin);
     market.mint_prepared_exact_quantity(
@@ -1011,7 +1012,7 @@ fun mint_prepared_exact_quantity(
 ): u256 {
     let terms = market
         .strike_exposure
-        .quote_mint_terms(pricer, lower_tick, higher_tick, quantity, leverage);
+        .quote_mint_terms(pricer, lower_tick, higher_tick, quantity, leverage, clock);
     assert!(terms.entry_probability() <= max_probability, EMintProbabilityAboveMax);
     // Same pre-fold penalty the quotes compute; ewma_penalty folds after charging.
     let penalty_amount = market.ewma_penalty(config.ewma_config(), quantity, clock, ctx);
@@ -1055,6 +1056,7 @@ fun max_mint_quantity_for_amount(
     higher_tick: u64,
     amount: u64,
     leverage: u64,
+    clock: &Clock,
 ): u64 {
     let entry_probability = market
         .strike_exposure
@@ -1063,6 +1065,7 @@ fun max_mint_quantity_for_amount(
             lower_tick,
             higher_tick,
             leverage,
+            clock,
         );
     let quantity = strike_exposure_config::max_quantity_for_net_premium(
         entry_probability,

--- a/packages/predict/sources/strike_exposure/strike_exposure.move
+++ b/packages/predict/sources/strike_exposure/strike_exposure.move
@@ -272,6 +272,7 @@ public(package) fun quote_mint_terms(
     higher_tick: u64,
     quantity: u64,
     leverage: u64,
+    clock: &Clock,
 ): MintTerms {
     let entry_probability = exposure.admitted_entry_probability(pricer, lower_tick, higher_tick);
     let admission = exposure
@@ -280,6 +281,7 @@ public(package) fun quote_mint_terms(
             entry_probability,
             quantity,
             leverage,
+            exposure.expiry_ms - clock.timestamp_ms(),
         );
     // Runs after admission so the quote path keeps mint's abort order (mint hits
     // this check inside order construction, after admission).
@@ -343,9 +345,16 @@ public(package) fun quote_mint_entry_probability(
     lower_tick: u64,
     higher_tick: u64,
     leverage: u64,
+    clock: &Clock,
 ): u64 {
     let entry_probability = exposure.admitted_entry_probability(pricer, lower_tick, higher_tick);
-    exposure.config.assert_mint_probability_and_leverage_policy(entry_probability, leverage);
+    exposure
+        .config
+        .assert_mint_probability_and_leverage_policy(
+            entry_probability,
+            leverage,
+            exposure.expiry_ms - clock.timestamp_ms(),
+        );
     entry_probability
 }
 
@@ -353,11 +362,7 @@ public(package) fun quote_mint_entry_probability(
 ///
 /// Already-liquidated and currently-liquidatable orders have zero holder value;
 /// otherwise this returns the order's current range value net of its static floor.
-public(package) fun order_value(
-    exposure: &StrikeExposure,
-    pricer: &Pricer,
-    order: &Order,
-): u64 {
+public(package) fun order_value(exposure: &StrikeExposure, pricer: &Pricer, order: &Order): u64 {
     if (exposure.is_liquidated_order(order)) return 0;
 
     let gross_value = exposure.gross_order_value(pricer, order);
@@ -494,11 +499,7 @@ public(package) fun materialize_settled_liability(
     settled_liability
 }
 
-fun gross_order_value(
-    exposure: &StrikeExposure,
-    pricer: &Pricer,
-    order: &Order,
-): u64 {
+fun gross_order_value(exposure: &StrikeExposure, pricer: &Pricer, order: &Order): u64 {
     let (lower, higher) = exposure.order_boundaries(order);
     let range_probability = pricer.range_price(lower, higher);
     math::mul(range_probability, order.quantity())

--- a/packages/predict/tests/config/protocol_config_bounds_tests.move
+++ b/packages/predict/tests/config/protocol_config_bounds_tests.move
@@ -116,6 +116,19 @@ fun template_expiry_fee_window_above_max_aborts() {
     abort 999
 }
 
+// The taper window's minimum is 0 (0 disables the taper), so only the upper
+// bound can be violated.
+#[test, expected_failure(abort_code = config_constants::EInvalidLeverageTaperWindowMs)]
+fun template_leverage_taper_window_above_max_aborts() {
+    let (scenario, admin_cap, config_id) = new_shared_config();
+    let mut config = scenario.take_shared_by_id<ProtocolConfig>(config_id);
+    config.set_template_leverage_taper_window_ms(
+        &admin_cap,
+        config_constants::max_leverage_taper_window_ms!() + 1,
+    );
+    abort 999
+}
+
 #[test, expected_failure(abort_code = config_constants::EInvalidExpiryFeeMaxMultiplier)]
 fun template_expiry_fee_max_multiplier_below_min_aborts() {
     let (scenario, admin_cap, config_id) = new_shared_config();

--- a/packages/predict/tests/config/strike_exposure_config_tests.move
+++ b/packages/predict/tests/config/strike_exposure_config_tests.move
@@ -39,6 +39,19 @@ const THREE_X_FIRST_OVERFLOW_NET_PREMIUM: u64 = 6_148_914_691;
 const HALF_PROBABILITY_TWO_AND_HALF_X_NET_PREMIUM: u64 = 200_000_000;
 const HALF_PROBABILITY_TWO_AND_HALF_X_FLOOR_SHARES: u64 = 300_000_000;
 const UNLEVERAGED_FLOOR_SHARES: u64 = 0;
+const LEVERAGE_ONE_POINT_EIGHT_X: u64 = 1_800_000_000;
+/// Time-to-expiry far beyond the default 1h leverage-taper window, so the taper
+/// is inactive and admission behaves at the full probability-derived cap (1 week).
+const FAR_FROM_EXPIRY_MS: u64 = 604_800_000;
+/// Half of the default 1h leverage-taper window (30 minutes). At half the window
+/// the taper multiplier is exactly 0.5.
+const HALF_TAPER_WINDOW_MS: u64 = 1_800_000;
+/// p = 0.5, 1.8x, quantity 1e9: entry value 500_000_000; net premium
+/// 500_000_000 / 1.8 = 277_777_777 (floor); floor shares 500_000_000 - 277_777_777.
+const HALF_PROBABILITY_ONE_POINT_EIGHT_X_NET_PREMIUM: u64 = 277_777_777;
+const HALF_PROBABILITY_ONE_POINT_EIGHT_X_FLOOR_SHARES: u64 = 222_222_223;
+/// p = 0.5 at 1x: net premium equals the full entry value 500_000_000, floor 0.
+const HALF_PROBABILITY_ONE_X_NET_PREMIUM: u64 = 500_000_000;
 
 /// Create a real shared `ProtocolConfig` (template values at defaults) and an
 /// `AdminCap`, ready for admin setter calls in the next transaction.
@@ -251,6 +264,7 @@ fun mint_admission_probability_one_above_max_entry_probability_aborts() {
         float!(),
         test_constants::mint_quantity(),
         test_constants::leverage_one_x(),
+        FAR_FROM_EXPIRY_MS,
     );
     abort 999
 }
@@ -265,6 +279,7 @@ fun mint_admission_probability_below_min_entry_probability_aborts() {
         ENTRY_PROBABILITY_BELOW_MIN,
         test_constants::mint_quantity(),
         test_constants::leverage_one_x(),
+        FAR_FROM_EXPIRY_MS,
     );
     abort 999
 }
@@ -278,6 +293,7 @@ fun mint_admission_leverage_below_one_x_aborts() {
         ENTRY_PROBABILITY_HALF,
         test_constants::mint_quantity(),
         LEVERAGE_BELOW_ONE_X,
+        FAR_FROM_EXPIRY_MS,
     );
     abort 999
 }
@@ -290,6 +306,7 @@ fun mint_admission_low_probability_two_x_above_curve_aborts() {
         ENTRY_PROBABILITY_LOW,
         test_constants::mint_quantity(),
         LEVERAGE_TWO_X,
+        FAR_FROM_EXPIRY_MS,
     );
     abort 999
 }
@@ -303,6 +320,7 @@ fun mint_admission_template_cap_scales_curve_aborts() {
         ENTRY_PROBABILITY_HALF,
         test_constants::mint_quantity(),
         LEVERAGE_TWO_X,
+        FAR_FROM_EXPIRY_MS,
     );
     abort 999
 }
@@ -318,6 +336,7 @@ fun mint_admission_half_probability_two_and_half_x_succeeds() {
         ENTRY_PROBABILITY_HALF,
         test_constants::mint_quantity(),
         LEVERAGE_TWO_AND_HALF_X,
+        FAR_FROM_EXPIRY_MS,
     );
     assert_eq!(admission.net_premium(), HALF_PROBABILITY_TWO_AND_HALF_X_NET_PREMIUM);
     assert_eq!(admission.floor_shares(), HALF_PROBABILITY_TWO_AND_HALF_X_FLOOR_SHARES);
@@ -335,6 +354,7 @@ fun mint_admission_net_premium_one_lot_below_minimum_aborts() {
         ENTRY_PROBABILITY_HALF,
         2 * constants::min_net_premium!() - constants::position_lot_size!(),
         test_constants::leverage_one_x(),
+        FAR_FROM_EXPIRY_MS,
     );
     abort 999
 }
@@ -347,6 +367,7 @@ fun mint_admission_net_premium_at_minimum_succeeds() {
         ENTRY_PROBABILITY_HALF,
         2 * constants::min_net_premium!(),
         test_constants::leverage_one_x(),
+        FAR_FROM_EXPIRY_MS,
     );
     assert_eq!(admission.net_premium(), constants::min_net_premium!());
     assert_eq!(admission.floor_shares(), UNLEVERAGED_FLOOR_SHARES);
@@ -366,6 +387,87 @@ fun mint_admission_liquidation_ltv_still_controls_open_threshold() {
         ENTRY_PROBABILITY_HALF,
         test_constants::mint_quantity(),
         LEVERAGE_TWO_X,
+        FAR_FROM_EXPIRY_MS,
     );
     abort 999
+}
+
+// === Near-expiry leverage taper (ELeverageAboveAdmissionCap via time) ===
+
+// Far from expiry the taper is inactive and 2x at p = 0.5 clears the full cap
+// 2.714285714x. Inside the window the cap shrinks: at half the window the taper
+// multiplier is 0.5, giving cap 1 + 2 * 0.857142857 * 0.5 = 1.857142857x, so the
+// same 2x order is now rejected.
+#[test, expected_failure(abort_code = strike_exposure_config::ELeverageAboveAdmissionCap)]
+fun taper_rejects_leverage_admitted_far_from_expiry() {
+    let config = strike_exposure_config::new();
+    config.assert_mint_admission(
+        ENTRY_PROBABILITY_HALF,
+        test_constants::mint_quantity(),
+        LEVERAGE_TWO_X,
+        HALF_TAPER_WINDOW_MS,
+    );
+    abort 999
+}
+
+// At half the window (taper 0.5) the reduced cap is 1.857142857x, so 1.8x is
+// still admitted; the taper only gates admission and does not reprice the terms.
+#[test]
+fun taper_admits_reduced_leverage_within_window() {
+    let config = strike_exposure_config::new();
+    let admission = config.assert_mint_admission(
+        ENTRY_PROBABILITY_HALF,
+        test_constants::mint_quantity(),
+        LEVERAGE_ONE_POINT_EIGHT_X,
+        HALF_TAPER_WINDOW_MS,
+    );
+    assert_eq!(admission.net_premium(), HALF_PROBABILITY_ONE_POINT_EIGHT_X_NET_PREMIUM);
+    assert_eq!(admission.floor_shares(), HALF_PROBABILITY_ONE_POINT_EIGHT_X_FLOOR_SHARES);
+    destroy(config);
+}
+
+// At expiry (time_to_expiry_ms = 0) the taper multiplier is 0, so the cap
+// collapses to exactly 1x: an unleveraged order is admitted with a zero floor.
+#[test]
+fun taper_at_expiry_admits_one_x() {
+    let config = strike_exposure_config::new();
+    let admission = config.assert_mint_admission(
+        ENTRY_PROBABILITY_HALF,
+        test_constants::mint_quantity(),
+        test_constants::leverage_one_x(),
+        0,
+    );
+    assert_eq!(admission.net_premium(), HALF_PROBABILITY_ONE_X_NET_PREMIUM);
+    assert_eq!(admission.floor_shares(), UNLEVERAGED_FLOOR_SHARES);
+    destroy(config);
+}
+
+// At expiry the cap is exactly 1x, so any leverage above 1x is rejected.
+#[test, expected_failure(abort_code = strike_exposure_config::ELeverageAboveAdmissionCap)]
+fun taper_at_expiry_rejects_leverage_above_one_x() {
+    let config = strike_exposure_config::new();
+    config.assert_mint_admission(
+        ENTRY_PROBABILITY_HALF,
+        test_constants::mint_quantity(),
+        LEVERAGE_TWO_X,
+        0,
+    );
+    abort 999
+}
+
+// A zero window disables the taper: full leverage is admitted even at expiry.
+// 2.5x at p = 0.5 is inside the full cap 2.714285714x.
+#[test]
+fun taper_disabled_admits_full_leverage_at_expiry() {
+    let mut config = strike_exposure_config::new();
+    config.set_leverage_taper_window_ms(0);
+    let admission = config.assert_mint_admission(
+        ENTRY_PROBABILITY_HALF,
+        test_constants::mint_quantity(),
+        LEVERAGE_TWO_AND_HALF_X,
+        0,
+    );
+    assert_eq!(admission.net_premium(), HALF_PROBABILITY_TWO_AND_HALF_X_NET_PREMIUM);
+    assert_eq!(admission.floor_shares(), HALF_PROBABILITY_TWO_AND_HALF_X_FLOOR_SHARES);
+    destroy(config);
 }

--- a/packages/predict/tests/config/strike_exposure_config_tests.move
+++ b/packages/predict/tests/config/strike_exposure_config_tests.move
@@ -52,6 +52,15 @@ const HALF_PROBABILITY_ONE_POINT_EIGHT_X_NET_PREMIUM: u64 = 277_777_777;
 const HALF_PROBABILITY_ONE_POINT_EIGHT_X_FLOOR_SHARES: u64 = 222_222_223;
 /// p = 0.5 at 1x: net premium equals the full entry value 500_000_000, floor 0.
 const HALF_PROBABILITY_ONE_X_NET_PREMIUM: u64 = 500_000_000;
+const LEVERAGE_ONE_POINT_FIVE_X: u64 = 1_500_000_000;
+const LEVERAGE_TWO_POINT_SEVEN_X: u64 = 2_700_000_000;
+/// A quarter of the default 1h leverage-taper window (15 minutes); the taper
+/// multiplier is exactly 0.25.
+const QUARTER_TAPER_WINDOW_MS: u64 = 900_000;
+/// p = 0.5, 2.7x, quantity 1e9: net premium 500_000_000 / 2.7 = 185_185_185
+/// (floor); floor shares 500_000_000 - 185_185_185.
+const HALF_PROBABILITY_TWO_POINT_SEVEN_X_NET_PREMIUM: u64 = 185_185_185;
+const HALF_PROBABILITY_TWO_POINT_SEVEN_X_FLOOR_SHARES: u64 = 314_814_815;
 
 /// Create a real shared `ProtocolConfig` (template values at defaults) and an
 /// `AdminCap`, ready for admin setter calls in the next transaction.
@@ -470,4 +479,53 @@ fun taper_disabled_admits_full_leverage_at_expiry() {
     assert_eq!(admission.net_premium(), HALF_PROBABILITY_TWO_AND_HALF_X_NET_PREMIUM);
     assert_eq!(admission.floor_shares(), HALF_PROBABILITY_TWO_AND_HALF_X_FLOOR_SHARES);
     destroy(config);
+}
+
+// At exactly the window boundary (time_to_expiry == window) the taper is full, so
+// the cap is the untapered 2.714285714x and 2.7x is admitted. Pins the `>=` edge
+// (the far-from-expiry tests only exercise time >> window).
+#[test]
+fun taper_at_window_boundary_admits_full_leverage() {
+    let config = strike_exposure_config::new();
+    let admission = config.assert_mint_admission(
+        ENTRY_PROBABILITY_HALF,
+        test_constants::mint_quantity(),
+        LEVERAGE_TWO_POINT_SEVEN_X,
+        constants::one_hour_ms!(),
+    );
+    assert_eq!(admission.net_premium(), HALF_PROBABILITY_TWO_POINT_SEVEN_X_NET_PREMIUM);
+    assert_eq!(admission.floor_shares(), HALF_PROBABILITY_TWO_POINT_SEVEN_X_FLOOR_SHARES);
+    destroy(config);
+}
+
+// The taper is linear: at a quarter of the window the multiplier is 0.25, giving
+// cap 1 + 2 * 0.857142857 * 0.25 = 1.428571428x, so 1.5x is rejected — even though
+// the same 1.5x clears the 1.857142857x cap at half the window (a second point on
+// the taper line).
+#[test, expected_failure(abort_code = strike_exposure_config::ELeverageAboveAdmissionCap)]
+fun taper_quarter_window_rejects_leverage_admitted_at_half_window() {
+    let config = strike_exposure_config::new();
+    config.assert_mint_admission(
+        ENTRY_PROBABILITY_HALF,
+        test_constants::mint_quantity(),
+        LEVERAGE_ONE_POINT_FIVE_X,
+        QUARTER_TAPER_WINDOW_MS,
+    );
+    abort 999
+}
+
+// The near-expiry taper multiplies the low-probability risk curve. At p = 0.1 the
+// full cap is 1.8x; at half the window the taper halves the excess to give
+// 1 + 2 * 0.4 * 0.5 = 1.4x, so 1.5x is rejected here even though it would be
+// admitted far from expiry.
+#[test, expected_failure(abort_code = strike_exposure_config::ELeverageAboveAdmissionCap)]
+fun taper_composes_with_low_probability_curve() {
+    let config = strike_exposure_config::new();
+    config.assert_mint_admission(
+        ENTRY_PROBABILITY_LOW,
+        test_constants::mint_quantity(),
+        LEVERAGE_ONE_POINT_FIVE_X,
+        HALF_TAPER_WINDOW_MS,
+    );
+    abort 999
 }

--- a/packages/predict/tests/helper/flow_test_helpers.move
+++ b/packages/predict/tests/helper/flow_test_helpers.move
@@ -194,12 +194,17 @@ public fun setup_market(tick: u64): Fixture {
         bs_svi_id,
     );
     let mut registry = scenario.take_shared<Registry>();
-    let config = scenario.take_shared<ProtocolConfig>();
+    let mut config = scenario.take_shared<ProtocolConfig>();
     let lifecycle_cap = registry.mint_lifecycle_cap(
         &config,
         &admin_cap,
         scenario.ctx(),
     );
+    // Flow fixtures exercise leverage / close / liquidation mechanics on short-lived
+    // markets, so disable the near-expiry leverage taper by default (a valid
+    // `window == 0` admin config). The taper is covered by the config unit tests and
+    // a dedicated flow test that re-enables it.
+    config.set_template_leverage_taper_window_ms(&admin_cap, 0);
     return_shared(config);
     return_shared(registry);
     let vault = scenario.take_shared<PoolVault>();
@@ -408,6 +413,14 @@ public fun set_template_max_admission_leverage(self: &mut Fixture, value: u64) {
     self.scenario.next_tx(test_constants::admin());
     let mut config = self.scenario.take_shared<ProtocolConfig>();
     config.set_template_max_admission_leverage(&self.admin_cap, value);
+    return_shared(config);
+    self.scenario.next_tx(test_constants::admin());
+}
+
+public fun set_template_leverage_taper_window_ms(self: &mut Fixture, value: u64) {
+    self.scenario.next_tx(test_constants::admin());
+    let mut config = self.scenario.take_shared<ProtocolConfig>();
+    config.set_template_leverage_taper_window_ms(&self.admin_cap, value);
     return_shared(config);
     self.scenario.next_tx(test_constants::admin());
 }

--- a/packages/predict/tests/reference_tick_tests.move
+++ b/packages/predict/tests/reference_tick_tests.move
@@ -165,7 +165,7 @@ fun set_reference_tick_floor_to_zero_aborts() {
 
 #[test, expected_failure(abort_code = strike_exposure::EInvalidAdmissionTick)]
 fun off_grid_tick_before_reference_tick_is_set_aborts() {
-    let (_fx, pricer, mut harness) = setup_priced_harness();
+    let (fx, pricer, mut harness) = setup_priced_harness();
 
     let terms = harness
         .exposure
@@ -175,6 +175,7 @@ fun off_grid_tick_before_reference_tick_is_set_aborts() {
             constants::pos_inf_tick!(),
             test_constants::mint_quantity(),
             test_constants::leverage_one_x(),
+            fx.clock(),
         );
     harness.exposure.allocate_mint_order(terms);
     abort EUnexpectedSuccess
@@ -194,6 +195,7 @@ fun reference_tick_admits_up_and_down_ranges() {
             constants::pos_inf_tick!(),
             test_constants::mint_quantity(),
             test_constants::leverage_one_x(),
+            fx.clock(),
         );
     let up_order = harness.exposure.allocate_mint_order(up_terms);
     let down_terms = harness
@@ -204,6 +206,7 @@ fun reference_tick_admits_up_and_down_ranges() {
             ADMISSIBLE_OFF_GRID_REFERENCE_TICK,
             test_constants::mint_quantity(),
             test_constants::leverage_one_x(),
+            fx.clock(),
         );
     let down_order = harness.exposure.allocate_mint_order(down_terms);
 
@@ -215,7 +218,7 @@ fun reference_tick_admits_up_and_down_ranges() {
 
 #[test, expected_failure(abort_code = strike_exposure::EInvalidAdmissionTick)]
 fun different_off_grid_tick_after_reference_tick_is_set_aborts() {
-    let (_fx, pricer, mut harness) = setup_priced_harness();
+    let (fx, pricer, mut harness) = setup_priced_harness();
 
     harness.exposure.set_reference_tick(REFERENCE_TICK);
     let terms = harness
@@ -226,6 +229,7 @@ fun different_off_grid_tick_after_reference_tick_is_set_aborts() {
             constants::pos_inf_tick!(),
             test_constants::mint_quantity(),
             test_constants::leverage_one_x(),
+            fx.clock(),
         );
     harness.exposure.allocate_mint_order(terms);
     abort EUnexpectedSuccess

--- a/packages/predict/tests/strike_exposure/liquidated_settled_redeem_tests.move
+++ b/packages/predict/tests/strike_exposure/liquidated_settled_redeem_tests.move
@@ -82,6 +82,7 @@ fun liquidated_order_fixture(): (OracleFixture, OracleBundle, ExposureHarness, O
             constants::pos_inf_tick!(),
             test_constants::mint_quantity(),
             LEVERAGE_TWO_X,
+            fx.clock(),
         );
     let order = harness.exposure.allocate_mint_order(terms);
 
@@ -97,13 +98,19 @@ fun create_and_share_exposure_harness(fx: &mut OracleFixture): ID {
     let expiry_ms = fx.expiry();
     let id = object::new(fx.scenario_mut().ctx());
     let harness_id = id.to_inner();
+    // Short-expiry harness for leverage-liquidation mechanics: disable the
+    // near-expiry leverage taper so the 2x order is admissible (a valid
+    // `window == 0` config). The taper is covered by the config unit tests and a
+    // dedicated flow test.
+    let mut config = strike_exposure_config::new();
+    config.set_leverage_taper_window_ms(0);
     let exposure = strike_exposure::new(
         expiry_market_id,
         expiry_ms,
         test_constants::default_tick_size(),
         test_constants::default_tick_size(),
         expiry_ms - test_constants::default_cadence_period_ms(),
-        strike_exposure_config::new(),
+        config,
         fx.scenario_mut().ctx(),
     );
     transfer::share_object(ExposureHarness { id, exposure });

--- a/packages/predict/tests/strike_exposure/mint_terms_binding_tests.move
+++ b/packages/predict/tests/strike_exposure/mint_terms_binding_tests.move
@@ -50,6 +50,7 @@ fun allocating_terms_priced_on_another_exposure_aborts() {
             constants::pos_inf_tick!(),
             test_constants::mint_quantity(),
             test_constants::leverage_one_x(),
+            fx.clock(),
         );
     harness_b.exposure.allocate_mint_order(terms);
 

--- a/packages/predict/tests/strike_exposure/strike_exposure_c1_tests.move
+++ b/packages/predict/tests/strike_exposure/strike_exposure_c1_tests.move
@@ -87,6 +87,30 @@ fun near_expiry_leverage_mint_rejected_by_taper() {
     abort 999
 }
 
+/// The sizing path (`mint_exact_amount`) applies the same taper via a second
+/// admission entry (`quote_mint_entry_probability`): a 2x sized mint ~2 minutes
+/// from expiry is rejected at admission through the real entrypoint.
+#[test, expected_failure(abort_code = strike_exposure_config::ELeverageAboveAdmissionCap)]
+fun near_expiry_leverage_exact_amount_mint_rejected_by_taper() {
+    let mut fx = helpers::setup_market_default();
+    fx.set_template_leverage_taper_window_ms(constants::one_hour_ms!());
+    let expiry_id = fx.create_expiry(test_constants::short_expiry_ms());
+    let trader = fx.create_funded_manager(test_constants::mint_deposit());
+    let mut market = fx.take_market_bundle(expiry_id);
+    let mut account = fx.take_account_bundle(&trader);
+    fx.prepare_live_oracle_bundle(&mut market, test_constants::default_live_price());
+    fx.mint_exact_amount_bundle(
+        &mut market,
+        &mut account,
+        helpers::strike_tick(),
+        constants::pos_inf_tick!(),
+        test_constants::mint_deposit(),
+        constants::position_lot_size!(),
+        LEVERAGE_TWO_X,
+    );
+    abort 999
+}
+
 /// Closing a max-sized 6x ATM order down to one lot must leave a valid replacement.
 ///
 /// The old two-step split left `ceil(floor_shares / 1e9) = 17_896` floor shares on

--- a/packages/predict/tests/strike_exposure/strike_exposure_c1_tests.move
+++ b/packages/predict/tests/strike_exposure/strike_exposure_c1_tests.move
@@ -21,7 +21,13 @@
 #[test_only]
 module deepbook_predict::strike_exposure_c1_tests;
 
-use deepbook_predict::{constants, flow_test_helpers as helpers, order, test_constants};
+use deepbook_predict::{
+    constants,
+    flow_test_helpers as helpers,
+    order,
+    strike_exposure_config,
+    test_constants
+};
 use std::unit_test::assert_eq;
 
 /// 2x leverage gives a non-zero floor (required for the gap to exist).
@@ -52,6 +58,33 @@ fun partial_close_survivor_stays_backed() {
 #[test]
 fun double_partial_close_survivor_reinsertion_stays_backed() {
     run_live_close_schedule(vector[FIRST_CLOSE, SECOND_CLOSE]);
+}
+
+/// End-to-end coverage of the near-expiry leverage taper through the real mint
+/// entrypoint: with the taper re-enabled at its 1h default, a 2x mint on a market
+/// only ~2 minutes from expiry (`short_expiry_ms - now_ms`) is rejected at
+/// admission. This proves the mint flow threads the clock into the leverage cap;
+/// the taper math itself is covered in `config/strike_exposure_config_tests.move`.
+#[test, expected_failure(abort_code = strike_exposure_config::ELeverageAboveAdmissionCap)]
+fun near_expiry_leverage_mint_rejected_by_taper() {
+    let mut fx = helpers::setup_market_default();
+    // Re-enable the taper (flow fixtures disable it) BEFORE market creation so the
+    // market snapshots the 1h window.
+    fx.set_template_leverage_taper_window_ms(constants::one_hour_ms!());
+    let expiry_id = fx.create_expiry(test_constants::short_expiry_ms());
+    let trader = fx.create_funded_manager(test_constants::mint_deposit());
+    let mut market = fx.take_market_bundle(expiry_id);
+    let mut account = fx.take_account_bundle(&trader);
+    fx.prepare_live_oracle_bundle(&mut market, test_constants::default_live_price());
+    fx.mint_bundle(
+        &mut market,
+        &mut account,
+        helpers::strike_tick(),
+        constants::pos_inf_tick!(),
+        test_constants::mint_quantity(),
+        LEVERAGE_TWO_X,
+    );
+    abort 999
 }
 
 /// Closing a max-sized 6x ATM order down to one lot must leave a valid replacement.


### PR DESCRIPTION
## Summary
- Add an admin-tunable `leverage_taper_window_ms` to the strike-exposure config. Within this window before expiry, the mint-admission leverage cap tapers linearly from the probability-derived cap down to **1x (no leverage) at expiry**.
- The leverage-above-1x is now scaled by **both** the existing low-probability risk curve **and** the new near-expiry taper, so the cap collapses to 1x at the price tails **or** at expiry. A window of `0` disables the taper.
- Thread the market clock through `quote_mint_terms` / `quote_mint_entry_probability` so admission can derive `time_to_expiry` (mirrors how the trade-fee ramp already reads `expiry_ms - now`). The taper is a mint-admission gate only.
- Add the `protocol_config::set_template_leverage_taper_window_ms` admin setter. Default window: **1 hour**.

## Why
- Lower the max allowed leverage the closer a market is to expiration. Near expiry a contract's probability can move a lot in a single tick, which can leap a leveraged position past its knockout before liquidation can fire — so leverage is riskiest exactly there. Tapering it down bounds LP exposure.

## What this looks like in practice

At `p = 0.5`, with the default 3x admission cap and the 1h taper window:

| Time to expiry | Max admissible leverage | Financed floor `F` (% of entry value) |
| --- | --- | --- |
| 1 hour | 2.71x | 63% |
| 30 min | 1.86x | 46% |
| 15 min | 1.43x | 30% |
| 1 min | **1.03x** | 2.8% |
| 10 sec | **1.005x** | 0.5% |
| 1 sec | **1.0005x** | 0.05% |

The taper is continuous, so it never hard-blocks a mint — it drives the admissible leverage asymptotically to 1x. By the final minute the LP-financed floor is under 3% of entry value, and by the final seconds it is a rounding error, so a near-expiry position is economically indistinguishable from an unleveraged one. That is the point: no cliff for traders to game by piling in right before a cutoff, and no meaningful leverage originated into the highest-gamma window.

## Key decisions
- **Continuous taper to 1x, not a hard cutoff.** A linear taper that reaches 1x at expiry gives both "less leverage near expiry" and "no meaningful leverage in the final moments" without a cliff (a cliff would just concentrate max-leverage opens right before it). Reuses the same shape as the existing `expiry_fee_multiplier` ramp.
- **Default window = 1 hour; `0` fully disables the taper.** Both settled: 1h is the intended default, and a full disable is deliberately available as an admin escape hatch (mirrors how the fee ramp can be disabled). It's a template setter, so it is tunable post-deploy with no redeploy.
- **Monotonic by construction.** The taper multiplier is always in `[0, 1]` and only scales the leverage-*above-1x* term, so the cap can only ever be **lower** than before — it can never admit leverage the old code rejected. With `window == 0` the formula is bit-identical to the previous behavior.
- **Gates origination only; does not reprice.** Once admitted, an order's premium/floor/terms are unchanged, and existing orders keep their frozen floor `F` (the settled static-floor design). Consequence worth noting for reviewers: a position opened *before* the window still carries its full leverage into expiry — reducing risk on those seasoned positions needs a different lever (e.g. a near-expiry `liquidation_ltv` tightening), not an admission gate.
- **Flow-test fixtures disable the taper by default** (a valid `window == 0` config) so leverage/close/liquidation mechanics tests can still mint leveraged orders on short-lived markets. The taper's own behavior is covered by config unit tests plus dedicated end-to-end flow tests.
- Aligned with open-item **O-1** ("recalibrate near-expiry time-to-expiry behavior or block the affected market shape"); no rejected direction touched.

## Test plan
- [x] `sui move build --path packages/predict` — clean
- [x] `sui move test --path packages/predict --gas-limit 100000000000` — **404/404 pass**
- [x] `python3 packages/predict/predeploy/check.py` — 0 warnings
- [x] `bunx prettier-move` — clean
- [x] Config unit tests, each against an independently hand-derived cap: far-from-expiry inactive; exact `time == window` boundary (pins the `>=` edge, full 2.714x cap); half-window rejects 2x / admits 1.8x with exact terms (cap 1.857x); quarter-window rejects 1.5x (cap 1.428x — a second point proving linearity); taper composes with the low-probability curve (p=0.1 half-window → cap 1.4x); at expiry admits 1x / rejects >1x; `window == 0` disables.
- [x] Bounds abort: `EInvalidLeverageTaperWindowMs`.
- [x] Flow tests through the real entrypoints (taper re-enabled), covering **both** admission entries: `mint_exact_quantity` and the `mint_exact_amount` sizing path — a 2x mint ~2 minutes from expiry is rejected at admission, proving the clock is threaded into the cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
