### PR TITLE
Gate bot approval on Codex findings

### DIFF
--- a/.github/AUTO_APPROVE.md
+++ b/.github/AUTO_APPROVE.md
@@ -1,8 +1,9 @@
 # Auto-approval setup
 
-The `auto-approve` workflow approves a pull request when its author is an
-active member of `MystenLabs/defi-eng`. It then runs Codex as an advisory
-reviewer and records the result in Slack.
+The `auto-approve` workflow reviews a pull request with Codex when its author is
+an active member of `MystenLabs/defi-eng`. It submits the GitHub App approval
+only when Codex reports no significant findings, then records the result in
+Slack.
 
 ## Behavior
 
@@ -12,14 +13,17 @@ reviewer and records the result in Slack.
   `MystenLabs/defi-eng`.
 - Approval is bound to the head commit that was current when the label was
   applied.
-- The `auto-approve` label is removed after approval. A later commit requires
-  the label to be applied again.
+- The `auto-approve` label is removed after the workflow attempt, whether or
+  not approval is submitted. A later attempt requires the label to be applied
+  again.
 - A push after auto-approval invalidates the bot review. The workflow first
   tries to dismiss the old approval and falls back to `REQUEST_CHANGES` if the
   repository does not let the App dismiss protected-branch reviews.
-- Codex findings are advisory and never revoke or block the approval.
+- Significant Codex findings, a missing or failed Codex review, and invalid
+  Codex output prevent the bot from approving the pull request.
+- Minor Codex findings do not prevent bot approval.
 - Significant Codex findings, Codex failures, and approval failures send a
-  top-level `<!channel>` notification in Slack.
+  top-level `@here` notification in Slack.
 - Pull request text is escaped before it is copied to Slack so it cannot inject
   mentions.
 
@@ -76,6 +80,10 @@ review input, and runs Codex with the `:read-only` permission profile and the
 `drop-sudo` safety strategy. A separate trusted workflow step formats the
 structured output and posts the advisory pull request comment.
 
+Codex gates only the bot's approval. A significant finding does not submit a
+`REQUEST_CHANGES` review or otherwise prevent a human reviewer from deciding
+that the pull request may proceed.
+
 ## Slack
 
 Create or reuse a Slack App, enable Incoming Webhooks, and add a webhook for the
@@ -99,7 +107,7 @@ App credentials are configured:
 ```bash
 gh label create auto-approve \
   --repo MystenLabs/deepbookv3 \
-  --description "Request bot approval and an advisory Codex review" \
+  --description "Request Codex-gated bot approval" \
   --color 0E8A16
 ```
 
@@ -107,13 +115,16 @@ gh label create auto-approve \
 
 Use a small test pull request authored by a `defi-eng` member:
 
-1. Apply `auto-approve` and confirm the custom GitHub App submits the approval.
+1. Apply `auto-approve` and confirm Codex completes before the custom GitHub
+   App submits the approval.
 2. Confirm the label is removed and the approval references the expected SHA.
-3. Confirm Codex posts a review summary without changing the approval state.
-4. Confirm Slack gets one request message and one final result message.
-5. Push another commit and confirm it is not automatically re-approved.
+3. Confirm a review with no significant findings is posted before approval.
+4. Confirm a review with a significant finding leaves the pull request
+   unapproved and sends an `@here` Slack alert.
+5. Confirm Slack gets one request message and one final result message.
+6. Push another commit and confirm it is not automatically re-approved.
    Confirm the old approval is dismissed or replaced with `REQUEST_CHANGES`.
-6. Apply the label to a PR from a non-member and confirm authorization fails.
+7. Apply the label to a PR from a non-member and confirm authorization fails.
 
 The GitHub Actions workflow uses `pull_request_target` so it can access secrets.
 It must continue checking out only the trusted base commit and must never run

--- a/.github/AUTO_APPROVE.md
+++ b/.github/AUTO_APPROVE.md
@@ -21,7 +21,13 @@ Slack.
   repository does not let the App dismiss protected-branch reviews.
 - Significant Codex findings, a missing or failed Codex review, and invalid
   Codex output prevent the bot from approving the pull request.
+- Codex output is validated against the complete expected schema before it can
+  authorize approval.
+- The Codex review comment must be published successfully before approval.
 - Minor Codex findings do not prevent bot approval.
