### PR TITLE
DBU-596 fix(predict): add a backwardation floor to the pricing-safe envelope

### DIFF
--- a/packages/predict/sources/pricing/pricing.move
+++ b/packages/predict/sources/pricing/pricing.move
@@ -394,12 +394,23 @@ fun timestamp_is_fresh(source_timestamp_ms: u64, max_age_ms: u64, clock: &Clock)
 fun assert_inputs_pricing_safe(spot: u64, forward: u64, svi: &SVIParams) {
     assert!(spot > 0 && forward > 0, EBlockScholesInputsInvalid);
     assert!(forward <= max_pricing_spot!(), EBlockScholesInputsInvalid);
-    // Basis cap at exactly `factor` (`basis <= factor`): forward <= factor * spot
-    // <=> ceil(forward / factor) <= spot, u64-native with no widening. The exact
-    // bound is what keeps the re-anchored forward `mul_div_down(spot, forward,
-    // spot')` inside u64; rejecting a too-high basis at this input gate is
-    // fail-safe, never a fund path.
+    // Basis band, BOTH edges. `load_live_pricer` re-anchors the live forward as
+    // `mul_div_down(pyth_spot, forward, spot)`, so the basis `forward/spot` must be
+    // bounded on both sides or the re-anchored forward degenerates:
+    //   - ceiling `basis <= factor` (forward <= factor * spot): caps contango and
+    //     keeps the re-anchored forward inside u64.
+    //   - floor `basis >= 1/factor` (spot <= factor * forward): caps backwardation.
+    //     Without it an envelope-valid tiny `forward` (or large `spot`) collapses the
+    //     re-anchored forward toward 0 — every strike deep-OTM (all range prices 0)
+    //     or, rounding to 0, `EZeroForward` in `compute_up_price`. The floor keeps
+    //     the re-anchored forward >= pyth_spot / factor > 0.
+    // Both use the exact `div_ceil` form (u64-native, no widening); rejecting an
+    // out-of-band basis at this input gate is fail-safe, never a fund path. This does
+    // NOT change the pool-flush liveness class: a degenerate feed on an active market
+    // is rejected here instead of aborting deeper, but either way that market cannot
+    // be valued (see C-1 / DBU-557).
     assert!(forward.div_ceil(max_pricing_basis_factor!()) <= spot, EBlockScholesInputsInvalid);
+    assert!(spot.div_ceil(max_pricing_basis_factor!()) <= forward, EBlockScholesInputsInvalid);
     assert!(svi.a() <= max_svi_input!(), EBlockScholesInputsInvalid);
     assert!(svi.b() <= max_svi_input!(), EBlockScholesInputsInvalid);
     assert!(svi.rho().magnitude() <= math::float_scaling!(), EBlockScholesInputsInvalid);

--- a/packages/predict/tests/pricing/pricing_guard_tests.move
+++ b/packages/predict/tests/pricing/pricing_guard_tests.move
@@ -278,6 +278,20 @@ fun surface_with_forward_above_spot_ceiling_aborts() {
 }
 
 #[test, expected_failure(abort_code = pricing::EBlockScholesInputsInvalid)]
+fun surface_with_basis_below_min_aborts() {
+    // basis = forward / spot = 1/101 < 1/100 fails the new backwardation FLOOR
+    // (spot <= factor * forward), the symmetric twin of the contango ceiling above.
+    // forward under the spot ceiling and spot = 101*forward so the ceiling and
+    // contango branches pass and only the floor rejects. This is the residual an
+    // absolute spot ceiling misses: a tiny forward collapses the re-anchored forward
+    // (`pyth_spot * forward / spot` -> 0) regardless of spot's absolute magnitude.
+    let forward = 100 * test_constants::float();
+    let spot = forward * 101;
+    load_pricer_with_spot_forward(spot, forward);
+    abort EUnexpectedSuccess
+}
+
+#[test, expected_failure(abort_code = pricing::EBlockScholesInputsInvalid)]
 fun surface_with_basis_above_max_aborts() {
     // basis = forward * 1e9 / spot = 101e9 > 100e9, with forward still under the
     // spot ceiling so the basis branch (not the ceiling branch) is the one that fires.
@@ -385,14 +399,16 @@ fun surface_with_svi_sigma_above_max_aborts() {
     abort EUnexpectedSuccess
 }
 
-// === Deep-math abort (EZeroForward) ===
+// === Re-anchor collapse rejected at the envelope (basis floor) ===
 
-/// A surface whose forward is tiny relative to the BS spot passes the envelope
-/// (there is no LOWER basis bound), but re-anchoring at a pyth spot far below the
-/// BS spot floors `spot * bs_forward / bs_spot` to 0, and `compute_nd2` aborts on
-/// the first finite-strike quote.
-#[test, expected_failure(abort_code = pricing::EZeroForward)]
-fun re_anchored_zero_forward_aborts() {
+/// A surface whose forward is tiny relative to the BS spot is now rejected by the
+/// backwardation floor (`spot <= factor * forward`) at the input gate, BEFORE
+/// re-anchoring. Previously it passed the envelope (no lower basis bound) and
+/// re-anchoring at a pyth spot far below the BS spot floored the forward to 0,
+/// aborting `EZeroForward` deep in `compute_nd2` — or, one ulp above 0, silently
+/// priced every strike to 0. The floor rejects the whole degenerate class here.
+#[test, expected_failure(abort_code = pricing::EBlockScholesInputsInvalid)]
+fun re_anchor_collapsing_surface_rejected_at_envelope() {
     let mut fx = oracle_fixture::setup_oracle_default();
     let mut oracle = fx.take_oracle_bundle();
     let bs_spot = 100_000_000_000_000_000; // 1e17, under the spot ceiling


### PR DESCRIPTION
> **⚠ Reviewer: this changes a deliberate, documented behavior — please weigh the design call, don't just rubber-stamp.** Details under Key decisions.

## Summary
- Adds the missing **basis floor** to `pricing::assert_inputs_pricing_safe` — a backwardation cap symmetric with the existing contango ceiling — so an envelope-valid degenerate surface can no longer collapse the re-anchored forward.
- Retargets one existing test and adds one boundary test.

## Why
- The envelope capped the basis *above* (`forward <= factor * spot`) but not *below*. The live forward is re-anchored as `pyth_spot · bs_forward / bs_spot`, so a tiny `bs_forward` (or large `bs_spot`) collapses it toward 0:
  - **forward small-but-positive** → every real strike deep-OTM → **all range prices 0** → a trader mints real positions for **free** during the window (LP-funded value leak), with **no abort**. This silent case is the genuinely new hole.
  - **forward exactly 0** → `EZeroForward`.
- The basis floor `spot.div_ceil(factor) <= forward` keeps the re-anchored forward `>= pyth_spot / factor > 0`, closing the whole class at the input gate.

## Key decisions (reviewer: read this)
- **This changes deliberate, documented behavior.** The prior code omitted the lower basis bound *on purpose* — the retargeted test's own comment said "there is no LOWER basis bound," premised on the `:368-374` claim that "compute_nd2's deep-tail saturations keep pricing live." **That premise is false for a realistic strike grid:** a 0.6 forward puts every BTC strike deep-OTM, so prices collapse to 0 rather than saturating live. The floor corrects the envelope to match reality. This is the audit's anti-ossification case — a well-reasoned decision wrong by omission — so it deserves a conscious re-decision, not an auto-merge.
- **The audit's own recommended fix was incomplete — verified.** It proposed an absolute `spot <= max_pricing_spot` ceiling; that blocks the one stated scenario (`bs_spot=6e18`) but not the class — a tiny `bs_forward` collapses the forward at any spot magnitude (checked: `bs_forward=1, bs_spot=1e14` passes that ceiling and still re-anchors to 0). The basis floor is the complete fix.
- **`EZeroForward` is kept as a backstop.** After the floor it is only reachable via a sub-100 normalized pyth spot (absurd for a real asset). Kept, not removed; its now-marginal reachability is a Rule-4 follow-up, noted rather than resolved here.
- **Does not resolve the all-or-nothing pool-flush brick** (C-1 / DBU-557) — a degenerate feed on an active market is now rejected at the gate instead of aborting deeper, but either way that market can't be valued.
- **Provenance:** headline finding of the 2026-07-17 predict-audit security fan-out. The cross-model verify panel was codex-degraded (0 machine-confirmed), so the finding *and the fix* were verified against source in the main loop.

## Test plan
- [x] `sui move build --warnings-are-errors` clean; predict **428/428**
- [x] `surface_with_basis_below_min_aborts` pins the floor; **negative control**: it fails without the assert
- [x] `re_anchor_collapsing_surface_rejected_at_envelope` (was `re_anchored_zero_forward_aborts`): the degenerate re-anchor input is now rejected at the envelope, not deep at `EZeroForward`
- [x] `pnpm run format:move:check` (pinned prettier-move 0.4.0) clean

Closes DBU-596.
