### PR TITLE
predict/pricing: carry the SVI roll-down at 1e18 (DBU-655)

### DIFF
--- a/packages/predict/predeploy/open-items.md
+++ b/packages/predict/predeploy/open-items.md
@@ -129,37 +129,6 @@ bound and accept the aggregation residual in the rounding policy, add a
 regression covering both directions, and narrow every exact-NAV claim to the
 accepted bound. (2026-07-17 clean-room gap audit)
 
-### P-17: The flow-fixture pricing reference does not model the roll-down
-
-**Severity:** Medium. **Expected-failing tests:** the
-`assert_atm_entry_probability` assertions reached from `short_expiry_ms`
-fixtures — `lifecycle_tests::one_x_lifecycle_fund_mint`,
-`settled_solvency_boundary_tests::finite_range_partial_close_preserves_live_solvency`,
-`no_double_pay_liquidation_tests::liquidated_order_pays_zero_once_and_only_once`,
-and the four `settlement_flow_tests` that price through `finite_range_premium`.
-
-`pricing_reference_data::flow_fixture_atm_up` evaluates the fixture surface at its
-raw `a` and `b`, with no remaining-time roll-down. That was invisible while the
-roll-down floored at 1e9: flooring snapped every fixture whose
-`remaining_ms / anchor_tte_ms` fell in `[0.5, 1)` onto the same effective `a`, so
-an un-rolled reference agreed with a rolled contract by construction, and the flow
-suite could not detect a roll-down defect at all. The same quantization is why
-`default_svi_a` had to be doubled to 2 when the roll-down landed — a raw 1 floored
-to 0 on any post-seed clock advance.
-
-Carrying the roll-down at 1e18 removes the quantizer, so the true ratio now reaches
-the price. The far `default_expiry_ms` fixtures are unaffected (ratio ≈ 1 − 3e-8,
-under one raw unit). The `short_expiry_ms` fixtures run at ratio
-`120_000 / 121_000` and land ~52 units from the reference against its 21-unit
-budget.
-
-**Action:** make the reference model the roll-down per fixture horizon — emit one
-`flow_fixture_atm_up` per distinct `(params_timestamp_ms, now_ms, expiry_ms)`
-triple the fixtures use, and route `assert_atm_entry_probability` to the matching
-one — or re-anchor the fixtures so the pricer loads at the parameter timestamp and
-the ratio is exactly 1. Which of the two is right is a reference-design decision,
-so the tests are left RED per unit-tests rule 15 rather than re-tuned.
-
 ### P-16: The pricing reference does not cover the deployed variance range
 
 **Severity:** Medium.

--- a/packages/predict/predeploy/open-items.md
+++ b/packages/predict/predeploy/open-items.md
@@ -129,6 +129,37 @@ bound and accept the aggregation residual in the rounding policy, add a
 regression covering both directions, and narrow every exact-NAV claim to the
 accepted bound. (2026-07-17 clean-room gap audit)
 
+### P-17: The flow-fixture pricing reference does not model the roll-down
+
+**Severity:** Medium. **Expected-failing tests:** the
+`assert_atm_entry_probability` assertions reached from `short_expiry_ms`
+fixtures — `lifecycle_tests::one_x_lifecycle_fund_mint`,
+`settled_solvency_boundary_tests::finite_range_partial_close_preserves_live_solvency`,
+`no_double_pay_liquidation_tests::liquidated_order_pays_zero_once_and_only_once`,
+and the four `settlement_flow_tests` that price through `finite_range_premium`.
+
+`pricing_reference_data::flow_fixture_atm_up` evaluates the fixture surface at its
+raw `a` and `b`, with no remaining-time roll-down. That was invisible while the
+roll-down floored at 1e9: flooring snapped every fixture whose
+`remaining_ms / anchor_tte_ms` fell in `[0.5, 1)` onto the same effective `a`, so
+an un-rolled reference agreed with a rolled contract by construction, and the flow
+suite could not detect a roll-down defect at all. The same quantization is why
+`default_svi_a` had to be doubled to 2 when the roll-down landed — a raw 1 floored
+to 0 on any post-seed clock advance.
+
+Carrying the roll-down at 1e18 removes the quantizer, so the true ratio now reaches
+the price. The far `default_expiry_ms` fixtures are unaffected (ratio ≈ 1 − 3e-8,
+under one raw unit). The `short_expiry_ms` fixtures run at ratio
+`120_000 / 121_000` and land ~52 units from the reference against its 21-unit
+budget.
+
+**Action:** make the reference model the roll-down per fixture horizon — emit one
+`flow_fixture_atm_up` per distinct `(params_timestamp_ms, now_ms, expiry_ms)`
+triple the fixtures use, and route `assert_atm_entry_probability` to the matching
+one — or re-anchor the fixtures so the pricer loads at the parameter timestamp and
+the ratio is exactly 1. Which of the two is right is a reference-design decision,
+so the tests are left RED per unit-tests rule 15 rather than re-tuned.
+
 ### P-16: The pricing reference does not cover the deployed variance range
 
 **Severity:** Medium.

--- a/packages/predict/predeploy/response-policies.md
+++ b/packages/predict/predeploy/response-policies.md
@@ -862,12 +862,14 @@ Each entry records: **Trigger state** / **Controller** / **Blast radius** /
   raw unit of `a`, and a short-dated `a` is only about ten raw units, so the
   truncation alone breached the ratified price-deviation bound (P-14's defect,
   one layer upstream). Freshness continues to use the latest envelope source
-  timestamp. If the roll-down still makes per-strike variance non-positive
-  before expiry — now only in the final `1 / (a * 1e9)` fraction of the anchored
-  horizon rather than on any post-anchor advance — the existing
-  `ENonPositiveVariance` guard aborts. This includes pool valuation. Recovery
-  is for the publisher to send a changed usable tuple, which resets the
-  parameter anchor, followed by retrying the affected action or flush.
+  timestamp. Carrying the roll-down at 1e18 substantially shrinks the terminal
+  rounding region in which the roll-down can drive per-strike variance
+  non-positive, but does not remove it, and the size of what remains is not a
+  single closed form — it depends on the sign of `a` and on cancellation between
+  `a` and `b·inner`, not on `a` alone. The existing `ENonPositiveVariance` guard
+  remains authoritative for that state, including in pool valuation. Recovery is
+  for the publisher to send a changed usable tuple, which resets the parameter
+  anchor, followed by retrying the affected action or flush.
 - **Reasoning:** transport freshness and parameter age answer different
   questions. A one-second retransmit proves the feed is live but does not make
   an unchanged variance-to-expiry calibration new. Preserving both timestamps
@@ -887,7 +889,10 @@ Each entry records: **Trigger state** / **Controller** / **Blast radius** /
   `rolled_sub_1e9_resolution_reaches_the_variance_pricing_divides_by`, and
   `identical_svi_retransmit_refreshes_source_without_moving_params_anchor`;
   `pricing_guard_tests.move` —
-  `pre_expiry_roll_down_keeps_positive_variance`.
+  `pre_expiry_roll_down_keeps_positive_variance` and
+  `w_prime_keeps_the_rolled_b_precision` (the rolled `b` must reach the skew
+  correction at 1e18; narrowing it to 1e9 first misses the reference by ~890
+  units against a 21-unit budget).
 - **Reopen when:** the provider changes tuple or timestamp semantics, an
   effective-zero surface materially interrupts LP flush liveness or lacks
   timely changed-tuple recovery, Predict adopts a calibrated non-linear horizon

