### PR TITLE
Revoke App approval for every blocked Codex gate result

### DIFF
--- a/.github/AUTO_APPROVE.md
+++ b/.github/AUTO_APPROVE.md
@@ -28,9 +28,12 @@ Slack.
   the head commit is unchanged. Rerunning the same Actions run updates that
   run's comment instead of creating a duplicate.
 - Minor Codex findings do not prevent bot approval.
-- If a retry on the same commit finds significant issues after the App already
-  approved it, the workflow dismisses that approval. If GitHub refuses the
-  dismissal, the workflow replaces it with `REQUEST_CHANGES`.
+- If any retry cannot establish a valid, published Codex result with no
+  significant findings, the workflow dismisses an existing App approval for
+  that commit. This includes authorization failures, missing configuration,
+  Codex failures, invalid output, significant findings, and comment publication
+  failures. If GitHub refuses the dismissal, the workflow replaces the approval
+  with `REQUEST_CHANGES`.
 - If a later clean retry follows `REQUEST_CHANGES`, the App submits a new
   approval because decisions use its latest review for that commit.
 - Significant Codex findings, Codex failures, and approval failures send a
@@ -91,8 +94,8 @@ review input, and runs Codex with the `:read-only` permission profile and the
 `drop-sudo` safety strategy. A separate trusted workflow step formats the
 structured output and posts the advisory pull request comment.
 
-Codex gates the bot's approval. A fresh significant result does not submit a
-`REQUEST_CHANGES` review. On a significant retry of an already approved commit,
+Codex gates the bot's approval. A fresh blocked result does not submit a
+`REQUEST_CHANGES` review. On a blocked retry of an already approved commit,
 `REQUEST_CHANGES` is used only as a fallback when GitHub refuses to dismiss the
 existing App approval; a human reviewer may dismiss that fallback review after
 deciding how to proceed.
@@ -136,15 +139,17 @@ Use a small test pull request authored by a `defi-eng` member:
    unapproved and sends an `@here` Slack alert.
 5. Reapply the label to an already approved commit and confirm a significant
    retry dismisses or replaces the existing App approval.
-6. Reapply the label without changing the commit and confirm the new Codex
+6. Confirm failed Codex execution, invalid output, and comment publication
+   failure also dismiss or replace an existing App approval.
+7. Reapply the label without changing the commit and confirm the new Codex
    result is published in a new comment.
-7. Confirm a clean retry after fallback `REQUEST_CHANGES` submits a newer App
+8. Confirm a clean retry after fallback `REQUEST_CHANGES` submits a newer App
    approval.
-8. Confirm a comment publication failure does not submit bot approval.
-9. Confirm Slack gets one request message and one final result message.
-10. Push another commit and confirm it is not automatically re-approved.
+9. Confirm a comment publication failure does not submit bot approval.
+10. Confirm Slack gets one request message and one final result message.
+11. Push another commit and confirm it is not automatically re-approved.
    Confirm the old approval is dismissed or replaced with `REQUEST_CHANGES`.
-11. Apply the label to a PR from a non-member and confirm authorization fails.
+12. Apply the label to a PR from a non-member and confirm authorization fails.
 
 The GitHub Actions workflow uses `pull_request_target` so it can access secrets.
 It must continue checking out only the trusted base commit and must never run

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -475,14 +475,23 @@ jobs:
             });
             core.setOutput("comment_url", comment.html_url);
 
-      - name: Invalidate existing approval after significant findings
+      - name: Reconcile existing approval with gate result
         id: revoke-approval
-        if: steps.codex-decision.outputs.significant == 'true'
+        if: >-
+          always() &&
+          steps.app-token.outcome == 'success' &&
+          (
+            steps.authorize.outcome != 'success' ||
+            steps.codex-decision.outcome != 'success' ||
+            steps.codex-decision.outputs.significant != 'false' ||
+            steps.publish-codex-review.outcome != 'success' ||
+            steps.publish-codex-review.outputs.comment_url == ''
+          )
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
-          HEAD_SHA: ${{ steps.authorize.outputs.head_sha }}
-          PR_NUMBER: ${{ steps.authorize.outputs.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -520,7 +529,7 @@ jobs:
                   repo,
                   pull_number: pullNumber,
                   review_id: latestBotReview.id,
-                  message: `Codex found significant issues in retry for ${shortSha}`,
+                  message: `Current auto-approval attempt did not pass the Codex gate for ${shortSha}`,
                   event: "DISMISS",
                 },
               );
@@ -536,7 +545,7 @@ jobs:
                 commit_id: process.env.HEAD_SHA,
                 event: "REQUEST_CHANGES",
                 body: [
-                  `Codex found significant issues in commit \`${shortSha}\` after it was auto-approved.`,
+                  `The current auto-approval attempt did not establish a valid, published Codex review with no significant findings for \`${shortSha}\`.`,
                   "The previous App approval could not be dismissed automatically.",
                   "A human reviewer may dismiss this review after deciding how to proceed.",
                 ].join(" "),
@@ -689,23 +698,49 @@ jobs:
               .replaceAll(">", "&gt;");
             const prLink = `<${process.env.PR_URL}|PR #${process.env.PR_NUMBER}>`;
             const shortSha = process.env.PR_HEAD_SHA?.slice(0, 12) || "unknown";
