### PR TITLE
DBU-593 fix(account): remove the 0-timestamp settlement sentinel

### DIFF
--- a/packages/account/sources/account.move
+++ b/packages/account/sources/account.move
@@ -309,17 +309,23 @@ fun unsettled_balance<T>(self: &Account, root: &AccumulatorRoot, clock: &Clock):
 /// accumulator suppression. `settled_funds_value` observes beginning-of-commit
 /// funds, so same-timestamp balance reads after `settle` must not add that
 /// accumulator view on top of the newly stored balance.
-fun settled_this_timestamp<T>(self: &Account, clock: &Clock): bool {
-    clock.timestamp_ms() == self.last_settlement_ms<T>()
+/// `public(package)` so the latch predicate is directly testable without a
+/// test-only seam: a never-settled coin (`last_settlement_ms` is `none`) must
+/// read as not-settled even at `clock.timestamp_ms() == 0`.
+public(package) fun settled_this_timestamp<T>(self: &Account, clock: &Clock): bool {
+    self.last_settlement_ms<T>() == option::some(clock.timestamp_ms())
 }
 
-fun last_settlement_ms<T>(self: &Account): u64 {
+/// `none` when `T` has never been settled — distinct from a real settlement at
+/// timestamp 0. Returning `0` for "never settled" would collide with a clock at
+/// timestamp 0, making a never-settled coin read as already-settled.
+fun last_settlement_ms<T>(self: &Account): Option<u64> {
     let key = CoinKey<T>();
     if (self.settlements.contains(key)) {
         let timestamp: &u64 = &self.settlements[key];
-        *timestamp
+        option::some(*timestamp)
     } else {
-        0
+        option::none()
     }
 }
 

--- a/packages/account/tests/account_tests.move
+++ b/packages/account/tests/account_tests.move
@@ -119,6 +119,47 @@ fun owner_auth_opens_account_and_coin_paths() {
     scenario.end();
 }
 
+#[test]
+fun never_settled_coin_reads_unsettled_at_clock_zero() {
+    let mut scenario = setup_with_account(ALICE);
+    scenario.next_tx(ALICE);
+    let wrapper = take_account_wrapper(&scenario, ALICE);
+    let clock = scenario.take_shared<Clock>();
+
+    // Clock sits at timestamp 0 (never incremented). A coin type that has never
+    // been settled must NOT read as settled-this-timestamp — the former `0`
+    // sentinel for "never settled" collided with a clock at 0.
+    assert!(!wrapper.load_account().settled_this_timestamp<TEST_COIN>(&clock));
+
+    return_shared(clock);
+    return_shared(wrapper);
+    scenario.end();
+}
+
+#[test]
+fun settlement_latch_holds_within_timestamp_and_releases_next() {
+    let mut scenario = setup_with_account(ALICE);
+    scenario.next_tx(ALICE);
+    let mut wrapper = take_account_wrapper(&scenario, ALICE);
+    let root = accumulator_support::take_root(&scenario);
+    let mut clock = scenario.take_shared<Clock>();
+    clock.increment_for_testing(5);
+
+    // Not latched before the first settle at this timestamp.
+    assert!(!wrapper.load_account().settled_this_timestamp<TEST_COIN>(&clock));
+    wrapper.settle<TEST_COIN>(&root, &clock);
+    // Latched at the settlement timestamp (the duplicate-settle guard)...
+    assert!(wrapper.load_account().settled_this_timestamp<TEST_COIN>(&clock));
+    // ...and released once the clock advances.
+    clock.increment_for_testing(1);
+    assert!(!wrapper.load_account().settled_this_timestamp<TEST_COIN>(&clock));
+
+    return_shared(clock);
+    return_shared(root);
+    return_shared(wrapper);
+    scenario.end();
+}
+
 #[test, expected_failure(abort_code = account::EInvalidOwner)]
 fun owner_auth_from_wrong_sender_aborts() {
     let mut scenario = setup_with_account(ALICE);


### PR DESCRIPTION
## Summary
- Removes a `0`-timestamp sentinel collision in `account::account`: `last_settlement_ms<T>()` now returns `Option<u64>` (`none` = never settled) instead of `0`.
- Adds two latch-predicate tests; widens `settled_this_timestamp` to `public(package)` so they can assert it directly.

## Why
- The sentinel `0` ("never settled") collided with a legitimate clock timestamp of `0`. At `clock == 0`, a never-settled coin read as already-settled — `settle` early-returned (skipping the real settlement) and `unsettled_balance` reported `0` while accumulator funds were still unsettled.
- **Not reachable on a live network** — a Sui `Clock` is never `0` on mainnet/testnet (it is real Unix-ms). So this is a latent footgun and a test-environment hazard, not a live bug. Tell: the existing account test does `clock.increment_for_testing(1)` before settling, implicitly stepping around it. Pre-deploy is the cheap moment to remove it, before the account package ships.

## Key decisions
- **`Option<u64>`, not a different magic number.** `none` can never equal any real timestamp including `0`, which closes the collision at the source. Storage is unchanged — the `settlements` Bag still holds `u64`; only the read wraps presence/absence.
- **Tested via a `public(package)` predicate, not a `#[test_only]` seam.** `unit-tests.md` Rule 4 endorses exposing a guard's pure precondition at package visibility for testability; Rule 18 discourages test-only seams in sources. Widening `settled_this_timestamp` to `public(package)` satisfies both.
- **Coverage is on the latch, not fund suppression.** The fund-folding path has no Move-unit-test seam — the accumulator cannot be funded in unit tests (`ACCUMULATOR_TESTING_STATUS.md`) — so the observable I can drive is the settlement-timestamp latch.
- **Negative control run.** `never_settled_coin_reads_unsettled_at_clock_zero` was verified to FAIL against the old sentinel semantics before landing, so it genuinely catches the bug rather than passing vacuously.

## Test plan
- [x] `sui move build --lint` — zero warnings: account, and dependents predict + deepbook_core_account
- [x] `sui move test` — account **13/13** (11 + 2 new)
- [x] Negative control: the clock-0 test fails against the pre-fix sentinel logic, passes with the fix
- [x] Latch regression test: holds within a nonzero timestamp, releases at the next
- [x] `pnpm run format:move:check` with lockfile-pinned prettier-move 0.4.0 — clean

Closes DBU-593.