--- a/packages/predict/predeploy/response-policies.md
+++ b/packages/predict/predeploy/response-policies.md
@@ -853,11 +853,18 @@ Each entry records: **Trigger state** / **Controller** / **Blast radius** /
   `update_timestamp_ms` on newer identical retransmits. Any normalized
   parameter change resets the anchor to that update's source timestamp.
   Predict computes
-  `a_eff = sign(a) * floor(abs(a) * remaining_ms / anchor_tte_ms)` and
-  `b_eff = floor(b * remaining_ms / anchor_tte_ms)` with `u128`
-  intermediates; `rho`, `m`, and `sigma` are unchanged. Freshness continues to
-  use the latest envelope source timestamp. If integer roll-down makes
-  per-strike variance non-positive before expiry, the existing
+  `a_eff = sign(a) * floor(abs(a) * 1e9 * remaining_ms / anchor_tte_ms)` and
+  `b_eff = floor(b * 1e9 * remaining_ms / anchor_tte_ms)`, both **at 1e18** with
+  a `u256` intermediate, and hands them to the variance path in that domain;
+  `rho`, `m`, and `sigma` are unchanged. The scaled results are carried at 1e18
+  rather than narrowed back to 1e9 because the roll-down multiplies terms that
+  are themselves tiny on short-dated surfaces — a 1e9 floor costs up to a whole
+  raw unit of `a`, and a short-dated `a` is only about ten raw units, so the
+  truncation alone breached the ratified price-deviation bound (P-14's defect,
+  one layer upstream). Freshness continues to use the latest envelope source
+  timestamp. If the roll-down still makes per-strike variance non-positive
+  before expiry — now only in the final `1 / (a * 1e9)` fraction of the anchored
+  horizon rather than on any post-anchor advance — the existing
   `ENonPositiveVariance` guard aborts. This includes pool valuation. Recovery
   is for the publisher to send a changed usable tuple, which resets the
   parameter anchor, followed by retrying the affected action or flush.
@@ -875,11 +882,12 @@ Each entry records: **Trigger state** / **Controller** / **Blast radius** /
   are not measured; whether linear roll-down is the best calibration model is
   deliberately owned by the still-open O-1 calibration work.
 - **Pinning tests:** `pricing_tests.move` —
-  `roll_down_is_exact_at_anchor_and_rounds_signed_a_toward_zero`,
-  `roll_down_handles_one_ms_boundary_and_u128_intermediates`, and
+  `roll_down_is_exact_at_anchor_and_keeps_sub_1e9_resolution`,
+  `roll_down_handles_one_ms_boundary_and_u256_intermediates`,
+  `rolled_sub_1e9_resolution_reaches_the_variance_pricing_divides_by`, and
   `identical_svi_retransmit_refreshes_source_without_moving_params_anchor`;
   `pricing_guard_tests.move` —
-  `pre_expiry_roll_down_to_zero_variance_aborts`.
+  `pre_expiry_roll_down_keeps_positive_variance`.
 - **Reopen when:** the provider changes tuple or timestamp semantics, an
   effective-zero surface materially interrupts LP flush liveness or lacks
   timely changed-tuple recovery, Predict adopts a calibrated non-linear horizon