+- If a retry on the same commit finds significant issues after the App already
+  approved it, the workflow dismisses that approval. If GitHub refuses the
+  dismissal, the workflow replaces it with `REQUEST_CHANGES`.
 - Significant Codex findings, Codex failures, and approval failures send a
   top-level `@here` notification in Slack.
 - Pull request text is escaped before it is copied to Slack so it cannot inject
@@ -80,9 +86,11 @@ review input, and runs Codex with the `:read-only` permission profile and the
 `drop-sudo` safety strategy. A separate trusted workflow step formats the
 structured output and posts the advisory pull request comment.
 
-Codex gates only the bot's approval. A significant finding does not submit a
-`REQUEST_CHANGES` review or otherwise prevent a human reviewer from deciding
-that the pull request may proceed.
+Codex gates the bot's approval. A fresh significant result does not submit a
+`REQUEST_CHANGES` review. On a significant retry of an already approved commit,
+`REQUEST_CHANGES` is used only as a fallback when GitHub refuses to dismiss the
+existing App approval; a human reviewer may dismiss that fallback review after
+deciding how to proceed.
 
 ## Slack
 
@@ -121,10 +129,13 @@ Use a small test pull request authored by a `defi-eng` member:
 3. Confirm a review with no significant findings is posted before approval.
 4. Confirm a review with a significant finding leaves the pull request
    unapproved and sends an `@here` Slack alert.
-5. Confirm Slack gets one request message and one final result message.
-6. Push another commit and confirm it is not automatically re-approved.
+5. Reapply the label to an already approved commit and confirm a significant
+   retry dismisses or replaces the existing App approval.
+6. Confirm a comment publication failure does not submit bot approval.
+7. Confirm Slack gets one request message and one final result message.
+8. Push another commit and confirm it is not automatically re-approved.
    Confirm the old approval is dismissed or replaced with `REQUEST_CHANGES`.
-7. Apply the label to a PR from a non-member and confirm authorization fails.
+9. Apply the label to a PR from a non-member and confirm authorization fails.
 
 The GitHub Actions workflow uses `pull_request_target` so it can access secrets.
 It must continue checking out only the trusted base commit and must never run

--- a/.github/AUTO_APPROVE.md
+++ b/.github/AUTO_APPROVE.md
@@ -24,10 +24,15 @@ Slack.
 - Codex output is validated against the complete expected schema before it can
   authorize approval.
 - The Codex review comment must be published successfully before approval.
+- Each label-triggered run publishes its own Codex review comment, even when
+  the head commit is unchanged. Rerunning the same Actions run updates that
+  run's comment instead of creating a duplicate.
 - Minor Codex findings do not prevent bot approval.
 - If a retry on the same commit finds significant issues after the App already
   approved it, the workflow dismisses that approval. If GitHub refuses the
   dismissal, the workflow replaces it with `REQUEST_CHANGES`.
+- If a later clean retry follows `REQUEST_CHANGES`, the App submits a new
+  approval because decisions use its latest review for that commit.
 - Significant Codex findings, Codex failures, and approval failures send a
   top-level `@here` notification in Slack.
 - Pull request text is escaped before it is copied to Slack so it cannot inject
@@ -131,11 +136,15 @@ Use a small test pull request authored by a `defi-eng` member:
    unapproved and sends an `@here` Slack alert.
 5. Reapply the label to an already approved commit and confirm a significant
    retry dismisses or replaces the existing App approval.
-6. Confirm a comment publication failure does not submit bot approval.
-7. Confirm Slack gets one request message and one final result message.
-8. Push another commit and confirm it is not automatically re-approved.
+6. Reapply the label without changing the commit and confirm the new Codex
+   result is published in a new comment.
+7. Confirm a clean retry after fallback `REQUEST_CHANGES` submits a newer App
+   approval.
+8. Confirm a comment publication failure does not submit bot approval.
+9. Confirm Slack gets one request message and one final result message.
+10. Push another commit and confirm it is not automatically re-approved.
    Confirm the old approval is dismissed or replaced with `REQUEST_CHANGES`.
