### PR TITLE
margin: restore deployed public surface and fix testnet dep resolution (DBU-667)

### DIFF
--- a/packages/deepbook_margin/Move.lock
+++ b/packages/deepbook_margin/Move.lock
@@ -59,7 +59,7 @@ manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5E
 deps = { std = "MoveStdlib", sui = "Sui" }
 
 [pinned.testnet.MoveStdlib]
-source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "85400e2bd37b490fcd057776e700d3fdca643396" }
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "d50b78880fdacb1bbde92e6974ed71a7650c1090" }
 use_environment = "testnet"
 manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
 deps = {}
@@ -71,13 +71,13 @@ manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05
 deps = {}
 
 [pinned.testnet.Pyth]
-source = { git = "https://github.com/pyth-network/pyth-crosschain.git", subdir = "target_chains/sui/contracts", rev = "3bd1262dcba9518a6901aa6a15f04072799bfb37" }
+source = { git = "https://github.com/pyth-network/pyth-crosschain.git", subdir = "target_chains/sui/contracts", rev = "62c7a5bc0fc857ba6417ad780190552d4919ceca" }
 use_environment = "testnet"
-manifest_digest = "9942AAB3725BC51DADB046B4440A3D008E554C9286ECC72B3DE5CC0309C0D63D"
+manifest_digest = "EE442EEB0E1F71B244DBB1E016B1D0D8F67061BDAFA606B6C86F093D15CA0755"
 deps = { Sui = "Sui_1", Wormhole = "Wormhole" }
 
 [pinned.testnet.Sui]
-source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "85400e2bd37b490fcd057776e700d3fdca643396" }
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "d50b78880fdacb1bbde92e6974ed71a7650c1090" }
 use_environment = "testnet"
 manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
 deps = { MoveStdlib = "MoveStdlib" }
@@ -89,7 +89,7 @@ manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D
 deps = { MoveStdlib = "MoveStdlib_1" }
 
 [pinned.testnet.Wormhole]
-source = { git = "https://github.com/wormhole-foundation/wormhole.git", subdir = "sui/wormhole", rev = "b71be5cbb9537c4aac8e23e74371affa3825efcd" }
+source = { git = "https://github.com/wormhole-foundation/wormhole.git", subdir = "sui/wormhole", rev = "1b1cb69e809e0e7081cf1bf9b2779c41c14fc7f0" }
 use_environment = "testnet"
 manifest_digest = "6996F1AB8CD448FFBA142C085C488FE8A46B485E61E38A1891EFA52B30D9C12E"
 deps = { Sui = "Sui_1" }
@@ -103,11 +103,11 @@ deps = { std = "MoveStdlib", sui = "Sui", token = "token" }
 [pinned.testnet.deepbook_margin]
 source = { root = true }
 use_environment = "testnet"
-manifest_digest = "0399AA4FC0023475DA450CD4E893FAA707F2D974710687B551D39BD9679B288E"
+manifest_digest = "2B11F937CAB0205DF499B09DD0EC9FCC6EC7B178DF3DDC4861AE35E4F18D2AF3"
 deps = { deepbook = "deepbook", pyth = "Pyth", std = "MoveStdlib", sui = "Sui", token = "token" }
 
 [pinned.testnet.token]
-source = { git = "https://github.com/MystenLabs/deepbookv3.git", subdir = "packages/token", rev = "190ab8fd15bca03b20965ab2a7b6911fcdf2bf1f" }
+source = { git = "https://github.com/MystenLabs/deepbookv3.git", subdir = "packages/token", rev = "0b6d9cca8975f38cf55c3e9bf5dcca2563b148cb" }
 use_environment = "testnet"
 manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
 deps = { std = "MoveStdlib", sui = "Sui" }

