### PR TITLE
DBU-575 docs(predict): document unreachable abort codes and sentinel field semantics

### DIFF
--- a/packages/account/sources/account.move
+++ b/packages/account/sources/account.move
@@ -37,6 +37,12 @@ use fun df::remove as UID.remove;
 // === Errors ===
 const EInvalidOwner: u64 = 0;
 const EBalanceTooLow: u64 = 1;
+/// Unreachable, and so carries no `expected_failure` test: `Auth`'s fields are
+/// module-private and its only constructors set `kind` to `AUTH_OWNER`
+/// (`generate_auth`, `generate_auth_as_object`) or `AUTH_APP`
+/// (`generate_auth_as_app`). `load_account_mut` reaches this assert only in the
+/// `kind != AUTH_OWNER` branch, which therefore already implies `AUTH_APP`. It is
+/// a defensive backstop against a future third kind, not a live rejection path.
 const EInvalidAuth: u64 = 2;
 
 // === Auth Kinds ===
@@ -75,7 +81,8 @@ public struct CoinKey<phantom T>() has copy, drop, store;
 
 /// Hot-potato authority to mutably open an `AccountWrapper`.
 public struct Auth {
-    /// `AUTH_OWNER` or `AUTH_APP`; anything else is rejected by `EInvalidAuth`.
+    /// `AUTH_OWNER` or `AUTH_APP`. No other value is constructible: the fields are
+    /// module-private and every constructor sets one of the two.
     kind: u8,
     /// Meaningful only when `kind == AUTH_OWNER`, where it is the authority the
     /// account is matched against — a transaction sender (`generate_auth`) or an

--- a/packages/account/sources/account.move
+++ b/packages/account/sources/account.move
@@ -75,7 +75,13 @@ public struct CoinKey<phantom T>() has copy, drop, store;
 
 /// Hot-potato authority to mutably open an `AccountWrapper`.
 public struct Auth {
+    /// `AUTH_OWNER` or `AUTH_APP`; anything else is rejected by `EInvalidAuth`.
     kind: u8,
+    /// Meaningful only when `kind == AUTH_OWNER`, where it is the authority the
+    /// account is matched against — a transaction sender (`generate_auth`) or an
+    /// object address (`generate_auth_as_object`). When `kind == AUTH_APP` this
+    /// is the `@0x0` sentinel and is never read: app authority is carried by the
+    /// registry's authorization of the app, not by an address here.
     owner: address,
 }
 

--- a/packages/predict/sources/config/protocol_config.move
+++ b/packages/predict/sources/config/protocol_config.move
@@ -310,6 +310,13 @@ public(package) fun ewma_config(config: &ProtocolConfig): &EwmaConfig {
 /// The single version gate for the package: every version-gated flow threads the
 /// shared `ProtocolConfig` and calls this first. Replaces the former per-object
 /// `allowed_versions` mirrors.
+///
+/// `EPackageVersionDisabled` is unreachable within any one package version, and
+/// so carries no `expected_failure` test: `bump_version_watermark` only ever
+/// stores the *running* `current_version!()`, so `version_watermark` can never
+/// exceed the version of the package that wrote it. The gate fires only after a
+/// live upgrade, when a superseded package calls this with a watermark a newer
+/// package advanced past it — which is exactly what it exists to do.
 public(package) fun assert_version(config: &ProtocolConfig) {
     assert!(constants::current_version!() >= config.version_watermark, EPackageVersionDisabled);
 }

--- a/packages/predict/sources/events/order_events.move
+++ b/packages/predict/sources/events/order_events.move
@@ -26,6 +26,8 @@ public struct OrderMinted has copy, drop, store {
     /// form, `tick * tick_size` with the `tick_size` from `MarketCreated`.
     lower_tick: u64,
     higher_tick: u64,
+    /// 1e9-scaled; `1_000_000_000` is 1x (unleveraged) and is the floor enforced
+    /// at mint.
     leverage: u64,
     /// 1e9-scaled range probability quoted at entry.
     entry_probability: u64,

--- a/packages/propbook/sources/feeds/block_scholes_forward_feed.move
+++ b/packages/propbook/sources/feeds/block_scholes_forward_feed.move
@@ -14,6 +14,11 @@ use sui::{clock::Clock, table::{Self, Table}};
 
 const EWrongSource: u64 = 0;
 const ERawForwardNotFound: u64 = 1;
+/// `EWrongVersion` is unreachable within any one package version, and so carries
+/// no `expected_failure` test: `create_and_share` stamps the feed with
+/// `current_version!()`, and `migrate` only advances it forward to that same
+/// compiled constant. The gate fires only after a live package upgrade, against
+/// a feed that has not been migrated yet — which is what it exists to do.
 const EWrongVersion: u64 = 2;
 const ENotNewerVersion: u64 = 3;
 

--- a/packages/propbook/sources/feeds/block_scholes_spot_feed.move
+++ b/packages/propbook/sources/feeds/block_scholes_spot_feed.move
@@ -17,6 +17,11 @@ use sui::clock::Clock;
 
 const EWrongSource: u64 = 0;
 const ERawSpotNotFound: u64 = 1;
+/// `EWrongVersion` is unreachable within any one package version, and so carries
+/// no `expected_failure` test: `create_and_share` stamps the feed with
+/// `current_version!()`, and `migrate` only advances it forward to that same
+/// compiled constant. The gate fires only after a live package upgrade, against
+/// a feed that has not been migrated yet — which is what it exists to do.
 const EWrongVersion: u64 = 2;
 const ENotNewerVersion: u64 = 3;
 

--- a/packages/propbook/sources/feeds/block_scholes_svi_feed.move
+++ b/packages/propbook/sources/feeds/block_scholes_svi_feed.move
@@ -15,6 +15,11 @@ use sui::{clock::Clock, table::{Self, Table}};
 
 const EWrongSource: u64 = 0;
 const ERawSVINotFound: u64 = 1;
+/// `EWrongVersion` is unreachable within any one package version, and so carries
+/// no `expected_failure` test: `create_and_share` stamps the feed with
+/// `current_version!()`, and `migrate` only advances it forward to that same
+/// compiled constant. The gate fires only after a live package upgrade, against
+/// a feed that has not been migrated yet — which is what it exists to do.
 const EWrongVersion: u64 = 2;
 const ENotNewerVersion: u64 = 3;
 

--- a/packages/propbook/sources/feeds/pyth_feed.move
+++ b/packages/propbook/sources/feeds/pyth_feed.move
@@ -16,6 +16,11 @@ use propbook::{constants, oracle_lane::{Self, OracleLane, OracleRead}};
 use pyth_lazer::{i16::I16 as LazerI16, i64::I64 as LazerI64, update::Update as LazerUpdate};
 use sui::clock::Clock;
 
+/// `EWrongVersion` is unreachable within any one package version, and so carries
+/// no `expected_failure` test: `create_and_share` stamps the feed with
+/// `current_version!()`, and `migrate` only advances it forward to that same
+/// compiled constant. The gate fires only after a live package upgrade, against
+/// a feed that has not been migrated yet — which is what it exists to do.
 const EWrongVersion: u64 = 0;
 const ENotNewerVersion: u64 = 1;
 const ERawSpotNotFound: u64 = 2;


### PR DESCRIPTION
> **Stacked on #1134** (which is stacked on #1133). Review the stack bottom-up; this PR's diff is only the third tranche.

## Summary
- Documents five abort codes that have no `expected_failure` test because they are structurally unreachable at a single package version — with the argument for *why*, so the gap is a recorded decision rather than an oversight.
- Documents two field semantics that a reader cannot infer from the type: `Auth.owner`'s `@0x0` sentinel, and `OrderMinted.leverage`'s 1e9 scale.
- Comment-only. No code changes.

## Why
- `unit-tests.md` Rule 4 requires every reachable `const E*` to carry an `expected_failure` test, and says that for a genuinely unreachable code you **document why instead of contriving a bypass test** (Rule 12 forbids the bypass). The sweep flagged these as "untested abort codes"; the honest remedy is the doc, not a test that fakes reachability.
- The version gates are unreachable for a reason worth writing down: `bump_version_watermark` can only ever store the *running* `current_version!()`, so the watermark can never exceed the package that wrote it. The gate exists to fire **after** an upgrade, against a superseded package. That is a property a future reader would otherwise have to re-derive.
- `Auth { kind: u8, owner: address }` gave no hint that `owner` is meaningless in half its states. Under `AUTH_APP` it is `@0x0` and never read — authority comes from the registry's app authorization. That is exactly the sentinel case `move.md` says to comment.

## Key decisions
- **Documented rather than tested, deliberately.** Making these codes reachable would mean adding a test-only bypass to production sources, which Rule 12 forbids and Rule 18 ("minimize test-only seams in source") reinforces.
- **Each unreachability claim was verified against source**, not taken from the sweep: `bump_version_watermark` at `protocol_config.move:249-253`, feed construction/`migrate` in each propbook feed, `Auth { kind: AUTH_APP, owner: @0x0 }` at `account.move:282`, and `assert!(leverage >= float_scaling!())` at `strike_exposure_config.move:127`.

## Test plan
- [x] `sui move build --lint` — zero warnings: account, propbook, predict
- [x] `sui move test` — account 11/11, propbook 55/55, predict 393/393
- [x] `pnpm run format:move:check` with lockfile-pinned prettier-move 0.4.0 — clean
- [x] Every claim checked against the source that pins it (cited above)

Closes DBU-575 — last of the three-PR stack (#1133 -> #1134 -> #1135). Merging this one completes the deliverable, so the ticket closes here.