-9. Apply the label to a PR from a non-member and confirm authorization fails.
+11. Apply the label to a PR from a non-member and confirm authorization fails.
 
 The GitHub Actions workflow uses `pull_request_target` so it can access secrets.
 It must continue checking out only the trusted base commit and must never run

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,4 +1,4 @@
-name: Auto-approve with Codex review
+name: Auto-approve after Codex review
 
 on:
   pull_request_target:
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   auto-approve:
-    name: Approve and run advisory review
+    name: Review and conditionally approve
     if: github.event.action == 'labeled' && github.event.label.name == 'auto-approve'
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -40,7 +40,7 @@ jobs:
             echo "codex=true" >> "$GITHUB_OUTPUT"
           else
             echo "codex=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::OPENAI_API_KEY is not configured; the advisory review will be skipped"
+            echo "::warning::OPENAI_API_KEY is not configured; Codex review and auto-approval will be skipped"
           fi
 
           if [[ -n "$SLACK_WEBHOOK_URL" ]]; then
@@ -192,110 +192,6 @@ jobs:
               throw new Error(`Slack incoming webhook failed: ${response.status} ${result}`);
             }
 
-      - name: Approve the pull request
-        id: approve
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
-          CODEX_CONFIGURED: ${{ steps.config.outputs.codex }}
-          HEAD_SHA: ${{ steps.authorize.outputs.head_sha }}
-          PR_AUTHOR: ${{ steps.authorize.outputs.author }}
-          PR_NUMBER: ${{ steps.authorize.outputs.number }}
-          SLACK_CONFIGURED: ${{ steps.config.outputs.slack }}
-        with:
-          github-token: ${{ steps.app-token.outputs.token }}
-          script: |
-            const { owner, repo } = context.repo;
-            const pullNumber = Number(process.env.PR_NUMBER);
-            const botLogin = `${process.env.APP_SLUG}[bot]`;
-            const shortSha = process.env.HEAD_SHA.slice(0, 12);
-            const codexLine = process.env.CODEX_CONFIGURED === "true"
-              ? "Codex is reviewing this commit separately and its findings are advisory."
-              : "Codex review was skipped because it is not configured.";
-
-            const { data: livePull } = await github.rest.pulls.get({
-              owner,
-              repo,
-              pull_number: pullNumber,
-            });
-            if (livePull.head.sha !== process.env.HEAD_SHA) {
-              throw new Error(
-                `PR #${pullNumber} changed before approval; remove and re-add auto-approve`,
-              );
-            }
-
-            const reviews = await github.paginate(github.rest.pulls.listReviews, {
-              owner,
-              repo,
-              pull_number: pullNumber,
-              per_page: 100,
-            });
-            const existingApproval = reviews.find(
-              (review) => review.user?.login === botLogin
-                && review.commit_id === process.env.HEAD_SHA
-                && review.state === "APPROVED",
-            );
-
-            if (existingApproval) {
-              core.info(`Commit ${shortSha} is already approved by ${botLogin}`);
-              core.setOutput("created", "false");
-            } else {
-              await github.rest.pulls.createReview({
-                owner,
-                repo,
-                pull_number: pullNumber,
-                commit_id: process.env.HEAD_SHA,
-                event: "APPROVE",
-                body: [
-                  `Auto-approved commit \`${shortSha}\` because @${process.env.PR_AUTHOR}`,
-                  `is an active member of ${process.env.AUTHORIZED_ORG}/${process.env.AUTHORIZED_TEAM}.`,
-                  codexLine,
-                ].join(" "),
-              });
-              core.setOutput("created", "true");
-            }
-
-            const marker = `<!-- auto-approve:${process.env.HEAD_SHA} -->`;
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number: pullNumber,
-              per_page: 100,
-            });
-            if (!comments.some((comment) => comment.body?.includes(marker))) {
-              const slackLine = process.env.SLACK_CONFIGURED === "true"
-                ? "The event was also posted to Slack."
-                : "Slack notification was not configured or could not be delivered.";
-              try {
-                await github.rest.issues.createComment({
-                  owner,
-                  repo,
-                  issue_number: pullNumber,
-                  body: [
-                    marker,
-                    `Auto-approved \`${shortSha}\`. ${codexLine}`,
-                    "Significant findings will be called out prominently but will not revoke this approval.",
-                    slackLine,
-                  ].join("\n\n"),
-                });
-              } catch (error) {
-                core.warning(`Approval succeeded, but the audit comment failed: ${error.message}`);
-              }
-            }
-
-            try {
-              await github.rest.issues.removeLabel({
-                owner,
-                repo,
-                issue_number: pullNumber,
-                name: "auto-approve",
-              });
-            } catch (error) {
-              if (error.status !== 404) {
-                core.warning(`Approval succeeded, but label cleanup failed: ${error.message}`);
-              }
-            }
-
       - name: Check out the trusted base commit for Codex
         if: steps.config.outputs.codex == 'true'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