--- a/packages/deepbook_margin/Move.lock
+++ b/packages/deepbook_margin/Move.lock
@@ -35,7 +35,7 @@ manifest_digest = "CD547CB1ACCE0880C835DAED2D8FFCB91D56C833AE5240D3AA5B918398263
 deps = { MoveStdlib = "MoveStdlib_1" }
 
 [pinned.mainnet.Wormhole]
-source = { git = "https://github.com/wormhole-foundation/wormhole.git", subdir = "sui/wormhole", rev = "b71be5cbb9537c4aac8e23e74371affa3825efcd" }
+source = { git = "https://github.com/wormhole-foundation/wormhole.git", subdir = "sui/wormhole", rev = "1b1cb69e809e0e7081cf1bf9b2779c41c14fc7f0" }
 use_environment = "mainnet"
 manifest_digest = "0D766A0380B75080707CFA6099AF469A2E502B0D9DC334A9E9983B391C5555D9"
 deps = { Sui = "Sui_1" }
@@ -59,7 +59,7 @@ manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5E
 deps = { std = "MoveStdlib", sui = "Sui" }
 
 [pinned.testnet.MoveStdlib]
-source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "d50b78880fdacb1bbde92e6974ed71a7650c1090" }
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "85400e2bd37b490fcd057776e700d3fdca643396" }
 use_environment = "testnet"
 manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
 deps = {}
@@ -77,7 +77,7 @@ manifest_digest = "EE442EEB0E1F71B244DBB1E016B1D0D8F67061BDAFA606B6C86F093D15CA0
 deps = { Sui = "Sui_1", Wormhole = "Wormhole" }
 
 [pinned.testnet.Sui]
-source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "d50b78880fdacb1bbde92e6974ed71a7650c1090" }
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "85400e2bd37b490fcd057776e700d3fdca643396" }
 use_environment = "testnet"
 manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
 deps = { MoveStdlib = "MoveStdlib" }

