### PR TITLE
DBU-575 refactor(predict): clear linter warnings, correct contradictory comments, Move 2024 conventions

### DIFF
--- a/packages/account/sources/account.move
+++ b/packages/account/sources/account.move
@@ -113,7 +113,7 @@ public fun receive_address(self: &Account): address {
 }
 
 /// Generate owner authority from the transaction sender.
-public fun generate_auth(ctx: &TxContext): Auth {
+public fun generate_auth(ctx: &mut TxContext): Auth {
     Auth { kind: AUTH_OWNER, owner: ctx.sender() }
 }
 

--- a/packages/fixed_math/sources/math.move
+++ b/packages/fixed_math/sources/math.move
@@ -124,11 +124,11 @@ const INV_9_U128: u128 = 111_111_111;
 const INV_11_U128: u128 = 90_909_091;
 const INV_13_U128: u128 = 76_923_077;
 
-// === Public Functions ===
-
 /// Fixed-point scaling factor (1e9) for math operations and prices.
 /// 500_000_000 = 50%, 1_000_000_000 = 100%.
 public macro fun float_scaling(): u64 { 1_000_000_000 }
+
+// === Public Functions ===
 
 /// Multiply two 1e9-scaled fixed-point values, rounding down.
 public fun mul(x: u64, y: u64): u64 {

--- a/packages/fixed_math/sources/math.move
+++ b/packages/fixed_math/sources/math.move
@@ -96,7 +96,7 @@ const B1: u128 = 976_098_551_738;
 const B2: u128 = 10_260_932_208_619;
 const B3: u128 = 45_507_789_335_027;
 
-// Medium range (0.66291 ≤ |x| < √32): Φ = exp(-x²/2) * P(|x|) / Q(|x|)
+// Medium range (0.66291 ≤ |x| < √32): complement = exp(-x²/2) * P(|x|) / Q(|x|)
 const MEDIUM_THRESHOLD: u128 = 5_656_854_249;
 const C0: u128 = 398_941_512;
 const C1: u128 = 8_883_149_794;

--- a/packages/fixed_math/tests/math/math_tests.move
+++ b/packages/fixed_math/tests/math/math_tests.move
@@ -232,6 +232,12 @@ fun mul_div_up_zero_denominator_aborts() {
     abort 999
 }
 
+#[test, expected_failure(abort_code = math::EInputZero)]
+fun mul_div_down_zero_denominator_aborts() {
+    math::mul_div_down(10, 10, 0);
+    abort 999
+}
+
 // === ln ===
 
 #[test]

--- a/packages/predict/sources/capabilities/pause_cap.move
+++ b/packages/predict/sources/capabilities/pause_cap.move
@@ -7,8 +7,8 @@
 module deepbook_predict::pause_cap;
 
 /// Capability for emergency pause operations. Admin can mint these for
-/// trusted operators; holders can disable versions, pause global trading,
-/// and pause per-market minting. Cannot unpause anything.
+/// trusted operators; holders can pause global trading and pause per-market
+/// minting. Cannot unpause anything.
 public struct PauseCap has key, store {
     id: UID,
 }

--- a/packages/predict/sources/config/strike_exposure_config.move
+++ b/packages/predict/sources/config/strike_exposure_config.move
@@ -278,7 +278,7 @@ fun fee_rate(
     timestamp_ms: u64,
 ): u64 {
     let raw_fee = config.raw_bernoulli_fee_rate(probability);
-    let base = if (raw_fee > config.min_fee) raw_fee else config.min_fee;
+    let base = raw_fee.max(config.min_fee);
     let multiplier = config.expiry_fee_multiplier(expiry_ms - timestamp_ms);
     math::mul(base, multiplier)
 }

--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -303,7 +303,7 @@ public fun quote_mint(
     exact_quantity: bool,
     leverage: u64,
     clock: &Clock,
-    ctx: &TxContext,
+    ctx: &mut TxContext,
 ): MintQuote {
     market.assert_live_mint_allowed(config, pricer);
     let terms = market
@@ -345,7 +345,7 @@ public fun quote_mint_for_account(
     leverage: u64,
     root: &AccumulatorRoot,
     clock: &Clock,
-    ctx: &TxContext,
+    ctx: &mut TxContext,
 ): MintQuote {
     market.assert_live_mint_allowed(config, pricer);
     let account = wrapper.load_account();

--- a/packages/predict/sources/plp/plp.move
+++ b/packages/predict/sources/plp/plp.move
@@ -469,7 +469,7 @@ public fun sponsor_fee_incentives(
     vault: &mut PoolVault,
     config: &ProtocolConfig,
     payment: Coin<DUSDC>,
-    ctx: &TxContext,
+    ctx: &mut TxContext,
 ) {
     config.assert_version();
     config.assert_not_valuation_in_progress();

--- a/packages/predict/sources/predict_account.move
+++ b/packages/predict/sources/predict_account.move
@@ -207,7 +207,7 @@ public(package) fun remove_position(
     let d = data_mut(account, ctx);
     let key = position_key(expiry_market_id, order_id);
     assert!(d.positions.contains(key), EPositionNotFound);
-    let Position { root_id, opened_at_ms: _ } = d.positions.remove(key);
+    let Position { root_id, .. } = d.positions.remove(key);
     d.ensure_summary(expiry_market_id);
     let summary = &mut d.expiry_summaries[expiry_market_id];
     assert!(summary.open_position_count > 0, EInsufficientPosition);

--- a/packages/predict/sources/pricing/pricing.move
+++ b/packages/predict/sources/pricing/pricing.move
@@ -20,7 +20,7 @@ use propbook::{
     pyth_feed::PythFeed,
     registry::OracleRegistry
 };
-use sui::{clock::Clock, object::ID};
+use sui::clock::Clock;
 
 /// Value snapshot of live oracle inputs for one market's price calculations.
 public struct Pricer has copy, drop {
@@ -107,6 +107,8 @@ public fun range_price(pricer: &Pricer, lower: Strike, higher: Strike): u64 {
     compute_range_price(&pricer.svi, pricer.forward, lower, higher)
 }
 
+// === Public-Package Functions ===
+
 /// Return the expiry market this pricer was loaded for.
 public(package) fun expiry_market_id(pricer: &Pricer): ID {
     pricer.expiry_market_id
@@ -132,8 +134,6 @@ public(package) fun into_spot(read: ExactSpotRead): Option<u64> {
     let ExactSpotRead { spot } = read;
     spot
 }
-
-// === Public-Package Functions ===
 
 /// Validate the current live pricing boundary and snapshot oracle inputs for
 /// one market's repeated quote calculations.

--- a/packages/predict/sources/registry/registry.move
+++ b/packages/predict/sources/registry/registry.move
@@ -297,7 +297,7 @@ public fun create_and_share_builder_code(
 /// Package initializer - creates Registry and AdminCap.
 fun init(ctx: &mut TxContext) {
     let (registry, admin_cap) = new_registry_and_admin_cap(ctx);
-    protocol_config::create_and_share(ctx);
+    let _ = protocol_config::create_and_share(ctx);
     transfer::share_object(registry);
     transfer::public_transfer(admin_cap, ctx.sender());
 }

--- a/packages/predict/sources/registry/registry.move
+++ b/packages/predict/sources/registry/registry.move
@@ -333,7 +333,7 @@ fun assert_valid_lifecycle_cap(registry: &Registry, cap: &MarketLifecycleCap) {
 public fun init_for_testing(ctx: &mut TxContext): ID {
     let (registry, admin_cap) = new_registry_and_admin_cap(ctx);
     let registry_id = registry.id();
-    protocol_config::create_and_share(ctx);
+    let _ = protocol_config::create_and_share(ctx);
     transfer::share_object(registry);
     transfer::public_transfer(admin_cap, ctx.sender());
 

--- a/packages/predict/sources/strike_exposure/range_codec.move
+++ b/packages/predict/sources/strike_exposure/range_codec.move
@@ -59,7 +59,7 @@ public fun strike_for_testing(raw: u64): Strike {
 /// Smallest tick whose strike is `>= settlement`: every finite boundary with
 /// `tick < prefix_limit_tick` satisfies `tick * tick_size < settlement` and is
 /// therefore active in the settlement prefix walk, which preserves the half-open
-/// `(lower, higher]` payoff (settlement equal to a higher boundary does not apply
+/// `(lower, higher]` payoff (settlement equal to a lower boundary does not apply
 /// it). Equals `ceil(settlement / tick_size)`, which can legitimately exceed
 /// `pos_inf_tick` (settlement above the encodable range) and so is a plain `u64`
 /// comparison bound, never validated as a domain tick.

--- a/packages/predict/tests/pricing/pricing_guard_tests.move
+++ b/packages/predict/tests/pricing/pricing_guard_tests.move
@@ -23,8 +23,9 @@
 /// leaving every other input default so only the targeted branch fires. The
 /// `spot == 0` / `forward == 0` branch of that assert is unreachable through
 /// `load_live_pricer`: the split Block Scholes feed reads drop a zero spot or zero
-/// forward upstream (-> `EBlockScholesPriceStale`), so those two conditions are
-/// defensive-only and not tested here. `EZeroForward` is reached
+/// forward upstream, so the read arrives as `none` and pricing aborts on absence
+/// (-> `EBlockScholesPriceUnavailable`) before any staleness check runs. Those two
+/// conditions are defensive-only and not tested here. `EZeroForward` is reached
 /// via a pyth spot far below the BS spot (no LOWER basis bound), where the
 /// re-anchored `spot * bs_forward / bs_spot` floors to 0. `EZeroVariance` is reached by a
 /// degenerate-but-in-envelope surface (`a == 0, b == 0`, so total variance

--- a/packages/predict/tests/pricing/pricing_guard_tests.move
+++ b/packages/predict/tests/pricing/pricing_guard_tests.move
@@ -17,7 +17,7 @@
 /// `pricing_tests::live_forward_switches_source_exactly_at_pyth_staleness_boundary`,
 /// so it is not duplicated here.
 ///
-/// The `assert_surface_pricing_safe` envelope rejects (`EBlockScholesInputsInvalid`)
+/// The `assert_inputs_pricing_safe` envelope rejects (`EBlockScholesInputsInvalid`)
 /// is covered here too: one test per reachable branch seeds a surface that violates
 /// exactly that bound (`forward` ceiling, `basis`, `a`, `b`, `rho`, `m`, `sigma`),
 /// leaving every other input default so only the targeted branch fires. The
@@ -421,7 +421,7 @@ fun re_anchored_zero_forward_aborts() {
 // === Deep-math abort (EZeroVariance) ===
 
 /// A degenerate but in-envelope surface (`a == 0, b == 0`) has zero SVI total
-/// variance (`total_var = a + b*inner == 0`). It passes `assert_surface_pricing_safe`
+/// variance (`total_var = a + b*inner == 0`). It passes `assert_inputs_pricing_safe`
 /// (a/b are bounded only from above), but `compute_nd2` fails closed on the first
 /// finite-strike quote. The `min_svi_sigma` floor does not prevent this: it bounds
 /// the SVI wing parameter, not the total variance. This is the same recoverable
@@ -462,7 +462,7 @@ fun default_svi_sigma(): u64 { test_constants::default_svi_sigma() }
 fun default_svi_m_magnitude(): u64 { test_constants::default_svi_m() }
 
 /// Seed a surface with the given spot/forward and default SVI, then load the pricer
-/// (where `assert_surface_pricing_safe` runs).
+/// (where `assert_inputs_pricing_safe` runs).
 fun load_pricer_with_spot_forward(spot: u64, forward: u64) {
     load_pricer_with_full_svi_and_spot(
         spot,
@@ -539,7 +539,7 @@ fun load_pricer_with_full_svi_and_spot(
         svi_m_magnitude,
         svi_m_is_negative,
     );
-    // `load_pricer` runs `assert_surface_pricing_safe`; the invalid surface aborts
+    // `load_pricer` runs `assert_inputs_pricing_safe`; the invalid surface aborts
     // here before the pricer is returned.
     let _pricer = fx.load_pricer_bundle(&oracle);
 

--- a/packages/propbook/sources/constants.move
+++ b/packages/propbook/sources/constants.move
@@ -13,7 +13,8 @@ public(package) macro fun current_version(): u64 {
     1
 }
 
-/// Decimal places of the 1e9 price scaling that `normalize_pyth_price` targets.
+/// Decimal places of the 1e9 price scaling that `pyth_feed::normalize_raw_spot`
+/// targets.
 public(package) macro fun float_scaling_decimals(): u64 {
     9
 }

--- a/packages/propbook/sources/feeds/block_scholes_forward_feed.move
+++ b/packages/propbook/sources/feeds/block_scholes_forward_feed.move
@@ -196,7 +196,7 @@ fun update_expiry(
     if (feed.expiries.contains(expiry_ms)) {
         feed.expiries.borrow_mut(expiry_ms).update(read, propbook_oracle_id);
     } else {
-        if (!oracle_lane::read_has_valid_timestamp(&read)) return;
+        if (!read.read_has_valid_timestamp()) return;
         let mut lane = oracle_lane::new(ctx);
         lane.update(read, propbook_oracle_id);
         feed.expiries.add(expiry_ms, lane);
@@ -213,7 +213,7 @@ fun insert_expiry_at(
     if (feed.expiries.contains(expiry_ms)) {
         feed.expiries.borrow_mut(expiry_ms).insert_at(read, propbook_oracle_id);
     } else {
-        if (!oracle_lane::read_has_valid_timestamp(&read)) return;
+        if (!read.read_has_valid_timestamp()) return;
         let mut lane = oracle_lane::new(ctx);
         lane.insert_at(read, propbook_oracle_id);
         feed.expiries.add(expiry_ms, lane);

--- a/packages/propbook/sources/feeds/block_scholes_forward_feed.move
+++ b/packages/propbook/sources/feeds/block_scholes_forward_feed.move
@@ -112,6 +112,7 @@ public fun raw_forward_value(raw: &RawForward): u64 {
 
 // === Write Functions ===
 
+// TODO(bs-verifier): "unverified" holds only while block_scholes_oracle is a stub.
 /// Ingest an unverified (stub-oracle) BS forward update into the oracle lane for the update's expiry.
 public fun update(
     feed: &mut BlockScholesForwardFeed,

--- a/packages/propbook/sources/feeds/block_scholes_forward_feed.move
+++ b/packages/propbook/sources/feeds/block_scholes_forward_feed.move
@@ -112,7 +112,7 @@ public fun raw_forward_value(raw: &RawForward): u64 {
 
 // === Write Functions ===
 
-/// Ingest a verified BS forward update into the oracle lane for the update's expiry.
+/// Ingest an unverified (stub-oracle) BS forward update into the oracle lane for the update's expiry.
 public fun update(
     feed: &mut BlockScholesForwardFeed,
     update: ForwardUpdate,

--- a/packages/propbook/sources/feeds/block_scholes_spot_feed.move
+++ b/packages/propbook/sources/feeds/block_scholes_spot_feed.move
@@ -4,7 +4,9 @@
 /// Block Scholes spot oracle: one shared object per source id, storing the
 /// source-native spot stream through a generic Propbook oracle lane.
 ///
-/// The verified `SpotUpdate` is its own provenance proof. Predict-unaware: this
+/// `SpotUpdate` carries no provenance proof today: `block_scholes_oracle` is a
+/// stub that performs no validation, so update values are forgeable until the
+/// production verifier lands (see that module's warning). Predict-unaware: this
 /// module stores raw source facts and leaves feed binding, freshness, and
 /// pricing-safe envelopes to consumers.
 module propbook::block_scholes_spot_feed;
@@ -96,7 +98,7 @@ public fun raw_spot_value(raw: &RawSpot): u64 {
 
 // === Write Functions ===
 
-/// Ingest a verified BS spot update into this feed's generic oracle lane.
+/// Ingest an unverified (stub-oracle) BS spot update into this feed's generic oracle lane.
 public fun update(feed: &mut BlockScholesSpotFeed, update: SpotUpdate, clock: &Clock) {
     assert!(feed.version == constants::current_version!(), EWrongVersion);
     assert!(update.spot_source_id() == feed.bs_source_id, EWrongSource);

--- a/packages/propbook/sources/feeds/block_scholes_spot_feed.move
+++ b/packages/propbook/sources/feeds/block_scholes_spot_feed.move
@@ -1,6 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+// TODO(bs-verifier): once block_scholes_oracle validates signatures, these
+// updates become verified provenance. Flip the "unverified (stub-oracle)"
+// wording back to "verified" at every `grep -rn 'TODO(bs-verifier)'` site.
 /// Block Scholes spot oracle: one shared object per source id, storing the
 /// source-native spot stream through a generic Propbook oracle lane.
 ///
@@ -98,6 +101,7 @@ public fun raw_spot_value(raw: &RawSpot): u64 {
 
 // === Write Functions ===
 
+// TODO(bs-verifier): "unverified" holds only while block_scholes_oracle is a stub.
 /// Ingest an unverified (stub-oracle) BS spot update into this feed's generic oracle lane.
 public fun update(feed: &mut BlockScholesSpotFeed, update: SpotUpdate, clock: &Clock) {
     assert!(feed.version == constants::current_version!(), EWrongVersion);

--- a/packages/propbook/sources/feeds/block_scholes_svi_feed.move
+++ b/packages/propbook/sources/feeds/block_scholes_svi_feed.move
@@ -144,6 +144,7 @@ public fun sigma(params: &SVIParams): u64 {
 
 // === Write Functions ===
 
+// TODO(bs-verifier): "unverified" holds only while block_scholes_oracle is a stub.
 /// Ingest an unverified (stub-oracle) BS SVI update into the oracle lane for the update's expiry.
 public fun update(
     feed: &mut BlockScholesSVIFeed,

--- a/packages/propbook/sources/feeds/block_scholes_svi_feed.move
+++ b/packages/propbook/sources/feeds/block_scholes_svi_feed.move
@@ -144,7 +144,7 @@ public fun sigma(params: &SVIParams): u64 {
 
 // === Write Functions ===
 
-/// Ingest a verified BS SVI update into the oracle lane for the update's expiry.
+/// Ingest an unverified (stub-oracle) BS SVI update into the oracle lane for the update's expiry.
 public fun update(
     feed: &mut BlockScholesSVIFeed,
     update: SVIUpdate,

--- a/packages/propbook/sources/feeds/block_scholes_svi_feed.move
+++ b/packages/propbook/sources/feeds/block_scholes_svi_feed.move
@@ -234,7 +234,7 @@ fun update_expiry(
     if (feed.expiries.contains(expiry_ms)) {
         feed.expiries.borrow_mut(expiry_ms).update(read, propbook_oracle_id);
     } else {
-        if (!oracle_lane::read_has_valid_timestamp(&read)) return;
+        if (!read.read_has_valid_timestamp()) return;
         let mut lane = oracle_lane::new(ctx);
         lane.update(read, propbook_oracle_id);
         feed.expiries.add(expiry_ms, lane);
@@ -251,7 +251,7 @@ fun insert_expiry_at(
     if (feed.expiries.contains(expiry_ms)) {
         feed.expiries.borrow_mut(expiry_ms).insert_at(read, propbook_oracle_id);
     } else {
-        if (!oracle_lane::read_has_valid_timestamp(&read)) return;
+        if (!read.read_has_valid_timestamp()) return;
         let mut lane = oracle_lane::new(ctx);
         lane.insert_at(read, propbook_oracle_id);
         feed.expiries.add(expiry_ms, lane);


### PR DESCRIPTION
## Summary
- Clears all five `sui move build --lint` warnings across `account`, `fixed_math`, `predict`, `propbook`.
- Corrects eight docs that state the opposite of what the code does — including one that inverts a settlement payout boundary, one that overstates a compromised capability's blast radius, and four that call forgeable stub-oracle payloads "verified".
- Move 2024 convention conformance, two function-ordering fixes, and one genuine test gap (`fixed_math::mul_div_down`'s zero-denominator abort).
- **No behaviour change.** Every edit is a comment, a compiler-verified motion, a pure test addition, or a `&`→`&mut` widening that no call site needed to adapt to.

## Why
- **Pre-deploy is the only window in which the signature changes here are free.** There is no mainnet deployment of predict/account/propbook and testnet gens are fresh v1 publishes, so the `&TxContext` → `&mut TxContext` widenings carry no upgrade-compatibility cost today and become one-way doors at mainnet.
- **Docs that contradict the code are worse than missing docs.** `range_codec.move` told readers that settlement at a range's *higher* boundary does not pay — `strike_exposure.move` (`if (settlement <= lower || settlement > higher) return 0`) proves it does, and the comment contradicted the `(lower, higher]` notation in its own sentence. `pause_cap.move` told an auditor that a compromised `PauseCap` can disable package versions; no such entrypoint exists. The propbook BS feeds documented their **permissionless** ingest as taking "verified" updates, when `block_scholes_oracle` is a stub whose own module doc warns values are **forgeable** — propbook's `registry.move:11` already said so, so the package contradicted itself.

## Key decisions
- **`&TxContext` → `&mut TxContext` (W99009) is included, deliberately.** The linter recommends it for upgradability, and it is only free before mainnet. TxContext is runtime-injected rather than a PTB argument, so off-chain callers are unaffected; no Move call site needed a change either, because `test_scenario::ctx()` already returns `&mut TxContext` and Move auto-reborrows to `&`.
- **Scoped to zero-risk themes.** A broader sweep surfaced ~97 candidate edits; this lands only those with no behaviour risk. Held back: public-surface deletion/tightening (its "zero consumers" evidence is grep-based, and grep cannot see devInspect/PTB/SDK callers), dropping `store` from 31 event structs, and an `oracle_lane` generic extraction.
- **The cadence read path was NOT deleted**, though a lens flagged it unreachable end-to-end. That is exactly the surface DBU-495 (enumerated `CadenceConfig` getter) and DBU-550 (off-chain cadence auto-discovery) build on; it reads as dead only because off-chain currently keeps cadence local.
- **`vault_events.move:203` `reserve_after` → `pool_reserve_after` excluded.** Real naming drift against its two siblings, but it is an **event field**, and contracts→indexer schema parity is a live cross-repo concern. Needs a coordinated change, not a ride-along.
- **`saturating_sub` → `-` excluded.** The clamp provably cannot fire, but `move.md` treats removing a clamp as a guard change requiring a duty inventory. Not a refactor.

## Independent review
This diff was reviewed from an independent context (per CLAUDE.md, an author's own pass does not satisfy the default review). The reviewer **could not falsify the refactor-only claim** — every code change is behaviour-identical — and separately verified the `range_codec` flip, the `pause_cap` claim, the stub-oracle corrections, the Φ-complement fix, `&mut TxContext` safety, the `..` unpack, and `.max()` equivalence.

It found two defects, both fixed here in `11aaabc0`:
- **`pricing_guard_tests.move:26` named the wrong abort code.** An earlier pass in this branch looked at this line and *excluded* it, reasoning that `EBlockScholesPriceStale` exists and is asserted elsewhere. Existing is not the same as being the code the path raises: a zero spot/forward makes the feed return `none`, so `pricing.move:268` fires `EBlockScholesPriceUnavailable`; the staleness assert is only reached once the read is already `some`. The same file self-refutes at :103.
- **`registry.move:336` — the W02013 fix covered one of two identical sites.** `init` was fixed; `init_for_testing`, a deliberate mirror of it, kept the same bare discard. It hid because `--lint` does not compile `#[test_only]` code, so the earlier "zero warnings" claim was true only by measurement gap.

## Test plan
- [x] `sui move build --lint` — zero warnings: account, fixed_math, predict, propbook, and the dependent deepbook_core_account
- [x] `sui move test` — account 11/11, fixed_math 134/134, propbook 55/55, predict **421/421**
- [x] `pnpm run format:move:check` with the lockfile-pinned prettier-move 0.4.0 — clean
- [x] Rebased onto current `main`; the one conflict (`pricing.move`) was this branch's header move against #1132's new `into_spot` — `into_spot` kept, only the duplicated section header dropped
- [x] Every changed line traces to a finding verified against the source that pins the rule

Part of DBU-575. A follow-up carries the remaining documentation work (unreachable abort codes, `Auth` sentinel semantics) and closes the ticket.
