### PR TITLE
DBU-575 docs(predict): document unreachable abort codes and sentinel field semantics

### DIFF
--- a/packages/account/sources/account.move
+++ b/packages/account/sources/account.move
@@ -37,6 +37,12 @@ use fun df::remove as UID.remove;
 // === Errors ===
 const EInvalidOwner: u64 = 0;
 const EBalanceTooLow: u64 = 1;
+/// Unreachable, and so carries no `expected_failure` test (unit-tests.md Rule 4):
+/// `Auth`'s fields are module-private and its only constructors set `kind` to
+/// `AUTH_OWNER` (`generate_auth`, `generate_auth_as_object`) or `AUTH_APP`
+/// (`generate_auth_as_app`). `load_account_mut` reaches this assert only in the
+/// `kind != AUTH_OWNER` branch, which therefore already implies `AUTH_APP`. It is
+/// a defensive backstop against a future third kind, not a live rejection path.
 const EInvalidAuth: u64 = 2;
 
 // === Auth Kinds ===
@@ -75,7 +81,14 @@ public struct CoinKey<phantom T>() has copy, drop, store;
 
 /// Hot-potato authority to mutably open an `AccountWrapper`.
 public struct Auth {
+    /// `AUTH_OWNER` or `AUTH_APP`. No other value is constructible: the fields are
+    /// module-private and every constructor sets one of the two.
     kind: u8,
+    /// Meaningful only when `kind == AUTH_OWNER`, where it is the authority the
+    /// account is matched against — a transaction sender (`generate_auth`) or an
+    /// object address (`generate_auth_as_object`). When `kind == AUTH_APP` this
+    /// is the `@0x0` sentinel and is never read: app authority is carried by the
+    /// registry's authorization of the app, not by an address here.
     owner: address,
 }
 