--- a/packages/deepbook_margin/Move.toml
+++ b/packages/deepbook_margin/Move.toml
@@ -12,6 +12,3 @@ pyth = { git = "https://github.com/pyth-network/pyth-crosschain.git", subdir = "
 
 [dep-replacements.testnet]
 pyth = { git = "https://github.com/pyth-network/pyth-crosschain.git", subdir = "target_chains/sui/contracts", rev = "sui-contract-testnet" }
-
-[addresses]
-deepbook_margin = "0x0"

--- a/packages/deepbook_margin/Published.toml
+++ b/packages/deepbook_margin/Published.toml
@@ -13,9 +13,9 @@ upgrade-capability = "0xd57c7a41b31c0a1fab5e71d296a75daf2e9e09945df383d4745daa49
 
 [published.testnet]
 chain-id = "4c78adac"
-published-at = "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580"
+published-at = "0x3a636035f0bbcced1bbc9157654b75a402a09a91ccf0c7e9bd043feaf98b8608"
 original-id = "0xb8620c24c9ea1a4a41e79613d2b3d1d93648d1bb6f6b789a7c8f261c94110e4b"
-version = 14
-toolchain-version = "1.64.1"
+version = 15
+toolchain-version = "1.76.0"
 build-config = { flavor = "sui", edition = "2024" }
 upgrade-capability = "0x36eb7f6bdbcd7445386eb13f13e24c3cc6248eb4b969c3917cb502f32a65ba6a"

--- a/packages/deepbook_margin/sources/helper/oracle.move
+++ b/packages/deepbook_margin/sources/helper/oracle.move
@@ -8,7 +8,7 @@ use deepbook::{constants, math};
 use deepbook_margin::{margin_constants, margin_registry::MarginRegistry};
 use pyth::{price_info::PriceInfoObject, pyth};
 use std::type_name::{Self, TypeName};
-use sui::{clock::Clock, coin_registry::Currency, vec_map::{Self, VecMap}};
+use sui::{clock::Clock, coin::CoinMetadata, coin_registry::Currency, vec_map::{Self, VecMap}};
 
 use fun get_config_for_type as MarginRegistry.get_config_for_type;
 
@@ -42,6 +42,19 @@ public struct ConversionConfig has copy, drop {
     base_decimals: u8,
     pyth_price: u64,
     pyth_decimals: u8,
+}
+
+/// Superseded by `new_coin_type_data_from_currency`, which reads decimals from
+/// `Currency` instead of trusting the caller-supplied `CoinMetadata`. Retained as an
+/// aborting stub because it is public in the deployed package: a `compatible` upgrade
+/// cannot drop a public function.
+public fun new_coin_type_data<T>(
+    _coin_metadata: &CoinMetadata<T>,
+    _price_feed_id: vector<u8>,
+    _max_conf_bps: u64,
+    _max_ewma_difference_bps: u64,
+): CoinTypeData {
+    abort 1337
 }
 
 /// Creates a new CoinTypeData struct of type T.

--- a/packages/deepbook_margin/sources/margin_manager.move
+++ b/packages/deepbook_margin/sources/margin_manager.move
@@ -13,6 +13,7 @@ use deepbook::{
         WithdrawCap,
         TradeProof,
         DeepBookPoolReferral,
+        DeepBookReferral,
     },
     constants,
     math,
@@ -492,6 +493,26 @@ public fun unset_margin_manager_referral<BaseAsset, QuoteAsset>(
 ) {
     self.validate_owner(ctx);
     self.balance_manager.unset_balance_manager_referral(pool_id, &self.trade_cap);
+}
+
+/// Superseded by `set_margin_manager_referral`, which takes a pool-scoped
+/// `DeepBookPoolReferral`. Retained as an aborting stub because it is public in the
+/// deployed package: a `compatible` upgrade cannot drop a public function.
+public fun set_referral<BaseAsset, QuoteAsset>(
+    _self: &mut MarginManager<BaseAsset, QuoteAsset>,
+    _referral_cap: &DeepBookReferral,
+    _ctx: &mut TxContext,
+) {
+    abort
+}
+
+/// Superseded by `unset_margin_manager_referral`, which is pool-scoped. Retained as an
+/// aborting stub for the same reason as `set_referral`.
+public fun unset_referral<BaseAsset, QuoteAsset>(
+    _self: &mut MarginManager<BaseAsset, QuoteAsset>,
+    _ctx: &mut TxContext,
+) {
+    abort
 }
 
 // === Public Functions - Margin Manager ===
@@ -1162,6 +1183,109 @@ public fun manager_state<BaseAsset, QuoteAsset>(
         current_price,
         lowest_trigger_above_price,
         highest_trigger_below_price,
+    )
+}
+
+/// Returns comprehensive state information for multiple margin managers.
+/// Same as manager_state but takes a vector and returns vectors of all values.
+/// All managers must be of the same type.
+public fun manager_states<BaseAsset, QuoteAsset>(
+    margin_managers: &vector<MarginManager<BaseAsset, QuoteAsset>>,
+    registry: &MarginRegistry,
+    base_oracle: &PriceInfoObject,
+    quote_oracle: &PriceInfoObject,
+    pool: &Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    clock: &Clock,
+): (
+    vector<ID>,
+    vector<ID>,
+    vector<u64>,
+    vector<u64>,
+    vector<u64>,
+    vector<u64>,
+    vector<u64>,
+    vector<u64>,
+    vector<u8>,
+    vector<u64>,
+    vector<u8>,
+    vector<u64>,
+    vector<u64>,
+    vector<u64>,
+) {
+    let mut manager_ids = vector[];
+    let mut deepbook_pool_ids = vector[];
+    let mut risk_ratios = vector[];
+    let mut base_assets = vector[];
+    let mut quote_assets = vector[];
+    let mut base_debts = vector[];
+    let mut quote_debts = vector[];
+    let mut base_pyth_prices = vector[];
+    let mut base_pyth_decimals_vec = vector[];
+    let mut quote_pyth_prices = vector[];
+    let mut quote_pyth_decimals_vec = vector[];
+    let mut current_prices = vector[];
+    let mut lowest_trigger_above_prices = vector[];
+    let mut highest_trigger_below_prices = vector[];
+
+    margin_managers.do_ref!(|manager| {
+        let (
+            manager_id,
+            deepbook_pool_id,
+            risk_ratio,
+            base_asset,
+            quote_asset,
+            base_debt,
+            quote_debt,
+            base_pyth_price,
+            base_pyth_decimals,
+            quote_pyth_price,
+            quote_pyth_decimals,
+            current_price,
+            lowest_trigger_above_price,
+            highest_trigger_below_price,
+        ) = manager.manager_state(
+            registry,
+            base_oracle,
+            quote_oracle,
+            pool,
+            base_margin_pool,
+            quote_margin_pool,
+            clock,
+        );
+
+        manager_ids.push_back(manager_id);
+        deepbook_pool_ids.push_back(deepbook_pool_id);
+        risk_ratios.push_back(risk_ratio);
+        base_assets.push_back(base_asset);
+        quote_assets.push_back(quote_asset);
+        base_debts.push_back(base_debt);
+        quote_debts.push_back(quote_debt);
+        base_pyth_prices.push_back(base_pyth_price);
+        base_pyth_decimals_vec.push_back(base_pyth_decimals);
+        quote_pyth_prices.push_back(quote_pyth_price);
+        quote_pyth_decimals_vec.push_back(quote_pyth_decimals);
+        current_prices.push_back(current_price);
+        lowest_trigger_above_prices.push_back(lowest_trigger_above_price);
+        highest_trigger_below_prices.push_back(highest_trigger_below_price);
+    });
+
+    (
+        manager_ids,
+        deepbook_pool_ids,
+        risk_ratios,
+        base_assets,
+        quote_assets,
+        base_debts,
+        quote_debts,
+        base_pyth_prices,
+        base_pyth_decimals_vec,
+        quote_pyth_prices,
+        quote_pyth_decimals_vec,
+        current_prices,
+        lowest_trigger_above_prices,
+        highest_trigger_below_prices,
     )
 }
 