+            const reconciliationLine = () => {
+              if (process.env.REVOCATION_OUTCOME !== "success") {
+                return "An existing App approval may still be active because reconciliation did not complete. Check the GitHub Actions run.";
+              }
+              if (process.env.REVOCATION_INVALIDATED !== "true") {
+                return "No active App approval remains for this commit.";
+              }
+              return process.env.REVOCATION_METHOD === "dismissed"
+                ? "An existing App approval was dismissed."
+                : "An existing App approval was replaced with REQUEST_CHANGES.";
+            };
             let text;
 
             if (process.env.AUTHORIZATION_OUTCOME !== "success") {
-              text = `<!here> *AUTO-APPROVAL FAILED* for ${prLink} at \`${shortSha}\`. Check the GitHub Actions run.`;
+              text = [
+                `<!here> *AUTO-APPROVAL FAILED* for ${prLink} at \`${shortSha}\`. Check the GitHub Actions run.`,
+                reconciliationLine(),
+              ].join("\n");
             } else if (process.env.CODEX_CONFIGURED !== "true") {
-              text = `<!here> *CODEX REVIEW IS NOT CONFIGURED* for ${prLink} at \`${shortSha}\`. Bot approval was withheld.`;
+              text = [
+                `<!here> *CODEX REVIEW IS NOT CONFIGURED* for ${prLink} at \`${shortSha}\`.`,
+                reconciliationLine(),
+              ].join("\n");
             } else if (process.env.CODEX_OUTCOME !== "success" || !process.env.CODEX_RESULT) {
-              text = `<!here> *CODEX REVIEW DID NOT COMPLETE* for ${prLink} at \`${shortSha}\`. Bot approval was withheld; check the GitHub Actions run.`;
+              text = [
+                `<!here> *CODEX REVIEW DID NOT COMPLETE* for ${prLink} at \`${shortSha}\`. Check the GitHub Actions run.`,
+                reconciliationLine(),
+              ].join("\n");
             } else if (process.env.CODEX_DECISION_OUTCOME !== "success") {
-              text = `<!here> *CODEX REVIEW OUTPUT WAS INVALID* for ${prLink} at \`${shortSha}\`. Bot approval was withheld; check the GitHub Actions run.`;
+              text = [
+                `<!here> *CODEX REVIEW OUTPUT WAS INVALID* for ${prLink} at \`${shortSha}\`. Check the GitHub Actions run.`,
+                reconciliationLine(),
+              ].join("\n");
             } else {
               let result;
               try {
                 result = JSON.parse(process.env.CODEX_RESULT);
               } catch (error) {
                 core.warning(`Could not parse Codex structured output: ${error.message}`);
-                text = `<!here> *CODEX REVIEW OUTPUT WAS INVALID* for ${prLink} at \`${shortSha}\`. Bot approval was withheld; check the GitHub Actions run.`;
+                text = [
+                  `<!here> *CODEX REVIEW OUTPUT WAS INVALID* for ${prLink} at \`${shortSha}\`. Check the GitHub Actions run.`,
+                  reconciliationLine(),
+                ].join("\n");
               }
 
               if (result) {
@@ -729,17 +764,10 @@ jobs:
                     ? significantFindings
                     : findings;
                   const findingLines = formatFindings(displayedFindings);
-                  let approvalLine = "Bot approval was withheld. A human reviewer must decide how to proceed.";
-                  if (process.env.REVOCATION_OUTCOME !== "success") {
-                    approvalLine = "Bot approval was withheld, but an existing App approval may not have been invalidated. Check the GitHub Actions run.";
-                  } else if (process.env.REVOCATION_INVALIDATED === "true") {
-                    approvalLine = process.env.REVOCATION_METHOD === "dismissed"
-                      ? "An existing App approval was dismissed. A human reviewer must decide how to proceed."
-                      : "An existing App approval was replaced with REQUEST_CHANGES. A human reviewer must decide how to proceed.";
-                  }
                   text = [
                     `<!here> *SIGNIFICANT CODEX FINDINGS* for ${prLink} at \`${shortSha}\`${reviewLink}`,
-                    approvalLine,
+                    reconciliationLine(),
+                    "A human reviewer must decide how to proceed.",
                     summary,
                     ...findingLines,
                     findingLines.length < displayedFindings.length
@@ -750,7 +778,8 @@ jobs:
                   || !process.env.CODEX_COMMENT_URL) {
                   text = [
                     `<!here> *CODEX REVIEW COULD NOT BE PUBLISHED* for ${prLink} at \`${shortSha}\``,
-                    "Codex found no significant issues, but bot approval was withheld because the PR comment was not published. Check the GitHub Actions run.",
+                    "Codex found no significant issues, but the PR comment was not published. Check the GitHub Actions run.",
+                    reconciliationLine(),
                     summary,
                   ].join("\n");
                 } else if (process.env.APPROVAL_OUTCOME !== "success") {


### PR DESCRIPTION
## Summary

Follow-up to #1127 that makes every retry fail closed at the effective GitHub review state.

- Reconcile an existing same-commit App approval whenever the current attempt cannot establish a valid, published Codex review with no significant findings.
- Cover authorization failure, missing configuration, Codex execution or output failure, invalid schema, significant findings, and comment publication failure.
- Dismiss the active approval when possible, with a `REQUEST_CHANGES` fallback when GitHub refuses dismissal.
- Include the reconciliation result in blocked Slack notifications.

## Why

Previously, only a valid `significant_findings: true` result triggered revocation. A malformed or failed retry could therefore leave an approval from an earlier attempt active and still satisfy branch protection.

## Verification

- Parsed the workflow YAML successfully.
- Syntax-checked all 11 embedded `github-script` programs.
- Exercised the exact reconciliation script for no approval, successful dismissal, dismissal fallback, and an already-inactive approval.
- Confirmed `git diff --check` passes.