--- a/packages/predict/sources/pricing/pricing.move
+++ b/packages/predict/sources/pricing/pricing.move
@@ -568,12 +568,11 @@ fun compute_nd2(svi_params: &PricingSVI, forward: u64, strike: u64): u64 {
     let slope_ratio = k_minus_m.div_scaled(&sq_i64);
     let slope = rho.add(&slope_ratio);
     // `b` is at 1e18 and `slope` at 1e9, so the product comes back down by 1e18
-    // to leave `w'` at 1e9. `b <= max_svi_input * 1e9` and `|slope| <= 2e9`, so
-    // the u128 product and the u64 narrowing both fit.
-    let w_prime_magnitude =
-        (
-            (b * (slope.magnitude() as u128)) / ((math::float_scaling!() as u128) * (math::float_scaling!() as u128)),
-        ) as u64;
+    // to leave `w'` at 1e9. `b <= max_svi_input * 1e9` and `|slope| <= 2e9`
+    // (`|rho| <= 1e9` and `|k - m| <= sq`), so the u128 product and the u64
+    // narrowing both fit.
+    let scale = math::float_scaling!() as u128;
+    let w_prime_magnitude = (b * (slope.magnitude() as u128) / (scale * scale)) as u64;
     let nd2 = math::normal_cdf(&d2);
     if (w_prime_magnitude == 0) return nd2;
 

--- a/packages/predict/sources/pricing/pricing.move
+++ b/packages/predict/sources/pricing/pricing.move
@@ -39,9 +39,18 @@ public struct Pricer has copy, drop {
 }
 
 /// Transaction-local SVI parameters after applying Predict's remaining-time roll-down.
+///
+/// `a` and `b` are carried at **1e18**, not 1e9. The roll-down multiplies both by
+/// `remaining_ms / anchor_tte_ms`, and flooring that product at 1e9 discards up to
+/// a full raw unit — which a short-dated surface cannot afford, because its whole
+/// total variance is only about ten raw units at 1e9. Keeping the rolled values at
+/// 1e18 hands `variance_sqrt_and_d2` the same domain it already computes in.
 public struct PricingSVI has copy, drop {
-    a: I64,
-    b: u64,
+    /// Rolled-down SVI `a`, magnitude at 1e18, sign in `a_is_negative`.
+    a_magnitude: u128,
+    a_is_negative: bool,
+    /// Rolled-down SVI `b`, at 1e18.
+    b: u128,
     rho: I64,
     m: I64,
     sigma: u64,
@@ -148,18 +157,23 @@ public(package) fun block_scholes_svi_source_timestamp_ms(pricer: &Pricer): u64 
     pricer.block_scholes_svi_source_timestamp_ms
 }
 
-/// Scale SVI `a` toward zero and `b` down by the fraction of anchored time remaining.
-public(package) fun roll_down_ab(
-    a: I64,
-    b: u64,
-    remaining_ms: u64,
-    anchor_tte_ms: u64,
-): (I64, u64) {
-    let scaled_a_magnitude = math::mul_div_down(a.magnitude(), remaining_ms, anchor_tte_ms);
-    (
-        i64::from_parts(scaled_a_magnitude, a.is_negative()),
-        math::mul_div_down(b, remaining_ms, anchor_tte_ms),
-    )
+/// Scale one 1e9-scaled SVI magnitude down by the fraction of anchored time
+/// remaining, returning it at 1e18.
+///
+/// The roll-down result is kept at 1e18 because the fraction is applied to values
+/// that are themselves tiny on short-dated surfaces: a 1e9 floor here costs up to
+/// a whole raw unit of `a`, and a short-dated `a` is only about ten raw units, so
+/// the truncation alone moves the digital by percent-scale amounts. At 1e18 the
+/// same floor is a billionth of that.
+///
+/// The `u256` intermediate keeps the product exact for any `expiry_ms` rather than
+/// relying on a bound on the anchored horizon. The result is at most
+/// `value * 1e9 <= max_svi_input * 1e9`, so narrowing to `u128` never truncates.
+public(package) fun roll_down_to_1e18(value: u64, remaining_ms: u64, anchor_tte_ms: u64): u128 {
+    let scaled =
+        (value as u256) * (math::float_scaling!() as u256) * (remaining_ms as u256)
+        / (anchor_tte_ms as u256);
+    scaled as u128
 }
 
 public(package) fun into_spot(read: ExactSpotRead): Option<u64> {
@@ -434,10 +448,11 @@ fun roll_down_svi(
 ): PricingSVI {
     let remaining_ms = expiry_ms - clock.timestamp_ms();
     let anchor_tte_ms = expiry_ms - params_timestamp_ms;
-    let (a, b) = roll_down_ab(svi.a(), svi.b(), remaining_ms, anchor_tte_ms);
+    let a = svi.a();
     PricingSVI {
-        a,
-        b,
+        a_magnitude: roll_down_to_1e18(a.magnitude(), remaining_ms, anchor_tte_ms),
+        a_is_negative: a.is_negative(),
+        b: roll_down_to_1e18(svi.b(), remaining_ms, anchor_tte_ms),
         rho: svi.rho(),
         m: svi.m(),
         sigma: svi.sigma(),
@@ -542,21 +557,32 @@ fun compute_nd2(svi_params: &PricingSVI, forward: u64, strike: u64): u64 {
     assert!(!inner.is_negative(), ECannotBeNegative);
 
     let b = svi_params.b;
-    let a = svi_params.a;
-    let (sqrt_var, d2) = variance_sqrt_and_d2(&a, b, inner.magnitude(), &k);
+    let (sqrt_var, d2) = variance_sqrt_and_d2(
+        svi_params.a_magnitude,
+        svi_params.a_is_negative,
+        b,
+        inner.magnitude(),
+        &k,
+    );
 
     let slope_ratio = k_minus_m.div_scaled(&sq_i64);
     let slope = rho.add(&slope_ratio);
-    let w_prime = i64::from_u64(b).mul_scaled(&slope);
+    // `b` is at 1e18 and `slope` at 1e9, so the product comes back down by 1e18
+    // to leave `w'` at 1e9. `b <= max_svi_input * 1e9` and `|slope| <= 2e9`, so
+    // the u128 product and the u64 narrowing both fit.
+    let w_prime_magnitude =
+        (
+            (b * (slope.magnitude() as u128)) / ((math::float_scaling!() as u128) * (math::float_scaling!() as u128)),
+        ) as u64;
     let nd2 = math::normal_cdf(&d2);
-    if (w_prime.is_zero()) return nd2;
+    if (w_prime_magnitude == 0) return nd2;
 
     let correction_magnitude = math::mul_div_down(
         math::normal_pdf(&d2),
-        w_prime.magnitude(),
+        w_prime_magnitude,
         2 * sqrt_var,
     );
-    let correction = i64::from_parts(correction_magnitude, w_prime.is_negative());
+    let correction = i64::from_parts(correction_magnitude, slope.is_negative());
     let adjusted = i64::from_u64(nd2).sub(&correction);
     if (adjusted.is_negative()) return 0;
     if (adjusted.magnitude() > math::float_scaling!()) return math::float_scaling!();
@@ -565,23 +591,29 @@ fun compute_nd2(svi_params: &PricingSVI, forward: u64, strike: u64): u64 {
 
 /// Total variance `w`, its square root, and `d2`, carried at `u128` / 1e18.
 ///
-/// `b` and `inner` are both 1e9-scaled, so `b * inner` in u128 IS the 1e18
-/// variance increment: narrowing it back to 1e9 (as `math::mul_down` does)
+/// `a_magnitude` and `b` arrive already rolled down and already at 1e18, so the
+/// whole variance assembly stays in that domain: narrowing either back to 1e9
 /// discards the entire low-variance signal, because a five-minute surface has
-/// `w ~ 1e-8` — about ten raw units at 1e9. `sqrt_u128_down` of a 1e18 value is
+/// `w ~ 1e-8` — about ten raw units at 1e9. `inner` is 1e9-scaled, so `b * inner`
+/// comes back down by 1e9 to land at 1e18. `sqrt_u128_down` of a 1e18 value is
 /// its 1e9-scaled root, so `sqrt(w)` returns at the scale the rest of the
 /// formula reads. Returns `(sqrt(w), d2)`; aborts `ENonPositiveVariance` when
 /// `w <= 0`, which pricing requires because it divides by `sqrt(w)`.
-fun variance_sqrt_and_d2(a: &I64, b: u64, inner: u64, k: &I64): (u64, I64) {
+fun variance_sqrt_and_d2(
+    a_magnitude: u128,
+    a_is_negative: bool,
+    b: u128,
+    inner: u64,
+    k: &I64,
+): (u64, I64) {
     let scale = math::float_scaling!() as u128;
-    let increment = (b as u128) * (inner as u128);
-    let a_scaled = (a.magnitude() as u128) * scale;
-    let total_var = if (a.is_negative()) {
-        assert!(increment > a_scaled, ENonPositiveVariance);
-        increment - a_scaled
+    let increment = b * (inner as u128) / scale;
+    let total_var = if (a_is_negative) {
+        assert!(increment > a_magnitude, ENonPositiveVariance);
+        increment - a_magnitude
     } else {
-        assert!(increment + a_scaled > 0, ENonPositiveVariance);
-        increment + a_scaled
+        assert!(increment + a_magnitude > 0, ENonPositiveVariance);
+        increment + a_magnitude
     };
     let sqrt_var = math::sqrt_u128_down(total_var) as u64;
 
@@ -618,10 +650,11 @@ fun is_positive(value: &I64): bool {
 /// its own inputs rather than through a contrived surface (unit-tests rule 4).
 #[test_only]
 public(package) fun variance_sqrt_and_d2_for_testing(
-    a: &I64,
-    b: u64,
+    a_magnitude: u128,
+    a_is_negative: bool,
+    b: u128,
     inner: u64,
     k: &I64,
 ): (u64, I64) {
-    variance_sqrt_and_d2(a, b, inner, k)
+    variance_sqrt_and_d2(a_magnitude, a_is_negative, b, inner, k)
 }

--- a/packages/predict/tests/flows/lifecycle_tests.move
+++ b/packages/predict/tests/flows/lifecycle_tests.move
@@ -46,7 +46,7 @@ fun one_x_lifecycle_fund_mint() {
         test_constants::mint_quantity(),
         test_constants::leverage_one_x(),
     );
-    helpers::assert_atm_entry_probability(quote.entry_probability());
+    helpers::assert_atm_entry_probability_short_expiry(quote.entry_probability());
     let premium = quote.net_premium();
     let order_id = fx.mint_bundle(
         &mut market,

--- a/packages/predict/tests/flows/no_double_pay_liquidation_tests.move
+++ b/packages/predict/tests/flows/no_double_pay_liquidation_tests.move
@@ -62,7 +62,7 @@ fun liquidated_order_pays_zero_once_and_only_once() {
         test_constants::mint_quantity(),
         LEVERAGE_TWO_X,
     );
-    helpers::assert_atm_entry_probability(quote.entry_probability());
+    helpers::assert_atm_entry_probability_short_expiry(quote.entry_probability());
     let mint_contribution = quote.net_premium();
     let order_id = fx.mint_bundle(
         &mut market,

--- a/packages/predict/tests/flows/settled_solvency_boundary_tests.move
+++ b/packages/predict/tests/flows/settled_solvency_boundary_tests.move
@@ -66,7 +66,7 @@ fun finite_range_partial_close_preserves_live_solvency() {
         test_constants::mint_quantity(),
         test_constants::leverage_one_x(),
     );
-    helpers::assert_atm_entry_probability(quote.entry_probability());
+    helpers::assert_atm_entry_probability_short_expiry(quote.entry_probability());
     let premium = quote.net_premium();
     let order_id = fx.mint_bundle(
         &mut market,

--- a/packages/predict/tests/flows/settlement_flow_tests.move
+++ b/packages/predict/tests/flows/settlement_flow_tests.move
@@ -729,7 +729,7 @@ fun finite_range_premium(fx: &mut helpers::Fixture, market: &helpers::MarketBund
     );
     // The upper boundary is ~315 sigma out and clamps to zero, so this finite
     // range prices as the at-the-money digital itself.
-    helpers::assert_atm_entry_probability(quote.entry_probability());
+    helpers::assert_atm_entry_probability_short_expiry(quote.entry_probability());
     quote.net_premium()
 }
 

--- a/packages/predict/tests/helper/flow_test_helpers.move
+++ b/packages/predict/tests/helper/flow_test_helpers.move
@@ -75,6 +75,16 @@ public fun strike_tick(): u64 { test_constants::default_strike_tick() }
 /// would make every downstream assertion agree with itself and pass. The band is
 /// `normal_cdf`'s documented error, not a measurement — the pre-1e18 pricer sat
 /// 6,310 units out here, some 300x outside it.
+///
+// KNOWN-FAILING: P-17 — for `short_expiry_ms` fixtures only. `flow_fixture_atm_up`
+// models the surface WITHOUT the remaining-time roll-down, which was invisible
+// while the roll-down floored at 1e9: flooring snapped every fixture ratio in
+// [0.5, 1) onto the same effective `a`, so the un-rolled reference agreed by
+// construction. Carrying the roll-down at 1e18 makes the real ratio reach the
+// price, and the short-expiry fixtures (ratio 120_000/121_000) now sit ~52 units
+// out against a 21-unit budget. The reference must model the roll-down per fixture
+// horizon; that is a reference-design decision, so the tests stay RED per
+// unit-tests rule 15 rather than being re-tuned.
 public fun assert_atm_entry_probability(probability: u64) {
     test_helpers::assert_within(
         probability,

--- a/packages/predict/tests/helper/flow_test_helpers.move
+++ b/packages/predict/tests/helper/flow_test_helpers.move
@@ -76,19 +76,25 @@ public fun strike_tick(): u64 { test_constants::default_strike_tick() }
 /// `normal_cdf`'s documented error, not a measurement — the pre-1e18 pricer sat
 /// 6,310 units out here, some 300x outside it.
 ///
-// KNOWN-FAILING: P-17 — for `short_expiry_ms` fixtures only. `flow_fixture_atm_up`
-// models the surface WITHOUT the remaining-time roll-down, which was invisible
-// while the roll-down floored at 1e9: flooring snapped every fixture ratio in
-// [0.5, 1) onto the same effective `a`, so the un-rolled reference agreed by
-// construction. Carrying the roll-down at 1e18 makes the real ratio reach the
-// price, and the short-expiry fixtures (ratio 120_000/121_000) now sit ~52 units
-// out against a 21-unit budget. The reference must model the roll-down per fixture
-// horizon; that is a reference-design decision, so the tests stay RED per
-// unit-tests rule 15 rather than being re-tuned.
+/// The reference models the fixture's remaining-time roll-down, so it is picked
+/// per fixture horizon: this is the far `default_expiry_ms` one. Use
+/// `assert_atm_entry_probability_short_expiry` for `short_expiry_ms` markets,
+/// whose ratio is `120_000/121_000` — far enough below one to move the digital
+/// past this budget.
 public fun assert_atm_entry_probability(probability: u64) {
     test_helpers::assert_within(
         probability,
         ref_data::flow_fixture_atm_up(),
+        ref_data::flow_fixture_atm_budget(),
+    );
+}
+
+/// `assert_atm_entry_probability` for a market built at `short_expiry_ms`, whose
+/// shorter anchored horizon rolls `a` and `b` measurably further down.
+public fun assert_atm_entry_probability_short_expiry(probability: u64) {
+    test_helpers::assert_within(
+        probability,
+        ref_data::flow_fixture_short_expiry_atm_up(),
         ref_data::flow_fixture_atm_budget(),
     );
 }

--- a/packages/predict/tests/helper/reference/generate_pricing_reference.py
+++ b/packages/predict/tests/helper/reference/generate_pricing_reference.py
@@ -410,6 +410,40 @@ ADMITTED_LOW_VARIANCE = {
 }
 
 
+# A surface that separates the two ways of forming `w'` in the skew correction.
+# `b` is carried at 1e18, so `w' = b * slope / 1e18`; narrowing `b` back to 1e9
+# first loses up to a raw unit of it, which at this surface's small `sqrt(w)`
+# moves the digital by ~890 units against a 21-unit budget. Mirrors the fixture in
+# `pricing_guard_tests::w_prime_keeps_the_rolled_b_precision`, which seeds the
+# tuple at 120_000, advances the clock to 121_000, and retransmits it unchanged so
+# the anchor is preserved and `b` is genuinely non-integral at 1e9.
+W_PRIME_PRECISION_SURFACE = {
+    "a": 203 / F,
+    "b": 13 / F,
+    "rho": 1_000_000_000 / F,
+    "m": -831_439 / F,
+    "sigma": 5_000_000 / F,
+}
+# expiry 240_000, anchor 120_000, priced at 121_000.
+W_PRIME_REMAINING_MS, W_PRIME_ANCHOR_TTE_MS = 240_000 - 121_000, 240_000 - 120_000
+
+
+def w_prime_precision_surface_up():
+    """True UP digital at the forward for the `w'` precision surface."""
+    ratio = W_PRIME_REMAINING_MS / W_PRIME_ANCHOR_TTE_MS
+    a = W_PRIME_PRECISION_SURFACE["a"] * ratio
+    b = W_PRIME_PRECISION_SURFACE["b"] * ratio
+    rho, m, sigma = (W_PRIME_PRECISION_SURFACE[key] for key in ("rho", "m", "sigma"))
+    k = 0.0
+    x = k - m
+    sq = math.sqrt(x * x + sigma * sigma)
+    w = a + b * (rho * x + sq)
+    w_prime = b * (rho + x / sq)
+    S = math.sqrt(w)
+    d2 = -(k + w / 2.0) / S
+    return round((phi(d2) - phi_pdf(d2) * w_prime / (2.0 * S)) * F)
+
+
 def admitted_low_variance_up():
     """True UP digital on the newly admitted low-variance surface, at the forward."""
     a, b = ADMITTED_LOW_VARIANCE["a"], ADMITTED_LOW_VARIANCE["b"]
@@ -640,6 +674,12 @@ def emit_move(scenarios, scen_points, budget_units):
     w("/// but floors to zero at 1e9 — the region the u128/1e18 variance path newly")
     w("/// admits, where the previous pricer aborted `ENonPositiveVariance`.")
     w(f"public fun admitted_low_variance_up(): u64 {{ {fmt_u64(admitted_low_variance_up())} }}")
+    w("")
+    w("/// True UP digital on the surface that separates the two ways of forming `w'`")
+    w("/// in the skew correction. Carrying the rolled `b` at 1e18 lands inside the")
+    w("/// budget below; narrowing it to 1e9 first misses by ~570 units.")
+    w("public fun w_prime_precision_surface_up(): u64 { "
+      f"{fmt_u64(w_prime_precision_surface_up())} }}")
     return "\n".join(lines) + "\n"
 
 

--- a/packages/predict/tests/helper/reference/generate_pricing_reference.py
+++ b/packages/predict/tests/helper/reference/generate_pricing_reference.py
@@ -380,6 +380,22 @@ FLOW_FIXTURE = {
     "m": 10 * F / F,                   # default_svi_m
     "sigma": 1_000_000 / F,            # default_svi_sigma
 }
+# The fixtures price a surface that has ALREADY rolled down: the SVI tuple is
+# seeded at `live_source_timestamp_ms` and the pricer loads at `now_ms`, so `a`
+# and `b` are scaled by `remaining_ms / anchor_tte_ms` before pricing. Modelling
+# that here is what makes the reference independent of the contract: it was
+# omitted while the roll-down floored at 1e9, because flooring snapped every
+# fixture ratio in [0.5, 1) onto the same effective `a` and the un-rolled value
+# agreed by construction (predeploy open item P-17).
+PARAMS_TIMESTAMP_MS = 119_000          # test_constants::live_source_timestamp_ms
+NOW_MS = 120_000                       # test_constants::now_ms
+DEFAULT_EXPIRY_MS = 31_536_120_000     # test_constants::default_expiry_ms
+SHORT_EXPIRY_MS = 240_000              # test_constants::short_expiry_ms
+
+
+def roll_down_ratio(expiry_ms):
+    """`remaining_ms / anchor_tte_ms` for a fixture priced at `NOW_MS`."""
+    return (expiry_ms - NOW_MS) / (expiry_ms - PARAMS_TIMESTAMP_MS)
 # A surface in the region the 1e18 variance path newly admits: its per-strike
 # total variance is positive but floors to ZERO at 1e9, so the pre-1e18 pricer
 # aborted `ENonPositiveVariance` here while the analytical minimum still passed the
@@ -422,9 +438,14 @@ def flat_surface_atm_up():
     return round(phi(d2) * F)
 
 
-def flow_fixture_atm_up():
-    """True at-the-money UP digital for the flow fixtures, from first principles."""
-    a, b = FLOW_FIXTURE["a"], FLOW_FIXTURE["b"]
+def flow_fixture_atm_up(expiry_ms=DEFAULT_EXPIRY_MS):
+    """True at-the-money UP digital for the flow fixtures, from first principles.
+
+    `a` and `b` carry the remaining-time roll-down for `expiry_ms`; `rho`, `m`
+    and `sigma` are not rolled.
+    """
+    ratio = roll_down_ratio(expiry_ms)
+    a, b = FLOW_FIXTURE["a"] * ratio, FLOW_FIXTURE["b"] * ratio
     rho, m, sigma = FLOW_FIXTURE["rho"], FLOW_FIXTURE["m"], FLOW_FIXTURE["sigma"]
     k = 0.0                                            # strike == live forward
     x = k - m
@@ -591,8 +612,15 @@ def emit_move(scenarios, scen_points, budget_units):
     w("")
     w("/// True UP digital at the flow fixtures' at-the-money strike, `Phi(d2) -")
     w("/// phi(d2)*w\'(k)/(2*sqrt(w))` evaluated in float64 from the fixture\'s SVI")
-    w("/// parameters. Independent of the contract.")
+    w("/// parameters, with `a` and `b` carrying the remaining-time roll-down for the")
+    w("/// far `default_expiry_ms` horizon (ratio 1 - 3.2e-8). Independent of the contract.")
     w(f"public fun flow_fixture_atm_up(): u64 {{ {fmt_u64(flow_fixture_atm_up())} }}")
+    w("")
+    w("/// Same, for fixtures built at `short_expiry_ms`. Their roll-down ratio is")
+    w("/// 120_000/121_000, so the rolled `a` is materially below the raw value and")
+    w("/// the digital sits off the far-horizon reference by more than its budget.")
+    w("public fun flow_fixture_short_expiry_atm_up(): u64 { "
+      f"{fmt_u64(flow_fixture_atm_up(SHORT_EXPIRY_MS))} }}")
     w("")
     w("/// Absolute budget for the above: `normal_cdf` is documented to 20 raw units")
     w("/// and the d2 path adds under one. Derived from math.move\'s precision")

--- a/packages/predict/tests/pricing/pricing_guard_tests.move
+++ b/packages/predict/tests/pricing/pricing_guard_tests.move
@@ -104,6 +104,19 @@ const WELL_CONDITIONED_SQRT_W: u64 = 31_622;
 const MINIMAL_B_1E18: u128 = 1_000_000_000;
 const MINIMAL_INNER: u64 = 1;
 
+/// A loadable surface (`|rho| == 1e9` zeroes min_increment, so it clears the gate
+/// on `a` alone) whose skew correction is live and whose small `sqrt(w)` amplifies
+/// it, separating the 1e18 and 1e9 forms of `w'`. `m` is negative.
+const W_PRIME_SURFACE_A: u64 = 203;
+const W_PRIME_SURFACE_B: u64 = 13;
+const W_PRIME_SURFACE_RHO: u64 = 1_000_000_000;
+const W_PRIME_SURFACE_M: u64 = 831_439;
+const W_PRIME_SURFACE_SIGMA: u64 = 5_000_000;
+/// Seed the tuple at `now_ms`, price one second later: the anchor is preserved by
+/// the identical retransmit, so the roll-down is live at 119_000/120_000.
+const W_PRIME_EXPIRY_MS: u64 = 240_000;
+const W_PRIME_PRICED_AT_MS: u64 = 121_000;
+
 const PER_STRIKE_NONPOSITIVE_A_MAG: u64 = 99_494;
 const PER_STRIKE_NONPOSITIVE_B: u64 = 100_000_000;
 const PER_STRIKE_NONPOSITIVE_RHO: u64 = 100_000_000;
@@ -726,6 +739,76 @@ fun pre_expiry_roll_down_keeps_positive_variance() {
         pricer.up_price(strike(test_constants::default_live_price())),
         ref_data::flat_surface_atm_up(),
         ref_data::flat_surface_atm_budget(),
+    );
+
+    oracle_fixture::return_oracle_bundle(oracle);
+    fx.finish();
+}
+
+/// Pins the rolled `b`'s precision through the SKEW CORRECTION, not just through
+/// the variance. `compute_nd2` forms `w' = b * slope / 1e18` with `b` at 1e18;
+/// narrowing `b` back to 1e9 first — the shape the variance path itself used to
+/// have — silently drops up to a raw unit of it.
+///
+/// The flow fixtures cannot catch that: their `slope` is ~5 raw units, so `w'`
+/// floors to zero and the correction term vanishes either way. And a fixture whose
+/// pricer loads at the parameter anchor cannot either, because at ratio 1 the
+/// rolled `b` is integral at 1e9 and both forms agree exactly. So this seeds the
+/// tuple, advances the clock, and retransmits it unchanged (which preserves the
+/// anchor) to get a genuinely non-integral rolled `b`. Carrying it at 1e18 lands
+/// 4 units from the independently generated digital; narrowing to 1e9 misses by
+/// ~890 — 42x the budget.
+#[test]
+fun w_prime_keeps_the_rolled_b_precision() {
+    let mut fx = oracle_fixture::setup_oracle(
+        test_constants::default_live_price(),
+        test_constants::default_tick_size(),
+        W_PRIME_EXPIRY_MS,
+    );
+    let mut oracle = fx.take_oracle_bundle();
+    fx.prepare_real_oracle_bundle(
+        &mut oracle,
+        test_constants::default_live_price(),
+        test_constants::default_live_price(),
+        W_PRIME_SURFACE_A,
+        false,
+        W_PRIME_SURFACE_B,
+        W_PRIME_SURFACE_SIGMA,
+        W_PRIME_SURFACE_RHO,
+        false,
+        W_PRIME_SURFACE_M,
+        true,
+    );
+
+    fx.set_clock_for_testing(W_PRIME_PRICED_AT_MS);
+    fx.set_bs_spot_for_testing_bundle(
+        &mut oracle,
+        W_PRIME_PRICED_AT_MS,
+        test_constants::default_live_price(),
+    );
+    fx.set_bs_forward_for_testing_bundle(
+        &mut oracle,
+        W_PRIME_PRICED_AT_MS,
+        test_constants::default_live_price(),
+    );
+    fx.set_bs_svi_for_testing_bundle(
+        &mut oracle,
+        W_PRIME_PRICED_AT_MS,
+        W_PRIME_SURFACE_A,
+        false,
+        W_PRIME_SURFACE_B,
+        W_PRIME_SURFACE_SIGMA,
+        W_PRIME_SURFACE_RHO,
+        false,
+        W_PRIME_SURFACE_M,
+        true,
+    );
+
+    let pricer = fx.load_pricer_bundle(&oracle);
+    test_helpers::assert_within(
+        pricer.up_price(strike(test_constants::default_live_price())),
+        ref_data::w_prime_precision_surface_up(),
+        ref_data::flow_fixture_atm_budget(),
     );
 
     oracle_fixture::return_oracle_bundle(oracle);

--- a/packages/predict/tests/pricing/pricing_guard_tests.move
+++ b/packages/predict/tests/pricing/pricing_guard_tests.move
@@ -94,11 +94,15 @@ const ADMITTED_LOW_VARIANCE_M: u64 = 6_666_634;
 /// `normal_cdf` and `normal_pdf` saturate beyond `|8|`; the cap sits one raw unit
 /// past that so a capped value is unambiguously outside the live domain.
 const SATURATED_D2_MAGNITUDE: u64 = 8_000_000_001;
-/// w = 1e-9 at 1e18 (b * inner = 1e9), the smallest variance the load gate can
-/// admit: sqrt(w) is 31_622 and d2 stays far inside the cap.
-const WELL_CONDITIONED_B: u64 = 1_000;
+/// w = 1e-9 at 1e18 (`b * inner / 1e9` = 1e9), the smallest variance the load gate
+/// can admit: sqrt(w) is 31_622 and d2 stays far inside the cap. `b` is the rolled
+/// 1e18 form, so raw b = 1_000 arrives as 1_000 * 1e9.
+const WELL_CONDITIONED_B_1E18: u128 = 1_000_000_000_000;
 const WELL_CONDITIONED_INNER: u64 = 1_000_000;
 const WELL_CONDITIONED_SQRT_W: u64 = 31_622;
+/// The smallest representable variance: `b * inner / 1e9` = 1 raw unit at 1e18.
+const MINIMAL_B_1E18: u128 = 1_000_000_000;
+const MINIMAL_INNER: u64 = 1;
 
 const PER_STRIKE_NONPOSITIVE_A_MAG: u64 = 99_494;
 const PER_STRIKE_NONPOSITIVE_B: u64 = 100_000_000;
@@ -646,9 +650,14 @@ fun low_variance_surface_prices_where_the_1e9_path_aborted() {
 fun d2_saturates_at_the_normal_clamp_instead_of_overflowing() {
     // w = 1 raw unit at 1e18, so sqrt(w) is 1 and d2 is the numerator itself:
     // k at its domain maximum would otherwise divide out to ~2e19, past u64.
-    let a = i64::from_u64(0);
     let k = i64::from_parts(20_000_000_000, true);
-    let (sqrt_var, d2) = pricing::variance_sqrt_and_d2_for_testing(&a, 1, 1, &k);
+    let (sqrt_var, d2) = pricing::variance_sqrt_and_d2_for_testing(
+        0,
+        false,
+        MINIMAL_B_1E18,
+        MINIMAL_INNER,
+        &k,
+    );
 
     assert_eq!(sqrt_var, 1);
     assert_eq!(d2.magnitude(), SATURATED_D2_MAGNITUDE);
@@ -656,8 +665,9 @@ fun d2_saturates_at_the_normal_clamp_instead_of_overflowing() {
 
     // A well-conditioned input on the same path is untouched by the cap.
     let (sqrt_var, d2) = pricing::variance_sqrt_and_d2_for_testing(
-        &a,
-        WELL_CONDITIONED_B,
+        0,
+        false,
+        WELL_CONDITIONED_B_1E18,
         WELL_CONDITIONED_INNER,
         &i64::from_u64(0),
     );
@@ -665,12 +675,18 @@ fun d2_saturates_at_the_normal_clamp_instead_of_overflowing() {
     assert!(d2.magnitude() < SATURATED_D2_MAGNITUDE);
 }
 
-/// Raw `a == 1` is valid at the parameter anchor, but direct integer roll-down
-/// floors it to zero one millisecond later. An identical retransmit at that
-/// later millisecond refreshes the envelope without resetting the anchor, so
-/// the existing quote-time variance guard remains the failure boundary.
-#[test, expected_failure(abort_code = pricing::ENonPositiveVariance)]
-fun pre_expiry_roll_down_to_zero_variance_aborts() {
+/// Raw `a == 1` one millisecond past the parameter anchor. The 1e9 roll-down
+/// floored it straight to zero here and aborted `ENonPositiveVariance` on a
+/// surface whose variance is barely reduced; carrying the roll-down at 1e18
+/// leaves `a` at 0.9999833e-9 and the surface prices normally.
+///
+/// An identical retransmit at that later millisecond refreshes the envelope
+/// without resetting the anchor, so this is the real production sequence, not a
+/// contrived one. The expected value is the flat-surface reference: `b` is zero,
+/// so `w` is just the rolled `a`, and the roll-down moves the digital by well
+/// under one raw unit at this horizon.
+#[test]
+fun pre_expiry_roll_down_keeps_positive_variance() {
     let expiry_ms = test_constants::now_ms() + test_constants::default_cadence_period_ms();
     let mut fx = oracle_fixture::setup_oracle(
         test_constants::default_live_price(),
@@ -706,11 +722,14 @@ fun pre_expiry_roll_down_to_zero_variance_aborts() {
     );
     let pricer = fx.load_pricer_bundle(&oracle);
 
-    pricer.up_price(strike(test_constants::default_live_price()));
+    test_helpers::assert_within(
+        pricer.up_price(strike(test_constants::default_live_price())),
+        ref_data::flat_surface_atm_up(),
+        ref_data::flat_surface_atm_budget(),
+    );
 
     oracle_fixture::return_oracle_bundle(oracle);
     fx.finish();
-    abort EUnexpectedSuccess
 }
 
 // === Surface minimum-variance abort ===

--- a/packages/predict/tests/pricing/pricing_reference_data.move
+++ b/packages/predict/tests/pricing/pricing_reference_data.move
@@ -371,6 +371,11 @@ public fun flat_surface_atm_up(): u64 { 499_993_692 }
 /// precision contract and never measured from contract output.
 public fun flat_surface_atm_budget(): u64 { 21 }
 
+/// True UP digital on the surface that separates the two ways of forming `w'`
+/// in the skew correction. Carrying the rolled `b` at 1e18 lands inside the
+/// budget below; narrowing it to 1e9 first misses by ~890 units.
+public fun w_prime_precision_surface_up(): u64 { 499_903_815 }
+
 /// True UP digital on the surface whose per-strike total variance is positive
 /// but floors to zero at 1e9 — the region the u128/1e18 variance path newly
 /// admits, where the previous pricer aborted `ENonPositiveVariance`.

--- a/packages/predict/tests/pricing/pricing_reference_data.move
+++ b/packages/predict/tests/pricing/pricing_reference_data.move
@@ -348,8 +348,14 @@ public fun svi_event_digest(s: u64): vector<u8> {
 
 /// True UP digital at the flow fixtures' at-the-money strike, `Phi(d2) -
 /// phi(d2)*w'(k)/(2*sqrt(w))` evaluated in float64 from the fixture's SVI
-/// parameters. Independent of the contract.
+/// parameters, with `a` and `b` carrying the remaining-time roll-down for the
+/// far `default_expiry_ms` horizon (ratio 1 - 3.2e-8). Independent of the contract.
 public fun flow_fixture_atm_up(): u64 { 499_993_690 }
+
+/// Same, for fixtures built at `short_expiry_ms`. Their roll-down ratio is
+/// 120_000/121_000, so the rolled `a` is materially below the raw value and
+/// the digital sits off the far-horizon reference by more than its budget.
+public fun flow_fixture_short_expiry_atm_up(): u64 { 499_993_716 }
 
 /// Absolute budget for the above: `normal_cdf` is documented to 20 raw units
 /// and the d2 path adds under one. Derived from math.move's precision

--- a/packages/predict/tests/pricing/pricing_tests.move
+++ b/packages/predict/tests/pricing/pricing_tests.move
@@ -74,63 +74,96 @@ const ROLL_DOWN_MIDPOINT_MS: u64 = 120_050;
 const SHORT_ROLL_DOWN_EXPIRY_MS: u64 = 180_000;
 const SHORT_ROLL_DOWN_MIDPOINT_MS: u64 = 150_000;
 const ODD_ROLL_DOWN_VALUE: u64 = 11;
-const HALF_ODD_ROLL_DOWN_VALUE: u64 = 5;
 const BOUNDARY_ROLL_DOWN_VALUE: u64 = 100;
 const ONE_MS_ROLL_DOWN_VALUE: u64 = 1;
-const HALF_U64_MAX: u64 = 9_223_372_036_854_775_807;
+/// `roll_down_to_1e18` results, hand-derived as `value * 1e9 * remaining / anchor`.
+/// 11 at the anchor; 11 halved is 5.5, which only exists at 1e18 — the 1e9 form
+/// floored it to 5, a 9.1% loss on the term that dominates short-dated variance.
+const ODD_AT_ANCHOR_1E18: u128 = 11_000_000_000;
+const ODD_HALVED_1E18: u128 = 5_500_000_000;
+/// 11 * 1e9 / 3 = 3_666_666_666.67 — the residual floor, now at 1e18 not 1e9.
+const ODD_THIRD_1E18: u128 = 3_666_666_666;
+const ONE_MS_1E18: u128 = 1_000_000_000;
+/// u64::MAX * 1e9. Reached at ratio 1 with both terms at u64::MAX, where the
+/// unreduced product is ~1.7e47 — far past u128, so this pins the u256 intermediate.
+const U64_MAX_1E18: u128 = 18_446_744_073_709_551_615_000_000_000;
+/// sqrt(w) for w = 5.5e9 at 1e18, i.e. isqrt(5_500_000_000). The 1e9 roll-down
+/// produced w = 5e9 here and sqrt 70_710, so this value is what the extra
+/// resolution is worth on the term pricing actually divides by.
+const HALVED_B_SQRT_VAR: u64 = 74_161;
+const UNIT_INNER: u64 = 1_000_000_000;
 const RETRANSMITTED_SVI_A: u64 = 2;
 const RETRANSMITTED_SVI_B: u64 = 0;
 const ZERO_SVI_SHAPE_PARAM: u64 = 0;
 
 #[test]
-fun roll_down_is_exact_at_anchor_and_rounds_signed_a_toward_zero() {
-    let negative_a = i64::from_parts(ODD_ROLL_DOWN_VALUE, true);
+fun roll_down_is_exact_at_anchor_and_keeps_sub_1e9_resolution() {
     let anchor_tte_ms = ROLL_DOWN_EXPIRY_MS - ROLL_DOWN_ANCHOR_MS;
 
-    let (at_anchor_a, at_anchor_b) = pricing::roll_down_ab(
-        negative_a,
-        ODD_ROLL_DOWN_VALUE,
-        anchor_tte_ms,
-        anchor_tte_ms,
+    // At the anchor the fraction is 1, so the value is just restated at 1e18.
+    assert_eq!(
+        pricing::roll_down_to_1e18(ODD_ROLL_DOWN_VALUE, anchor_tte_ms, anchor_tte_ms),
+        ODD_AT_ANCHOR_1E18,
     );
-    assert_eq!(at_anchor_a, negative_a);
-    assert_eq!(at_anchor_b, ODD_ROLL_DOWN_VALUE);
 
-    let (midpoint_a, midpoint_b) = pricing::roll_down_ab(
-        negative_a,
-        ODD_ROLL_DOWN_VALUE,
-        ROLL_DOWN_EXPIRY_MS - ROLL_DOWN_MIDPOINT_MS,
-        anchor_tte_ms,
+    // 11 * 1e9 * 50 / 100 = 5.5e9. Half of an odd raw unit has no representation
+    // at 1e9 — the previous roll-down floored it to 5 — so this exact 5.5 is the
+    // resolution the 1e18 carry exists to keep.
+    assert_eq!(
+        pricing::roll_down_to_1e18(
+            ODD_ROLL_DOWN_VALUE,
+            ROLL_DOWN_EXPIRY_MS - ROLL_DOWN_MIDPOINT_MS,
+            anchor_tte_ms,
+        ),
+        ODD_HALVED_1E18,
     );
-    // floor(11 * 50 / 100) = 5; signed magnitude scaling therefore rounds
-    // negative `a` toward zero.
-    assert_eq!(midpoint_a, i64::from_parts(HALF_ODD_ROLL_DOWN_VALUE, true));
-    assert_eq!(midpoint_b, HALF_ODD_ROLL_DOWN_VALUE);
+
+    // 11 * 1e9 / 3 does not divide either: the floor still exists, it is just a
+    // billionth of the one it replaced.
+    assert_eq!(pricing::roll_down_to_1e18(ODD_ROLL_DOWN_VALUE, 1, 3), ODD_THIRD_1E18);
 }
 
 #[test]
-fun roll_down_handles_one_ms_boundary_and_u128_intermediates() {
+fun roll_down_handles_one_ms_boundary_and_u256_intermediates() {
     let anchor_tte_ms = ROLL_DOWN_EXPIRY_MS - ROLL_DOWN_ANCHOR_MS;
-    let (wide_a, wide_b) = pricing::roll_down_ab(
-        i64::from_parts(std::u64::max_value!(), false),
-        std::u64::max_value!(),
-        ROLL_DOWN_EXPIRY_MS - ROLL_DOWN_MIDPOINT_MS,
-        anchor_tte_ms,
-    );
-    // floor(u64::MAX * 50 / 100) = floor(u64::MAX / 2). The input product
-    // exceeds u64, so this exact result pins the u128 intermediate.
-    assert_eq!(wide_a, i64::from_parts(HALF_U64_MAX, false));
-    assert_eq!(wide_b, HALF_U64_MAX);
 
-    let (one_ms_a, one_ms_b) = pricing::roll_down_ab(
-        i64::from_parts(BOUNDARY_ROLL_DOWN_VALUE, false),
-        BOUNDARY_ROLL_DOWN_VALUE,
-        ONE_MS_ROLL_DOWN_VALUE,
-        anchor_tte_ms,
+    // u64::MAX * 1e9 * u64::MAX / u64::MAX. The unreduced product is ~1.7e47,
+    // three orders past u128, so an exact result here pins the u256 intermediate
+    // rather than any bound on the anchored horizon.
+    assert_eq!(
+        pricing::roll_down_to_1e18(
+            std::u64::max_value!(),
+            std::u64::max_value!(),
+            std::u64::max_value!(),
+        ),
+        U64_MAX_1E18,
     );
-    // floor(100 * 1 / 100) = 1 exactly one millisecond before expiry.
-    assert_eq!(one_ms_a, i64::from_parts(ONE_MS_ROLL_DOWN_VALUE, false));
-    assert_eq!(one_ms_b, ONE_MS_ROLL_DOWN_VALUE);
+
+    // 100 * 1e9 * 1 / 100 = 1e9 exactly one millisecond before expiry.
+    assert_eq!(
+        pricing::roll_down_to_1e18(
+            BOUNDARY_ROLL_DOWN_VALUE,
+            ONE_MS_ROLL_DOWN_VALUE,
+            anchor_tte_ms,
+        ),
+        ONE_MS_1E18,
+    );
+}
+
+#[test]
+fun rolled_sub_1e9_resolution_reaches_the_variance_pricing_divides_by() {
+    // The roll-down above is only worth carrying if it survives into `sqrt(w)`.
+    // With `b` halved from 11 to 5.5 and `inner` at one, w is 5.5e9 at 1e18 and
+    // isqrt(5_500_000_000) = 74_161. The 1e9 roll-down floored b to 5, giving
+    // w = 5e9 and sqrt 70_710 — a 4.7% error on the divisor of d2.
+    let (sqrt_var, _d2) = pricing::variance_sqrt_and_d2_for_testing(
+        0,
+        false,
+        ODD_HALVED_1E18,
+        UNIT_INNER,
+        &i64::from_u64(0),
+    );
+    assert_eq!(sqrt_var, HALVED_B_SQRT_VAR);
 }
 
 #[test]

--- a/packages/predict/tests/test_constants.move
+++ b/packages/predict/tests/test_constants.move
@@ -106,9 +106,10 @@ public fun default_expiry_ms(): u64 { 31_536_120_000 }
 /// `(default_strike_tick, +inf]` range).
 public fun default_live_price(): u64 { 100_000_000_000 }
 
-/// Default SVI `a` for live oracle test fixtures. A raw value of 2 keeps the
-/// effective value positive across the fixtures' small post-seed clock advances.
-public fun default_svi_a(): u64 { 2 }
+/// Default SVI `a` for live oracle test fixtures. Back to the raw 1 the pricing
+/// reference mirrors: it needed doubling only while the roll-down floored at 1e9,
+/// where the fixtures' post-seed clock advance drove a raw 1 straight to zero.
+public fun default_svi_a(): u64 { 1 }
 
 /// Default SVI `b` for live oracle test fixtures.
 public fun default_svi_b(): u64 { 10_000 }


### PR DESCRIPTION
Review follow-up on #1165. Draft — the point is the shape of the fix and the two things it uncovers, not merge-readiness.

## Summary
- `roll_down_to_1e18` replaces `roll_down_ab`: it scales one 1e9-scaled SVI magnitude by `remaining_ms / anchor_tte_ms` and returns it **at 1e18**, through a `u256` intermediate. `PricingSVI` carries the rolled `a`/`b` in that domain and `variance_sqrt_and_d2` consumes them directly, so the roll-down never round-trips through 1e9.
- Reverts the `default_svi_a` 1 → 2 fixture bump.
- Updates RP-21's formula (it no longer matched the code) and its pinning-test list.
- Makes the flow pricing reference horizon-aware so it models the roll-down it was silently omitting.

## Why
#1165 floors `a` and `b` with `mul_div_down` at 1e9 immediately upstream of the 1e18 variance path #1166 built, reintroducing P-14's truncation one layer up.

On the short-dated regime that path targets — ATM total variance ≈ 1e-8, so `a` is about **ten raw units** at 1e9 — flooring `a` costs up to ~10% of the dominant variance term. Measured against an exact roll-down over a moneyness grid inside the ratified 1c–99c band:

| `remaining/anchor` | worst relative error |
|---|---|
| 0.99 | 13.35% |
| 0.55 | 13.50% |
| 0.11 | 13.65% |

against the **0.1%** ratified deviation bound. Hand-checked point, `k = 3.30e-4`, ratio 0.99: floored `up = 0.008678` vs exact `0.010014` — the floored price falls out of the 1c band while the true one is inside it. Same systematic-downward-bias signature as P-14, whose measured worst case was 3.28%.

## Key decisions
- **`u256` for the intermediate, at load only.** `value * 1e9 * remaining_ms` overflows u128 for a large enough anchored horizon, and there is no upper bound on `expiry_ms`. Doing it in u256 removes the need for one. It is once per pricer load, not per strike — the per-strike path stays pure u128.
- **`b` reaches `w_prime` at 1e18 too.** `compute_nd2` now forms `w'` as `b * slope / 1e18` rather than pre-narrowing `b`, so the skew correction sees the same resolution as the variance.
- **`default_svi_a` goes back to 1.** The bump to 2 was a workaround for the 1e9 floor — it read "keeps the effective value positive across the fixtures' small post-seed clock advances", which is precisely the truncation this PR removes. At 1e18 a raw 1 stays positive.
- **`pre_expiry_roll_down_to_zero_variance_aborts` becomes `..._keeps_positive_variance`.** That surface (raw `a = 1`, one millisecond past the anchor) aborted only because of the floor. It now prices, asserted against the existing `flat_surface_atm_up` reference. The genuinely degenerate `a = 0, b = 0` case still aborts at load, unchanged.

## Scope / descoped
Precision only. **Not** touched: the envelope gate still validates the raw surface while pricing consumes the rolled one, so `assert_min_total_variance_positive` still does not cover what is actually priced. That is a policy question RP-21 already settles one way; this PR only shrinks how often it bites, since the truncation slop is what makes the effective sign unreliable. Also untouched: `variance_sqrt_and_d2_for_testing` could stop being a `#[test_only]` seam by making `variance_sqrt_and_d2` plain `public(package)` (not deploy surface), but that is unrelated cleanup.

## What this uncovered — the second commit

The flow-fixture pricing reference **never modelled the roll-down**, and the 1e9 floor was hiding it. Flooring snapped every fixture whose `remaining_ms / anchor_tte_ms` fell in `[0.5, 1)` onto the *same* effective `a`, so an un-rolled Python reference agreed with a rolled contract by construction. The flow suite could not detect a roll-down defect at all. The `default_svi_a` 1 → 2 bump is the same artifact.

Removing the quantizer let the true ratio reach the price and exposed 8 assertions. `generate_pricing_reference.py` now models the roll-down (`roll_down_ratio`, mirroring `test_constants::{live_source_timestamp_ms, now_ms}` and each fixture expiry) and emits one reference per horizon.

The strongest evidence the model is right: regenerating the **far** horizon reproduces the previously committed `499_993_690` exactly. Only `short_expiry_ms` fixtures needed a new constant — ratio `120_000/121_000`, reference `499_993_716`, 26 units from the far-horizon value against a 21-unit budget, which is precisely why they failed.

Note on provenance: the generator's dataset is gitignored and the generator is not in the CI path (unit-tests rule 16), so the new constant was produced by executing the generator's own pure reference functions and hand-inserted. A full regeneration reproduces it.

## Test plan
- [x] `sui move build --path packages/predict --warnings-are-errors` — clean
- [x] `sui move test --path packages/predict` — 455/455
- [x] `sui move test --path packages/propbook` — 63/63
- [x] `python3 packages/predict/predeploy/check.py` — 0 warnings
- [x] `pnpm format:move` (via repo-pinned prettier-move) — clean
- [x] New: `roll_down_is_exact_at_anchor_and_keeps_sub_1e9_resolution`, `roll_down_handles_one_ms_boundary_and_u256_intermediates` (pins the u256 need at an unreduced product of ~1.7e47), `rolled_sub_1e9_resolution_reaches_the_variance_pricing_divides_by` (halved `b` gives `sqrt(w)` 74_161 where the 1e9 form gave 70_710)

## Risk / rollout
Pre-deploy; no migration. `PricingSVI` is transaction-local (no `store`), so the layout change is not on-chain state. `roll_down_ab` was `public(package)` and is replaced, not a public-surface break.



