### PR TITLE
ci: make the Move format check actually check the Move files

### DIFF
--- a/.claude/rules/move.md
+++ b/.claude/rules/move.md
@@ -156,7 +156,9 @@ Then call as `self.id.exists_(key)`, `self.id.add(key, value)`, `self.id.borrow(
 - Build/test/format commands live in `CLAUDE.md` (§ Quick Commands and § Predict Build & Verify). The high test gas limit is required because sui 1.66+ lowered the default test gas budget.
 - When `sui move test` shows warnings (e.g., unused `mut` modifiers, unused variables), fix them immediately before proceeding.
 - Before claiming Move or protocol work is complete, run the impacted package test suite(s) and confirm they pass with zero failures. If the change affects multiple packages or local package manifests, run each impacted package's tests.
-- When you have completed making Move changes, run `bunx prettier-move -c path/to/file.move --write` on any files that are modified to format them correctly.
+- When you have completed making Move changes, run `pnpm install --frozen-lockfile && pnpm format:move` before opening the PR. CI runs the same script (`format:move:check`) over the same file set, so a clean local run means a clean check.
+- **Never format with `bunx`/`npx prettier-move`, a globally-installed prettier, or `sui move format`.** Those resolve whatever plugin version is latest; the lockfile pins the version CI enforces, and the two format differently. A local run with the wrong version silently rewrites files CI then rejects — or worse, passes locally and reddens someone else's PR later.
+- `pnpm format:move` formats every package, not just your files. That is deliberate and safe: the tree is formatted at HEAD, so it is a no-op outside your own edits. If it reports changes to files you did not touch, do not just commit them — that means something upstream drifted, and the drift belongs in its own PR (why: the check once matched only 45 of 182 files, so drift accumulated where it could not be seen, and the next PR to format such a file inherited unrelated churn in its diff — deepbookv3#1126).
 
 ## Upstream Move Style (2024 Edition)
 

--- a/.github/workflows/move-formatter.yml
+++ b/.github/workflows/move-formatter.yml
@@ -9,22 +9,24 @@ on:
     branches:
       - main
 
-env:
-  MOVE_PACKAGES_PATH: packages
-
 jobs:
   prettier-move:
     name: Check Move files formatting
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ env.MOVE_PACKAGES_PATH }}
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js
         uses: actions/setup-node@v4
-      - run: npm i @mysten/prettier-plugin-move
-      - run: npx prettier-move -c $PWD/../packages/deepbook/**/*.move
-      - run: npx prettier-move -c $PWD/../packages/deepbook_margin/**/*.move
-      - run: npx prettier-move -c $PWD/../packages/margin_liquidation/**/*.move
-      - run: npx prettier-move -c $PWD/../packages/predict/**/*.move
+        with:
+          node-version: 22
+      - name: Do a global PNPM install
+        run: npm install -g pnpm
+      # Install the formatter pinned by the lockfile, so a new plugin release can
+      # never silently change what CI enforces on unrelated PRs.
+      - name: Install the pinned toolchain
+        run: pnpm install --frozen-lockfile
+      # One recursive glob over every package. Quoted so prettier expands it: bash
+      # leaves globstar off, so an unquoted `**` collapses to `*` and matches only
+      # one directory level.
+      - name: Check Move formatting
+        run: pnpm exec prettier-move -c "packages/**/*.move"

--- a/.github/workflows/move-formatter.yml
+++ b/.github/workflows/move-formatter.yml
@@ -25,8 +25,7 @@ jobs:
       # never silently change what CI enforces on unrelated PRs.
       - name: Install the pinned toolchain
         run: pnpm install --frozen-lockfile
-      # One recursive glob over every package. Quoted so prettier expands it: bash
-      # leaves globstar off, so an unquoted `**` collapses to `*` and matches only
-      # one directory level.
+      # Same script contributors run (`pnpm format:move`), so the file set and the
+      # plugin version have exactly one definition and CI cannot drift from local.
       - name: Check Move formatting
-        run: pnpm exec prettier-move -c "packages/**/*.move"
+        run: pnpm run format:move:check

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+# Move build output: generated, and it vendors dependency sources (wormhole, pyth,
+# sui framework) that this repo does not own. CI never sees these because it checks
+# out fresh; ignoring them keeps a local run honest against the same file set.
+build/
+**/build/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,8 +51,10 @@ This file is the repo-level entry point for coding agents working in `deepbookv3
 - Run all tests for a package:
   - `sui move test --path packages/predict --gas-limit 100000000000`
   - `sui move test --path packages/deepbook --gas-limit 100000000000`
