### PR TITLE
margin v6: register mainnet package 0x8af25e44

### DIFF
--- a/packages/deepbook_margin/Published.toml
+++ b/packages/deepbook_margin/Published.toml
@@ -4,9 +4,9 @@
 
 [published.mainnet]
 chain-id = "35834a8a"
-published-at = "0x124bb3d8105d6d301c0d40feaa54d65df6b301e4d8ddd5eb8475b0f8a18cff2e"
+published-at = "0x8af25e44bcdfb8b19ceffef5a1bd457a89a4270b8237e1025f30cd26acb4edbe"
 original-id = "0x97d9473771b01f77b0940c589484184b49f6444627ec121314fae6a6d36fb86b"
-version = 5
+version = 6
 toolchain-version = "1.63.1"
 build-config = { flavor = "sui", edition = "2024" }
 upgrade-capability = "0xd57c7a41b31c0a1fab5e71d296a75daf2e9e09945df383d4745daa49f06d9c56"


### PR DESCRIPTION
## Summary
- Register mainnet margin package **`0x8af25e44bcdfb8b19ceffef5a1bd457a89a4270b8237e1025f30cd26acb4edbe`** as **version 6** in `packages/deepbook_margin/Published.toml`.
- `published-at` and `version` only, matching the v5 bump (#1018). `original-id`, `upgrade-capability`, `chain-id`, and `toolchain-version` are unchanged.

## Why
- The v6 margin upgrade is published on mainnet, so `Published.toml` — the signature authority for anything building against margin — still points at the v5 package.
- Pairs with #1122, which set `versionToEnable = 6` in the `enableMarginVersion` script.

## Key decisions
- **`published-at` moves, `original-id` does not.** On Sui, `original-id` is the first-published id and is stable across upgrades; `published-at` is the latest package. Verified on-chain that the new id belongs to this lineage rather than assuming it.
- **`toolchain-version` left at `1.63.1`.** The v5 bump did not touch it either, and the builder's toolchain is not readable from chain — so changing it would be a guess. Flagging it as a known-possibly-stale field rather than inventing a value.

## Heads-up: v6 is published but NOT yet enabled

Recording the id here does not make v6 callable. Verified on-chain today: the `MarginRegistry` (`0x0e40998b…`) still has `allowed_versions = {5}`, while `margin_constants::MARGIN_VERSION` is already 6. Until an admin runs `enable_version(6)`, every margin entry through the v6 package aborts `EPackageVersionDisabled` — exactly what `margin_constants.move`'s own header warns about:

> Bump ahead of EVERY on-chain package upgrade. After the upgrade the admin must also call `enable_version(N)` on the live `MarginRegistry` (and later `disable_version(N-1)`), or all entries abort `EPackageVersionDisabled`.

`scripts/transactions/enableMarginVersion.ts` is already set to 6 (#1122) and is ready to run; `disable_version(5)` is the separate later step. This PR is the record of what is published, which is a different axis from what the gate allows — it is correct to land independently of that sequencing.

## Verification (all against mainnet, before landing)
- [x] `0x8af25e44…` exists on mainnet, `type = package`, `owner = Immutable`, `previousTransaction = BtKJCip9zFFKW8EMh6eJ9JT2XE13ntb5b8VBH2y1Yefx`
- [x] **Object version = 6** — matches the version claimed here
- [x] Its 12 modules are the margin modules: `margin_constants`, `margin_manager`, `margin_pool`, `margin_registry`, `margin_state`, `oracle`, `pool_proxy`, `position_manager`, `protocol_config`, `protocol_fees`, `rate_limiter`, `tpsl`
- [x] **Lineage confirmed** — the package's normalized modules declare address `0x97d9473771b01f77b0940c589484184b49f6444627ec121314fae6a6d36fb86b`, exactly the `original-id` already in this file. It is an upgrade of *this* package, not a lookalike that merely happens to be at version 6.
- [x] **`sui client verify-source packages/deepbook_margin` → "Source verification succeeded!"** — the on-chain v6 bytecode matches this branch's source.
- [x] **Control test proving that check discriminates**: pointing `published-at` at the previous v5 package (`0x124bb3d8…`) and re-running gives *"Multiple source verification errors found"*. So the pass above is meaningful — main's source matches **v6 specifically**, not v5.

No Linear ticket: registering a published package id is a metadata/config update, exempt from the ticket bar; #1018 (the v5 equivalent) was landed unticketed on the same basis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
