### PR TITLE
account: record immutable referrer at creation (DBU-666)

### DIFF
--- a/packages/account/README.md
+++ b/packages/account/README.md
@@ -27,6 +27,7 @@ public struct Account has store {
     receive_address: address,
     balances: Bag,
     settlements: Bag,
+    referrer_account_id: Option<ID>,
 }
 ```
 
@@ -40,6 +41,8 @@ the **wrapper object's address** — the accumulator/funds-receive anchor. Coins
 delivered to and settled from the wrapper address, because only a real shared
 object's UID can back an address-balance withdrawal (the nested `account_id` UID
 never can). Use `receive_address` for `balance::send_funds`, never the account ID.
+`Account.referrer_account_id()` returns the immutable canonical account ID supplied
+at referral-based creation, if any.
 
 ### `account::account_registry`
 
@@ -49,6 +52,11 @@ The registry creates canonical accounts:
 
 ```move
 public fun new(registry: &mut AccountRegistry, ctx: &mut TxContext): AccountWrapper
+public fun new_with_referrer(
+    registry: &mut AccountRegistry,
+    referrer: &Account,
+    ctx: &mut TxContext,
+): AccountWrapper
 public fun new_self_owned(
     registry: &mut AccountRegistry,
     owner_uid: &mut UID,
@@ -57,6 +65,11 @@ public fun new_self_owned(
 ```
 
 The returned wrapper must be shared with `account::share`.
+
+`new_with_referrer` records the supplied account's canonical ID on the created
+account and in its `AccountCreated` event. This is caller-selected attribution:
+passing an account proves that it exists, not that its owner authorized or endorsed
+the referral. The package does not provide a setter or removal path.
 
 The registry exposes both derived addresses:
 
@@ -78,6 +91,9 @@ Each owner gets two derived IDs under the registry root:
 - canonical account ID: app data root and event `account_id`
 - wrapper ID: shared object handle that gates account loading; its address is the
   accumulator/funds-receive anchor (`Account.receive_address`)
+
+An account created through `new_with_referrer` also stores the supplied canonical
+account ID as immutable creation attribution and mirrors it in `AccountCreated`.
 
 The canonical account ID is the account's public identity. The wrapper ID is an
 implementation detail needed because Sui shared objects are what transactions pass
@@ -254,6 +270,14 @@ wrapper.share();
 let auth = account::generate_auth(ctx);
 let account = wrapper.load_account_mut(auth);
 some_app::do_something(account, ...);
+```
+
+Referred EOA-owned account:
+
+```move
+let referrer = referrer_wrapper.load_account();
+let wrapper = registry.new_with_referrer(referrer, ctx);
+wrapper.share();
 ```
 
 Object-owned account:

--- a/packages/account/sources/account.move
+++ b/packages/account/sources/account.move
@@ -53,6 +53,8 @@ public struct Account has store {
     balances: Bag,
     /// Type-indexed timestamps of the latest settlement attempt.
     settlements: Bag,
+    /// Canonical account ID supplied at referral-based creation, if any.
+    referrer_account_id: Option<ID>,
 }
 
 /// Dynamic-field key for one app's per-account data slot. The phantom `App` is the
@@ -94,6 +96,11 @@ public fun owner(self: &Account): address {
 /// Returns the canonical account ID.
 public fun account_id(self: &Account): ID {
     self.account_id.to_inner()
+}
+
+/// Returns the canonical referrer account ID recorded at creation for external Move composition.
+public fun referrer_account_id(self: &Account): Option<ID> {
+    self.referrer_account_id
 }
 
 /// Returns the accumulator receive address for this account (the wrapper address).
@@ -235,6 +242,7 @@ public(package) fun new_derived<WrapperKey: copy + drop + store, AccountKey: cop
     wrapper_key: WrapperKey,
     account_key: AccountKey,
     owner: address,
+    referrer_account_id: Option<ID>,
     ctx: &mut TxContext,
 ): AccountWrapper {
     let id = derived_object::claim(parent, wrapper_key);
@@ -246,6 +254,7 @@ public(package) fun new_derived<WrapperKey: copy + drop + store, AccountKey: cop
             receive_address: id.to_address(),
             balances: bag::new(ctx),
             settlements: bag::new(ctx),
+            referrer_account_id,
         },
         id,
     }

--- a/packages/account/sources/account_events.move
+++ b/packages/account/sources/account_events.move
@@ -9,13 +9,18 @@ use std::ascii::String;
 use sui::event;
 
 /// A canonical derived account was created. `self_owned` is true when it was
-/// created via `new_self_owned` (the owner is an object address) rather than `new`
-/// (the owner is the transaction sender).
+/// created via `new_self_owned` (the owner is an object address).
+/// `referrer_account_id` is the canonical account ID supplied to `new_with_referrer`, if any.
 public struct AccountCreated has copy, drop {
     account_id: ID,
     wrapper_id: ID,
     owner: address,
     self_owned: bool,
+    referrer_account_id: Option<ID>,
+}
+
+public(package) fun referrer_account_id(self: &AccountCreated): Option<ID> {
+    self.referrer_account_id
 }
 
 public(package) fun emit_account_created(
@@ -23,8 +28,15 @@ public(package) fun emit_account_created(
     wrapper_id: ID,
     owner: address,
     self_owned: bool,
+    referrer_account_id: Option<ID>,
 ) {
-    event::emit(AccountCreated { account_id, wrapper_id, owner, self_owned });
+    event::emit(AccountCreated {
+        account_id,
+        wrapper_id,
+        owner,
+        self_owned,
+        referrer_account_id,
+    });
 }
 
 /// An app witness type was added to the registry's mutable-load whitelist.

--- a/packages/account/sources/account_events.move
+++ b/packages/account/sources/account_events.move
@@ -19,10 +19,6 @@ public struct AccountCreated has copy, drop {
     referrer_account_id: Option<ID>,
 }
 
-public(package) fun referrer_account_id(self: &AccountCreated): Option<ID> {
-    self.referrer_account_id
-}
-
 public(package) fun emit_account_created(
     account_id: ID,
     wrapper_id: ID,

--- a/packages/account/sources/account_registry.move
+++ b/packages/account/sources/account_registry.move
@@ -6,7 +6,7 @@
 /// `account::account` owns wrapper construction, custody, accumulator settlement, and app-data invariants.
 module account::account_registry;
 
-use account::{account::{Self, AccountWrapper, Auth}, account_events};
+use account::{account::{Self, Account, AccountWrapper, Auth}, account_events};
 use std::{internal::Permit, type_name};
 use sui::{derived_object, dynamic_field as df};
 
@@ -73,7 +73,17 @@ public fun derived_wrapper_exists(registry: &AccountRegistry, owner: address): b
 /// Creates the sender's canonical account and wrapper, aborting if either derived ID is already claimed.
 public fun new(registry: &mut AccountRegistry, ctx: &mut TxContext): AccountWrapper {
     let owner = ctx.sender();
-    registry.new_for_owner(owner, false, ctx)
+    registry.new_for_owner(owner, false, option::none(), ctx)
+}
+
+/// Creates the sender's canonical account and permanently records the supplied account as its referrer.
+public fun new_with_referrer(
+    registry: &mut AccountRegistry,
+    referrer: &Account,
+    ctx: &mut TxContext,
+): AccountWrapper {
+    let owner = ctx.sender();
+    registry.new_for_owner(owner, false, option::some(referrer.account_id()), ctx)
 }
 
 /// Creates the canonical account owned by `owner_uid`'s object address, aborting if either derived ID is already claimed.
@@ -83,7 +93,7 @@ public fun new_self_owned(
     ctx: &mut TxContext,
 ): AccountWrapper {
     let owner = owner_uid.to_inner().to_address();
-    registry.new_for_owner(owner, true, ctx)
+    registry.new_for_owner(owner, true, option::none(), ctx)
 }
 
 /// Returns whether `App` may request package-issued mutable account authority.
@@ -129,6 +139,7 @@ fun new_for_owner(
     registry: &mut AccountRegistry,
     owner: address,
     self_owned: bool,
+    referrer_account_id: Option<ID>,
     ctx: &mut TxContext,
 ): AccountWrapper {
     registry.assert_account_does_not_exist(owner);
@@ -137,6 +148,7 @@ fun new_for_owner(
         AccountWrapperKey(owner),
         AccountKey(owner),
         owner,
+        referrer_account_id,
         ctx,
     );
     account_events::emit_account_created(
@@ -144,6 +156,7 @@ fun new_for_owner(
         wrapper.id(),
         owner,
         self_owned,
+        referrer_account_id,
     );
     wrapper
 }

--- a/packages/account/tests/account_tests.move
+++ b/packages/account/tests/account_tests.move
@@ -6,11 +6,18 @@ module account::account_tests;
 
 use account::{
     account::{Self, AccountWrapper},
+    account_events,
     account_registry::{Self, AccountAdminCap, AccountRegistry},
     accumulator_support
 };
 use std::{internal::permit, unit_test::{assert_eq, destroy}};
-use sui::{clock::Clock, coin, object, test_scenario::{Self as test, Scenario, return_shared}};
+use sui::{
+    clock::Clock,
+    coin,
+    event,
+    object,
+    test_scenario::{Self as test, Scenario, return_shared}
+};
 
 const ADMIN: address = @0xAD;
 const ALICE: address = @0xA11CE;
@@ -20,6 +27,7 @@ const WITHDRAW_AMOUNT: u64 = 350;
 const POST_WITHDRAW_BALANCE: u64 = 650;
 const DATA_INITIAL_VALUE: u64 = 17;
 const DATA_UPDATED_VALUE: u64 = 29;
+const CREATION_EVENT_COUNT: u64 = 1;
 
 public struct TEST_COIN has drop {}
 
@@ -51,6 +59,7 @@ fun registry_creates_one_canonical_account_per_owner() {
 
     assert_eq!(account.owner(), ALICE);
     assert_eq!(account.account_id(), account_id);
+    assert!(account.referrer_account_id().is_none());
     // Funds receive/settle at the wrapper address now (a real shared input object),
     // not the nested account_id.
     assert_eq!(account.receive_address(), wrapper_id.to_address());
@@ -58,9 +67,40 @@ fun registry_creates_one_canonical_account_per_owner() {
     assert!(registry.derived_wrapper_exists(ALICE));
     assert_eq!(registry.derived_address(ALICE).to_id(), account_id);
     assert_eq!(registry.derived_wrapper_address(ALICE).to_id(), wrapper_id);
+    let events = event::events_by_type<account_events::AccountCreated>();
+    assert_eq!(events.length(), CREATION_EVENT_COUNT);
+    assert!(events[0].referrer_account_id().is_none());
 
     wrapper.share();
     return_shared(registry);
+    scenario.end();
+}
+
+#[test]
+fun registry_records_referrer_on_account_and_creation_event() {
+    let mut scenario = setup_with_account(BOB);
+    scenario.next_tx(ALICE);
+    let mut registry = scenario.take_shared<AccountRegistry>();
+    let referrer_wrapper_id = registry.derived_wrapper_address(BOB).to_id();
+    let referrer_wrapper = scenario.take_shared_by_id<AccountWrapper>(referrer_wrapper_id);
+    let referrer_account_id = referrer_wrapper.load_account().account_id();
+    let wrapper = registry.new_with_referrer(referrer_wrapper.load_account(), scenario.ctx());
+    let wrapper_id = wrapper.id();
+
+    assert_eq!(wrapper.load_account().referrer_account_id(), option::some(referrer_account_id));
+    let events = event::events_by_type<account_events::AccountCreated>();
+    assert_eq!(events.length(), CREATION_EVENT_COUNT);
+    assert_eq!(events[0].referrer_account_id(), option::some(referrer_account_id));
+
+    wrapper.share();
+    return_shared(referrer_wrapper);
+    return_shared(registry);
+    scenario.next_tx(ADMIN);
+
+    let wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    assert_eq!(wrapper.load_account().referrer_account_id(), option::some(referrer_account_id));
+
+    return_shared(wrapper);
     scenario.end();
 }
 
@@ -90,6 +130,19 @@ fun creating_second_account_for_same_owner_aborts() {
     first.share();
 
     let second = registry.new(scenario.ctx());
+    second.share();
+
+    abort 999
+}
+
+#[test, expected_failure(abort_code = account_registry::EAccountAlreadyExists)]
+fun referral_constructor_cannot_create_second_account_for_same_owner() {
+    let mut scenario = setup();
+    scenario.next_tx(ALICE);
+    let mut registry = scenario.take_shared<AccountRegistry>();
+    let first = registry.new(scenario.ctx());
+    let second = registry.new_with_referrer(first.load_account(), scenario.ctx());
+    first.share();
     second.share();
 
     abort 999
@@ -156,6 +209,7 @@ fun object_auth_opens_self_owned_account() {
     let wrapper = registry.new_self_owned(&mut owner.id, scenario.ctx());
 
     assert_eq!(wrapper.load_account().owner(), owner_address);
+    assert!(wrapper.load_account().referrer_account_id().is_none());
     wrapper.share();
     return_shared(registry);
     scenario.next_tx(ADMIN);

--- a/packages/account/tests/account_tests.move
+++ b/packages/account/tests/account_tests.move
@@ -6,18 +6,11 @@ module account::account_tests;
 
 use account::{
     account::{Self, AccountWrapper},
-    account_events,
     account_registry::{Self, AccountAdminCap, AccountRegistry},
     accumulator_support
 };
 use std::{internal::permit, unit_test::{assert_eq, destroy}};
-use sui::{
-    clock::Clock,
-    coin,
-    event,
-    object,
-    test_scenario::{Self as test, Scenario, return_shared}
-};
+use sui::{clock::Clock, coin, object, test_scenario::{Self as test, Scenario, return_shared}};
 
 const ADMIN: address = @0xAD;
 const ALICE: address = @0xA11CE;
@@ -27,7 +20,6 @@ const WITHDRAW_AMOUNT: u64 = 350;
 const POST_WITHDRAW_BALANCE: u64 = 650;
 const DATA_INITIAL_VALUE: u64 = 17;
 const DATA_UPDATED_VALUE: u64 = 29;
-const CREATION_EVENT_COUNT: u64 = 1;
 
 public struct TEST_COIN has drop {}
 
@@ -67,9 +59,6 @@ fun registry_creates_one_canonical_account_per_owner() {
     assert!(registry.derived_wrapper_exists(ALICE));
     assert_eq!(registry.derived_address(ALICE).to_id(), account_id);
     assert_eq!(registry.derived_wrapper_address(ALICE).to_id(), wrapper_id);
-    let events = event::events_by_type<account_events::AccountCreated>();
-    assert_eq!(events.length(), CREATION_EVENT_COUNT);
-    assert!(events[0].referrer_account_id().is_none());
 
     wrapper.share();
     return_shared(registry);
@@ -77,7 +66,7 @@ fun registry_creates_one_canonical_account_per_owner() {
 }
 
 #[test]
-fun registry_records_referrer_on_account_and_creation_event() {
+fun registry_records_referrer_on_account() {
     let mut scenario = setup_with_account(BOB);
     scenario.next_tx(ALICE);
     let mut registry = scenario.take_shared<AccountRegistry>();
@@ -88,9 +77,6 @@ fun registry_records_referrer_on_account_and_creation_event() {
     let wrapper_id = wrapper.id();
 
     assert_eq!(wrapper.load_account().referrer_account_id(), option::some(referrer_account_id));
-    let events = event::events_by_type<account_events::AccountCreated>();
-    assert_eq!(events.length(), CREATION_EVENT_COUNT);
-    assert_eq!(events[0].referrer_account_id(), option::some(referrer_account_id));
 
     wrapper.share();
     return_shared(referrer_wrapper);


### PR DESCRIPTION
## Summary
- Add `new_with_referrer`, which stores the supplied Account canonical ID permanently on the new Account.
- Expose the optional referrer ID through a public read-only getter and mirror it in `AccountCreated`.
- Cover ordinary, self-owned, referred, persisted, and duplicate-owner creation behavior in Account package tests and documentation.

## Why
- The Account package provides the canonical on-chain identity used by Predict and other applications. Accounts created through a referral path currently have no permanent record of which existing Account was supplied during creation.
- Recording that provenance now gives later referral work a stable Account-package fact without introducing fee, reward, or referral-processing behavior.

## Key decisions
- The referrer ID is caller-selected attribution, not proof that the referenced Account owner authorized or endorsed the referral.
- `new` and `new_self_owned` store and emit no referrer; only `new_with_referrer` stores and emits `some(referrer.account_id())`.
- No setter or removal path is provided.
- SDK, indexer, and API support remain out of scope. This changes the serialized Account and AccountCreated layouts, so the contract PR is safe to merge independently but the package must not be published until those consumers are coordinated. Migration of previously published Account objects is also outside this PR.

## Test plan
- [x] `sui move build --path packages/account --warnings-are-errors`
- [x] `sui move test --path packages/account --gas-limit 100000000000` (13/13)
- [x] `bash checks/format-move.sh <changed Move files>`
- [x] `git diff --check`
- [x] Fresh-context independent Move/API review