-- Format Move code:
-  - `bunx prettier-move -c path/to/file.move --write`
+- Format Move code (run before opening a PR; CI runs the same script):
+  - `pnpm install --frozen-lockfile && pnpm format:move`
+  - Do NOT use `bunx`/`npx prettier-move`: they fetch the latest plugin, which formats
+    differently from the version CI pins in the lockfile.
 
 ### Rust
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ DeepBook is a decentralized order book on the Sui blockchain.
 ### Move
 - `sui move build` - Build Move packages
 - `sui move test --gas-limit 100000000000` - Run Move tests
-- `bunx prettier-move -c path/to/file.move --write` - Format Move code
+- `pnpm install --frozen-lockfile && pnpm format:move` - Format Move code. Run before opening a PR; CI runs the same script (`format:move:check`). Formats every package, which is a no-op outside your own edits. Do NOT use `bunx`/`npx prettier-move` — those fetch whatever plugin version is latest, which formats differently from the version CI pins.
 
 ### Indexer
 - `cargo build -p deepbook-server` - Build indexer

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
 	"author": "",
 	"license": "Apache-2.0",
 	"dependencies": {
-		"@mysten/prettier-plugin-move": "^0.3.5"
+		"@mysten/prettier-plugin-move": "^0.4.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
 		"prettier:check": "prettier -c --ignore-unknown .",
 		"prettier:fix": "prettier -w --ignore-unknown .",
 		"prettier:fix:watch": "onchange '**' -i -f add -f change -j 5 -- prettier -w --ignore-unknown {{file}}",
+		"format:move": "prettier-move --write \"packages/**/*.move\"",
+		"format:move:check": "prettier-move -c \"packages/**/*.move\"",
 		"eslint:check": "eslint --max-warnings=0 .",
 		"eslint:fix": "pnpm run eslint:check --fix",
 		"lint": "pnpm run eslint:check && pnpm run prettier:check",

--- a/packages/deepbook/sources/pool.move
+++ b/packages/deepbook/sources/pool.move
@@ -14,7 +14,7 @@ use deepbook::{
         DeepBookReferral,
         TradeCap,
         DepositCap,
-        WithdrawCap
+        WithdrawCap,
     },
     balances,
     big_vector::BigVector,

--- a/packages/deepbook/tests/balance_manager_tests.move
+++ b/packages/deepbook/tests/balance_manager_tests.move
@@ -11,7 +11,7 @@ use deepbook::{
         TradeCap,
         DepositCap,
         WithdrawCap,
-        DeepBookPoolReferral
+        DeepBookPoolReferral,
     },
     registry
 };

