### PR TITLE
predict: skew quotes by the pool's directional inventory (DBU-627)

### DIFF
--- a/packages/predict/sources/config/config_constants.move
+++ b/packages/predict/sources/config/config_constants.move
@@ -31,6 +31,8 @@ const EInvalidMaxAdmissionLeverage: u64 = 20;
 const EInvalidCadenceWindowSize: u64 = 21;
 const EMarketTickSizeTooLarge: u64 = 22;
 const EInvalidNoLeverageWindowMs: u64 = 23;
+const EInvalidSkewCapitalFraction: u64 = 24;
+const EInvalidMaxSkewShift: u64 = 25;
 
 // === Fees ===
 
@@ -130,6 +132,51 @@ public(package) fun assert_no_leverage_window_ms(value: u64) {
         value >= min_no_leverage_window_ms!() && value <= max_no_leverage_window_ms!(),
         EInvalidNoLeverageWindowMs,
     );
+}
+
+/// Fraction of an expiry's own allocated capital at which the inventory skew
+/// reaches its full `max_skew_shift`.
+///
+/// The skew depth is derived, not configured in absolute size: an expiry funded
+/// with twice the capital absorbs twice the directional position before quoting
+/// at the same distance from fair. Half the expiry's allocation by default.
+public(package) macro fun default_skew_capital_fraction(): u64 { 500_000_000 }
+
+/// Nonzero: a zero fraction would make every nonzero position instantly
+/// saturate the skew. Disable the skew with `max_skew_shift = 0` instead.
+public(package) macro fun min_skew_capital_fraction(): u64 { 1 }
+
+/// The pool cannot take more one-sided directional risk on an expiry than that
+/// expiry's whole capital budget, so saturating past 100% of it is unreachable.
+public(package) macro fun max_skew_capital_fraction(): u64 {
+    fixed_math::math::float_scaling!()
+}
+
+public(package) fun assert_skew_capital_fraction(value: u64) {
+    assert!(
+        value >= min_skew_capital_fraction!() && value <= max_skew_capital_fraction!(),
+        EInvalidSkewCapitalFraction,
+    );
+}
+
+/// Largest probability the inventory skew may move a single strike's mid, at
+/// full depth and peak moneyness weight. `0` disables the skew entirely.
+///
+/// Ships disabled. Whether skewing on inventory improves LP outcomes under the
+/// current fee-only model is an open question, so markets quote at the fair mark
+/// until an admin snapshots a nonzero shift into a new expiry.
+public(package) macro fun default_max_skew_shift(): u64 { 0 }
+
+public(package) macro fun min_max_skew_shift(): u64 { 0 }
+
+/// The hard ceiling is what keeps the shifted mid inside `(0, 1)` without a
+/// clamp: the per-strike shift is `4·p·(1-p)·s`, so a mid stays positive while
+/// `4·(1-p)·s < 1`, which holds for every `p` once `s <= 0.05`. Raising this
+/// bound reintroduces the need for a saturating clamp in `skewed_up_price`.
+public(package) macro fun max_max_skew_shift(): u64 { 50_000_000 }
+
+public(package) fun assert_max_skew_shift(value: u64) {
+    assert!(value >= min_max_skew_shift!() && value <= max_max_skew_shift!(), EInvalidMaxSkewShift);
 }
 
 public(package) macro fun default_backing_buffer_lambda(): u64 { 250_000_000 }

--- a/packages/predict/sources/config/protocol_config.move
+++ b/packages/predict/sources/config/protocol_config.move
@@ -182,6 +182,28 @@ public fun set_template_max_entry_probability(
     config.strike_exposure_template_config.set_max_entry_probability(value);
 }
 
+/// Set the fraction of an expiry's allocated capital at which the inventory
+/// skew saturates, snapshotted by newly created expiry markets.
+public fun set_template_skew_capital_fraction(
+    config: &mut ProtocolConfig,
+    _admin_cap: &AdminCap,
+    value: u64,
+) {
+    config.assert_version();
+    config.strike_exposure_template_config.set_skew_capital_fraction(value);
+}
+
+/// Set the maximum inventory-skew mid shift snapshotted by newly created expiry
+/// markets. `0` snapshots the skew off.
+public fun set_template_max_skew_shift(
+    config: &mut ProtocolConfig,
+    _admin_cap: &AdminCap,
+    value: u64,
+) {
+    config.assert_version();
+    config.strike_exposure_template_config.set_max_skew_shift(value);
+}
+
 /// Select which source the live forward is built from: `true` carries the Block
 /// Scholes basis on a fresh Pyth spot, `false` uses the Block Scholes forward
 /// directly. Locked during valuation so one flush marks every market on one formula.

--- a/packages/predict/sources/config/strike_exposure_config.move
+++ b/packages/predict/sources/config/strike_exposure_config.move
@@ -10,7 +10,7 @@
 module deepbook_predict::strike_exposure_config;
 
 use deepbook_predict::{config_constants, constants};
-use fixed_math::math;
+use fixed_math::{i64::I64, math};
 
 const EOrderBelowLiquidationThreshold: u64 = 0;
 const EEntryProbabilityOutOfBounds: u64 = 1;
@@ -50,6 +50,14 @@ public struct StrikeExposureConfig has store {
     /// Window before expiry within which mint admission caps leverage at 1x, in ms.
     /// `0` disables the block.
     no_leverage_window_ms: u64,
+    /// Fraction of the expiry's own allocated capital at which the inventory
+    /// skew reaches `max_skew_shift`. The depth itself is derived per expiry
+    /// (`skew_depth_lots`), so a bigger market absorbs a proportionally bigger
+    /// position before quoting at the same distance from fair.
+    skew_capital_fraction: u64,
+    /// Largest probability the inventory skew may move one strike's mid, at full
+    /// depth and at the money. `0` disables the skew.
+    max_skew_shift: u64,
 }
 
 /// Mint admission outcome: the net premium charged for the order and the static