@@ -416,6 +312,35 @@ jobs:
           output-schema: |
             {"type":"object","properties":{"significant_findings":{"type":"boolean"},"summary":{"type":"string"},"findings":{"type":"array","maxItems":10,"items":{"type":"object","properties":{"severity":{"type":"string","enum":["significant","minor"]},"title":{"type":"string"},"location":{"type":"string"},"description":{"type":"string"}},"required":["severity","title","location","description"],"additionalProperties":false}}},"required":["significant_findings","summary","findings"],"additionalProperties":false}
 
+      - name: Evaluate Codex approval decision
+        id: codex-decision
+        if: >-
+          steps.config.outputs.codex == 'true' &&
+          steps.codex-review.outcome == 'success' &&
+          steps.codex-review.outputs.final-message != ''
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          CODEX_RESULT: ${{ steps.codex-review.outputs.final-message }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            let result;
+            try {
+              result = JSON.parse(process.env.CODEX_RESULT);
+            } catch (error) {
+              throw new Error(`Could not parse Codex structured output: ${error.message}`);
+            }
+
+            const findings = Array.isArray(result.findings) ? result.findings : [];
+            const isSignificant = result.significant_findings === true
+              || findings.some((finding) => finding.severity === "significant");
+            core.setOutput("significant", String(isSignificant));
+            core.info(
+              isSignificant
+                ? "Codex found significant issues; bot approval is blocked"
+                : "Codex found no significant issues; bot approval is allowed",
+            );
+
       - name: Publish Codex advisory review
         id: publish-codex-review
         if: >-
@@ -470,7 +395,9 @@ jobs:
               safeMarkdown(result.summary || "Codex returned no summary.", 4000),
               findingLines.length > 0 ? "#### Findings" : "",
               ...findingLines,
-              "_Advisory only. This review does not change the bot approval._",
+              isSignificant
+                ? "_Bot approval was withheld. A human reviewer must decide how to proceed._"
+                : "_No significant findings were detected; bot approval may proceed._",
             ].filter(Boolean).join("\n\n");
 
             const comments = await github.paginate(github.rest.issues.listComments, {
@@ -494,12 +421,122 @@ jobs:
             });
             core.setOutput("comment_url", comment.html_url);
 
+      - name: Approve the pull request
+        id: approve
+        if: steps.codex-decision.outputs.significant == 'false'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          HEAD_SHA: ${{ steps.authorize.outputs.head_sha }}
+          PR_AUTHOR: ${{ steps.authorize.outputs.author }}
+          PR_NUMBER: ${{ steps.authorize.outputs.number }}
+          SLACK_CONFIGURED: ${{ steps.config.outputs.slack }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const { owner, repo } = context.repo;
+            const pullNumber = Number(process.env.PR_NUMBER);
+            const botLogin = `${process.env.APP_SLUG}[bot]`;
+            const shortSha = process.env.HEAD_SHA.slice(0, 12);
+            const codexLine = "Codex found no significant issues in its review of this commit.";
+
+            const { data: livePull } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pullNumber,
+            });
+            if (livePull.head.sha !== process.env.HEAD_SHA) {
+              throw new Error(
+                `PR #${pullNumber} changed before approval; remove and re-add auto-approve`,
+              );
+            }
+
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner,
+              repo,
+              pull_number: pullNumber,
+              per_page: 100,
+            });
+            const existingApproval = reviews.find(
+              (review) => review.user?.login === botLogin
+                && review.commit_id === process.env.HEAD_SHA
+                && review.state === "APPROVED",
+            );
+
+            if (existingApproval) {
+              core.info(`Commit ${shortSha} is already approved by ${botLogin}`);
+              core.setOutput("created", "false");
+            } else {
+              await github.rest.pulls.createReview({
+                owner,
+                repo,
+                pull_number: pullNumber,
+                commit_id: process.env.HEAD_SHA,
+                event: "APPROVE",
+                body: [
+                  `Auto-approved commit \`${shortSha}\` because @${process.env.PR_AUTHOR}`,
+                  `is an active member of ${process.env.AUTHORIZED_ORG}/${process.env.AUTHORIZED_TEAM}.`,
+                  codexLine,
+                ].join(" "),
+              });
+              core.setOutput("created", "true");
+            }
+
+            const marker = `<!-- auto-approve:${process.env.HEAD_SHA} -->`;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: pullNumber,
+              per_page: 100,
+            });
+            if (!comments.some((comment) => comment.body?.includes(marker))) {
+              const slackLine = process.env.SLACK_CONFIGURED === "true"
+                ? "The event was also posted to Slack."
+                : "Slack notification was not configured or could not be delivered.";
+              try {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: pullNumber,
+                  body: [
+                    marker,
+                    `Auto-approved \`${shortSha}\` after Codex reported no significant findings.`,
+                    slackLine,
+                  ].join("\n\n"),
+                });
+              } catch (error) {
+                core.warning(`Approval succeeded, but the audit comment failed: ${error.message}`);
+              }
+            }
+
+      - name: Remove auto-approve label
+        if: always() && steps.app-token.outcome == 'success'
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const { owner, repo } = context.repo;
+            try {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: context.payload.pull_request.number,
+                name: "auto-approve",
+              });
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+            }
+
       - name: Publish final Slack update
         if: always() && steps.config.outputs.slack == 'true'
         continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           APPROVAL_OUTCOME: ${{ steps.approve.outcome }}
