### PR TITLE
test(predict): cover the lp_book tail/middle-page unlink relink

### DIFF
--- a/packages/predict/tests/plp/lp_book_tests.move
+++ b/packages/predict/tests/plp/lp_book_tests.move
@@ -450,15 +450,18 @@ fun cancel_tail_page_request_unlinks_page_and_keeps_queue_drainable() {
     finish(scenario, book, ledger);
 }
 
+// The middle-page unlink relinks BOTH neighbors — `page 0.next -> page 2` and
+// `page 2.prev -> page 0`. The two directions need separate tests: a forward
+// drain can only observe `.next` (it never reads `.prev`), and page 0's own later
+// unlink overwrites `page 2.prev` before a forward drain would reach it, masking a
+// wrong backward relink. So one test drives each direction to its own observation.
+
 #[test]
-fun cancel_entire_middle_page_relinks_both_neighbors() {
+fun cancel_middle_page_forward_relinks_predecessor_to_successor() {
     let (mut scenario, mut book, mut ledger) = setup();
     book.mint_locked_liquidity(min_supply!());
 
-    // Three pages: page 0 (0..63), page 1 (64..127), page 2 (128). Emptying the
-    // middle page is the only path that unlinks with BOTH `prev = some` and
-    // `next = some`, exercising the full relink (page 0.next -> page 2 and
-    // page 2.prev -> page 0) in one call.
+    // Three pages: page 0 (0..63), page 1 (64..127), page 2 (128).
     let page_capacity = 64u64;
     let total = 2 * page_capacity + 1;
     let mut i = 0u64;
@@ -468,7 +471,7 @@ fun cancel_entire_middle_page_relinks_both_neighbors() {
         i = i + 1;
     };
 
-    // Cancel the whole middle page; the last cancel (index 127) empties it.
+    // Empty the middle page (last cancel at index 127 triggers the unlink).
     let mut j = page_capacity;
     while (j < 2 * page_capacity) {
         let (_id, _amount, refund) = book.cancel_supply_request(ALICE, j);
@@ -477,8 +480,8 @@ fun cancel_entire_middle_page_relinks_both_neighbors() {
     };
     assert_eq!(book.supply_requests_pending(), page_capacity + 1);
 
-    // The relink held: a FIFO drain reaches page 2 only through page 0's rewired
-    // `next`, so all 65 surviving requests (page 0's 64 + page 2's 1) fill.
+    // Forward relink: a FIFO drain reaches page 2 only through page 0's rewired
+    // `next`, so all 65 survivors (page 0's 64 + page 2's 1) fill.
     let summary = book.drain(
         &mut ledger,
         lp_book::new_flush_mark(min_supply!(), min_supply!()),
@@ -488,6 +491,53 @@ fun cancel_entire_middle_page_relinks_both_neighbors() {
         scenario.ctx(),
     );
     assert_drain_summary(&summary, page_capacity + 1, 0, page_capacity + 1);
+    assert_eq!(book.supply_requests_pending(), 0);
+
+    finish(scenario, book, ledger);
+}
+
+#[test]
+fun cancel_middle_page_backward_relinks_successor_to_predecessor() {
+    let (mut scenario, mut book, mut ledger) = setup();
+    book.mint_locked_liquidity(min_supply!());
+
+    // Same three pages: page 0 (0..63), page 1 (64..127), page 2 (128).
+    let page_capacity = 64u64;
+    let total = 2 * page_capacity + 1;
+    let mut i = 0u64;
+    while (i < total) {
+        let coin = coin::mint_for_testing<DUSDC>(min_supply!(), scenario.ctx());
+        book.request_supply(coin, alice_id(), ALICE, NO_MIN_OUTPUT);
+        i = i + 1;
+    };
+
+    // Empty the middle page: sets `page 2.prev -> page 0`.
+    let mut j = page_capacity;
+    while (j < 2 * page_capacity) {
+        let (_id, _amount, refund) = book.cancel_supply_request(ALICE, j);
+        destroy(refund);
+        j = j + 1;
+    };
+    assert_eq!(book.supply_requests_pending(), page_capacity + 1);
+
+    // Backward relink: now empty page 2 (its lone index 128). Its unlink reads
+    // `page 2.prev` and relinks it — if the middle unlink left it pointing at the
+    // removed page 1, this `borrow_mut` hits a missing page and aborts. Page 0 is
+    // still full, so it is untouched here and cannot mask the check.
+    let (_id, _amount, refund) = book.cancel_supply_request(ALICE, 2 * page_capacity);
+    destroy(refund);
+    assert_eq!(book.supply_requests_pending(), page_capacity);
+
+    // Page 0 survived intact: draining fills all 64.
+    let summary = book.drain(
+        &mut ledger,
+        lp_book::new_flush_mark(min_supply!(), min_supply!()),
+        vault_id(),
+        option::none(),
+        option::none(),
+        scenario.ctx(),
+    );
+    assert_drain_summary(&summary, page_capacity, 0, page_capacity);
     assert_eq!(book.supply_requests_pending(), 0);
 
     finish(scenario, book, ledger);

--- a/packages/predict/tests/plp/lp_book_tests.move
+++ b/packages/predict/tests/plp/lp_book_tests.move
@@ -411,6 +411,89 @@ fun unbounded_flush_drains_every_queued_supply() {
 }
 
 #[test]
+fun cancel_tail_page_request_unlinks_page_and_keeps_queue_drainable() {
+    let (mut scenario, mut book, mut ledger) = setup();
+    book.mint_locked_liquidity(min_supply!());
+
+    // Fill exactly two pages (PAGE_CAPACITY = 64): page 0 holds 0..63, page 1
+    // holds the single index 64. A FIFO drain only ever empties the head page,
+    // so the tail-page unlink (`prev = some`, `next = none`) is reached only by
+    // cancelling that lone tail entry.
+    let page_capacity = 64u64;
+    let total = page_capacity + 1;
+    let mut tail_index = 0u64;
+    let mut i = 0u64;
+    while (i < total) {
+        let coin = coin::mint_for_testing<DUSDC>(min_supply!(), scenario.ctx());
+        tail_index = book.request_supply(coin, alice_id(), ALICE, NO_MIN_OUTPUT);
+        i = i + 1;
+    };
+    assert_eq!(book.supply_requests_pending(), total);
+
+    let (_id, _amount, refund) = book.cancel_supply_request(ALICE, tail_index);
+    destroy(refund);
+    assert_eq!(book.supply_requests_pending(), page_capacity);
+
+    // The list survived the unlink: draining fills all 64 page-0 requests, so
+    // head_page_id and tail_page_id still point at a coherent single page.
+    let summary = book.drain(
+        &mut ledger,
+        lp_book::new_flush_mark(min_supply!(), min_supply!()),
+        vault_id(),
+        option::none(),
+        option::none(),
+        scenario.ctx(),
+    );
+    assert_drain_summary(&summary, page_capacity, 0, page_capacity);
+    assert_eq!(book.supply_requests_pending(), 0);
+
+    finish(scenario, book, ledger);
+}
+
+#[test]
+fun cancel_entire_middle_page_relinks_both_neighbors() {
+    let (mut scenario, mut book, mut ledger) = setup();
+    book.mint_locked_liquidity(min_supply!());
+
+    // Three pages: page 0 (0..63), page 1 (64..127), page 2 (128). Emptying the
+    // middle page is the only path that unlinks with BOTH `prev = some` and
+    // `next = some`, exercising the full relink (page 0.next -> page 2 and
+    // page 2.prev -> page 0) in one call.
+    let page_capacity = 64u64;
+    let total = 2 * page_capacity + 1;
+    let mut i = 0u64;
+    while (i < total) {
+        let coin = coin::mint_for_testing<DUSDC>(min_supply!(), scenario.ctx());
+        book.request_supply(coin, alice_id(), ALICE, NO_MIN_OUTPUT);
+        i = i + 1;
+    };
+
+    // Cancel the whole middle page; the last cancel (index 127) empties it.
+    let mut j = page_capacity;
+    while (j < 2 * page_capacity) {
+        let (_id, _amount, refund) = book.cancel_supply_request(ALICE, j);
+        destroy(refund);
+        j = j + 1;
+    };
+    assert_eq!(book.supply_requests_pending(), page_capacity + 1);
+
+    // The relink held: a FIFO drain reaches page 2 only through page 0's rewired
+    // `next`, so all 65 surviving requests (page 0's 64 + page 2's 1) fill.
+    let summary = book.drain(
+        &mut ledger,
+        lp_book::new_flush_mark(min_supply!(), min_supply!()),
+        vault_id(),
+        option::none(),
+        option::none(),
+        scenario.ctx(),
+    );
+    assert_drain_summary(&summary, page_capacity + 1, 0, page_capacity + 1);
+    assert_eq!(book.supply_requests_pending(), 0);
+
+    finish(scenario, book, ledger);
+}
+
+#[test]
 fun bounded_supply_budget_fills_up_to_budget_and_carries() {
     let (mut scenario, mut book, mut ledger) = setup();
     book.mint_locked_liquidity(min_supply!());


### PR DESCRIPTION
## Summary
- Adds two tests covering `lp_book::unlink_empty_page`'s `prev = some` relink branches, which had no coverage.
- Test-only. No source change.

## Why
- `lp_book`'s request queue is a linked list of 64-entry pages. When a page empties, `unlink_empty_page` relinks its neighbors. The existing multi-page test drains 101 requests FIFO — but a FIFO drain always empties the **head** page, so it only ever exercises the `next = some` branch. The `prev = some` case (unlinking a page while an earlier one still exists) was never reached.
- That branch **is** reachable in production: `cancel_supply_request` / `cancel_withdraw_request` remove by index from any page, so a cancel of a tail or middle page's last entry empties a non-head page. An untested relink on a linked-list mutation is exactly where a silent corruption would hide.

## Key decisions
- **Assert integrity through behavior, not private pointers.** Each test cancels to trigger the unlink, then drains the survivors and asserts every expected request fills. A broken relink makes the follow-up drain walk into a removed page and abort — so the drain result is the integrity check, and the tests never read `head_page_id`/`tail_page_id` directly (no circular assertion).
- **Both `prev = some` shapes covered.** Tail-page cancel gives `prev = some, next = none`; middle-page cancel gives `prev = some, next = some` (the full double relink) — the combination most prone to a one-sided relink bug.
- **Negative control run.** The tail-page test was verified to FAIL against a deliberately broken `prev.next` relink before landing, so it genuinely catches list corruption.

## Test plan
- [x] `sui move test` — predict **423/423** (421 + 2 new)
- [x] `sui move build --lint` — clean
- [x] Negative control: tail-page test fails against a broken relink, passes with correct code
- [x] `pnpm run format:move:check` with lockfile-pinned prettier-move 0.4.0 — clean

Surfaced by the DBU-575 sweep (test hygiene; no ticket per the mechanical-chore exemption).