--- a/packages/deepbook/tests/order_query_tests.move
+++ b/packages/deepbook/tests/order_query_tests.move
@@ -7,7 +7,7 @@ module deepbook::order_query_tests;
 use deepbook::{
     balance_manager_tests::{
         USDC,
-        create_acct_and_share_with_funds as create_acct_and_share_with_funds
+        create_acct_and_share_with_funds as create_acct_and_share_with_funds,
     },
     constants,
     order_query::iter_orders,

--- a/packages/deepbook/tests/pool_tests.move
+++ b/packages/deepbook/tests/pool_tests.move
@@ -11,7 +11,7 @@ use deepbook::{
         TradeCap,
         DeepBookPoolReferral,
         DepositCap,
-        WithdrawCap
+        WithdrawCap,
     },
     balance_manager_tests::{
         USDC,
@@ -21,7 +21,7 @@ use deepbook::{
         create_acct_and_share_with_funds_typed,
         create_acct_only_deep_and_share_with_funds,
         create_caps,
-        asset_balance
+        asset_balance,
     },
     big_vector::BigVector,
     constants,

--- a/packages/deepbook_margin/sources/margin_manager.move
+++ b/packages/deepbook_margin/sources/margin_manager.move
@@ -12,7 +12,7 @@ use deepbook::{
         DepositCap,
         WithdrawCap,
         TradeProof,
-        DeepBookPoolReferral
+        DeepBookPoolReferral,
     },
     constants,
     math,
@@ -31,7 +31,7 @@ use deepbook_margin::{
         get_pyth_price,
         get_pyth_price_unsafe,
         calculate_price,
-        calculate_price_unsafe
+        calculate_price_unsafe,
     },
     tpsl::{Self, TakeProfitStopLoss, PendingOrder, Condition, ConditionalOrder}
 };

--- a/packages/deepbook_margin/tests/helper/oracle_tests.move
+++ b/packages/deepbook_margin/tests/helper/oracle_tests.move
@@ -11,7 +11,7 @@ use deepbook_margin::{
         calculate_target_currency_amount,
         calculate_usd_price,
         calculate_target_amount,
-        test_conversion_config
+        test_conversion_config,
     },
     test_constants::{Self, USDC},
     test_helpers::{build_pyth_price_info_object, create_test_pyth_config}

--- a/packages/deepbook_margin/tests/helper/test_helpers.move
+++ b/packages/deepbook_margin/tests/helper/test_helpers.move
@@ -14,7 +14,7 @@ use deepbook_margin::{
         MarginAdminCap,
         MaintainerCap,
         PoolConfig,
-        MarginPoolCap
+        MarginPoolCap,
     },
     oracle::{Self, PythConfig},
     pool_proxy,

--- a/packages/deepbook_margin/tests/margin_manager_borrow_share_tests.move
+++ b/packages/deepbook_margin/tests/margin_manager_borrow_share_tests.move
@@ -19,7 +19,7 @@ use deepbook_margin::{
         destroy_2,
         return_shared_2,
         return_shared_3,
-        supply_to_pool
+        supply_to_pool,
     }
 };
 use std::unit_test::destroy;

--- a/packages/deepbook_margin/tests/margin_manager_math_tests.move
+++ b/packages/deepbook_margin/tests/margin_manager_math_tests.move
@@ -20,7 +20,7 @@ use deepbook_margin::{
         setup_btc_sui_deepbook_margin,
         destroy_3,
         return_shared_3,
-        return_shared_4
+        return_shared_4,
     }
 };
 use std::unit_test::destroy;

--- a/packages/deepbook_margin/tests/margin_manager_tests.move
+++ b/packages/deepbook_margin/tests/margin_manager_tests.move
@@ -36,7 +36,7 @@ use deepbook_margin::{
         return_shared_4,
         advance_time,
         get_margin_pool_caps,
-        return_to_sender_2
+        return_to_sender_2,
     },
     tpsl
 };

--- a/packages/deepbook_margin/tests/pool_proxy_tests.move
+++ b/packages/deepbook_margin/tests/pool_proxy_tests.move
@@ -32,7 +32,7 @@ use deepbook_margin::{
         build_demo_usdc_price_info_object_with_price,
         setup_orderbook_liquidity_stablecoin,
         setup_orderbook_liquidity_at_prices,
-        setup_orderbook_liquidity_out_of_bounds_stablecoin
+        setup_orderbook_liquidity_out_of_bounds_stablecoin,
     }
 };
 use std::unit_test::{assert_eq, destroy};

--- a/packages/deepbook_margin/tests/tpsl_tests.move
+++ b/packages/deepbook_margin/tests/tpsl_tests.move
@@ -25,7 +25,7 @@ use deepbook_margin::{
         mint_coin,
         build_pyth_price_info_object,
         destroy_2,
-        return_shared_2
+        return_shared_2,
     },
     tpsl
 };

--- a/packages/predict/sources/config/config_constants.move
+++ b/packages/predict/sources/config/config_constants.move
@@ -36,7 +36,9 @@ const EMarketTickSizeTooLarge: u64 = 22;
 /// Merged protocol + insurance reserve share of materialized terminal profit, in
 /// FLOAT_SCALING. The complement accrues to LPs.
 public(package) macro fun default_protocol_reserve_profit_share(): u64 { 400_000_000 }