--- a/packages/margin_liquidation/Move.toml
+++ b/packages/margin_liquidation/Move.toml
@@ -4,8 +4,12 @@ edition = "2024.alpha"
 version = "0.0.1"
 
 [dependencies]
+token = { git = "https://github.com/MystenLabs/deepbookv3.git", subdir = "packages/token", rev = "main"}
 deepbook = { local = "../deepbook" }
 deepbook_margin = { local = "../deepbook_margin" }
 
-[addresses]
-margin_liquidation = "0x0"
+# Pyth dependency
+pyth = { git = "https://github.com/pyth-network/pyth-crosschain.git", subdir = "target_chains/sui/contracts", rev = "sui-contract-mainnet" }
+
+[dep-replacements.testnet]
+pyth = { git = "https://github.com/pyth-network/pyth-crosschain.git", subdir = "target_chains/sui/contracts", rev = "sui-contract-testnet" }


### PR DESCRIPTION
## Summary
- Remove the legacy `[addresses]` section from `packages/deepbook_margin/Move.toml`, which was keeping the package in legacy mode where `[dep-replacements.<env>]` is silently ignored.
- Re-pin testnet Pyth (and, as it requires, testnet Wormhole) in `Move.lock`.
- Restore four public functions that exist in the deployed testnet package but were absent from main: `oracle::new_coin_type_data`, `margin_manager::manager_states`, `margin_manager::set_referral`, `margin_manager::unset_referral`.
- Migrate `packages/margin_liquidation` off the legacy manifest as well, declaring the `pyth` and `token` dependencies it actually uses.
- Record the testnet v15 publish in `Published.toml`.