+          AUTHORIZATION_OUTCOME: ${{ steps.authorize.outcome }}
           CODEX_COMMENT_URL: ${{ steps.publish-codex-review.outputs.comment_url }}
           CODEX_CONFIGURED: ${{ steps.config.outputs.codex }}
           CODEX_OUTCOME: ${{ steps.codex-review.outcome }}
@@ -519,19 +556,19 @@ jobs:
             const shortSha = process.env.PR_HEAD_SHA?.slice(0, 12) || "unknown";
             let text;
 
-            if (process.env.APPROVAL_OUTCOME !== "success") {
-              text = `<!channel> *AUTO-APPROVAL FAILED* for ${prLink} at \`${shortSha}\`. Check the GitHub Actions run.`;
+            if (process.env.AUTHORIZATION_OUTCOME !== "success") {
+              text = `<!here> *AUTO-APPROVAL FAILED* for ${prLink} at \`${shortSha}\`. Check the GitHub Actions run.`;
             } else if (process.env.CODEX_CONFIGURED !== "true") {
-              text = `*Approved* ${prLink} at \`${shortSha}\`. Codex review was skipped because it is not configured.`;
+              text = `<!here> *CODEX REVIEW IS NOT CONFIGURED* for ${prLink} at \`${shortSha}\`. Bot approval was withheld.`;
             } else if (process.env.CODEX_OUTCOME !== "success" || !process.env.CODEX_RESULT) {
-              text = `<!channel> *CODEX REVIEW DID NOT COMPLETE* for approved ${prLink} at \`${shortSha}\`. Check the GitHub Actions run.`;
+              text = `<!here> *CODEX REVIEW DID NOT COMPLETE* for ${prLink} at \`${shortSha}\`. Bot approval was withheld; check the GitHub Actions run.`;
             } else {
               let result;
               try {
                 result = JSON.parse(process.env.CODEX_RESULT);
               } catch (error) {
                 core.warning(`Could not parse Codex structured output: ${error.message}`);
-                text = `<!channel> *CODEX REVIEW OUTPUT WAS INVALID* for approved ${prLink} at \`${shortSha}\`. Check the GitHub Actions run.`;
+                text = `<!here> *CODEX REVIEW OUTPUT WAS INVALID* for ${prLink} at \`${shortSha}\`. Bot approval was withheld; check the GitHub Actions run.`;
               }
 
               if (result) {
@@ -556,13 +593,20 @@ jobs:
                     : findings;
                   const findingLines = formatFindings(displayedFindings);
                   text = [
-                    `<!channel> *SIGNIFICANT CODEX FINDINGS* for approved ${prLink} at \`${shortSha}\`${reviewLink}`,
+                    `<!here> *SIGNIFICANT CODEX FINDINGS* for ${prLink} at \`${shortSha}\`${reviewLink}`,
+                    "Bot approval was withheld. A human reviewer must decide how to proceed.",
                     summary,
                     ...findingLines,
                     findingLines.length < displayedFindings.length
                       ? `- Plus ${displayedFindings.length - findingLines.length} more findings on the PR.`
                       : "",
                   ].filter(Boolean).join("\n");
+                } else if (process.env.APPROVAL_OUTCOME !== "success") {
+                  text = [
+                    `<!here> *AUTO-APPROVAL FAILED* for ${prLink} at \`${shortSha}\`${reviewLink}`,
+                    "Codex found no significant issues, but the approval was not submitted. Check the GitHub Actions run.",
+                    summary,
+                  ].join("\n");
                 } else {
                   const findingLines = formatFindings(findings);
                   text = [

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -331,7 +331,53 @@ jobs:
               throw new Error(`Could not parse Codex structured output: ${error.message}`);
             }
 
-            const findings = Array.isArray(result.findings) ? result.findings : [];
+            const assertExactKeys = (value, expectedKeys, path) => {
+              if (value === null || typeof value !== "object" || Array.isArray(value)) {
+                throw new Error(`${path} must be an object`);
+              }
+              const actualKeys = Object.keys(value).sort();
+              const expected = [...expectedKeys].sort();
+              if (actualKeys.length !== expected.length
+                || actualKeys.some((key, index) => key !== expected[index])) {
+                throw new Error(
+                  `${path} must contain exactly: ${expectedKeys.join(", ")}`,
+                );
+              }
+            };
+
+            assertExactKeys(
+              result,
+              ["significant_findings", "summary", "findings"],
+              "Codex result",
+            );
+            if (typeof result.significant_findings !== "boolean") {
+              throw new Error("Codex result significant_findings must be a boolean");
+            }
+            if (typeof result.summary !== "string") {
+              throw new Error("Codex result summary must be a string");
+            }
+            if (!Array.isArray(result.findings) || result.findings.length > 10) {
+              throw new Error("Codex result findings must be an array of at most 10 items");
+            }
+
+            result.findings.forEach((finding, index) => {
+              const path = `Codex result findings[${index}]`;
+              assertExactKeys(
+                finding,
+                ["severity", "title", "location", "description"],
+                path,
+              );
+              if (!new Set(["significant", "minor"]).has(finding.severity)) {
+                throw new Error(`${path} severity must be significant or minor`);
+              }
+              for (const key of ["title", "location", "description"]) {
+                if (typeof finding[key] !== "string") {
+                  throw new Error(`${path} ${key} must be a string`);
+                }
+              }
+            });
+
+            const findings = result.findings;
             const isSignificant = result.significant_findings === true
               || findings.some((finding) => finding.severity === "significant");
             core.setOutput("significant", String(isSignificant));
@@ -346,6 +392,7 @@ jobs:
         if: >-
           steps.config.outputs.codex == 'true' &&
           steps.codex-review.outcome == 'success' &&
+          steps.codex-decision.outcome == 'success' &&
           steps.codex-review.outputs.final-message != ''
         continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -421,9 +468,83 @@ jobs:
             });
             core.setOutput("comment_url", comment.html_url);
 
+      - name: Invalidate existing approval after significant findings
+        id: revoke-approval
+        if: steps.codex-decision.outputs.significant == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          HEAD_SHA: ${{ steps.authorize.outputs.head_sha }}
+          PR_NUMBER: ${{ steps.authorize.outputs.number }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const { owner, repo } = context.repo;
+            const pullNumber = Number(process.env.PR_NUMBER);
+            const botLogin = `${process.env.APP_SLUG}[bot]`;
+            const shortSha = process.env.HEAD_SHA.slice(0, 12);
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner,
+              repo,
+              pull_number: pullNumber,
+              per_page: 100,
+            });
+            const latestBotReview = reviews
+              .filter(
+                (review) => review.user?.login === botLogin
+                  && review.commit_id === process.env.HEAD_SHA,
+              )
+              .sort((left, right) => left.id - right.id)
+              .at(-1);
+
+            if (!latestBotReview || latestBotReview.state !== "APPROVED") {
+              core.info(`No active ${botLogin} approval exists for ${shortSha}`);
+              core.setOutput("invalidated", "false");
+              core.setOutput("method", "none");
+              return;
+            }
+
+            let method = "dismissed";
+            try {
+              await github.request(
+                "PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/dismissals",
+                {
+                  owner,
+                  repo,
+                  pull_number: pullNumber,
+                  review_id: latestBotReview.id,
+                  message: `Codex found significant issues in retry for ${shortSha}`,
+                  event: "DISMISS",
+                },
+              );
+            } catch (error) {
+              method = "changes-requested";
+              core.warning(
+                `Could not dismiss existing approval; replacing it with REQUEST_CHANGES: ${error.message}`,
+              );
+              await github.rest.pulls.createReview({
+                owner,
+                repo,
+                pull_number: pullNumber,
+                commit_id: process.env.HEAD_SHA,
+                event: "REQUEST_CHANGES",
+                body: [
+                  `Codex found significant issues in commit \`${shortSha}\` after it was auto-approved.`,
+                  "The previous App approval could not be dismissed automatically.",
+                  "A human reviewer may dismiss this review after deciding how to proceed.",
+                ].join(" "),
+              });
+            }
+
+            core.setOutput("invalidated", "true");
+            core.setOutput("method", method);
+
       - name: Approve the pull request
         id: approve