+
 public(package) macro fun min_protocol_reserve_profit_share(): u64 { 0 }
+
 public(package) macro fun max_protocol_reserve_profit_share(): u64 {
     fixed_math::math::float_scaling!()
 }
@@ -52,7 +54,9 @@ public(package) fun assert_protocol_reserve_profit_share(value: u64) {
 // === Trade Liquidation ===
 
 public(package) macro fun default_trade_liquidation_budget(): u64 { 24 }
+
 public(package) macro fun min_trade_liquidation_budget(): u64 { 24 }
+
 public(package) macro fun max_trade_liquidation_budget(): u64 {
     3_000
 }
@@ -67,7 +71,9 @@ public(package) fun assert_trade_liquidation_budget(value: u64) {
 // === Backing and Liquidation ===
 
 public(package) macro fun default_liquidation_ltv(): u64 { 850_000_000 }
+
 public(package) macro fun min_liquidation_ltv(): u64 { 500_000_000 }
+
 public(package) macro fun max_liquidation_ltv(): u64 { 950_000_000 }
 
 public(package) fun assert_liquidation_ltv(value: u64) {
@@ -82,9 +88,11 @@ public(package) fun assert_liquidation_ltv(value: u64) {
 public(package) macro fun default_max_admission_leverage(): u64 {
     3 * fixed_math::math::float_scaling!()
 }
+
 public(package) macro fun min_max_admission_leverage(): u64 {
     fixed_math::math::float_scaling!()
 }
+
 public(package) macro fun max_max_admission_leverage(): u64 {
     10 * fixed_math::math::float_scaling!()
 }
@@ -103,7 +111,9 @@ public(package) fun assert_max_admission_leverage(value: u64) {
 public(package) macro fun admission_leverage_curve_k(): u64 { 200_000_000 }
 
 public(package) macro fun default_backing_buffer_lambda(): u64 { 250_000_000 }
+
 public(package) macro fun min_backing_buffer_lambda(): u64 { 50_000_000 }
+
 public(package) macro fun max_backing_buffer_lambda(): u64 {
     fixed_math::math::float_scaling!()
 }
@@ -118,7 +128,9 @@ public(package) fun assert_backing_buffer_lambda(value: u64) {
 // === Pricing ===
 
 public(package) macro fun default_base_fee(): u64 { 20_000_000 }
+
 public(package) macro fun min_base_fee(): u64 { 1 }
+
 public(package) macro fun max_base_fee(): u64 { fixed_math::math::float_scaling!() }
 
 public(package) fun assert_base_fee(value: u64) {
@@ -126,7 +138,9 @@ public(package) fun assert_base_fee(value: u64) {
 }
 
 public(package) macro fun default_min_fee(): u64 { 5_000_000 }
+
 public(package) macro fun min_min_fee(): u64 { 0 }
+
 public(package) macro fun max_min_fee(): u64 { fixed_math::math::float_scaling!() }
 
 public(package) fun assert_min_fee(value: u64) {
@@ -138,9 +152,11 @@ public(package) fun assert_min_fee(value: u64) {
 public(package) macro fun default_expiry_fee_window_ms(): u64 {
     deepbook_predict::constants::one_day_ms!()
 }
+
 public(package) macro fun min_expiry_fee_window_ms(): u64 {
     deepbook_predict::constants::five_minutes_ms!()
 }
+
 public(package) macro fun max_expiry_fee_window_ms(): u64 {
     deepbook_predict::constants::one_year_ms!()
 }
@@ -157,9 +173,11 @@ public(package) fun assert_expiry_fee_window_ms(value: u64) {
 public(package) macro fun default_expiry_fee_max_multiplier(): u64 {
     fixed_math::math::float_scaling!()
 }
+
 public(package) macro fun min_expiry_fee_max_multiplier(): u64 {
     fixed_math::math::float_scaling!()
 }
+
 public(package) macro fun max_expiry_fee_max_multiplier(): u64 {
     10 * fixed_math::math::float_scaling!()
 }
@@ -192,7 +210,9 @@ public(package) fun assert_cadence_window_size(value: u64) {
 }
 
 public(package) macro fun default_min_entry_probability(): u64 { 10_000_000 }
+
 public(package) macro fun min_min_entry_probability(): u64 { 0 }
+
 public(package) macro fun max_min_entry_probability(): u64 {
     fixed_math::math::float_scaling!() - 1
 }
@@ -206,7 +226,9 @@ public(package) fun assert_min_entry_probability(value: u64) {
 }
 
 public(package) macro fun default_max_entry_probability(): u64 { 990_000_000 }
+
 public(package) macro fun min_max_entry_probability(): u64 { 0 }
+
 public(package) macro fun max_max_entry_probability(): u64 {
     fixed_math::math::float_scaling!() - 1
 }
@@ -220,7 +242,9 @@ public(package) fun assert_max_entry_probability(value: u64) {
 }
 
 public(package) macro fun default_pyth_spot_freshness_ms(): u64 { 2_000 }
+
 public(package) macro fun min_pyth_spot_freshness_ms(): u64 { 1 }
+
 public(package) macro fun max_pyth_spot_freshness_ms(): u64 {
     deepbook_predict::constants::one_minute_ms!()
 }
@@ -233,7 +257,9 @@ public(package) fun assert_pyth_spot_freshness_ms(value: u64) {
 }
 
 public(package) macro fun default_block_scholes_price_freshness_ms(): u64 { 3_000 }
+
 public(package) macro fun min_block_scholes_price_freshness_ms(): u64 { 1 }
+
 public(package) macro fun max_block_scholes_price_freshness_ms(): u64 {
     deepbook_predict::constants::one_minute_ms!()
 }
@@ -247,7 +273,9 @@ public(package) fun assert_block_scholes_price_freshness_ms(value: u64) {
 }
 
 public(package) macro fun default_block_scholes_svi_freshness_ms(): u64 { 60_000 }
+
 public(package) macro fun min_block_scholes_svi_freshness_ms(): u64 { 1 }
+
 public(package) macro fun max_block_scholes_svi_freshness_ms(): u64 {
     deepbook_predict::constants::one_minute_ms!()
 }
@@ -265,7 +293,9 @@ public(package) fun assert_block_scholes_svi_freshness_ms(value: u64) {
 /// Smoothing factor for the gas-price EWMA in FLOAT_SCALING. ~1% reacts slowly,
 /// mirroring DeepBook core. Bounded below float_scaling so `1 - alpha` stays positive.
 public(package) macro fun default_ewma_alpha(): u64 { 10_000_000 }
+
 public(package) macro fun min_ewma_alpha(): u64 { 1 }
+
 public(package) macro fun max_ewma_alpha(): u64 { 100_000_000 }
 
 public(package) fun assert_ewma_alpha(value: u64) {
@@ -277,9 +307,11 @@ public(package) fun assert_ewma_alpha(value: u64) {
 /// cannot be tuned to surcharge near-average gas; the max keeps a single admin
 /// call from raising the bar so high the penalty can never trigger.
 public(package) macro fun default_ewma_z_score_threshold(): u64 { 3_000_000_000 }
+
 public(package) macro fun min_ewma_z_score_threshold(): u64 {
     fixed_math::math::float_scaling!()
 }
+
 public(package) macro fun max_ewma_z_score_threshold(): u64 { 10_000_000_000 }
 
 public(package) fun assert_ewma_z_score_threshold(value: u64) {
@@ -292,7 +324,9 @@ public(package) fun assert_ewma_z_score_threshold(value: u64) {
 /// Per-unit fee added to a penalized trade, in FLOAT_SCALING (10 bps by default,
 /// capped at 20 bps to bound how punitive the surcharge can be made).
 public(package) macro fun default_ewma_penalty_rate(): u64 { 1_000_000 }
+
 public(package) macro fun min_ewma_penalty_rate(): u64 { 0 }
+
 public(package) macro fun max_ewma_penalty_rate(): u64 { 2_000_000 }
 
 public(package) fun assert_ewma_penalty_rate(value: u64) {
@@ -307,7 +341,9 @@ public(package) fun assert_ewma_penalty_rate(value: u64) {
 public(package) macro fun default_trading_loss_rebate_rate(): u64 {
     500_000_000
 }
+
 public(package) macro fun min_trading_loss_rebate_rate(): u64 { 0 }
+
 public(package) macro fun max_trading_loss_rebate_rate(): u64 {
     fixed_math::math::float_scaling!()
 }
@@ -327,9 +363,11 @@ public(package) fun assert_trading_loss_rebate_rate(value: u64) {
 public(package) macro fun default_lower_benefit_power(): u64 {
     100_000 * deepbook_predict::constants::deep_decimals!()
 }
+
 public(package) macro fun min_lower_benefit_power(): u64 {
     10_000 * deepbook_predict::constants::deep_decimals!()
 }
+
 public(package) macro fun max_lower_benefit_power(): u64 {
     1_000_000 * deepbook_predict::constants::deep_decimals!()
 }
@@ -339,9 +377,11 @@ public(package) macro fun max_lower_benefit_power(): u64 {
 public(package) macro fun default_upper_benefit_power(): u64 {
     1_100_000 * deepbook_predict::constants::deep_decimals!()
 }
+
 public(package) macro fun min_upper_benefit_power(): u64 {
     100_000 * deepbook_predict::constants::deep_decimals!()
 }
+
 public(package) macro fun max_upper_benefit_power(): u64 {
     50_000_000 * deepbook_predict::constants::deep_decimals!()
 }

--- a/packages/predict/sources/pricing/pricing.move
+++ b/packages/predict/sources/pricing/pricing.move
@@ -73,10 +73,13 @@ const EBlockScholesSVIUnavailable: u64 = 15;
 /// tightly enough that Predict's fixed-point pricing math remains live and
 /// meaningful.
 macro fun max_pricing_basis(): u64 { 100 * math::float_scaling!() }
+
 // max_pricing_spot * max_pricing_basis / float_scaling <= u64::max by
 // construction: the re-anchored forward (spot * basis) can't overflow u64.
 macro fun max_pricing_spot(): u64 { std::u64::max_value!() / 100 }
+
 macro fun min_svi_sigma(): u64 { 1_000_000 }
+
 macro fun max_svi_input(): u64 { 100 * math::float_scaling!() }
 
 // === Public Functions ===
@@ -445,8 +448,11 @@ fun compute_nd2(svi_params: &SVIParams, forward: u64, strike: u64): u64 {
     let nd2 = math::normal_cdf(&d2);
     if (w_prime.is_zero()) return nd2;
 
-    let correction_magnitude =
-        math::mul_div_down(math::normal_pdf(&d2), w_prime.magnitude(), 2 * sqrt_var);
+    let correction_magnitude = math::mul_div_down(
+        math::normal_pdf(&d2),
+        w_prime.magnitude(),
+        2 * sqrt_var,
+    );
     let correction = i64::from_parts(correction_magnitude, w_prime.is_negative());
     let adjusted = i64::from_u64(nd2).sub(&correction);
     if (adjusted.is_negative()) return 0;

--- a/packages/predict/sources/strike_exposure/strike_exposure.move
+++ b/packages/predict/sources/strike_exposure/strike_exposure.move
@@ -353,11 +353,7 @@ public(package) fun quote_mint_entry_probability(
 ///
 /// Already-liquidated and currently-liquidatable orders have zero holder value;
 /// otherwise this returns the order's current range value net of its static floor.
-public(package) fun order_value(
-    exposure: &StrikeExposure,
-    pricer: &Pricer,
-    order: &Order,
-): u64 {
+public(package) fun order_value(exposure: &StrikeExposure, pricer: &Pricer, order: &Order): u64 {
     if (exposure.is_liquidated_order(order)) return 0;
 
     let gross_value = exposure.gross_order_value(pricer, order);
@@ -494,11 +490,7 @@ public(package) fun materialize_settled_liability(
     settled_liability
 }
 
-fun gross_order_value(
-    exposure: &StrikeExposure,
-    pricer: &Pricer,
-    order: &Order,
-): u64 {
+fun gross_order_value(exposure: &StrikeExposure, pricer: &Pricer, order: &Order): u64 {
     let (lower, higher) = exposure.order_boundaries(order);
     let range_probability = pricer.range_price(lower, higher);
     math::mul(range_probability, order.quantity())

--- a/packages/predict/tests/plp/lp_book_tests.move
+++ b/packages/predict/tests/plp/lp_book_tests.move
@@ -21,7 +21,7 @@ use deepbook_predict::{
         min_executable_plp_price as min_plp_price,
         min_supply_request as min_supply,
         min_withdraw_request as min_withdraw,
-        plp_price_unit as plp_unit
+        plp_price_unit as plp_unit,
     },
     lp_book::{Self, DrainSummary, LpBook},
     pool_accounting::{Self, Ledger}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@mysten/prettier-plugin-move':
-        specifier: ^0.3.5
-        version: 0.3.5
+        specifier: ^0.4.0
+        version: 0.4.0
     devDependencies:
       '@changesets/cli':
         specifier: ^2.27.9
@@ -996,8 +996,8 @@ packages:
   '@microsoft/tsdoc@0.14.2':
     resolution: {integrity: sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==}
 
-  '@mysten/prettier-plugin-move@0.3.5':
-    resolution: {integrity: sha512-PkYZkaH14OAy4S10o4SLl0odGgDHiaILEADiU06gj/MzYZAYq3wh4uCZCO8haX/Xyh2p6NfVy1sihMnUmRnE1g==}
+  '@mysten/prettier-plugin-move@0.4.0':
+    resolution: {integrity: sha512-oMmjU7837nQEsbT6Ygyxur5S/T3r/MjWhNiYycRknZ7M+xg+W03sjZq/lsL9QtKBcLoz81qwuE7QXIUwFOlQbw==}
     hasBin: true
 
   '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
@@ -1183,6 +1183,7 @@ packages:
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -3817,7 +3818,7 @@ snapshots:
 
   '@microsoft/tsdoc@0.14.2': {}
 
-  '@mysten/prettier-plugin-move@0.3.5':
+  '@mysten/prettier-plugin-move@0.4.0':
     dependencies:
       prettier: 3.3.3
       web-tree-sitter: 0.20.8


### PR DESCRIPTION
## Summary
- Fix three defects that each silently narrowed the Move format check. It ran on **45 of the repo's 182 Move files**; it now runs on all 182.
- Bump `@mysten/prettier-plugin-move` to **0.4.0** and install it **from the lockfile**, so CI stops floating to whatever is latest.
- Add `pnpm format:move` / `format:move:check` scripts, **have CI run the check script itself**, and point every doc at it — so contributors and CI share one definition of the file set and the plugin version.
- Add `.prettierignore` for Move `build/` output.
- Reformat the 16 files the check had never reached (separate commit, mechanical, no semantic change).

## Why

The check had a 75% blind spot, and each defect hid the others:

- **The glob only matched one directory level.** `npx prettier-move -c $PWD/../packages/predict/**/*.move` ran **unquoted in bash, where `globstar` is off by default** — so `**` collapses to `*`. `packages/predict/sources/config/` returns **zero** matches. Every nested directory (`sources/config/`, `sources/events/`, `sources/strike_exposure/`, all nested test dirs) has never been format-checked. Quoting hands expansion to prettier, which recurses.
- **Only four packages were enumerated.** `account`, `propbook`, `block_scholes_oracle`, `fixed_math`, `token`, `dusdc`, `dbtc`, and `deepbook_core_account` were checked by **nothing** — 29 files, including three packages this repo's own Predict rules govern. A newly added package would have been added unchecked.
- **The install ignored the lockfile.** `npm i @mysten/prettier-plugin-move` takes no version, so CI enforced **0.4.0** while `package.json` declared `^0.3.5` — a caret range that *excludes* 0.4.0. CI was running a formatter the repo never sanctioned, and the next plugin release would have reddened unrelated PRs for reasons nobody chose.
- **Every contributor instruction pointed at `bunx prettier-move`** (`CLAUDE.md`, `AGENTS.md`, `.claude/rules/move.md`). `bunx` resolves the *latest* plugin, so pinning CI alone would have left the drift wide open from the other side: format locally with 0.5.0 the day it ships, and CI rejects it.

This is not theoretical. It already leaked: **#1125** and **#1123** both contain collateral reformatting of `order_value`/`gross_order_value` — functions neither PR touched. They had drifted out of format *because the check never looked at them*, so the first PR to format that file inherited the churn in its diff.

## How future PRs avoid this

Before opening a PR: **`pnpm install --frozen-lockfile && pnpm format:move`**.

That is now the only sanctioned way to format Move here, and it is enforced by construction rather than by memory:
- **CI runs the same script** (`format:move:check`), so the glob and the version live in exactly one place — `package.json`. Local and CI cannot disagree.
- **`bunx`/`npx prettier-move`, global prettier, and `sui move format` are now explicitly prohibited** in `CLAUDE.md`, `AGENTS.md`, and `.claude/rules/move.md`, with the reason stated (they resolve the latest plugin and format differently from the pinned one).
- **A whole-repo format is a no-op** outside your own edits, because the tree is formatted at HEAD after this PR. `move.md` records the corollary: if `format:move` reports changes to files you did not touch, that is upstream drift — it belongs in its own PR, not silently in yours. That is the rule that would have stopped the #1125/#1123 churn.

## Key decisions
- **Upgrade to 0.4.0 rather than pin down to 0.3.5.** CI already enforced 0.4.0, so the stale thing was the declaration, not CI. Pinning to `^0.3.5` would have *downgraded* the formatter to match a stale `package.json`. Sweep cost was small either way: 16 files at 0.4.0 vs 2 at 0.3.5.
- **The real fix is pinning, not the version number.** Whichever version is chosen, CI must install it deterministically so upgrades are deliberate, reviewable bumps rather than a silent dependency on release timing.
- **One glob instead of four enumerated packages.** Enumeration is the same class of bug as the shallow glob — a silent omission nothing surfaces. `packages/**/*.move` makes "added a package, forgot the check" unrepresentable rather than merely discouraged.
- **CI calls the contributor script, not its own copy of the command.** Two copies of a glob is how they drift apart; this keeps one.
- **Fix and sweep are separate commits.** `c870b006` is the reviewable logic, `985c5e45` is mechanical output. Order matters: fixing the glob *without* the sweep turns CI red across the repo.
- **`.prettierignore` for `build/`.** CI checks out fresh and never sees build output, but a local run does — it pulls in ~130 vendored dependency sources (wormhole, pyth). Ignoring it keeps a local run honest against the same file set CI uses.

## Test plan
- [x] **Real CI on this PR is green**, and its logs confirm it ran these steps — installed `+ @mysten/prettier-plugin-move 0.4.0` from the lockfile, then `All matched files use Prettier code style!`
- [x] Coverage proven by set-diff, not by counting: files prettier actually processes (**182**) vs `find` ground truth (**182**) — **zero** gaps, **zero** over-reach. All 182 `.move` files in the repo are under `packages/`.
- [x] Root cause verified directly: in bash, `packages/predict/**/*.move` yields **0** matches under `sources/config/`; quoted, prettier finds all of them.
- [x] Edge cases probed: `.move` directly under `packages/` (`**` matching zero dirs) — caught; a brand-new package — caught with no workflow edit; 5 levels deep — caught; `build/` artifacts — correctly ignored.
- [x] **Cannot silently pass**: an empty glob exits **2**, not 0. Simulated the original bug by re-adding `working-directory: packages` → glob resolves to `packages/packages/**` → exit 2, red. (Note the limit: this guards zero matches, not partial ones — the original bug matched 45 files and legitimately exited 0, which is why it survived.)
- [x] `sui move build` clean: deepbook, deepbook_margin, predict
- [x] `sui move test`: deepbook **381/381**, deepbook_margin **372/372**, predict **393/393**
- [x] Sweep diff read in full — trailing commas in import lists, blank lines between adjacent macros, one rewrapped `mul_div_down`; no semantic change
- [x] `pnpm format:move` is a no-op on this branch; `pnpm run format:move:check` exits 0
- [x] `git diff --check` clean

No Linear ticket: a CI fix is exempt from the ticket bar (mechanical chore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