@@ -99,6 +107,82 @@ public(package) fun expiry_fee_max_multiplier(config: &StrikeExposureConfig): u6
 
 public(package) fun no_leverage_window_ms(config: &StrikeExposureConfig): u64 {
     config.no_leverage_window_ms
+}
+
+public(package) fun skew_capital_fraction(config: &StrikeExposureConfig): u64 {
+    config.skew_capital_fraction
+}
+
+public(package) fun max_skew_shift(config: &StrikeExposureConfig): u64 {
+    config.max_skew_shift
+}
+
+/// Net one-sided directional position, in position lots, at which the inventory
+/// skew saturates for an expiry funded with `allocated_capital`.
+///
+/// Derived rather than configured, so the skew self-scales: an expiry funded
+/// with twice the capital absorbs twice the position before quoting at the same
+/// distance from fair, and no operator has to hand-size a depth per market. The
+/// conversion to lots is exact — `allocated_capital` is DUSDC base units and one
+/// lot of a one-sided position is `position_lot_size` base units of max payout,
+/// which is what the pool actually has at risk against it.
+///
+/// Returns `0` when the expiry's share of the fraction is under one lot; callers
+/// treat that as fully saturated, since any position at all exceeds the depth.
+public(package) fun skew_depth_lots(config: &StrikeExposureConfig, allocated_capital: u64): u64 {
+    math::mul_down(config.skew_capital_fraction, allocated_capital)
+        / constants::position_lot_size!()
+}
+
+/// Return one strike boundary's UP probability skewed by the pool's directional
+/// inventory.
+///
+/// `fair_up_price` is the oracle's unskewed `P(settle > K)`. The shift is
+/// `4·p·(1-p) · max_skew_shift · min(1, |aggregate| / depth_lots)`, added when
+/// the aggregate is negative (the pool is net short UP, so UP must get dearer)
+/// and subtracted when it is positive. `depth_lots` comes from `skew_depth_lots`
+/// and is a fraction of the expiry's own allocated capital.
+///
+/// The moneyness factor `4·p·(1-p)` peaks at `1.0` at the money and vanishes in
+/// both tails. That makes the infinity sentinels inert for free — `P(-inf) = 1`
+/// and `P(+inf) = 0` both weight to zero — and keeps a deep out-of-the-money
+/// strike from being quoted far off a price the oracle says is nearly certain.
+///
+/// Applying the same function at every appearance of a boundary is what keeps
+/// the skew self-consistent: a set of ranges partitioning the whole line still
+/// costs exactly 1, because each interior boundary's shift appears once with
+/// each sign and cancels.
+///
+/// No saturating clamp: `config_constants::max_max_skew_shift` bounds the shift
+/// strictly below both `p` and `1 - p` for every `p`, so neither direction can
+/// leave `(0, 1)`.
+public(package) fun skewed_up_price(
+    config: &StrikeExposureConfig,
+    fair_up_price: u64,
+    directional_aggregate: &I64,
+    depth_lots: u64,
+): u64 {
+    if (config.max_skew_shift == 0 || directional_aggregate.is_zero()) return fair_up_price;
+
+    let float_scaling = math::float_scaling!();
+    // Checked, and `None` means saturated: a zero depth (allocation under one
+    // lot) or a ratio too large for `u64` both mean the position dwarfs the
+    // depth. Aborting there would brick the trade path on an under-funded expiry.
+    let depth_ratio = math::try_mul_div_down(
+        directional_aggregate.magnitude(),
+        float_scaling,
+        depth_lots,
+    )
+        .destroy_or!(float_scaling)
+        .min(float_scaling);
+    let moneyness = 4 * math::mul_down(fair_up_price, float_scaling - fair_up_price);
+    let shift = math::mul_down(math::mul_down(config.max_skew_shift, depth_ratio), moneyness);
+
+    if (directional_aggregate.is_negative()) {
+        fair_up_price + shift
+    } else {
+        fair_up_price - shift
+    }
 }
 
 /// Returns the raw trade fee for a live probability and quantity, rounded down so the trader keeps sub-unit dust.
@@ -196,6 +280,8 @@ public(package) fun new(): StrikeExposureConfig {
         expiry_fee_window_ms: config_constants::default_expiry_fee_window_ms!(),
         expiry_fee_max_multiplier: config_constants::default_expiry_fee_max_multiplier!(),
         no_leverage_window_ms: config_constants::default_no_leverage_window_ms!(),
+        skew_capital_fraction: config_constants::default_skew_capital_fraction!(),
+        max_skew_shift: config_constants::default_max_skew_shift!(),
     }
 }
 
@@ -212,6 +298,8 @@ public(package) fun snapshot(config: &StrikeExposureConfig): StrikeExposureConfi
         expiry_fee_window_ms: config.expiry_fee_window_ms,
         expiry_fee_max_multiplier: config.expiry_fee_max_multiplier,
         no_leverage_window_ms: config.no_leverage_window_ms,
+        skew_capital_fraction: config.skew_capital_fraction,
+        max_skew_shift: config.max_skew_shift,
     }
 }
 
