### PR TITLE
predict/sdk: pass the required all-in cost cap on budget mints (DBU-664)

### DIFF
--- a/packages/predict/sdk/src/client.ts
+++ b/packages/predict/sdk/src/client.ts
@@ -83,10 +83,15 @@ export interface MintOptions {
 	maxProbability?: number;
 }
 
-/** Options for `mintAmount` (spend an exact amount, floor the quantity received). */
+/**
+ * Options for `mintAmount` (spend an exact amount, floor the quantity received).
+ * `spend` bounds the premium only — fees and the congestion surcharge are charged
+ * on top — so `maxCost` is the ceiling on the total debit and is required.
+ */
 export interface MintAmountOptions {
 	spend: number;
 	minQuantity: number;
+	maxCost: number;
 	leverage?: number;
 }
 
@@ -405,6 +410,7 @@ export class PredictClient {
 				amountRaw: usdcToRaw(opts.spend),
 				minQuantityRaw,
 				leverageRaw: leverageToRaw(opts.leverage ?? 1),
+				maxCostRaw: usdcToRaw(opts.maxCost),
 				...feeds,
 			});
 			return tx;

--- a/packages/predict/sdk/src/tx/trade.ts
+++ b/packages/predict/sdk/src/tx/trade.ts
@@ -85,8 +85,10 @@ export function mintExactQuantity(
 
 // Mint by spending an exact `amountRaw` (raw quote units), enforcing a `minQuantityRaw`
 // floor on the position received, returning the new order id (u256). Command order is
-// pricer → auth → mint. Deployed sig `expiry_market.move:293` (`mint_exact_amount`, 12
-// moveCall args — note: no cost/probability ceilings, the floor is `min_quantity`).
+// pricer → auth → mint. Sig follows `expiry_market::mint_exact_amount` at head (13
+// moveCall args): fees and the congestion penalty are charged on top of `amountRaw`, so
+// `maxCostRaw` is the all-in ceiling and is REQUIRED — unlike `mintExactQuantity`'s
+// optional guards there is no disabling value, and the contract aborts on zero.
 export function mintExactAmount(
 	cfg: PredictConfig,
 	tx: Transaction,
@@ -98,6 +100,7 @@ export function mintExactAmount(
 		amountRaw: bigint;
 		minQuantityRaw: bigint;
 		leverageRaw: bigint;
+		maxCostRaw: bigint;
 	} & MarketFeeds,
 ): TransactionResult {
 	const pricer = loadLivePricer(cfg, tx, args);
@@ -115,6 +118,7 @@ export function mintExactAmount(
 			tx.pure.u64(args.amountRaw),
 			tx.pure.u64(args.minQuantityRaw),
 			tx.pure.u64(args.leverageRaw),
+			tx.pure.u64(args.maxCostRaw),
 			tx.object(ACCUMULATOR_ROOT_ID),
 			tx.object(CLOCK_ID),
 		],

--- a/packages/predict/sdk/tests/client.test.ts
+++ b/packages/predict/sdk/tests/client.test.ts
@@ -295,9 +295,21 @@ describe("tx.mint (market resolution + unit conversion)", () => {
 		const tx = await pc.tx.mintAmount(
 			OWNER,
 			{ underlying: "BTC", expiryMs: EXPIRY, strike: 105_000, side: "up" },
-			{ spend: 10, minQuantity: 0.015 },
+			{ spend: 10, minQuantity: 0.015, maxCost: 10.5 },
 		);
 		expect(tx).toBeTruthy();
+	});
+
+	test("mintAmount converts the required maxCost ceiling to raw quote units", async () => {
+		const pc = new PredictClient({ network: "testnet", client: mockClient().client });
+		const tx = await pc.tx.mintAmount(
+			OWNER,
+			{ underlying: "BTC", expiryMs: EXPIRY, strike: 105_000, side: "up" },
+			{ spend: 10, minQuantity: 0.015, maxCost: 10.5 },
+		);
+		// A $10.50 all-in ceiling is 10_500_000 at USDC's six decimals, and lands
+		// at the argument position the contract reads the cap from.
+		expect(argPureBytes(tx, 2, 10)).toBe(b64(10_500_000n));
 	});
 
 	test("read.markets returns tradeable summaries", async () => {

--- a/packages/predict/sdk/tests/tx-trade.test.ts
+++ b/packages/predict/sdk/tests/tx-trade.test.ts
@@ -98,7 +98,7 @@ test("mintExactQuantity: explicit maxCost/maxProbability override defaults", () 
 	expect(argPureBytes(tx, 2, 9)).not.toBe(U64_MAX_B64);
 });
 
-test("mintExactAmount: pricer → auth → mint, 12 args", () => {
+test("mintExactAmount: pricer → auth → mint, 13 args, required all-in cost cap", () => {
 	const tx = new Transaction();
 	mintExactAmount(cfg, tx, {
 		expiryMarketId: "0xabc",
@@ -108,6 +108,7 @@ test("mintExactAmount: pricer → auth → mint, 12 args", () => {
 		amountRaw: 5_000_000n,
 		minQuantityRaw: 1_000_000n,
 		leverageRaw: 1_000_000_000n,
+		maxCostRaw: 5_100_000n,
 		...feeds,
 	});
 	expect(targets(tx)).toEqual([
@@ -116,9 +117,15 @@ test("mintExactAmount: pricer → auth → mint, 12 args", () => {
 		`${cfg.packages.predict}::expiry_market::mint_exact_amount`,
 	]);
 	const mint = call(tx, 2);
-	expect(mint.arguments).toHaveLength(12);
+	expect(mint.arguments).toHaveLength(13);
 	expect(mint.arguments[2].$kind).toBe("Result"); // auth
 	expect(mint.arguments[4].$kind).toBe("Result"); // pricer
+	// The cap is passed through verbatim at the position the contract reads it,
+	// and is never defaulted to an uncapped sentinel.
+	expect(argPureBytes(tx, 2, 10)).toBe(
+		Buffer.from(bcs.u64().serialize(5_100_000n).toBytes()).toString("base64"),
+	);
+	expect(argPureBytes(tx, 2, 10)).not.toBe(U64_MAX_B64);
 });
 
 test("redeemLive: pricer → auth → redeem, 9 args, NO slippage-floor pair", () => {


### PR DESCRIPTION
Stacked on #1163 (which is itself stacked on #1162) — this PR's diff is the last commit only. It should merge together with #1163.

## Summary
- `mintExactAmount` takes a required `maxCostRaw` and passes it as the contract's new `max_cost` argument, taking the builder from 12 to 13 `moveCall` arguments.
- The friendly `PredictClient.tx.mintAmount` takes a required `maxCost` in USDC and converts it to raw quote units.
- Both are required rather than optional-with-a-default, mirroring the contract.

## Why
- The SDK builds `expiry_market::mint_exact_amount` as a positional argument list. #1163 makes that entrypoint take a required all-in cost cap, so an unchanged SDK would emit a call one argument short and every budget mint it produced would abort on landing.
- The SDK test suite is not part of CI, so nothing else would catch the mismatch before the package publishes.

## Key decisions
- **`maxCostRaw` is required, not optional with a `U64_MAX` default.** `mintExactQuantity` defaults its two guards that way because the contract accepts `u64::MAX` as "uncapped". The budget mint has no disabling value — the contract aborts on zero — so offering a default here would only produce calls the chain rejects.
- The friendly layer takes USDC and converts with `usdcToRaw`, matching how `mint`'s optional `maxCost` is already handled.

## Test plan
- [x] `pnpm test` in `packages/predict/sdk` — `Test Files 12 passed (12)`, `Tests 115 passed (115)`
- [x] `pnpm exec tsc --noEmit -p tsconfig.json` — exit 0
- [x] `tx-trade.test.ts` asserts the cap is serialized at the argument index the contract reads it from and is never the uncapped sentinel; `client.test.ts` asserts a $10.50 ceiling converts to `10_500_000` at USDC's six decimals
- [x] Before the client fix, `client.test.ts` failed with `Cannot convert undefined to a BigInt` at the new argument — the required type caught the second call site rather than shipping a silently short call

## Risk / rollout
- Breaking change for SDK consumers of `mintAmount` / `mintExactAmount`: they must supply a ceiling. The published SDK must not ship ahead of the contract that takes the argument.