### PR TITLE
predict: add enumerated per-underlying cadence config getter (DBU-495)

### DIFF
--- a/packages/predict/sources/registry/market_manager.move
+++ b/packages/predict/sources/registry/market_manager.move
@@ -155,6 +155,14 @@ public(package) fun cadence_config(
     *cadence
 }
 
+/// Return every stored deployment policy for one underlying, indexed by cadence ID.
+public(package) fun cadence_configs(
+    manager: &MarketManager,
+    propbook_underlying_id: u32,
+): vector<CadenceConfig> {
+    manager.underlying_config(propbook_underlying_id).cadences
+}
+
 /// Return the next expiry and snapshotted cadence terms for an underlying/cadence.
 ///
 /// The candidate is the greater of the next watermark slot and the first future

--- a/packages/predict/sources/registry/registry.move
+++ b/packages/predict/sources/registry/registry.move
@@ -67,6 +67,19 @@ public fun cadence_config(
     registry.market_manager.cadence_config(propbook_underlying_id, cadence_id)
 }
 
+/// Return one underlying's complete deployment policy as a single coherent
+/// snapshot, for off-chain consumers (SDK and devInspect cadence discovery by
+/// the keeper, price updater, and dashboard) that would otherwise need one
+/// read per cadence. The vector holds one entry per supported cadence, indexed
+/// by cadence ID; disabled cadences are present as their all-zero
+/// configuration. Aborts if the underlying is not registered.
+public fun cadence_configs(
+    registry: &Registry,
+    propbook_underlying_id: u32,
+): vector<CadenceConfig> {
+    registry.market_manager.cadence_configs(propbook_underlying_id)
+}
+
 // === PauseCap Lifecycle (admin) ===
 
 /// Mint a new `PauseCap`. This bypasses the version gate so emergency pause

--- a/packages/predict/tests/registry_create_tests.move
+++ b/packages/predict/tests/registry_create_tests.move
@@ -5,13 +5,21 @@
 module deepbook_predict::registry_create_tests;
 
 use deepbook_predict::{config_constants, market_manager, test_helpers};
+use std::unit_test::assert_eq;
 
 const UNDERLYING_BTC: u32 = 100;
+const UNDERLYING_ETH: u32 = 200;
 const BTC_TICK_SIZE: u64 = 1_000_000_000;
 const BTC_ADMISSION_TICK_SIZE: u64 = 10_000_000_000;
 const BTC_MAX_EXPIRY_ALLOCATION: u64 = 250_000_000_000;
 const BTC_INITIAL_EXPIRY_CASH: u64 = 50_000_000_000;
+const ETH_TICK_SIZE: u64 = 2_000_000_000;
+const ETH_ADMISSION_TICK_SIZE: u64 = 4_000_000_000;
+const ETH_MAX_EXPIRY_ALLOCATION: u64 = 500_000_000_000;
+const ETH_INITIAL_EXPIRY_CASH: u64 = 100_000_000_000;
 const WINDOW_SIZE_THREE: u64 = 3;
+const WINDOW_SIZE_TWO: u64 = 2;
+const SUPPORTED_CADENCE_COUNT: u64 = 6;
 const ABOVE_MAX_CADENCE_WINDOW_SIZE: u64 = 11;
 const DISABLED_VALUE: u64 = 0;
 const INVALID_CADENCE_ID: u8 = 6;
@@ -232,5 +240,174 @@ fun set_cadence_config_partial_disable_admission_tick_size_aborts() {
         BTC_INITIAL_EXPIRY_CASH,
         WINDOW_SIZE_THREE,
     );