@@ -265,6 +353,16 @@ public(package) fun set_expiry_fee_max_multiplier(config: &mut StrikeExposureCon
 public(package) fun set_no_leverage_window_ms(config: &mut StrikeExposureConfig, window_ms: u64) {
     config_constants::assert_no_leverage_window_ms(window_ms);
     config.no_leverage_window_ms = window_ms;
+}
+
+public(package) fun set_skew_capital_fraction(config: &mut StrikeExposureConfig, value: u64) {
+    config_constants::assert_skew_capital_fraction(value);
+    config.skew_capital_fraction = value;
+}
+
+public(package) fun set_max_skew_shift(config: &mut StrikeExposureConfig, value: u64) {
+    config_constants::assert_max_skew_shift(value);
+    config.max_skew_shift = value;
 }
 
 /// Return the 1e9-scaled per-unit trade fee.

--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -29,7 +29,7 @@ use deepbook_predict::{
     strike_exposure_config
 };
 use dusdc::dusdc::DUSDC;
-use fixed_math::math;
+use fixed_math::{i64::I64, math};
 use propbook::{
     block_scholes_forward_feed::BlockScholesForwardFeed,
     block_scholes_spot_feed::BlockScholesSpotFeed,
@@ -183,6 +183,14 @@ public fun tick_size(market: &ExpiryMarket): u64 {
 /// Return the admission-grid step for SDK and devInspect range construction.
 public fun admission_tick_size(market: &ExpiryMarket): u64 {
     market.strike_exposure.admission_tick_size()
+}
+
+/// Return the pool's net directional position against this expiry, in position
+/// lots, signed in UP-probability space: negative means the pool is net short
+/// UP, so UP quotes sit above the oracle's fair mark. Public for SDK and
+/// devInspect reads — this is the state that explains a quote sitting off fair.
+public fun directional_aggregate(market: &ExpiryMarket): I64 {
+    market.strike_exposure.directional_aggregate()
 }
 
 /// Return the admitted reference tick for SDK and devInspect range construction.
@@ -854,6 +862,7 @@ public(package) fun create_and_share(
     tick_size: u64,
     admission_tick_size: u64,
     reference_tick_source_timestamp_ms: u64,
+    allocated_capital: u64,
     ctx: &mut TxContext,
 ): ID {
     let id = object::new(ctx);
@@ -872,6 +881,7 @@ public(package) fun create_and_share(
             tick_size,
             admission_tick_size,
             reference_tick_source_timestamp_ms,
+            allocated_capital,
             strike_exposure_config,
             ctx,
         ),

--- a/packages/predict/sources/registry/registry.move
+++ b/packages/predict/sources/registry/registry.move
@@ -261,6 +261,7 @@ public fun create_and_share_expiry_market(
         tick_size,
         admission_tick_size,
         reference_tick_source_timestamp_ms,
+        max_expiry_allocation,
         ctx,
     );
     pool_vault.register_expiry(

--- a/packages/predict/sources/strike_exposure/strike_exposure.move
+++ b/packages/predict/sources/strike_exposure/strike_exposure.move
@@ -23,7 +23,7 @@ use deepbook_predict::{
     strike_exposure_config::StrikeExposureConfig,
     strike_payout_tree::{Self, StrikePayoutTree}
 };
-use fixed_math::math;
+use fixed_math::{i64::{Self, I64}, math};
 use sui::clock::Clock;
 
 const EInvalidCloseQuantity: u64 = 0;
@@ -59,6 +59,17 @@ public struct StrikeExposure has store {
     liquidation: LiquidationBook,
     /// Sparse payout tree for live cash backing and settled liability.
     payout: StrikePayoutTree,
+    /// Net directional position the pool holds against this expiry's traders, in
+    /// position lots, signed in UP-probability space: negative means the pool is
+    /// net short UP. Maintained by `directional_lots` at every book mutation and
+    /// read only by the trade-path quote — never by NAV, backing, or liquidation.
+    directional_aggregate: I64,
+    /// The pool capital budgeted to this expiry at creation (`max_expiry_allocation`),
+    /// in DUSDC base units. Sizes the inventory skew's saturation depth, so the
+    /// skew scales with the market rather than a hand-set constant. Snapshotted
+    /// and immutable: a depth that moved with LP flows would reprice open
+    /// interest with no trade occurring.
+    allocated_capital: u64,
 }
 
 /// Pure mint terms for one prospective live mint: the priced tick range,
@@ -268,6 +279,12 @@ public(package) fun reference_tick(exposure: &StrikeExposure): Option<u64> {
     exposure.reference_tick
 }
 
+/// Return the pool's net directional position against this expiry, in position
+/// lots. Negative means the pool is net short UP.
+public(package) fun directional_aggregate(exposure: &StrikeExposure): I64 {
+    exposure.directional_aggregate
+}
+
 /// Return the raw per-trade fee for a live price and quantity.
 ///
 /// Fee collection is expiry-market payment accounting; exposure only owns the
@@ -309,17 +326,23 @@ public(package) fun quote_mint_terms(
     leverage: u64,
     clock: &Clock,
 ): MintTerms {
-    let entry_probability = exposure.admitted_entry_probability(pricer, lower_tick, higher_tick);
+    exposure.assert_admitted_mint_ticks(lower_tick, higher_tick);
+    // Hoisted out of the sizing search: the fair boundary prices are the
+    // expensive part of a quote and do not vary with quantity. Only the skew
+    // does, and it is integer arithmetic over the probe's own inventory delta.
+    let fair_up_lower = exposure.fair_up_price(pricer, lower_tick);
+    let fair_up_higher = exposure.fair_up_price(pricer, higher_tick);
     let time_to_expiry_ms = exposure.expiry_ms - clock.timestamp_ms();
 
     let quantity = if (exact_quantity) {
         min_quantity
     } else {
-        // Validate policy before the search divides by leverage.
+        // Validate policy before the search divides by leverage. This reads the
+        // pre-trade price; mint admission below re-validates the post-trade one.
         exposure
             .config
             .assert_mint_probability_and_leverage_policy(
-                entry_probability,
+                exposure.skewed_range_price(fair_up_lower, fair_up_higher, &i64::zero()),
                 leverage,
                 time_to_expiry_ms,
             );
@@ -327,12 +350,24 @@ public(package) fun quote_mint_terms(
         // most one unit. The configured probability floor keeps that difference
         // below one lot, so sizing never exceeds the budget and may undershoot the
         // largest admissible quantity by at most one lot.
+        //
+        // Each probe prices against the inventory its own quantity would create,
+        // so budget mode cannot size against a flatter book than it trades on.
+        // The probe premium stays monotone in quantity — the search's
+        // precondition — because `max_max_skew_shift` keeps the per-lot price
+        // concession far below the per-lot premium at every probability.
         let lot = constants::position_lot_size!();
         let mut lo = 0;
         let mut hi = order::max_quantity_lots();
         while (lo < hi) {
             let mid = (lo + hi + 1) / 2;
-            if (math::mul_div_down(entry_probability, mid * lot, leverage) <= max_premium) {
+            let probe_quantity = mid * lot;
+            let probe_probability = exposure.skewed_range_price(
+                fair_up_lower,
+                fair_up_higher,
+                &directional_lots(lower_tick, higher_tick, probe_quantity),
+            );
+            if (math::mul_div_down(probe_probability, probe_quantity, leverage) <= max_premium) {
                 lo = mid
             } else {
                 hi = mid - 1
@@ -341,6 +376,12 @@ public(package) fun quote_mint_terms(
         lo * lot
     };
     assert!(quantity >= min_quantity, EMintQuantityBelowMin);
+
+    let entry_probability = exposure.skewed_range_price(
+        fair_up_lower,
+        fair_up_higher,
+        &directional_lots(lower_tick, higher_tick, quantity),
+    );
 
     let admission = exposure
         .config
@@ -385,6 +426,7 @@ public(package) fun allocate_mint_order(exposure: &mut StrikeExposure, terms: Mi
 
     exposure.liquidation.insert_order(&allocated_order);
     exposure.payout.insert_range(lower_tick, higher_tick, quantity, floor_shares);
+    exposure.apply_directional_delta(&directional_lots(lower_tick, higher_tick, quantity));
 
     allocated_order
 }
@@ -420,10 +462,19 @@ public(package) fun quote_close(
         return exposure.close_terms(order, CloseOutcome::Settled { payout })
     };
     assert!(pricer.is_some(), EPricerRequired);
-    // Price the range exactly once; the knock-out test and the live terms both
-    // read this one observation.
-    let range_probability = exposure.order_range_price(pricer.borrow(), order);
-    let gross_value = math::mul_down(range_probability, order.quantity());
+    let pricer = pricer.borrow();
+    let lower_tick = order.lower_tick();
+    let higher_tick = order.higher_tick();
+    let fair_up_lower = exposure.fair_up_price(pricer, lower_tick);
+    let fair_up_higher = exposure.fair_up_price(pricer, higher_tick);
+
+    // The knock-out test reads the FAIR mark, never the skewed one. A knock-out
+    // is a solvency event against the order's own floor, so the pool's inventory
+    // must not be able to push an order across its liquidation threshold.
+    let gross_value = math::mul_down(
+        fair_up_lower.saturating_sub(fair_up_higher),
+        order.quantity(),
+    );
     // Leveraged only: a 1x order has a zero floor, so the threshold test would
     // spuriously classify a currently-worthless 1x order as liquidatable.
     if (
@@ -431,6 +482,16 @@ public(package) fun quote_close(
     ) {
         return exposure.close_terms(order, CloseOutcome::Liquidatable { gross_value })
     };
+
+    // A close is a trade and pays the skew, priced against the inventory it
+    // leaves behind. Closing releases the position's own directional weight, so
+    // a close that flattens the book prices better than the fair mark.
+    let released = directional_lots(lower_tick, higher_tick, close_quantity).neg();
+    let range_probability = exposure.skewed_range_price(
+        fair_up_lower,
+        fair_up_higher,
+        &released,
+    );
     exposure.close_terms(
         order,
         CloseOutcome::Live(quote_live_close(order, close_quantity, range_probability)),
@@ -531,6 +592,7 @@ public(package) fun new(
     tick_size: u64,
     admission_tick_size: u64,
     reference_tick_source_timestamp_ms: u64,
+    allocated_capital: u64,
     config: StrikeExposureConfig,
     ctx: &mut TxContext,
 ): StrikeExposure {
@@ -547,22 +609,39 @@ public(package) fun new(
         settled_payout_liability: 0,
         liquidation: liquidation_book::new(ctx),
         payout: strike_payout_tree::new(ctx),
+        directional_aggregate: i64::zero(),
+        allocated_capital,
     }
 }
 
-/// Price the mint tick range `(lower_tick, higher_tick]` after admission-grid
-/// validation. The single pricing-prefix orchestration shared by every mint
-/// quote/terms path.
-fun admitted_entry_probability(
+/// The oracle's unskewed UP probability at one boundary tick.
+fun fair_up_price(exposure: &StrikeExposure, pricer: &Pricer, tick: u64): u64 {
+    pricer.up_price(range_codec::strike_from_tick(tick, exposure.tick_size))
+}
+
+/// Price `(lower, higher]` under the directional inventory the book would hold
+/// after `delta`, from boundary prices the caller already sampled. Passing
+/// `i64::zero()` prices the book as it stands.
+///
+/// Both boundaries are shifted by the same signed aggregate through one shared
+/// function, so every appearance of a boundary shifts identically and a set of
+/// ranges partitioning the line still costs exactly 1. Pricing against the
+/// post-trade delta is what makes the skew undodgeable by splitting or ordering:
+/// a trade is always quoted against the inventory it is about to create.
+fun skewed_range_price(
     exposure: &StrikeExposure,
-    pricer: &Pricer,
-    lower_tick: u64,
-    higher_tick: u64,
+    fair_up_lower: u64,
+    fair_up_higher: u64,
+    delta: &I64,
 ): u64 {
-    exposure.assert_admitted_mint_ticks(lower_tick, higher_tick);
-    let lower = range_codec::strike_from_tick(lower_tick, exposure.tick_size);
-    let higher = range_codec::strike_from_tick(higher_tick, exposure.tick_size);
-    pricer.range_price(lower, higher)
+    let aggregate = exposure.directional_aggregate.add(delta);
+    // Sampled once so both boundaries shift against the same depth.
+    let depth_lots = exposure.config.skew_depth_lots(exposure.allocated_capital);
+    let lower = exposure.config.skewed_up_price(fair_up_lower, &aggregate, depth_lots);
+    let higher = exposure.config.skewed_up_price(fair_up_higher, &aggregate, depth_lots);
+    // Mirror `pricing::range_price`: a fixed-point approximation can invert the
+    // boundary prices, and the range probability floors at zero.
+    lower.saturating_sub(higher)
 }
 
 fun assert_admitted_mint_ticks(exposure: &StrikeExposure, lower_tick: u64, higher_tick: u64) {
@@ -675,6 +754,7 @@ fun process_live_close(
             remove_floor_shares,
         );
     exposure.liquidation.remove_order(order);
+    exposure.release_directional_delta(order, close_quantity);
 
     // The survivor keeps exactly what the closed slice did not remove:
     // conservation by construction, with `order::replacement` re-validating
@@ -734,6 +814,7 @@ fun apply_liquidation(
             order.quantity(),
             order.floor_shares(),
         );
+    exposure.release_directional_delta(order, order.quantity());
 
     order_events::emit_order_liquidated(
         exposure.expiry_market_id,
@@ -760,4 +841,41 @@ fun order_range_price(exposure: &StrikeExposure, pricer: &Pricer, order: &Order)
         range_codec::strike_from_tick(order.lower_tick(), exposure.tick_size),
         range_codec::strike_from_tick(order.higher_tick(), exposure.tick_size),
     )
+}
+
+/// Return `quantity` of `order`'s range to the pool, undoing exactly the
+/// directional weight the mint of that slice added.
+fun release_directional_delta(exposure: &mut StrikeExposure, order: &Order, quantity: u64) {
+    let released = directional_lots(order.lower_tick(), order.higher_tick(), quantity).neg();
+    exposure.apply_directional_delta(&released);
+}
+
+fun apply_directional_delta(exposure: &mut StrikeExposure, delta: &I64) {
+    exposure.directional_aggregate = exposure.directional_aggregate.add(delta);
+}
+
+/// Net directional position, in position lots, that the pool takes on when a
+/// trader buys `quantity` of `(lower_tick, higher_tick]`.
+///
+/// The pool is short what the trader is long: short `P(lower)`, long `P(higher)`.
+/// Only finite boundaries carry directional risk, because `P(-inf) = 1` and
+/// `P(+inf) = 0` are constants — so a one-sided binary moves the aggregate by its
+/// full size, while a two-sided range is directionally flat and leaves it alone.
+///
+/// This is the single owned evaluator for the aggregate: mint, live close, and
+/// liquidation all route through it, so a removal subtracts bit-equal what the
+/// insert added. It reads only atoms that round-trip losslessly through the
+/// packed order id (the boundary ticks and a whole number of lots) and no oracle
+/// state whatsoever. That is deliberate and load-bearing: an aggregate weighted
+/// by the live surface — the shape this mechanism carried when it was first built
+/// and reverted — leaves a residual on every close whose surface has moved since
+/// the open, and the residual accumulates without bound. Moneyness weighting
+/// belongs at read time, in `strike_exposure_config::skewed_up_price`, where it
+/// is recomputed from the current mark and can never be stored stale.
+fun directional_lots(lower_tick: u64, higher_tick: u64, quantity: u64): I64 {
+    let lots = quantity / constants::position_lot_size!();
+    let long_leg = if (higher_tick == constants::pos_inf_tick!()) 0 else lots;
+    let short_leg = if (lower_tick == 0) 0 else lots;
+
+    i64::from_u64(long_leg).sub(&i64::from_u64(short_leg))
 }

--- a/packages/predict/tests/config/inventory_skew_tests.move
+++ b/packages/predict/tests/config/inventory_skew_tests.move
@@ -1,0 +1,268 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Unit coverage for `strike_exposure_config::skewed_up_price`, the read-time
+/// inventory skew applied to one strike boundary's UP probability.
+///
+/// Every expected value here is derived from the mechanism's specification, not
+/// from the implementation's expression: the shift is
+/// `max_skew_shift · min(1, |aggregate| / depth) · 4·p·(1-p)`, added when the
+/// pool is net short UP (negative aggregate) and subtracted when it is net long.
+/// Each constant below shows that arithmetic worked out by hand.
+///
+/// Setter-envelope coverage for `EInvalidSkewCapitalFraction` / `EInvalidMaxSkewShift`
+/// lives here too, driven through the package setters that the admin
+/// entrypoints delegate to.
+#[test_only]
+module deepbook_predict::inventory_skew_tests;
+
+use deepbook_predict::{config_constants, strike_exposure_config};
+use fixed_math::i64;
+use std::unit_test::{assert_eq, destroy};
+
+/// 2% — the shift a fully-loaded book applies at the money.
+const MAX_SHIFT_TWO_PERCENT: u64 = 20_000_000;
+/// Net one-sided position, in lots, at which the skew reaches its full shift.
+const DEPTH_LOTS: u64 = 1_000_000;
+const HALF_DEPTH_LOTS: u64 = 500_000;
+/// Ten times the depth, to exercise the saturation clamp on the depth ratio.
+const TEN_TIMES_DEPTH_LOTS: u64 = 10_000_000;
+
+/// 50%, in FLOAT_SCALING: the shipped default share of an expiry's capital.
+const HALF_OF_CAPITAL: u64 = 500_000_000;
+/// The test-fixture per-expiry allocation, in DUSDC base units.
+const EXPIRY_ALLOCATION: u64 = 250_000_000_000;
+/// 50% of 250_000e6 = 125_000e6 base units, over the 10_000-unit lot size.
+const HALF_ALLOCATION_DEPTH_LOTS: u64 = 12_500_000;
+/// An allocation whose half is under one lot (10_000 base units).
+const DUST_ALLOCATION: u64 = 10_000;
+
+/// p = 0.50 — at the money, where the moneyness weight `4·p·(1-p)` is exactly 1.
+const P_AT_THE_MONEY: u64 = 500_000_000;
+/// p = 0.25 — moneyness weight `4 · 0.25 · 0.75 = 0.75`.
+const P_QUARTER: u64 = 250_000_000;
+/// p = 0.01 — moneyness weight `4 · 0.01 · 0.99 = 0.0396`.
+const P_ONE_PERCENT: u64 = 10_000_000;
+/// p = 0.99 — moneyness weight `4 · 0.99 · 0.01 = 0.0396`, the mirror of the above.
+const P_NINETY_NINE_PERCENT: u64 = 990_000_000;
+/// `P(-inf) = 1`: the certain end of the range, where the skew must be inert.
+const P_NEGATIVE_INFINITY_SENTINEL: u64 = 1_000_000_000;
+/// `P(+inf) = 0`: the impossible end of the range, likewise inert.
+const P_POSITIVE_INFINITY_SENTINEL: u64 = 0;
+
+/// 0.50 + (0.02 · 1 · 1) = 0.52. Pool is short UP, so UP gets dearer.
+const ATM_FULL_SHORT: u64 = 520_000_000;
+/// 0.50 - (0.02 · 1 · 1) = 0.48. Pool is long UP, so UP gets cheaper.
+const ATM_FULL_LONG: u64 = 480_000_000;
+/// 0.50 + (0.02 · 0.5 · 1) = 0.51.
+const ATM_HALF_DEPTH_SHORT: u64 = 510_000_000;
+/// 0.25 + (0.02 · 1 · 0.75) = 0.25 + 0.015 = 0.265.
+const QUARTER_FULL_SHORT: u64 = 265_000_000;
+/// 0.01 - (0.05 · 1 · 0.0396) = 0.01 - 0.00198 = 0.00802. Still strictly above 0.
+const ONE_PERCENT_FULL_LONG_AT_CEILING: u64 = 8_020_000;
+/// 0.99 + (0.05 · 1 · 0.0396) = 0.99 + 0.00198 = 0.99198. Still strictly below 1.
+const NINETY_NINE_PERCENT_FULL_SHORT_AT_CEILING: u64 = 991_980_000;
+
+/// A config with the skew enabled at 2% over a 1,000,000-lot depth.
+fun skewed_config(): strike_exposure_config::StrikeExposureConfig {
+    let mut config = strike_exposure_config::new();
+    config.set_max_skew_shift(MAX_SHIFT_TWO_PERCENT);
+    config.set_skew_capital_fraction(HALF_OF_CAPITAL);
+    config
+}
+
+/// A config at the hard ceiling of the shift envelope, for the no-clamp tests.
+fun ceiling_config(): strike_exposure_config::StrikeExposureConfig {
+    let mut config = strike_exposure_config::new();
+    config.set_max_skew_shift(config_constants::max_max_skew_shift!());
+    config.set_skew_capital_fraction(HALF_OF_CAPITAL);
+    config
+}
+
+/// The pool is net SHORT UP by `lots` (traders bought UP): aggregate negative.
+fun short_up(lots: u64): i64::I64 {
+    i64::from_parts(lots, true)
+}
+
+/// The pool is net LONG UP by `lots`: aggregate positive.
+fun long_up(lots: u64): i64::I64 {
+    i64::from_u64(lots)
+}
+
+#[test]
+fun at_the_money_short_inventory_adds_the_full_shift() {
+    let config = skewed_config();
+    assert_eq!(
+        config.skewed_up_price(P_AT_THE_MONEY, &short_up(DEPTH_LOTS), DEPTH_LOTS),
+        ATM_FULL_SHORT,
+    );
+    destroy(config);
+}
+
+#[test]
+fun at_the_money_long_inventory_subtracts_the_full_shift() {
+    let config = skewed_config();
+    assert_eq!(
+        config.skewed_up_price(P_AT_THE_MONEY, &long_up(DEPTH_LOTS), DEPTH_LOTS),
+        ATM_FULL_LONG,
+    );
+    destroy(config);
+}
+
+/// The shift is linear in inventory up to the depth.
+#[test]
+fun half_depth_moves_half_the_shift() {
+    let config = skewed_config();
+    assert_eq!(
+        config.skewed_up_price(P_AT_THE_MONEY, &short_up(HALF_DEPTH_LOTS), DEPTH_LOTS),
+        ATM_HALF_DEPTH_SHORT,
+    );
+    destroy(config);
+}
+
+/// Off the money the moneyness weight scales the shift down: a strike the oracle
+/// prices at 0.25 moves by 0.75 of what an at-the-money strike moves.
+#[test]
+fun moneyness_weight_scales_the_shift_off_the_money() {
+    let config = skewed_config();
+    assert_eq!(
+        config.skewed_up_price(P_QUARTER, &short_up(DEPTH_LOTS), DEPTH_LOTS),
+        QUARTER_FULL_SHORT,
+    );
+    destroy(config);
+}
+
+/// Inventory past the depth saturates: the shift never exceeds `max_skew_shift`.
+#[test]
+fun inventory_beyond_depth_saturates_at_the_configured_shift() {
+    let config = skewed_config();
+    assert_eq!(
+        config.skewed_up_price(P_AT_THE_MONEY, &short_up(TEN_TIMES_DEPTH_LOTS), DEPTH_LOTS),
+        ATM_FULL_SHORT,
+    );
+    destroy(config);
+}
+
+/// `P(-inf) = 1` is a constant, not a directional price. The moneyness weight
+/// takes it to zero, so a one-sided range's infinity boundary never shifts —
+/// this is what keeps `(-inf, K]` and `(K, +inf]` complementary under skew.
+#[test]
+fun negative_infinity_sentinel_is_inert() {
+    let config = skewed_config();
+    assert_eq!(
+        config.skewed_up_price(P_NEGATIVE_INFINITY_SENTINEL, &short_up(DEPTH_LOTS), DEPTH_LOTS),
+        P_NEGATIVE_INFINITY_SENTINEL,
+    );
+    destroy(config);
+}
+
+#[test]
+fun positive_infinity_sentinel_is_inert() {
+    let config = skewed_config();
+    assert_eq!(
+        config.skewed_up_price(P_POSITIVE_INFINITY_SENTINEL, &short_up(DEPTH_LOTS), DEPTH_LOTS),
+        P_POSITIVE_INFINITY_SENTINEL,
+    );
+    destroy(config);
+}
+
+/// A flat book quotes the oracle's mark untouched.
+#[test]
+fun zero_inventory_quotes_the_fair_mark() {
+    let config = skewed_config();
+    assert_eq!(config.skewed_up_price(P_AT_THE_MONEY, &i64::zero(), DEPTH_LOTS), P_AT_THE_MONEY);
+    destroy(config);
+}
+
+/// The shipped default: markets quote fair until an admin snapshots a shift in.
+#[test]
+fun default_config_leaves_every_quote_at_the_fair_mark() {
+    let config = strike_exposure_config::new();
+    assert_eq!(config.max_skew_shift(), 0);
+    assert_eq!(
+        config.skewed_up_price(P_AT_THE_MONEY, &short_up(DEPTH_LOTS), DEPTH_LOTS),
+        P_AT_THE_MONEY,
+    );
+    destroy(config);
+}
+
+// === Capital-derived depth ===
+
+/// The depth is a fraction of the expiry's own allocated capital, converted to
+/// lots: 50% of 250_000e6 base units is 125_000e6, which is 12.5M lots at the
+/// 10_000-unit lot size.
+#[test]
+fun depth_is_a_fraction_of_the_expiry_allocation() {
+    let mut config = strike_exposure_config::new();
+    config.set_skew_capital_fraction(HALF_OF_CAPITAL);
+    assert_eq!(config.skew_depth_lots(EXPIRY_ALLOCATION), HALF_ALLOCATION_DEPTH_LOTS);
+    destroy(config);
+}
+
+/// Twice the capital absorbs twice the position before quoting at the same
+/// distance from fair — the property that makes the skew self-scaling, and the
+/// reason the depth is derived rather than hand-set per market.
+#[test]
+fun depth_scales_linearly_with_allocated_capital() {
+    let mut config = strike_exposure_config::new();
+    config.set_skew_capital_fraction(HALF_OF_CAPITAL);
+    assert_eq!(config.skew_depth_lots(2 * EXPIRY_ALLOCATION), 2 * HALF_ALLOCATION_DEPTH_LOTS);
+    destroy(config);
+}
+
+/// An expiry whose share of the fraction is under one lot yields depth zero. The
+/// quote must saturate rather than divide by zero: a trade on an under-funded
+/// expiry still has to price, and an abort here would brick its trade path.
+#[test]
+fun sub_lot_depth_saturates_instead_of_aborting() {
+    let mut config = skewed_config();
+    assert_eq!(config.skew_depth_lots(DUST_ALLOCATION), 0);
+    assert_eq!(config.skewed_up_price(P_AT_THE_MONEY, &short_up(1), 0), ATM_FULL_SHORT);
+    destroy(config);
+}
+
+/// At the hard ceiling of the shift envelope, a deep out-of-the-money strike
+/// under maximum opposing inventory still prices strictly above zero. This is
+/// the property that lets `skewed_up_price` omit a saturating clamp; raising
+/// `max_max_skew_shift` breaks it.
+#[test]
+fun ceiling_shift_stays_above_zero_at_the_low_tail() {
+    let config = ceiling_config();
+    assert_eq!(
+        config.skewed_up_price(P_ONE_PERCENT, &long_up(DEPTH_LOTS), DEPTH_LOTS),
+        ONE_PERCENT_FULL_LONG_AT_CEILING,
+    );
+    destroy(config);
+}
+
+/// The mirror bound: a near-certain strike stays strictly below 1.
+#[test]
+fun ceiling_shift_stays_below_one_at_the_high_tail() {
+    let config = ceiling_config();
+    assert_eq!(
+        config.skewed_up_price(P_NINETY_NINE_PERCENT, &short_up(DEPTH_LOTS), DEPTH_LOTS),
+        NINETY_NINE_PERCENT_FULL_SHORT_AT_CEILING,
+    );
+    destroy(config);
+}
+
+#[test, expected_failure(abort_code = config_constants::EInvalidMaxSkewShift)]
+fun max_skew_shift_above_ceiling_aborts() {
+    let mut config = strike_exposure_config::new();
+    config.set_max_skew_shift(config_constants::max_max_skew_shift!() + 1);
+    abort 1337
+}
+
+#[test, expected_failure(abort_code = config_constants::EInvalidSkewCapitalFraction)]
+fun zero_skew_capital_fraction_aborts() {
+    let mut config = strike_exposure_config::new();
+    config.set_skew_capital_fraction(0);
+    abort 1337
+}
+
+#[test, expected_failure(abort_code = config_constants::EInvalidSkewCapitalFraction)]
+fun skew_capital_fraction_above_one_aborts() {
+    let mut config = strike_exposure_config::new();
+    config.set_skew_capital_fraction(config_constants::max_skew_capital_fraction!() + 1);
+    abort 1337
+}

--- a/packages/predict/tests/flows/inventory_skew_flow_tests.move
+++ b/packages/predict/tests/flows/inventory_skew_flow_tests.move
@@ -1,0 +1,231 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Flow coverage for the inventory skew: the properties that make it safe to
+/// quote off the oracle's fair mark, driven through the production mint and
+/// redeem entrypoints.
+///
+/// Covered here: the aggregate's exact round trip (the drift property that sank
+/// the first build of this mechanism), post-trade and path-independent pricing,
+/// the no-free-money bound on a complete partition, and directional flatness of
+/// two-sided ranges. The shift arithmetic itself is unit-tested in
+/// `config/inventory_skew_tests`.
+#[test_only]
+module deepbook_predict::inventory_skew_flow_tests;
+
+use deepbook_predict::{constants, flow_test_helpers as helpers, test_constants};
+use fixed_math::math::float_scaling as float;
+use std::unit_test::assert_eq;
+
+/// 2% shift at full depth.
+const MAX_SHIFT_TWO_PERCENT: u64 = 20_000_000;
+/// Fraction of the expiry's allocated capital at which the skew saturates.
+/// Against the fixture's 250_000e6 allocation this is 2_000e6 base units, or
+/// 200_000 lots — so one `MINT_QUANTITY` is exactly half the depth and moves
+/// the skew by half its maximum, well clear of integer rounding.
+const SKEW_CAPITAL_FRACTION: u64 = 8_000_000;
+
+/// 1e9 base units at the 10_000-unit lot size = 100_000 lots. Above the
+/// `min_net_premium` floor at the ~0.5 probability these ranges price at.
+const MINT_QUANTITY: u64 = 1_000_000_000;
+const MINT_LOTS: u64 = 100_000;
+const HALF_MINT_QUANTITY: u64 = 500_000_000;
+const HALF_MINT_LOTS: u64 = 50_000;
+
+/// Finite mint boundaries must sit on the coarse admission grid, which is
+/// `default_admission_tick_size / default_tick_size = 10` fine ticks apart.
+const ADMISSION_TICK_MULTIPLE: u64 = 10;
+
+fun one_x(): u64 { test_constants::leverage_one_x() }
+
+/// The default strike, at roughly the money for the default live price.
+fun strike(): u64 { helpers::strike_tick() }
+
+/// Stand up a live market with the skew snapshotted in, ready for the trader to
+/// transact against.
+fun setup(): (helpers::Fixture, helpers::MarketBundle, helpers::AccountBundle) {
+    let (mut fx, expiry_id, trader) = helpers::setup_everything_with_skew(
+        MAX_SHIFT_TWO_PERCENT,
+        SKEW_CAPITAL_FRACTION,
+    );
+    fx.scenario_mut().next_tx(test_constants::alice());
+    let market = fx.take_market_bundle(expiry_id);
+    let account = fx.take_account_bundle(&trader);
+    (fx, market, account)
+}
+
+fun cleanup(fx: helpers::Fixture, market: helpers::MarketBundle, account: helpers::AccountBundle) {
+    helpers::return_account_bundle(account);
+    helpers::return_market_bundle(market);
+    fx.finish();
+}
+
+/// Quote a `(K, +inf]` UP binary of `quantity` without touching the book.
+fun quote_up(fx: &mut helpers::Fixture, market: &helpers::MarketBundle, quantity: u64): u64 {
+    fx
+        .quote_mint_bundle(market, strike(), constants::pos_inf_tick!(), quantity, one_x())
+        .entry_probability()
+}
+
+/// Quote the complementary `(-inf, K]` DOWN binary of `quantity`.
+fun quote_down(fx: &mut helpers::Fixture, market: &helpers::MarketBundle, quantity: u64): u64 {
+    fx
+        .quote_mint_bundle(market, constants::neg_inf!(), strike(), quantity, one_x())
+        .entry_probability()
+}
+
+fun mint_up(
+    fx: &mut helpers::Fixture,
+    market: &mut helpers::MarketBundle,
+    account: &mut helpers::AccountBundle,
+    quantity: u64,
+): u256 {
+    fx.mint_bundle(market, account, strike(), constants::pos_inf_tick!(), quantity, one_x())
+}
+
+/// Buying `(K, +inf]` makes the pool net SHORT UP: the aggregate goes negative
+/// by exactly the traded lots, and returns to exactly zero when the position
+/// closes — including across two partial closes, which exercise the survivor
+/// reinsertion path rather than one symmetric removal.
+#[test]
+fun up_binary_mint_moves_aggregate_by_its_lots_and_close_returns_it_to_zero() {
+    let (mut fx, mut market, mut account) = setup();
+
+    assert!(helpers::market(&market).directional_aggregate().is_zero());
+
+    let order_id = mint_up(&mut fx, &mut market, &mut account, MINT_QUANTITY);
+    let after_mint = helpers::market(&market).directional_aggregate();
+    assert!(after_mint.is_negative());
+    assert_eq!(after_mint.magnitude(), MINT_LOTS);
+
+    // A position cannot be minted and closed in the same millisecond.
+    fx.set_clock_for_testing(test_constants::now_ms() + 1);
+    let (_, replacement) = fx.redeem_bundle(
+        &mut market,
+        &mut account,
+        order_id,
+        HALF_MINT_QUANTITY,
+    );
+    let mid_close = helpers::market(&market).directional_aggregate();
+    assert!(mid_close.is_negative());
+    assert_eq!(mid_close.magnitude(), HALF_MINT_LOTS);
+
+    fx.redeem_bundle(&mut market, &mut account, replacement.destroy_some(), HALF_MINT_QUANTITY);
+    // Exactly zero, not approximately: the aggregate reads only atoms that
+    // round-trip through the packed order id, so no oracle-surface movement
+    // between open and close can leave a residual behind.
+    assert!(helpers::market(&market).directional_aggregate().is_zero());
+
+    cleanup(fx, market, account);
+}
+
+/// The mirror: buying `(-inf, K]` makes the pool net LONG UP.
+#[test]
+fun down_binary_mint_moves_the_aggregate_the_other_way() {
+    let (mut fx, mut market, mut account) = setup();
+
+    fx.mint_bundle(
+        &mut market,
+        &mut account,
+        constants::neg_inf!(),
+        strike(),
+        MINT_QUANTITY,
+        one_x(),
+    );
+
+    let aggregate = helpers::market(&market).directional_aggregate();
+    assert!(!aggregate.is_negative());
+    assert_eq!(aggregate.magnitude(), MINT_LOTS);
+
+    cleanup(fx, market, account);
+}
+
+/// A two-sided range carries no net directional exposure — the pool is short one
+/// boundary and long the other — so it leaves the aggregate untouched.
+#[test]
+fun two_sided_range_is_directionally_flat() {
+    let (mut fx, mut market, mut account) = setup();
+
+    fx.mint_bundle(
+        &mut market,
+        &mut account,
+        strike() - ADMISSION_TICK_MULTIPLE,
+        strike(),
+        MINT_QUANTITY,
+        one_x(),
+    );
+
+    assert!(helpers::market(&market).directional_aggregate().is_zero());
+
+    cleanup(fx, market, account);
+}
+
+/// A trade is quoted against the inventory it is about to create, so a bigger
+/// order prices worse than a smaller one on the same book, and the same size
+/// prices worse once the book is already leaning that way.
+///
+/// The equality is the sharp part: a quote depends only on the inventory the
+/// trade leaves behind, never on the path taken to it. Buying 2x at once and
+/// buying 1x after another 1x already landed both quote against the same
+/// aggregate, so they quote identically — which is what makes the skew
+/// independent of how a trader sequences their orders.
+#[test]
+fun quotes_worsen_with_size_and_depend_only_on_resulting_inventory() {
+    let (mut fx, mut market, mut account) = setup();
+
+    let single_on_flat_book = quote_up(&mut fx, &market, MINT_QUANTITY);
+    let double_on_flat_book = quote_up(&mut fx, &market, 2 * MINT_QUANTITY);
+    assert!(double_on_flat_book > single_on_flat_book);
+
+    mint_up(&mut fx, &mut market, &mut account, MINT_QUANTITY);
+    let single_after_the_first = quote_up(&mut fx, &market, MINT_QUANTITY);
+    assert!(single_after_the_first > single_on_flat_book);
+    assert_eq!(double_on_flat_book, single_after_the_first);
+
+    cleanup(fx, market, account);
+}
+
+/// Buying a complete partition of the line — `(-inf, K]` plus `(K, +inf]` —
+/// pays out exactly 1 per unit whatever settles, so it must never cost less
+/// than 1. Under the skew each leg is quoted against its own impact, which
+/// pushes both legs UP, so the pair costs strictly more than its payout. There
+/// is no inventory state that turns the pair into free money: the leg that would
+/// be discounted is exactly the leg whose own impact moves it back toward fair.
+#[test]
+fun complete_partition_never_costs_less_than_its_payout() {
+    let (mut fx, mut market, mut account) = setup();
+
+    let up_leg = quote_up(&mut fx, &market, MINT_QUANTITY);
+    let down_leg = quote_down(&mut fx, &market, MINT_QUANTITY);
+    assert!(up_leg + down_leg > float!());
+
+    // Now lean the book hard one way and re-check.
+    mint_up(&mut fx, &mut market, &mut account, 2 * MINT_QUANTITY);
+    let skewed_up_leg = quote_up(&mut fx, &market, MINT_QUANTITY);
+    let skewed_down_leg = quote_down(&mut fx, &market, MINT_QUANTITY);
+    assert!(skewed_up_leg + skewed_down_leg > float!());
+
+    cleanup(fx, market, account);
+}
+
+/// With the skew off — the shipped default — every quote is the fair mark, so
+/// the partition sums to exactly its payout and the aggregate never moves.
+#[test]
+fun disabled_skew_quotes_the_fair_mark_and_the_partition_sums_to_one() {
+    let (mut fx, expiry_id, trader) = helpers::setup_everything();
+    fx.scenario_mut().next_tx(test_constants::alice());
+    let mut market = fx.take_market_bundle(expiry_id);
+    let mut account = fx.take_account_bundle(&trader);
+
+    let up_leg = quote_up(&mut fx, &market, MINT_QUANTITY);
+    let down_leg = quote_down(&mut fx, &market, MINT_QUANTITY);
+    assert_eq!(up_leg + down_leg, float!());
+
+    // The aggregate is still maintained while the skew is off; it simply has no
+    // effect on price, so re-enabling on a future expiry needs no migration.
+    mint_up(&mut fx, &mut market, &mut account, MINT_QUANTITY);
+    assert_eq!(helpers::market(&market).directional_aggregate().magnitude(), MINT_LOTS);
+    assert_eq!(quote_up(&mut fx, &market, MINT_QUANTITY), up_leg);
+
+    cleanup(fx, market, account);
+}

--- a/packages/predict/tests/helper/flow_test_helpers.move
+++ b/packages/predict/tests/helper/flow_test_helpers.move
@@ -292,6 +292,25 @@ public fun setup_everything(): (Fixture, ID, Trader) {
     )
 }
 
+/// `setup_everything` with the inventory skew snapshotted into the expiry. The
+/// skew ships disabled and the per-expiry snapshot has no live setter, so the
+/// template must be set before the market is created.
+public fun setup_everything_with_skew(
+    max_shift: u64,
+    capital_fraction: u64,
+): (Fixture, ID, Trader) {
+    let mut fx = setup_market_default();
+    fx.set_template_inventory_skew(max_shift, capital_fraction);
+    let expiry_id = fx.create_expiry(test_constants::default_expiry_ms());
+    let trader = fx.create_funded_manager(test_constants::default_manager_deposit());
+    let mut market = fx.take_market_bundle(expiry_id);
+    fx.prepare_live_oracle_bundle(&mut market, test_constants::default_live_price());
+    fx.seed_market_cash(&mut market.market, test_constants::default_seeded_expiry_cash());
+    return_market_bundle(market);
+    fx.scenario.next_tx(test_constants::admin());
+    (fx, expiry_id, trader)
+}
+
 fun setup_funded_live_market(expiry_ms: u64, live_price: u64, deposit: u64): (Fixture, ID, Trader) {
     let mut fx = setup_market_default();
     let expiry_id = fx.create_expiry(expiry_ms);
@@ -453,6 +472,18 @@ public fun set_template_max_admission_leverage(self: &mut Fixture, value: u64) {
     self.scenario.next_tx(test_constants::admin());
     let mut config = self.scenario.take_shared<ProtocolConfig>();
     config.set_template_max_admission_leverage(&self.admin_cap, value);
+    return_shared(config);
+    self.scenario.next_tx(test_constants::admin());
+}
+
+/// Enable the inventory skew for expiries created after this call. The skew
+/// ships disabled, and the per-expiry snapshot has no live setter, so this must
+/// run before `create_expiry`.
+public fun set_template_inventory_skew(self: &mut Fixture, max_shift: u64, capital_fraction: u64) {
+    self.scenario.next_tx(test_constants::admin());
+    let mut config = self.scenario.take_shared<ProtocolConfig>();
+    config.set_template_max_skew_shift(&self.admin_cap, max_shift);
+    config.set_template_skew_capital_fraction(&self.admin_cap, capital_fraction);
     return_shared(config);
     self.scenario.next_tx(test_constants::admin());
 }

--- a/packages/predict/tests/reference_tick_tests.move
+++ b/packages/predict/tests/reference_tick_tests.move
@@ -277,6 +277,7 @@ fun create_and_share_exposure_harness(fx: &mut OracleFixture): ID {
         test_constants::default_tick_size(),
         test_constants::default_admission_tick_size(),
         fx.expiry() - test_constants::default_cadence_period_ms(),
+        test_constants::default_max_expiry_allocation(),
         strike_exposure_config::new(),
         fx.scenario_mut().ctx(),
     );

--- a/packages/predict/tests/strike_exposure/close_terms_boundary_tests.move
+++ b/packages/predict/tests/strike_exposure/close_terms_boundary_tests.move
@@ -171,6 +171,7 @@ fun create_and_share_exposure_harness(
         test_constants::default_tick_size(),
         test_constants::default_tick_size(),
         expiry_ms - test_constants::default_cadence_period_ms(),
+        test_constants::default_max_expiry_allocation(),
         config,
         fx.scenario_mut().ctx(),
     );

--- a/packages/predict/tests/strike_exposure/liquidated_settled_redeem_tests.move
+++ b/packages/predict/tests/strike_exposure/liquidated_settled_redeem_tests.move
@@ -142,6 +142,7 @@ fun create_and_share_exposure_harness(fx: &mut OracleFixture): ID {
         test_constants::default_tick_size(),
         test_constants::default_tick_size(),
         expiry_ms - test_constants::default_cadence_period_ms(),
+        test_constants::default_max_expiry_allocation(),
         config,
         fx.scenario_mut().ctx(),
     );

--- a/packages/predict/tests/strike_exposure/mint_terms_binding_tests.move
+++ b/packages/predict/tests/strike_exposure/mint_terms_binding_tests.move
@@ -72,6 +72,7 @@ fun create_and_share_exposure_harness(
         test_constants::default_tick_size(),
         test_constants::default_tick_size(),
         expiry_ms - test_constants::default_cadence_period_ms(),
+        test_constants::default_max_expiry_allocation(),
         strike_exposure_config::new(),
         fx.scenario_mut().ctx(),
     );


### PR DESCRIPTION
## Summary

- Skews each strike boundary's UP probability by the pool's own net directional position, so a trade that increases the pool's exposure prices worse and one that reduces it prices better. Both boundaries shift through one shared function, so a set of ranges partitioning the line stays self-consistent.
- Quotes are **post-trade**: a trade is priced against the inventory it is about to create, including inside the budget-sizing search. A quote depends only on the inventory the trade leaves behind, never the path taken to it.
- The stored aggregate is exact signed position lots, maintained by one owned evaluator at mint, live close, and liquidation.
- Two new admin-tunable knobs snapshotted per expiry (`skew_depth_lots`, `max_skew_shift`) with `set_template_*` entrypoints. **Ships disabled** (`max_skew_shift = 0`).

## Why

Predict quotes every trade at the oracle's fair mark — `entry_probability` comes straight from the pricer and the LP's only edge is the trading fee. The pool therefore accumulates directional inventory at no price, and nothing in the quote makes risk-adding flow more expensive or rewards flow that brings the book back toward neutral.

## Linear / Context

- DBU-627
- Prior art: #995 (merged, then reverted) and #999 (closed unmerged) built this against the pre-rework contracts. No code was portable — `predict.move`, `oracle.move`, `vault/vault.move`, and `helper/strike_matrix.move` were all deleted in the rework, and there is no spread on main to shift a mid inside of — so the mechanism is re-derived here.
- `packages/predict/docs/design/decisions.md` records "No inventory-aware mid shift" as a rejected direction, to revisit only once drift and overflow are solved **and** skew is shown to help LPs. The first two are addressed below; the third is explicitly out of scope, which is why this ships disabled.

## Key Decisions

- **Drift is solved structurally, not bounded.** The stored aggregate reads only atoms that round-trip losslessly through the packed order id, plus no oracle state at all, so a removal subtracts bit-equal what the insert added. The earlier build weighted the stored aggregate by a live-surface `n(d₂)`, which is exactly what drifted: any surface movement between open and close left a residual that accumulated without bound. Moneyness weighting moved to **read** time (`4·p·(1-p)`, recomputed from the current mark), where it cannot go stale. It also makes the infinity sentinels inert for free, since `P(-inf) = 1` and `P(+inf) = 0` both weight to zero.
- **Overflow is solved by removing its source.** There is no time-to-expiry amplification term; that was the named overflow risk. Every intermediate is a bounded fixed-point value, and `max_max_skew_shift = 0.05` holds the shift strictly below both `p` and `1-p` at every probability, so `skewed_up_price` needs no saturating clamp. The same bound is what keeps the budget-sizing search's cost function monotone in quantity, which the binary search requires.
- **Symmetric, no zero-edge floor.** A quote may sit below fair on the rebalancing side. The resulting mark-to-fair loss at trade time is the intended inducement, not an accident.
- **The skew never leaves the trade path.** NAV, the LP flush mark, and liquidation candidate selection all continue to read the exact fair mark. Inventory cannot push an order across its knockout, and cannot move the mark that prices LP supply and withdraw.
- **A complete partition always costs more than its payout.** Each leg is quoted against its own impact, which pushes both legs up, so no inventory state or leg ordering turns the pair into free money.

## Scope / Descoped

- **Whether the skew actually improves LP outcomes is not answered here.** That is a simulation question against the current fee-only model, and it is the reason the default is off.
- No bid/ask spread is introduced; the fee-only model stays.
- The aggregate treats a two-sided range as directionally flat and counts a deep out-of-the-money one-sided boundary at full weight. Sizing `max_skew_shift` against the trading fee is what bounds the value of using a cheap far-OTM position as a lever; that calibration belongs with the LP-benefit work above.

## Test Plan

- [x] `sui move build --path packages/predict --warnings-are-errors` — clean
- [x] `sui move test --path packages/predict --gas-limit 100000000000` — 459/459 pass (439 pre-existing unchanged + 20 new)
- [x] `pnpm format:move` equivalent over the changed files, via the repo-pinned `prettier-move`
- [x] Shift arithmetic unit-tested against hand-derived values in `tests/config/inventory_skew_tests.move`: full/half depth, moneyness scaling off the money, saturation past depth, both infinity sentinels, both config bound aborts, and the no-clamp property at each tail under the maximum configured shift
- [x] Flow coverage in `tests/flows/inventory_skew_flow_tests.move`: exact aggregate round trip across two partial closes, directional flatness of two-sided ranges, path-independent pricing, the partition bound at a flat and a skewed book, and a disabled-skew case pinning the fair mark
- [ ] Independent review (not yet run)

## Risk / Rollout

Ships inert: `default_max_skew_shift = 0`, so every market quotes the fair mark and the 439 pre-existing tests pass unchanged. Enabling is per-expiry and forward-only — the snapshot has no live setter, deliberately, because the depth is what makes a quoted shift reproducible. The aggregate is maintained even while the skew is off, so enabling a future expiry needs no migration.

**Open before this leaves draft:** `docs/design/decisions.md` still records this direction as rejected and needs a superseding entry.
