### PR TITLE
DBU-575 refactor(predict): Move 2024 conventions, function ordering, one test gap

### DIFF
--- a/packages/fixed_math/sources/math.move
+++ b/packages/fixed_math/sources/math.move
@@ -124,11 +124,11 @@ const INV_9_U128: u128 = 111_111_111;
 const INV_11_U128: u128 = 90_909_091;
 const INV_13_U128: u128 = 76_923_077;
 
-// === Public Functions ===
-
 /// Fixed-point scaling factor (1e9) for math operations and prices.
 /// 500_000_000 = 50%, 1_000_000_000 = 100%.
 public macro fun float_scaling(): u64 { 1_000_000_000 }
+
+// === Public Functions ===
 
 /// Multiply two 1e9-scaled fixed-point values, rounding down.
 public fun mul(x: u64, y: u64): u64 {

--- a/packages/fixed_math/tests/math/math_tests.move
+++ b/packages/fixed_math/tests/math/math_tests.move
@@ -232,6 +232,12 @@ fun mul_div_up_zero_denominator_aborts() {
     abort 999
 }
 
+#[test, expected_failure(abort_code = math::EInputZero)]
+fun mul_div_down_zero_denominator_aborts() {
+    math::mul_div_down(10, 10, 0);
+    abort 999
+}
+
 // === ln ===
 
 #[test]

--- a/packages/predict/sources/config/strike_exposure_config.move
+++ b/packages/predict/sources/config/strike_exposure_config.move
@@ -256,7 +256,7 @@ fun fee_rate(
     timestamp_ms: u64,
 ): u64 {
     let raw_fee = config.raw_bernoulli_fee_rate(probability);
-    let base = if (raw_fee > config.min_fee) raw_fee else config.min_fee;
+    let base = raw_fee.max(config.min_fee);
     let multiplier = config.expiry_fee_multiplier(expiry_ms - timestamp_ms);
     math::mul(base, multiplier)
 }

--- a/packages/predict/sources/predict_account.move
+++ b/packages/predict/sources/predict_account.move
@@ -207,7 +207,7 @@ public(package) fun remove_position(
     let d = data_mut(account, ctx);
     let key = position_key(expiry_market_id, order_id);
     assert!(d.positions.contains(key), EPositionNotFound);
-    let Position { root_id, opened_at_ms: _ } = d.positions.remove(key);
+    let Position { root_id, .. } = d.positions.remove(key);
     d.ensure_summary(expiry_market_id);
     let summary = &mut d.expiry_summaries[expiry_market_id];
     assert!(summary.open_position_count > 0, EInsufficientPosition);

--- a/packages/predict/sources/pricing/pricing.move
+++ b/packages/predict/sources/pricing/pricing.move
@@ -19,7 +19,7 @@ use propbook::{
     pyth_feed::PythFeed,
     registry::OracleRegistry
 };
-use sui::{clock::Clock, object::ID};
+use sui::clock::Clock;
 
 /// Value snapshot of live oracle inputs for one market's price calculations.
 public struct Pricer has copy, drop {
@@ -99,6 +99,8 @@ public fun range_price(pricer: &Pricer, lower: Strike, higher: Strike): u64 {
     compute_range_price(&pricer.svi, pricer.forward, lower, higher)
 }
 
+// === Public-Package Functions ===
+
 /// Return the expiry market this pricer was loaded for.
 public(package) fun expiry_market_id(pricer: &Pricer): ID {
     pricer.expiry_market_id
@@ -119,8 +121,6 @@ public(package) fun block_scholes_forward_source_timestamp_ms(pricer: &Pricer): 
 public(package) fun block_scholes_svi_source_timestamp_ms(pricer: &Pricer): u64 {
     pricer.block_scholes_svi_source_timestamp_ms
 }
-
-// === Public-Package Functions ===
 
 /// Validate the current live pricing boundary and snapshot oracle inputs for
 /// one market's repeated quote calculations.

--- a/packages/propbook/sources/feeds/block_scholes_forward_feed.move
+++ b/packages/propbook/sources/feeds/block_scholes_forward_feed.move
@@ -196,7 +196,7 @@ fun update_expiry(
     if (feed.expiries.contains(expiry_ms)) {
         feed.expiries.borrow_mut(expiry_ms).update(read, propbook_oracle_id);
     } else {
-        if (!oracle_lane::read_has_valid_timestamp(&read)) return;
+        if (!read.read_has_valid_timestamp()) return;
         let mut lane = oracle_lane::new(ctx);
         lane.update(read, propbook_oracle_id);
         feed.expiries.add(expiry_ms, lane);
@@ -213,7 +213,7 @@ fun insert_expiry_at(
     if (feed.expiries.contains(expiry_ms)) {
         feed.expiries.borrow_mut(expiry_ms).insert_at(read, propbook_oracle_id);
     } else {
-        if (!oracle_lane::read_has_valid_timestamp(&read)) return;
+        if (!read.read_has_valid_timestamp()) return;
         let mut lane = oracle_lane::new(ctx);
         lane.insert_at(read, propbook_oracle_id);
         feed.expiries.add(expiry_ms, lane);

--- a/packages/propbook/sources/feeds/block_scholes_svi_feed.move
+++ b/packages/propbook/sources/feeds/block_scholes_svi_feed.move
@@ -234,7 +234,7 @@ fun update_expiry(
     if (feed.expiries.contains(expiry_ms)) {
         feed.expiries.borrow_mut(expiry_ms).update(read, propbook_oracle_id);
     } else {
-        if (!oracle_lane::read_has_valid_timestamp(&read)) return;
+        if (!read.read_has_valid_timestamp()) return;
         let mut lane = oracle_lane::new(ctx);
         lane.update(read, propbook_oracle_id);
         feed.expiries.add(expiry_ms, lane);
@@ -251,7 +251,7 @@ fun insert_expiry_at(
     if (feed.expiries.contains(expiry_ms)) {
         feed.expiries.borrow_mut(expiry_ms).insert_at(read, propbook_oracle_id);
     } else {
-        if (!oracle_lane::read_has_valid_timestamp(&read)) return;
+        if (!read.read_has_valid_timestamp()) return;
         let mut lane = oracle_lane::new(ctx);
         lane.insert_at(read, propbook_oracle_id);
         feed.expiries.add(expiry_ms, lane);


### PR DESCRIPTION
> **Stacked on #1133** — review that one first. This PR's base is `tlee/DBU-575-predict-cluster-sweep`, so the diff here is only the second tranche.

## Summary
- Move 2024 convention conformance: `..` unpack, `std::u64::max`, receiver syntax, one redundant prelude import.
- Function ordering: two section headers that filed functions under the wrong visibility group.
- One genuine test gap: `fixed_math::mul_div_down`'s zero-denominator abort was the only one of four such paths with no test.
- No behaviour change. Every edit is compiler-verified motion or a pure test addition.

## Why
- Second tranche of the DBU-575 sweep, continuing #1133. Same principle: pre-deploy is when this is free.
- `pricing.move` filed five `public(package)` getters under a "Public Functions" header, and `fixed_math`'s `float_scaling!()` constant-like macro sat below the "Public Functions" header rather than in the constants section — both make the module's real surface harder to read than it is.
- The `mul_div_down` gap mattered because its three siblings (`try_mul_div_down`, `mul_div_up`, `try_mul_div_up`) all pin their zero-denominator behaviour, so the one unpinned path was invisible asymmetry rather than a deliberate choice.

## Key decisions
- **`vault_events.move:203` `reserve_after` → `pool_reserve_after` was excluded.** A lens flagged it as naming drift against its two siblings, which both use the sibling name for the identical fact — and it's correct about the drift. But it is an **event field**, and contracts→indexer event-schema parity is a live cross-repo hazard: renaming it breaks decoders in deepbook-services. It needs a coordinated change, not a ride-along in a refactor PR.
- **`saturating_sub` → `-` at `strike_exposure.move:364` was not taken.** The lens argued the clamp provably cannot fire, which looks right, but `move.md` treats removing a clamp as a guard change requiring a duty inventory. Not a refactor.
- **T5 "dead code with a proof" was largely skipped.** Most of those items delete guards or asserts, and `move.md` is explicit that deleting or weakening a guard requires a duty inventory first. The sweep's proofs are reasoning, not duty inventories.

## Test plan
- [x] `sui move build --lint` — zero warnings: fixed_math, propbook, predict
- [x] `sui move test` — fixed_math **134/134** (133 + the new test, confirming it runs and the abort fires), propbook 55/55, predict 393/393
- [x] `pnpm run format:move:check` with the lockfile-pinned prettier-move 0.4.0 — clean
- [x] Receiver-syntax change verified resolvable: `OracleRead` is declared in `oracle_lane`, so no `use fun` alias is needed

Part of DBU-575.