+    abort EUnexpectedSuccess
+}
+
+// === cadence_configs ===
+
+fun assert_all_zero_disabled(cadence: &market_manager::CadenceConfig) {
+    assert!(!cadence.cadence_enabled());
+    assert_eq!(cadence.cadence_tick_size(), DISABLED_VALUE);
+    assert_eq!(cadence.cadence_admission_tick_size(), DISABLED_VALUE);
+    assert_eq!(cadence.cadence_max_expiry_allocation(), DISABLED_VALUE);
+    assert_eq!(cadence.cadence_initial_expiry_cash(), DISABLED_VALUE);
+    assert_eq!(cadence.cadence_window_size(), DISABLED_VALUE);
+}
+
+#[test]
+fun cadence_configs_initial_all_disabled() {
+    let (scenario, mut reg, config, admin_cap) = test_helpers::begin_registry_test();
+    reg.register_underlying(&config, &admin_cap, UNDERLYING_BTC);
+
+    let configs = reg.cadence_configs(UNDERLYING_BTC);
+    assert_eq!(configs.length(), SUPPORTED_CADENCE_COUNT);
+    configs.do_ref!(|cadence| assert_all_zero_disabled(cadence));
+
+    test_helpers::finish_registry_test(scenario, reg, config, admin_cap);
+}
+
+#[test]
+fun cadence_configs_non_sequential_updates_round_trip() {
+    let (scenario, mut reg, config, admin_cap) = test_helpers::begin_registry_test();
+    reg.register_underlying(&config, &admin_cap, UNDERLYING_BTC);
+
+    // Update one-week (ID 4) before five-minute (ID 1): entries must land by
+    // cadence ID, not by update order.
+    reg.set_template_cadence_config(
+        &config,
+        &admin_cap,
+        UNDERLYING_BTC,
+        market_manager::cadence_one_week!(),
+        ETH_TICK_SIZE,
+        ETH_ADMISSION_TICK_SIZE,
+        ETH_MAX_EXPIRY_ALLOCATION,
+        ETH_INITIAL_EXPIRY_CASH,
+        WINDOW_SIZE_TWO,
+    );
+    reg.set_template_cadence_config(
+        &config,
+        &admin_cap,
+        UNDERLYING_BTC,
+        market_manager::cadence_five_minute!(),
+        BTC_TICK_SIZE,
+        BTC_ADMISSION_TICK_SIZE,
+        BTC_MAX_EXPIRY_ALLOCATION,
+        BTC_INITIAL_EXPIRY_CASH,
+        WINDOW_SIZE_THREE,
+    );
+
+    let configs = reg.cadence_configs(UNDERLYING_BTC);
+    assert_eq!(configs.length(), SUPPORTED_CADENCE_COUNT);
+
+    let five_minute = &configs[market_manager::cadence_five_minute!() as u64];
+    assert!(five_minute.cadence_enabled());
+    assert_eq!(five_minute.cadence_tick_size(), BTC_TICK_SIZE);
+    assert_eq!(five_minute.cadence_admission_tick_size(), BTC_ADMISSION_TICK_SIZE);
+    assert_eq!(five_minute.cadence_max_expiry_allocation(), BTC_MAX_EXPIRY_ALLOCATION);
+    assert_eq!(five_minute.cadence_initial_expiry_cash(), BTC_INITIAL_EXPIRY_CASH);
+    assert_eq!(five_minute.cadence_window_size(), WINDOW_SIZE_THREE);
+
+    let one_week = &configs[market_manager::cadence_one_week!() as u64];
+    assert!(one_week.cadence_enabled());
+    assert_eq!(one_week.cadence_tick_size(), ETH_TICK_SIZE);
+    assert_eq!(one_week.cadence_admission_tick_size(), ETH_ADMISSION_TICK_SIZE);
+    assert_eq!(one_week.cadence_max_expiry_allocation(), ETH_MAX_EXPIRY_ALLOCATION);
+    assert_eq!(one_week.cadence_initial_expiry_cash(), ETH_INITIAL_EXPIRY_CASH);
+    assert_eq!(one_week.cadence_window_size(), WINDOW_SIZE_TWO);
+
+    assert_all_zero_disabled(&configs[market_manager::cadence_one_minute!() as u64]);
+    assert_all_zero_disabled(&configs[market_manager::cadence_one_hour!() as u64]);
+    assert_all_zero_disabled(&configs[market_manager::cadence_one_day!() as u64]);
+    assert_all_zero_disabled(&configs[market_manager::cadence_one_month!() as u64]);
+
+    test_helpers::finish_registry_test(scenario, reg, config, admin_cap);
+}
+
+#[test]
+fun cadence_configs_disable_round_trip() {
+    let (scenario, mut reg, config, admin_cap) = test_helpers::begin_registry_test();
+    reg.register_underlying(&config, &admin_cap, UNDERLYING_BTC);
+
+    reg.set_template_cadence_config(
+        &config,
+        &admin_cap,
+        UNDERLYING_BTC,
+        market_manager::cadence_five_minute!(),
+        BTC_TICK_SIZE,
+        BTC_ADMISSION_TICK_SIZE,
+        BTC_MAX_EXPIRY_ALLOCATION,
+        BTC_INITIAL_EXPIRY_CASH,
+        WINDOW_SIZE_THREE,
+    );
+    let enabled_configs = reg.cadence_configs(UNDERLYING_BTC);
+    assert!(enabled_configs[market_manager::cadence_five_minute!() as u64].cadence_enabled());
+    reg.set_template_cadence_config(
+        &config,
+        &admin_cap,
+        UNDERLYING_BTC,
+        market_manager::cadence_five_minute!(),
+        DISABLED_VALUE,
+        DISABLED_VALUE,
+        DISABLED_VALUE,
+        DISABLED_VALUE,
+        DISABLED_VALUE,
+    );
+
+    let configs = reg.cadence_configs(UNDERLYING_BTC);
+    assert_eq!(configs.length(), SUPPORTED_CADENCE_COUNT);
+    assert_all_zero_disabled(&configs[market_manager::cadence_five_minute!() as u64]);
+
+    test_helpers::finish_registry_test(scenario, reg, config, admin_cap);
+}
+
+#[test]
+fun cadence_configs_two_underlyings_isolated() {
+    let (scenario, mut reg, config, admin_cap) = test_helpers::begin_registry_test();
+    reg.register_underlying(&config, &admin_cap, UNDERLYING_BTC);
+    reg.register_underlying(&config, &admin_cap, UNDERLYING_ETH);
+
+    // Same cadence ID, different values per underlying: a cross-underlying mixup
+    // would surface as the wrong value set.
+    reg.set_template_cadence_config(
+        &config,
+        &admin_cap,
+        UNDERLYING_BTC,
+        market_manager::cadence_five_minute!(),
+        BTC_TICK_SIZE,
+        BTC_ADMISSION_TICK_SIZE,
+        BTC_MAX_EXPIRY_ALLOCATION,
+        BTC_INITIAL_EXPIRY_CASH,
+        WINDOW_SIZE_THREE,
+    );
+    reg.set_template_cadence_config(
+        &config,
+        &admin_cap,
+        UNDERLYING_ETH,
+        market_manager::cadence_five_minute!(),
+        ETH_TICK_SIZE,
+        ETH_ADMISSION_TICK_SIZE,
+        ETH_MAX_EXPIRY_ALLOCATION,
+        ETH_INITIAL_EXPIRY_CASH,
+        WINDOW_SIZE_TWO,
+    );
+
+    let btc_configs = reg.cadence_configs(UNDERLYING_BTC);
+    let btc_five_minute = &btc_configs[market_manager::cadence_five_minute!() as u64];
+    assert_eq!(btc_five_minute.cadence_tick_size(), BTC_TICK_SIZE);
+    assert_eq!(btc_five_minute.cadence_window_size(), WINDOW_SIZE_THREE);
+
+    let eth_configs = reg.cadence_configs(UNDERLYING_ETH);
+    let eth_five_minute = &eth_configs[market_manager::cadence_five_minute!() as u64];
+    assert_eq!(eth_five_minute.cadence_tick_size(), ETH_TICK_SIZE);
+    assert_eq!(eth_five_minute.cadence_window_size(), WINDOW_SIZE_TWO);
+
+    test_helpers::finish_registry_test(scenario, reg, config, admin_cap);
+}
+
+#[test, expected_failure(abort_code = market_manager::EUnderlyingNotRegistered)]
+fun cadence_configs_unregistered_underlying_aborts() {
+    let (_scenario, reg, config, admin_cap) = test_helpers::begin_registry_test();
+
+    let _configs = reg.cadence_configs(UNDERLYING_BTC);
     abort EUnexpectedSuccess
 }