## Why
- `sui client upgrade` against margin testnet failed with `Failed to fetch package Pyth`. Under the testnet environment Pyth resolved to its **mainnet** addresses (`published-at 0x04e20ddf…`, `original-id 0x8d97f1cd…`), which do not exist on testnet. Root cause was the legacy `[addresses]` section — the new package system eliminates it, and its presence disables environment-specific dependency replacement.
- With that fixed, the on-chain compatibility check rejected the upgrade with four `Compatibility E01001: missing public declaration` errors. A `compatible` upgrade cannot drop a public function, and no laxer upgrade policy exists in Sui.
- Package v14 was published from an uncommitted working tree, so those four functions shipped on-chain and were then removed from main a day later. The deployed interface — not main's intent — is the binding constraint.
- Net effect: margin testnet had been un-upgradeable from main since February. Nobody noticed because nobody upgraded it in that window.

## Key decisions
- **Restored, not stubbed uniformly.** Three of the four are already aborting stubs in the deployed package, so they are restored exactly as deployed. `manager_states` keeps its real implementation, because that is what v14 actually does and callers would otherwise silently start aborting.
- **Comments say why each stub exists**, so the next person does not "clean them up" again and re-break upgrades.
- **`margin_liquidation` was dragged in by the rules, not by choice.** An old-style manifest cannot depend on a new-style package, and it depends on `deepbook_margin`. Migrating it requires declaring `pyth` and `token` explicitly: it uses both in sources and tests but never listed them, relying on the old system leaking transitive named addresses into scope.
- **Known duplication:** `margin_liquidation` now pins the Pyth revs independently of `deepbook_margin`. The new system has no re-export, so the declaration is required; if the two ever diverge the build fails loudly with `Address 'pyth' is defined more than once`.
- **Framework pins deliberately left alone.** Regenerating the lock also bumped the implicit Sui framework to `d50b7888`, which introduces `sui::scratch`; CI runs sui `testnet-v1.74.0`, whose Move VM cannot verify it, and all 372 margin tests failed with `UNEXPECTED_VERIFIER_ERROR`. Only the Pyth/Wormhole pins move. Framework rev does not affect the compiled bytecode.

## Scope / Descoped
- Migrates **two** packages: `deepbook_margin` and its only dependent, `margin_liquidation`. That is the dependency closure — nothing depends on `margin_liquidation`.
- Eight packages still carry the legacy `[addresses]` marker: `deepbook`, `token`, `account`, `fixed_math`, `block_scholes_oracle`, `dusdc`, `dbtc`, `deepbook_core_account`. Not migrated here.
- **`predict` is affected by the same defect** — its `pyth_lazer` and `wormhole` `published-at` overrides are silently ignored, so a testnet publish resolves the wrong addresses. It should be fixed before it publishes.

## Test plan
- [x] `sui move build --path packages/deepbook_margin` — exit 0, no new warnings.
- [x] `sui move test --path packages/deepbook_margin --gas-limit 100000000000` — 372/372.
- [x] `sui move test --path packages/margin_liquidation --gas-limit 100000000000` — 16/16.
- [x] `sui client upgrade --dry-run` — `execution status: success`; Pyth resolves to `0xabf837e9…`, Wormhole to `0xf47329f4…`, matching the deployed linkage table.
- [x] Move Test CI green on both linux and macos.
- [x] **Published to testnet as `0x3a636035f0bbcced1bbc9157654b75a402a09a91ccf0c7e9bd043feaf98b8608` (package v15)**, tx `EneJsGZ98mwcqsH3wvQsctGGwYbDboDUpzCGS6bsSzS`, tagged `margin-testnet-v15.0.0`. All 12 modules verified byte-identical to the tagged source.

## Risk / Rollout
- Already published to **testnet only**; mainnet margin is untouched (still v6).
- The publish happened before this PR merged. Source has not changed since — the two follow-up commits touch only lockfile pins and `margin_liquidation`'s manifest, and the published bytecode was re-verified against the post-revert tree.