-        if: steps.codex-decision.outputs.significant == 'false'
+        if: >-
+          steps.codex-decision.outputs.significant == 'false' &&
+          steps.publish-codex-review.outcome == 'success' &&
+          steps.publish-codex-review.outputs.comment_url != ''
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
@@ -539,11 +660,16 @@ jobs:
           AUTHORIZATION_OUTCOME: ${{ steps.authorize.outcome }}
           CODEX_COMMENT_URL: ${{ steps.publish-codex-review.outputs.comment_url }}
           CODEX_CONFIGURED: ${{ steps.config.outputs.codex }}
+          CODEX_DECISION_OUTCOME: ${{ steps.codex-decision.outcome }}
           CODEX_OUTCOME: ${{ steps.codex-review.outcome }}
           CODEX_RESULT: ${{ steps.codex-review.outputs.final-message }}
+          PUBLICATION_OUTCOME: ${{ steps.publish-codex-review.outcome }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_URL: ${{ github.event.pull_request.html_url }}
+          REVOCATION_INVALIDATED: ${{ steps.revoke-approval.outputs.invalidated }}
+          REVOCATION_METHOD: ${{ steps.revoke-approval.outputs.method }}
+          REVOCATION_OUTCOME: ${{ steps.revoke-approval.outcome }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
           github-token: ${{ github.token }}
@@ -562,6 +688,8 @@ jobs:
               text = `<!here> *CODEX REVIEW IS NOT CONFIGURED* for ${prLink} at \`${shortSha}\`. Bot approval was withheld.`;
             } else if (process.env.CODEX_OUTCOME !== "success" || !process.env.CODEX_RESULT) {
               text = `<!here> *CODEX REVIEW DID NOT COMPLETE* for ${prLink} at \`${shortSha}\`. Bot approval was withheld; check the GitHub Actions run.`;
+            } else if (process.env.CODEX_DECISION_OUTCOME !== "success") {
+              text = `<!here> *CODEX REVIEW OUTPUT WAS INVALID* for ${prLink} at \`${shortSha}\`. Bot approval was withheld; check the GitHub Actions run.`;
             } else {
               let result;
               try {
@@ -592,15 +720,30 @@ jobs:
                     ? significantFindings
                     : findings;
                   const findingLines = formatFindings(displayedFindings);
+                  let approvalLine = "Bot approval was withheld. A human reviewer must decide how to proceed.";
+                  if (process.env.REVOCATION_OUTCOME !== "success") {
+                    approvalLine = "Bot approval was withheld, but an existing App approval may not have been invalidated. Check the GitHub Actions run.";
+                  } else if (process.env.REVOCATION_INVALIDATED === "true") {
+                    approvalLine = process.env.REVOCATION_METHOD === "dismissed"
+                      ? "An existing App approval was dismissed. A human reviewer must decide how to proceed."
+                      : "An existing App approval was replaced with REQUEST_CHANGES. A human reviewer must decide how to proceed.";
+                  }
                   text = [
                     `<!here> *SIGNIFICANT CODEX FINDINGS* for ${prLink} at \`${shortSha}\`${reviewLink}`,
-                    "Bot approval was withheld. A human reviewer must decide how to proceed.",
+                    approvalLine,
                     summary,
                     ...findingLines,
                     findingLines.length < displayedFindings.length
                       ? `- Plus ${displayedFindings.length - findingLines.length} more findings on the PR.`
                       : "",
                   ].filter(Boolean).join("\n");
+                } else if (process.env.PUBLICATION_OUTCOME !== "success"
+                  || !process.env.CODEX_COMMENT_URL) {
+                  text = [
+                    `<!here> *CODEX REVIEW COULD NOT BE PUBLISHED* for ${prLink} at \`${shortSha}\``,
+                    "Codex found no significant issues, but bot approval was withheld because the PR comment was not published. Check the GitHub Actions run.",
+                    summary,
+                  ].join("\n");
                 } else if (process.env.APPROVAL_OUTCOME !== "success") {
                   text = [
                     `<!here> *AUTO-APPROVAL FAILED* for ${prLink} at \`${shortSha}\`${reviewLink}`,

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -400,12 +400,13 @@ jobs:
           CODEX_RESULT: ${{ steps.codex-review.outputs.final-message }}
           HEAD_SHA: ${{ steps.authorize.outputs.head_sha }}
           PR_NUMBER: ${{ steps.authorize.outputs.number }}
+          RUN_ID: ${{ github.run_id }}
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const { owner, repo } = context.repo;
             const pullNumber = Number(process.env.PR_NUMBER);
-            const marker = `<!-- codex-advisory:${process.env.HEAD_SHA} -->`;
+            const marker = `<!-- codex-advisory:${process.env.HEAD_SHA}:${process.env.RUN_ID} -->`;
             const shortSha = process.env.HEAD_SHA.slice(0, 12);
             const safeMarkdown = (value, limit = 2000) => String(value || "")
               .slice(0, limit)
@@ -455,8 +456,14 @@ jobs:
             });
             const existing = comments.find((comment) => comment.body?.includes(marker));
             if (existing) {
-              core.info(`Codex advisory comment already exists for ${shortSha}`);
-              core.setOutput("comment_url", existing.html_url);
+              const { data: comment } = await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body: body.slice(0, 65000),
+              });
+              core.info(`Updated Codex advisory comment for ${shortSha} in run ${process.env.RUN_ID}`);
+              core.setOutput("comment_url", comment.html_url);
               return;
             }
 