### PR DESCRIPTION
## Summary
- Add `registry::cadence_configs(registry, propbook_underlying_id): vector<CadenceConfig>`, returning every supported cadence's stored deployment policy in one read — six entries indexed by cadence ID (0–5), with disabled cadences present as their all-zero configuration.
- Back it with a package-visible `market_manager::cadence_configs` that copies the per-underlying cadence vector.
- Tests cover the initial all-disabled vector, non-sequential updates landing by cadence ID, exact enabled and disabled field round-trips, two-underlying isolation, and the unregistered-underlying abort.

## Why
- The Predict registry stores each underlying's per-cadence deployment terms (tick sizes, allocation cap, initial cash, deployment window), and off-chain consumers — the market keeper, price updater, and operational dashboard — need the complete set to know which cadences run and on what terms.
- The only existing read is the scalar `cadence_config(underlying_id, cadence_id)`, so reading the full configuration takes six separate reads that can interleave with an admin update and yield a mixed snapshot; one getter returns the whole configuration coherently.

## Key decisions
- Vector index is the cadence ID and disabled cadences stay in place as all-zero entries, so the result is always exactly six entries and consumers need no ID-matching or sparse handling. Both properties hold structurally: registration seeds six disabled configs and the setter overwrites in place.
- The scalar getter, `CadenceConfig` field accessors, and `CadenceConfigUpdated` event are unchanged. Registered-underlying enumeration and off-chain consumer reconciliation are out of scope (the latter is DBU-550).

## Test plan
- [x] `sui move build --path packages/predict --warnings-are-errors` clean
- [x] `sui move test --gas-limit 100000000000` (predict): 438/438 pass, including the 5 new `cadence_configs` tests
- [x] `pnpm format:move` no-op on the touched files