### PR TITLE
fix(deepbook): bound the expired-order scan in mid_price / best-price getters (DBU-594)

### DIFF
--- a/packages/deepbook/sources/book/book.move
+++ b/packages/deepbook/sources/book/book.move
@@ -301,32 +301,46 @@ public(package) fun modify_order(
 }
 
 /// Returns the best (lowest) ask price, skipping expired orders at the top of the book.
-/// Returns `none` if the ask side has no live orders.
+/// Returns `none` if the ask side has no live order within the first `max_fills`
+/// orders. The scan is bounded to `max_fills` — the same limit the matching
+/// engine uses (`match_against_book`) — so a large expired-order backlog cannot
+/// make this read cost unbounded gas. Bounding at `max_fills` also keeps the
+/// result consistent with the matcher: a taker cannot reach a live order buried
+/// under more than `max_fills` expired orders either, so treating that side as
+/// having no live top-of-book matches what a trade would actually see.
 public(package) fun best_ask_price(self: &Book, current_timestamp: u64): Option<u64> {
     let (mut slice_ref, mut offset) = self.asks.min_slice();
-    while (!slice_ref.is_null()) {
+    let mut scanned = 0;
+    while (!slice_ref.is_null() && scanned < constants::max_fills()) {
         let order = slice_borrow(self.asks.borrow_slice(slice_ref), offset);
         if (current_timestamp <= order.expire_timestamp()) return option::some(order.price());
         (slice_ref, offset) = self.asks.next_slice(slice_ref, offset);
+        scanned = scanned + 1;
     };
 
     option::none()
 }
 
 /// Returns the best (highest) bid price, skipping expired orders at the top of the book.
-/// Returns `none` if the bid side has no live orders.
+/// Returns `none` if the bid side has no live order within the first `max_fills`
+/// orders. Bounded to `max_fills` for the same reason as `best_ask_price`.
 public(package) fun best_bid_price(self: &Book, current_timestamp: u64): Option<u64> {
     let (mut slice_ref, mut offset) = self.bids.max_slice();
-    while (!slice_ref.is_null()) {
+    let mut scanned = 0;
+    while (!slice_ref.is_null() && scanned < constants::max_fills()) {
         let order = slice_borrow(self.bids.borrow_slice(slice_ref), offset);
         if (current_timestamp <= order.expire_timestamp()) return option::some(order.price());
         (slice_ref, offset) = self.bids.prev_slice(slice_ref, offset);
+        scanned = scanned + 1;
     };
 
     option::none()
 }
 
 /// Returns the mid price of the order book.
+/// Aborts `EEmptyOrderbook` if either side has no live order within the first
+/// `max_fills` orders (see `best_ask_price`) — i.e. a genuinely empty side, or a
+/// degenerate side whose top `max_fills` orders are all expired.
 public(package) fun mid_price(self: &Book, current_timestamp: u64): u64 {
     let ask = self.best_ask_price(current_timestamp);
     let bid = self.best_bid_price(current_timestamp);

--- a/packages/deepbook/sources/pool.move
+++ b/packages/deepbook/sources/pool.move
@@ -1395,8 +1395,10 @@ public fun mid_price<BaseAsset, QuoteAsset>(
     self.load_inner().book.mid_price(clock.timestamp_ms())
 }
 
-/// Returns the best (lowest) ask price, skipping expired orders.
-/// Returns `none` if the ask side has no live orders.
+/// Top-of-book read for PTB construction / devInspect (SDK, UI). Returns the
+/// best (lowest) ask price, skipping expired orders. Returns `none` if the ask
+/// side has no live order within the first `max_fills` orders (see
+/// `book::best_ask_price` for the bound).
 public fun best_ask_price<BaseAsset, QuoteAsset>(
     self: &Pool<BaseAsset, QuoteAsset>,
     clock: &Clock,
@@ -1404,8 +1406,10 @@ public fun best_ask_price<BaseAsset, QuoteAsset>(
     self.load_inner().book.best_ask_price(clock.timestamp_ms())
 }
 
-/// Returns the best (highest) bid price, skipping expired orders.
-/// Returns `none` if the bid side has no live orders.
+/// Top-of-book read for PTB construction / devInspect (SDK, UI). Returns the
+/// best (highest) bid price, skipping expired orders. Returns `none` if the bid
+/// side has no live order within the first `max_fills` orders (see
+/// `book::best_bid_price` for the bound).
 public fun best_bid_price<BaseAsset, QuoteAsset>(
     self: &Pool<BaseAsset, QuoteAsset>,
     clock: &Clock,

--- a/packages/deepbook/tests/pool_tests.move
+++ b/packages/deepbook/tests/pool_tests.move
@@ -965,6 +965,221 @@ fun best_bid_ask_skips_expired_orders() {
     end(test);
 }
 
+#[test_only]
+/// Place `count` resting orders on the `is_bid` side, all at `price`, owned by
+/// `trader`'s balance manager, expiring at `expire`. Used to build an expired
+/// top-of-book backlog larger than `max_fills` for the bounded-scan tests.
+/// Orders at the same price coexist as distinct entries, so the getter walks
+/// each one; the backlog is split across managers because a single manager is
+/// capped at `max_open_orders`.
+fun seed_resting_orders(
+    trader: address,
+    is_bid: bool,
+    count: u64,
+    price: u64,
+    expire: u64,
+    pool_id: ID,
+    balance_manager_id: ID,
+    test: &mut Scenario,
+) {
+    let quantity = 1 * constants::float_scaling();
+    let mut i = 0;
+    while (i < count) {
+        place_limit_order<SUI, USDC>(
+            trader,
+            pool_id,
+            balance_manager_id,
+            i + 1,
+            constants::no_restriction(),
+            constants::self_matching_allowed(),
+            price,
+            quantity,
+            is_bid,
+            true,
+            expire,
+            test,
+        );
+        i = i + 1;
+    };
+}
+
+#[test]
+fun best_ask_price_bounded_at_max_fills_returns_none() {
+    let mut test = begin(OWNER);
+    let registry_id = setup_test(OWNER, &mut test);
+    let balance_manager_id_alice = create_acct_and_share_with_funds(
+        ALICE,
+        1_000_000 * constants::float_scaling(),
+        &mut test,
+    );
+    let balance_manager_id_bob = create_acct_and_share_with_funds(
+        BOB,
+        1_000_000 * constants::float_scaling(),
+        &mut test,
+    );
+    let pool_id = setup_pool_with_default_fees_and_reference_pool<SUI, USDC, SUI, DEEP>(
+        ALICE,
+        registry_id,
+        balance_manager_id_alice,
+        &mut test,
+    );
+
+    let expired_price = 2 * constants::float_scaling();
+    let live_price = 3 * constants::float_scaling();
+    let expire_soon = get_time(&mut test) + 100;
+
+    // max_fills expired asks at the top of book (ALICE, at her open-order cap),
+    // then one live ask just beyond the cap from a second manager.
+    seed_resting_orders(
+        ALICE,
+        false,
+        constants::max_fills(),
+        expired_price,
+        expire_soon,
+        pool_id,
+        balance_manager_id_alice,
+        &mut test,
+    );
+    seed_resting_orders(
+        BOB,
+        false,
+        1,
+        live_price,
+        constants::max_u64(),
+        pool_id,
+        balance_manager_id_bob,
+        &mut test,
+    );
+
+    set_time(expire_soon + 1, &mut test);
+
+    // The live ask exists, but sits beyond max_fills expired orders. The bounded
+    // scan stops at the cap and reports the side as empty — the same horizon a
+    // taker sees, since matching is also capped at max_fills.
+    assert!(get_best_ask_price<SUI, USDC>(pool_id, &mut test).is_none());
+
+    end(test);
+}
+
+#[test]
+fun best_ask_price_finds_live_within_max_fills() {
+    let mut test = begin(OWNER);
+    let registry_id = setup_test(OWNER, &mut test);
+    let balance_manager_id_alice = create_acct_and_share_with_funds(
+        ALICE,
+        1_000_000 * constants::float_scaling(),
+        &mut test,
+    );
+    let balance_manager_id_bob = create_acct_and_share_with_funds(
+        BOB,
+        1_000_000 * constants::float_scaling(),
+        &mut test,
+    );
+    let pool_id = setup_pool_with_default_fees_and_reference_pool<SUI, USDC, SUI, DEEP>(
+        ALICE,
+        registry_id,
+        balance_manager_id_alice,
+        &mut test,
+    );
+
+    let expired_price = 2 * constants::float_scaling();
+    let live_price = 3 * constants::float_scaling();
+    let expire_soon = get_time(&mut test) + 100;
+
+    // One fewer than max_fills expired asks, then a live ask at the max_fills-th
+    // position — the scan reaches it (scanned = max_fills - 1 < max_fills).
+    seed_resting_orders(
+        ALICE,
+        false,
+        constants::max_fills() - 1,
+        expired_price,
+        expire_soon,
+        pool_id,
+        balance_manager_id_alice,
+        &mut test,
+    );
+    seed_resting_orders(
+        BOB,
+        false,
+        1,
+        live_price,
+        constants::max_u64(),
+        pool_id,
+        balance_manager_id_bob,
+        &mut test,
+    );
+
+    set_time(expire_soon + 1, &mut test);
+
+    assert_eq!(get_best_ask_price<SUI, USDC>(pool_id, &mut test).destroy_some(), live_price);
+
+    end(test);
+}
+
+#[test, expected_failure(abort_code = ::deepbook::book::EEmptyOrderbook)]
+fun mid_price_aborts_when_ask_top_of_book_expired_past_cap() {
+    let mut test = begin(OWNER);
+    let registry_id = setup_test(OWNER, &mut test);
+    let balance_manager_id_alice = create_acct_and_share_with_funds(
+        ALICE,
+        1_000_000 * constants::float_scaling(),
+        &mut test,
+    );
+    let balance_manager_id_bob = create_acct_and_share_with_funds(
+        BOB,
+        1_000_000 * constants::float_scaling(),
+        &mut test,
+    );
+    let pool_id = setup_pool_with_default_fees_and_reference_pool<SUI, USDC, SUI, DEEP>(
+        ALICE,
+        registry_id,
+        balance_manager_id_alice,
+        &mut test,
+    );
+
+    let expire_soon = get_time(&mut test) + 100;
+
+    // ALICE fills her open-order cap with max_fills expired asks. BOB adds a live
+    // bid (keeps the bid side valid) and a live ask beyond the cap.
+    seed_resting_orders(
+        ALICE,
+        false,
+        constants::max_fills(),
+        2 * constants::float_scaling(),
+        expire_soon,
+        pool_id,
+        balance_manager_id_alice,
+        &mut test,
+    );
+    seed_resting_orders(
+        BOB,
+        true,
+        1,
+        1 * constants::float_scaling(),
+        constants::max_u64(),
+        pool_id,
+        balance_manager_id_bob,
+        &mut test,
+    );
+    seed_resting_orders(
+        BOB,
+        false,
+        1,
+        3 * constants::float_scaling(),
+        constants::max_u64(),
+        pool_id,
+        balance_manager_id_bob,
+        &mut test,
+    );
+
+    set_time(expire_soon + 1, &mut test);
+
+    // A live ask exists (beyond the cap), but the bounded scan cannot reach it,
+    // so mid_price treats the ask side as empty and aborts.
+    let _mid = get_mid_price<SUI, USDC>(pool_id, &mut test);
+    end(test);
+}
+
 #[test]
 fun test_swap_exact_not_fully_filled_bid_ok() {
     test_swap_exact_not_fully_filled(true, false, false, false, false);

--- a/packages/deepbook/tests/pool_tests.move
+++ b/packages/deepbook/tests/pool_tests.move
@@ -983,8 +983,7 @@ fun seed_resting_orders(
     test: &mut Scenario,
 ) {
     let quantity = 1 * constants::float_scaling();
-    let mut i = 0;
-    while (i < count) {
+    count.do!(|i| {
         place_limit_order<SUI, USDC>(
             trader,
             pool_id,
@@ -999,8 +998,7 @@ fun seed_resting_orders(
             expire,
             test,
         );
-        i = i + 1;
-    };
+    });
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Bounds the expired-order walk in `book::best_ask_price` / `best_bid_price` (and therefore `book::mid_price`) to `max_fills` — the same limit the matching engine already uses — so a large expired top-of-book backlog can no longer make these reads cost unbounded gas.
- Documents the resulting `mid_price` contract and the getters' intended consumer class.

## Why
- The `best_bid_price` / `best_ask_price` getters (added in #973) and the pre-existing `book::mid_price` loop walk expired top-of-book orders with **no cap**. `max_fills = 100` bounds *matching* (`match_against_book`), not these reads. Expired orders linger at top-of-book until a crossing taker clears them (100 per fill), so a backlog can persist and be re-scanned on every read.
- This isn't only a read concern: `mid_price` already runs on a permissionless, state-mutating path — `pool::add_deep_price_point` → `reference_pool.mid_price(clock)`. An uncapped scan there is a latent gas-exhaustion vector. Flagged by a Codex advisory review of #973.

## Key decisions
- **Cap at `max_fills`, not an arbitrary number.** A taker cannot reach a live order buried under more than `max_fills` expired orders either — `match_against_book` stops at `max_fills` and rests a POST_ONLY order with `executed_quantity = 0`. Bounding the getters at the same limit makes them *consistent* with what a trade actually sees, not merely cheaper: a live order past the cap is one no single fill could reach anyway.
- **`mid_price` semantics change (deliberate).** When a side's top `max_fills` orders are all expired, `best_*_price` returns `none`, so `mid_price` aborts `EEmptyOrderbook` even though a live order exists deeper. This is the intended contract: a mid price sitting under 100 expired orders is not a usable top-of-book. Consumers on the mutative path (`add_deep_price_point`, margin reference pricing) would see a *transient* abort only in that degenerate state — whitelisted reference pools don't realistically reach it, and any backlog drains 100-per-taker.
- **No new error constants, no signature changes.** Only the loop bound and doc comments change; `EEmptyOrderbook` already existed.

## Test plan
- [x] `sui move build` passes for `packages/deepbook`
- [x] `sui move test --gas-limit 100000000000` — 397/397 pass, incl. 3 new boundary tests:
  - `best_ask_price_bounded_at_max_fills_returns_none` — `max_fills` expired asks + a live ask beyond → getter returns `none` (the live order is real but past the cap; fails without the bound)
  - `best_ask_price_finds_live_within_max_fills` — `max_fills − 1` expired + a live ask at the cap boundary → getter returns it (pins the off-by-one)
  - `mid_price_aborts_when_ask_top_of_book_expired_past_cap` — `EEmptyOrderbook` even though a live ask exists beyond the cap (pins the semantics change)
- [x] `pnpm format:move:check` clean (CI parity)

Stacked on #973 (`tonylee/dbu-366-add-place_post_only_limit_order-graceful-post-only-api`) — **merge after #973**.

Closes DBU-594.
