### PR TITLE
scripts: point margin MVR at v5 and v6 source tags

### DIFF
--- a/scripts/transactions/marginSetup.ts
+++ b/scripts/transactions/marginSetup.ts
@@ -13,57 +13,37 @@ import { prepareMultisigTx } from "../utils/utils.js";
     "0x9e120e97c91434c8102024edc0a64c2d18ab702333da947791707dee6a45da2c"; // @deepbook/margin-trading appCap
 
   const repository = "https://github.com/MystenLabs/deepbookv3";
+  const packageInfo =
+    "0x11c2e0f7292ea1b84ed894302b96146872fea53a99b933122fb193e48dac1005"; // @deepbook/margin-trading PackageInfo
+  const path = "packages/deepbook_margin";
 
-  const data2 = {
-    packageInfo:
-      "0x11c2e0f7292ea1b84ed894302b96146872fea53a99b933122fb193e48dac1005",
-    sha: "margin-v2.0.0",
-    version: "2",
-    path: "packages/deepbook_margin",
-  };
+  // Package versions to point at their source tag. MVR already holds 1-3; v5 and
+  // v6 are both published on chain with tags but were never registered. Each `sha`
+  // must be a tag that exists in the repository, and its `packages/deepbook_margin`
+  // tree must be the source that was published as that package version.
+  const versions = [
+    { sha: "margin-v5.0.0", version: "5" },
+    { sha: "margin-v6.0.0", version: "6" },
+  ];
 
-  const git2 = transaction.moveCall({
-    target: `@mvr/metadata::git::new`,
-    arguments: [
-      transaction.pure.string(repository),
-      transaction.pure.string(data2.path),
-      transaction.pure.string(data2.sha),
-    ],
-  });
+  versions.forEach(({ sha, version }) => {
+    const git = transaction.moveCall({
+      target: `@mvr/metadata::git::new`,
+      arguments: [
+        transaction.pure.string(repository),
+        transaction.pure.string(path),
+        transaction.pure.string(sha),
+      ],
+    });
 
-  transaction.moveCall({
-    target: `@mvr/metadata::package_info::set_git_versioning`,
-    arguments: [
-      transaction.object(data2.packageInfo),
-      transaction.pure.u64(data2.version),
-      git2,
-    ],
-  });
-
-  const data3 = {
-    packageInfo:
-      "0x11c2e0f7292ea1b84ed894302b96146872fea53a99b933122fb193e48dac1005",
-    sha: "margin-v3.0.0",
-    version: "3",
-    path: "packages/deepbook_margin",
-  };
-
-  const git3 = transaction.moveCall({
-    target: `@mvr/metadata::git::new`,
-    arguments: [
-      transaction.pure.string(repository),
-      transaction.pure.string(data3.path),
-      transaction.pure.string(data3.sha),
-    ],
-  });
-
-  transaction.moveCall({
-    target: `@mvr/metadata::package_info::set_git_versioning`,
-    arguments: [
-      transaction.object(data3.packageInfo),
-      transaction.pure.u64(data3.version),
-      git3,
-    ],
+    transaction.moveCall({
+      target: `@mvr/metadata::package_info::set_git_versioning`,
+      arguments: [
+        transaction.object(packageInfo),
+        transaction.pure.u64(version),
+        git,
+      ],
+    });
   });
 
   let res = await prepareMultisigTx(


### PR DESCRIPTION
## Summary
- Switch `scripts/transactions/marginSetup.ts` from the v2/v3 backfill it last ran to **margin v5 and v6**, pointing each at its source tag (`margin-v5.0.0`, `margin-v6.0.0`) via `@mvr/metadata::package_info::set_git_versioning`.
- Unchanged: the PackageInfo, the repository, the path, and the multisig this is signed as. Only the versions/tags moved.
- Run via the existing **"Margin Setup"** option of the `deepbookv3-build-tx` action — no workflow change needed.

## Why
- Margin's MVR PackageInfo currently registers versions **{1, 2, 3}**. v5 and v6 are both published on chain and both have tags, but neither was ever registered — so resolving either through MVR finds no source.
- That gap includes **v5, the version the registry currently allows**, i.e. the version live today.
- v6 was just recorded in `Published.toml` (#1128) and tagged `margin-v6.0.0`, so its source is now pinned and registerable.

## Key decisions
- **v5 and v6 in one transaction.** Each MVR update costs a multisig signing ceremony, and this script already had the two-version shape (it registered v2 and v3 together). Registering only v6 would leave the live version unresolvable and require a second ceremony to fix.
- **v4 stays unregistered.** There is no `margin-v4.0.0` tag, so there is no source to point at. Registering it would require creating a tag first — out of scope, and it is not a live version.
- **Collapsed the mirrored `data2`/`data3` blocks into one list.** They duplicated `packageInfo` and `path` verbatim and differed only by tag/version. Since both blocks were being replaced anyway, the replacement is a list — adding a future version is now a one-line change instead of a 25-line copy-paste.
- **`marginSetup.ts` rather than a new script.** It is already the margin MVR git-versioning script and already wired to the action's "Margin Setup" option. `newDeepbookVersion.ts` is the core equivalent ("Prep Deepbook MVR") and stays untouched.

## Verification (against mainnet, before landing)
- [x] PackageInfo `0x11c2e0f7…` is **margin's**: its `package_address` is `0x97d9473…`, margin's `original-id`, and its `upgrade_cap_id` is `0xd57c7a41…` — both matching `Published.toml`
- [x] It is **owned by `0xd0ec0b20…`**, exactly the multisig address this script signs as
- [x] Its `git_versioning` table holds exactly **{1, 2, 3}** — confirming v5/v6 are genuinely absent and this is not a no-op
- [x] **Both tags exist** and both resolve to real commits (`margin-v6.0.0` → `73253baa`, the #1128 merge)
- [x] **Both tags' source matches what is deployed**, via `sui client verify-source`: at `margin-v5.0.0` against on-chain v5 (`0x124bb3d8…`) → *"Source verification succeeded!"*; at `margin-v6.0.0` against v6 (`0x8af25e44…`) → likewise. So each MVR entry asserts true source rather than a plausible-looking tag.
- [x] `tsc` reports **no errors in this file** (the repo's existing `node_modules` and other `transactions/*` errors reproduce unchanged on main)
- [x] `prettier --check` clean

Not executed here: this script only *prepares* the multisig tx bytes. Running it needs a `GAS_OBJECT` from the AdminCap multisig via the GH action, then a signing request to **"Deepbook PKG - AdminCap"**.

No Linear ticket: a script constant switch is a mechanical chore, exempt from the ticket bar — same basis as #1122.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