--- a/packages/predict/sources/config/protocol_config.move
+++ b/packages/predict/sources/config/protocol_config.move
@@ -320,6 +320,14 @@ public(package) fun ewma_config(config: &ProtocolConfig): &EwmaConfig {
 /// The single version gate for the package: every version-gated flow threads the
 /// shared `ProtocolConfig` and calls this first. Replaces the former per-object
 /// `allowed_versions` mirrors.
+///
+/// `EPackageVersionDisabled` is unreachable within any one package version, and
+/// so carries no `expected_failure` test (unit-tests.md Rule 4):
+/// `bump_version_watermark` only ever stores the running `current_version!()`, so
+/// `version_watermark` can never exceed the version of the package that wrote it.
+/// The gate fires only after a live upgrade, when a superseded package calls this
+/// with a watermark a newer package advanced past it — which is what it exists to
+/// do.
 public(package) fun assert_version(config: &ProtocolConfig) {
     assert!(constants::current_version!() >= config.version_watermark, EPackageVersionDisabled);
 }

--- a/packages/predict/sources/events/order_events.move
+++ b/packages/predict/sources/events/order_events.move
@@ -26,6 +26,8 @@ public struct OrderMinted has copy, drop, store {
     /// form, `tick * tick_size` with the `tick_size` from `MarketCreated`.
     lower_tick: u64,
     higher_tick: u64,
+    /// 1e9-scaled; `1_000_000_000` is 1x (unleveraged) and is the floor enforced
+    /// at mint.
     leverage: u64,
     /// 1e9-scaled range probability quoted at entry.
     entry_probability: u64,

--- a/packages/propbook/sources/constants.move
+++ b/packages/propbook/sources/constants.move
@@ -9,6 +9,14 @@ module propbook::constants;
 
 /// Running package version: the exact version a feed must match to accept
 /// updates, and the target of each feed's `migrate`.
+///
+/// Why every feed's `EWrongVersion` gate is unreachable within one package
+/// version (and so carries no `expected_failure` test, per unit-tests.md Rule 4):
+/// `create_and_share` stamps a feed with `current_version!()`, and `migrate` only
+/// advances a feed forward to that same compiled constant. So a feed's `version`
+/// can never diverge from `current_version!()` at a single package version. The
+/// gate fires only after a live package upgrade, against a feed that has not been
+/// migrated yet — which is exactly what it exists to do.
 public(package) macro fun current_version(): u64 {
     1
 }

--- a/packages/propbook/sources/feeds/block_scholes_forward_feed.move
+++ b/packages/propbook/sources/feeds/block_scholes_forward_feed.move
@@ -14,6 +14,9 @@ use sui::{clock::Clock, table::{Self, Table}};
 
 const EWrongSource: u64 = 0;
 const ERawForwardNotFound: u64 = 1;
+/// Unreachable within one package version; documented at
+/// `constants::current_version`. Fires only against an unmigrated feed after
+/// a live package upgrade.
 const EWrongVersion: u64 = 2;
 const ENotNewerVersion: u64 = 3;
 

--- a/packages/propbook/sources/feeds/block_scholes_spot_feed.move
+++ b/packages/propbook/sources/feeds/block_scholes_spot_feed.move
@@ -20,6 +20,9 @@ use sui::clock::Clock;
 
 const EWrongSource: u64 = 0;
 const ERawSpotNotFound: u64 = 1;
+/// Unreachable within one package version; documented at
+/// `constants::current_version`. Fires only against an unmigrated feed after
+/// a live package upgrade.
 const EWrongVersion: u64 = 2;
 const ENotNewerVersion: u64 = 3;
 

--- a/packages/propbook/sources/feeds/block_scholes_svi_feed.move
+++ b/packages/propbook/sources/feeds/block_scholes_svi_feed.move
@@ -15,6 +15,9 @@ use sui::{clock::Clock, table::{Self, Table}};
 
 const EWrongSource: u64 = 0;
 const ERawSVINotFound: u64 = 1;
+/// Unreachable within one package version; documented at
+/// `constants::current_version`. Fires only against an unmigrated feed after
+/// a live package upgrade.
 const EWrongVersion: u64 = 2;
 const ENotNewerVersion: u64 = 3;
 

--- a/packages/propbook/sources/feeds/pyth_feed.move
+++ b/packages/propbook/sources/feeds/pyth_feed.move
@@ -16,6 +16,9 @@ use propbook::{constants, oracle_lane::{Self, OracleLane, OracleRead}};
 use pyth_lazer::{i16::I16 as LazerI16, i64::I64 as LazerI64, update::Update as LazerUpdate};
 use sui::clock::Clock;
 
+/// Unreachable within one package version; documented at
+/// `constants::current_version`. Fires only against an unmigrated feed after
+/// a live package upgrade.
 const EWrongVersion: u64 = 0;
 const ENotNewerVersion: u64 = 1;
 const ERawSpotNotFound: u64 = 2;


### PR DESCRIPTION
## Summary
- Documents five abort codes that have no `expected_failure` test because they are structurally unreachable at a single package version — with the argument for *why*, so each gap is a recorded decision rather than an oversight.
- Documents two field semantics a reader cannot infer from the type: `Auth`'s `kind`/`owner` (the `@0x0` sentinel), and `OrderMinted.leverage`'s 1e9 scale.
- Comment-only. No code changes.

## Why
- Final follow-up to #1133 (now merged). `unit-tests.md` Rule 4 requires every reachable `const E*` to carry an `expected_failure` test, and says that for a genuinely unreachable code you **document why instead of contriving a bypass test** (Rule 12 forbids the bypass). The sweep flagged these as untested abort codes; the honest remedy is the doc.
- The version gates are unreachable for a reason worth writing down: a feed's `version`/the protocol `version_watermark` can only ever equal the running `current_version!()` at one package version. The gate exists to fire **after** an upgrade, against a superseded package or unmigrated feed. That is a property a future reader would otherwise re-derive.

## Key decisions
- **The propbook `EWrongVersion` reasoning is single-homed.** All four feeds share one mechanism, so the full explanation lives once at `constants::current_version` and each feed's `EWrongVersion` carries a one-line pointer. (An earlier draft of this content copy-pasted the whole paragraph into all four feeds — this fixes that.)
- **`EPackageVersionDisabled` keeps its own explanation.** It is a distinct mechanism (`version_watermark` advanced by `bump_version_watermark`, not a feed `version` + `migrate`), so folding it into the propbook home would conflate two things.
- **Documented rather than tested, deliberately.** Making these reachable would mean adding a test-only bypass to production sources, which Rule 12 forbids and Rule 18 ("minimize test-only seams in source") reinforces.
- **`EInvalidAuth` is documented, not deleted.** It is `assert!(true)` today, but it guards an authorization branch on a bare `u8` discriminant: if a future `AUTH_DELEGATE = 2` is added, this is what catches it. The clean fix is to make `kind` a Move 2024 enum so a third value is unrepresentable — a struct change, tracked separately, out of scope for a comment-only PR.
- Each unreachability claim was verified against source: `bump_version_watermark` (`protocol_config.move`), feed `create_and_share`/`migrate`, `Auth { kind: AUTH_APP, owner: @0x0 }` (`account.move`), and `assert!(leverage >= float_scaling!())` (`strike_exposure_config.move`).

## Test plan
- [x] `sui move build --lint` — zero warnings: account, propbook, predict
- [x] `sui move test` — account 11/11, propbook 55/55, predict 421/421
- [x] `pnpm run format:move:check` with lockfile-pinned prettier-move 0.4.0 — clean
- [x] Doc-comment placement checked: every `///` is adjacent to its item (a `//` between a doc and its item orphans it — `W01004`)

Closes DBU-575.
