### PR TITLE
margin_liquidation: bump Published.toml mainnet to v4

### DIFF
--- a/packages/margin_liquidation/Published.toml
+++ b/packages/margin_liquidation/Published.toml
@@ -4,9 +4,9 @@
 
 [published.mainnet]
 chain-id = "35834a8a"
-published-at = "0x91cee4bdfaf353e9f36e0292e0065407379d741b75c1ee5e0e3674ca0169bb99"
+published-at = "0xf17bff1bf21e9587acc5708714e520aa967f82f256f626938a33c4109b08adb9"
 original-id = "0x73c593882cdb557703e903603f20bd373261fe6ba6e1a40515f4b62f10553e6a"
-version = 3
+version = 4
 toolchain-version = "1.63.1"
 build-config = { flavor = "sui", edition = "2024" }
 upgrade-capability = "0xd1b0608d02814ad1e15ddf6d8bf50bc4b8f375cd99d36f523dadc50c93fff565"


### PR DESCRIPTION
## Summary
- Bump `packages/margin_liquidation/Published.toml` mainnet `published-at` `0x91cee4bd…0169bb99` → `0xf17bff1b…b08adb9` and `version` 3 → 4.
- `original-id` (`0x73c59388…`) and `upgrade-capability` (`0xd1b0608d…`) unchanged — same package lineage, owned upgrade cap.
- Testnet entry untouched (already current at v3, `0x8d69c3ef…`).

## Why
- The mainnet liquidation package was upgraded on-chain to v4, but the corresponding `Published.toml` commit was never landed, so the repo sat one version behind. Future upgrade builds and any tooling resolving from `Published.toml` were pointing at the stale v3 package.
- Surfaced while syncing `@mysten/deepbook-v3`, which already targets v4 (`0xf17bff1b…`, ts-sdks#1077); this realigns the repo with the live deployment and the SDK.

## Key decisions
- **Verified against the authoritative on-chain source, not inferred.** The package's `UpgradeCap` (`0xd1b0608d…`) reads `package = 0xf17bff1b…`, `version = 4` — so v4 is the current tip and there is no v5. `sui move summary` on both addresses corroborates: `0xf17bff1b…` is version 4, `0x91cee4bd…` is version 3, both in the `0x73c59388…` lineage.
- Manual `published-at` + `version` edit, matching the prior v2→v3 bump (#1021). No source, lockfile, or ID-kind change.

## Test plan
- [x] Diff is 2 lines (`published-at`, `version`), mainnet only; `original-id`/`upgrade-capability` preserved.
- [x] `Move.lock` contains no reference to the liquidation `published-at`, so no lockfile change is required (consistent with #1021).
- [x] On-chain `UpgradeCap` confirms `package = 0xf17bff1b…`, `version = 4` (current tip, no newer version).
- [x] No `.move` files touched — `format:move:check` unaffected.