@@ -578,13 +585,15 @@ jobs:
               pull_number: pullNumber,
               per_page: 100,
             });
-            const existingApproval = reviews.find(
-              (review) => review.user?.login === botLogin
-                && review.commit_id === process.env.HEAD_SHA
-                && review.state === "APPROVED",
-            );
+            const latestBotReview = reviews
+              .filter(
+                (review) => review.user?.login === botLogin
+                  && review.commit_id === process.env.HEAD_SHA,
+              )
+              .sort((left, right) => left.id - right.id)
+              .at(-1);
 
-            if (existingApproval) {
+            if (latestBotReview?.state === "APPROVED") {
               core.info(`Commit ${shortSha} is already approved by ${botLogin}`);
               core.setOutput("created", "false");
             } else {


### PR DESCRIPTION
## Summary

- run Codex before submitting the GitHub App approval
- validate the complete structured-output schema and fail closed on malformed output
- approve only when Codex reports no significant findings and its PR comment publishes successfully
- publish a fresh Codex comment per label-triggered run, updating it only when that same Actions run is retried
- revoke an existing same-commit App approval when a retry finds significant issues, with a `REQUEST_CHANGES` fallback if dismissal fails
- submit a newer approval when a clean retry follows `CHANGES_REQUESTED` or a dismissed review
- withhold bot approval for missing configuration or review failures
- remove the trigger label after every attempted run so a retry is explicit
- replace Slack `@channel` escalations with `@here`

Codex gates the bot approval. Humans retain the final decision, including the ability to dismiss the fallback change request.

## Validation

- parsed the workflow successfully as YAML
- syntax-checked all 11 embedded `github-script` blocks
- ran the exact decision script through 12 valid and invalid schema cases
- ran the exact publish/approval scripts through 5 same-commit retry-state cases
- ran `git diff --check`
- confirmed the workflow matches the `deepbook-services` version