### PR TITLE
margin: add Pyth Pro entrypoints in _pro modules (DBU-668)

### DIFF
--- a/packages/deepbook_margin/Move.lock
+++ b/packages/deepbook_margin/Move.lock
@@ -41,7 +41,7 @@ manifest_digest = "CD547CB1ACCE0880C835DAED2D8FFCB91D56C833AE5240D3AA5B918398263
 deps = { MoveStdlib = "MoveStdlib_1" }
 
 [pinned.mainnet.Wormhole]
-source = { git = "https://github.com/wormhole-foundation/wormhole.git", subdir = "sui/wormhole", rev = "b71be5cbb9537c4aac8e23e74371affa3825efcd" }
+source = { git = "https://github.com/wormhole-foundation/wormhole.git", subdir = "sui/wormhole", rev = "1b1cb69e809e0e7081cf1bf9b2779c41c14fc7f0" }
 use_environment = "mainnet"
 manifest_digest = "0D766A0380B75080707CFA6099AF469A2E502B0D9DC334A9E9983B391C5555D9"
 deps = { Sui = "Sui_1" }

--- a/packages/deepbook_margin/Move.lock
+++ b/packages/deepbook_margin/Move.lock
@@ -88,6 +88,12 @@ use_environment = "testnet"
 manifest_digest = "EE442EEB0E1F71B244DBB1E016B1D0D8F67061BDAFA606B6C86F093D15CA0755"
 deps = { Sui = "Sui_1", Wormhole = "Wormhole" }
 
+[pinned.testnet.PythProCompatible]
+source = { git = "https://github.com/pyth-network/pyth-crosschain.git", subdir = "target_chains/sui/contracts", rev = "6c78a4d882daf4d91457ad5142cb58fc7e376f98" }
+use_environment = "testnet"
+manifest_digest = "AEAC3FAD5DCF925755E55B4498F4CED3B564F87B638049EF0A7C4E9F2EA7E9EC"
+deps = { Sui = "Sui_1", WormholeSimpleMajority = "WormholeSimpleMajority" }
+
 [pinned.testnet.Sui]
 source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "85400e2bd37b490fcd057776e700d3fdca643396" }
 use_environment = "testnet"
@@ -106,6 +112,12 @@ use_environment = "testnet"
 manifest_digest = "6996F1AB8CD448FFBA142C085C488FE8A46B485E61E38A1891EFA52B30D9C12E"
 deps = { Sui = "Sui_1" }
 
+[pinned.testnet.WormholeSimpleMajority]
+source = { git = "https://github.com/pyth-network/pyth-crosschain.git", subdir = "target_chains/sui/vendor/wormhole_simple_majority/wormhole", rev = "6c78a4d882daf4d91457ad5142cb58fc7e376f98" }
+use_environment = "testnet"
+manifest_digest = "6996F1AB8CD448FFBA142C085C488FE8A46B485E61E38A1891EFA52B30D9C12E"
+deps = { Sui = "Sui_1" }
+
 [pinned.testnet.deepbook]
 source = { local = "../deepbook" }
 use_environment = "testnet"
@@ -115,11 +127,11 @@ deps = { std = "MoveStdlib", sui = "Sui", token = "token" }
 [pinned.testnet.deepbook_margin]
 source = { root = true }
 use_environment = "testnet"
-manifest_digest = "2B11F937CAB0205DF499B09DD0EC9FCC6EC7B178DF3DDC4861AE35E4F18D2AF3"
-deps = { deepbook = "deepbook", pyth = "Pyth", std = "MoveStdlib", sui = "Sui", token = "token" }
+manifest_digest = "55032D0F8CAAAF41FE80CB3AB9E13122BDE117CDAB8D2EF91114C583232A3058"
+deps = { deepbook = "deepbook", pyth = "Pyth", pyth_pro = "PythProCompatible", std = "MoveStdlib", sui = "Sui", token = "token" }
 
 [pinned.testnet.token]
-source = { git = "https://github.com/MystenLabs/deepbookv3.git", subdir = "packages/token", rev = "0b6d9cca8975f38cf55c3e9bf5dcca2563b148cb" }
+source = { git = "https://github.com/MystenLabs/deepbookv3.git", subdir = "packages/token", rev = "2e0a88f860f1ae64f709b3978f1e206a91771169" }
 use_environment = "testnet"
 manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
 deps = { std = "MoveStdlib", sui = "Sui" }

--- a/packages/deepbook_margin/Move.lock
+++ b/packages/deepbook_margin/Move.lock
@@ -41,7 +41,7 @@ manifest_digest = "CD547CB1ACCE0880C835DAED2D8FFCB91D56C833AE5240D3AA5B918398263
 deps = { MoveStdlib = "MoveStdlib_1" }
 
 [pinned.mainnet.Wormhole]
-source = { git = "https://github.com/wormhole-foundation/wormhole.git", subdir = "sui/wormhole", rev = "1b1cb69e809e0e7081cf1bf9b2779c41c14fc7f0" }
+source = { git = "https://github.com/wormhole-foundation/wormhole.git", subdir = "sui/wormhole", rev = "b71be5cbb9537c4aac8e23e74371affa3825efcd" }
 use_environment = "mainnet"
 manifest_digest = "0D766A0380B75080707CFA6099AF469A2E502B0D9DC334A9E9983B391C5555D9"
 deps = { Sui = "Sui_1" }

--- a/packages/deepbook_margin/sources/helper/margin_constants.move
+++ b/packages/deepbook_margin/sources/helper/margin_constants.move
@@ -6,7 +6,7 @@ module deepbook_margin::margin_constants;
 // Bump ahead of EVERY on-chain package upgrade. After the upgrade the admin must
 // also call `enable_version(N)` on the live `MarginRegistry` (and later
 // `disable_version(N-1)`), or all entries abort `EPackageVersionDisabled`.
-const MARGIN_VERSION: u64 = 6;
+const MARGIN_VERSION: u64 = 7;
 const MAX_RISK_RATIO: u64 = 1_000 * 1_000_000_000; // Risk ratio above 1000 will be considered as 1000
 const DEFAULT_USER_LIQUIDATION_REWARD: u64 = 10_000_000; // 1%
 const DEFAULT_POOL_LIQUIDATION_REWARD: u64 = 40_000_000; // 4%

--- a/packages/deepbook_margin/sources/helper/oracle.move
+++ b/packages/deepbook_margin/sources/helper/oracle.move
@@ -53,6 +53,11 @@ public struct ConversionConfig has copy, drop {
 public struct PythReading has copy, drop {
     price: u64,
     decimals: u8,
+    /// `some` only for validated reads. The confidence bound is a *pricing* guard,
+    /// not a read guard: it is asserted in `price_config`, so a reading taken purely
+    /// for telemetry (the deposit event) is never rejected for a wide interval.
+    /// Unvalidated reads carry `none` and skip the check, as they always have.
+    conf: Option<u64>,
 }
 
 public(package) fun price(self: &PythReading): u64 {
@@ -264,6 +269,16 @@ fun price_config<T>(
 ): ConversionConfig {
     let type_config = registry.get_config_for_type<T>();
 
+    // Validated readings carry a confidence bound; unvalidated ones never did.
+    reading
+        .conf
+        .do_ref!(
+            |conf| assert!(
+                (*conf as u128) * 10_000 <= (type_config.max_conf_bps as u128) * (reading.price as u128),
+                EInvalidPythPriceConf,
+            ),
+        );
+
     let target_decimals = if (is_usd_price_config) {
         9
     } else {
@@ -326,6 +341,7 @@ public(package) fun read_price_unsafe<T>(
     PythReading {
         price: price.get_price().get_magnitude_if_positive(),
         decimals: price.get_expo().get_magnitude_if_negative() as u8,
+        conf: option::none(),
     }
 }
 
@@ -371,6 +387,7 @@ public(package) fun read_price_pro_unsafe<T>(
     PythReading {
         price: price.get_price().get_magnitude_if_positive(),
         decimals: price.get_expo().get_magnitude_if_negative() as u8,
+        conf: option::none(),
     }
 }
 
@@ -386,17 +403,12 @@ fun validate_reading(
     validate_feed_id(price_feed_id, type_config);
 
     assert!(
-        (pyth_conf as u128) * 10_000 <= (type_config.max_conf_bps as u128) * (pyth_price as u128),
-        EInvalidPythPriceConf,
-    );
-
-    assert!(
         (pyth_price as u128) * 10_000 <= (ewma_price as u128) * ((10_000 + type_config.max_ewma_difference_bps) as u128) &&
         (pyth_price as u128) * 10_000 >= (ewma_price as u128) * ((10_000 - type_config.max_ewma_difference_bps) as u128),
         EInvalidPythPrice,
     );
 
-    PythReading { price: pyth_price, decimals: pyth_decimals }
+    PythReading { price: pyth_price, decimals: pyth_decimals, conf: option::some(pyth_conf) }
 }
 
 fun validate_feed_id(price_feed_id: vector<u8>, type_config: CoinTypeData) {

--- a/packages/deepbook_margin/sources/helper/oracle.move
+++ b/packages/deepbook_margin/sources/helper/oracle.move
@@ -19,6 +19,7 @@ const EPriceFeedIdMismatch: u64 = 3;
 const EInvalidPythPriceConf: u64 = 4;
 const EInvalidOracleConfig: u64 = 5;
 const EInvalidPrice: u64 = 6;
+const EReadingAssetMismatch: u64 = 7;
 
 /// A buffer added to the exponent when doing currency conversions.
 const BUFFER: u8 = 10;
@@ -58,6 +59,12 @@ public struct PythReading has copy, drop {
     /// for telemetry (the deposit event) is never rejected for a wide interval.
     /// Unvalidated reads carry `none` and skip the check, as they always have.
     conf: Option<u64>,
+    /// The asset this price is *for*, stamped by the reader from the same config row
+    /// the feed id was checked against. `price_config` asserts it matches the type it
+    /// is being consumed as, so a reading routed to the wrong leg aborts instead of
+    /// silently mis-pricing. Without it, transposing the base and quote readings at a
+    /// call site is invisible: both are well-formed, both pass every other guard.
+    coin_type: TypeName,
 }
 
 public(package) fun price(self: &PythReading): u64 {
@@ -269,6 +276,10 @@ fun price_config<T>(
 ): ConversionConfig {
     let type_config = registry.get_config_for_type<T>();
 
+    // The reading must be for the asset it is being priced as. Every pricing path
+    // funnels through here, so this is the one place that has to hold.
+    assert!(reading.coin_type == type_config.type_name, EReadingAssetMismatch);
+
     // Validated readings carry a confidence bound; unvalidated ones never did.
     reading
         .conf
@@ -342,6 +353,7 @@ public(package) fun read_price_unsafe<T>(
         price: price.get_price().get_magnitude_if_positive(),
         decimals: price.get_expo().get_magnitude_if_negative() as u8,
         conf: option::none(),
+        coin_type: type_config.type_name,
     }
 }
 
@@ -388,6 +400,7 @@ public(package) fun read_price_pro_unsafe<T>(
         price: price.get_price().get_magnitude_if_positive(),
         decimals: price.get_expo().get_magnitude_if_negative() as u8,
         conf: option::none(),
+        coin_type: type_config.type_name,
     }
 }
 
@@ -408,7 +421,12 @@ fun validate_reading(
         EInvalidPythPrice,
     );
 
-    PythReading { price: pyth_price, decimals: pyth_decimals, conf: option::some(pyth_conf) }
+    PythReading {
+        price: pyth_price,
+        decimals: pyth_decimals,
+        conf: option::some(pyth_conf),
+        coin_type: type_config.type_name,
+    }
 }
 
 fun validate_feed_id(price_feed_id: vector<u8>, type_config: CoinTypeData) {

--- a/packages/deepbook_margin/sources/margin_manager.move
+++ b/packages/deepbook_margin/sources/margin_manager.move
@@ -448,11 +448,18 @@ public fun deposit<BaseAsset, QuoteAsset, DepositAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
+    let event_reading = if (!emits_collateral_event<BaseAsset, QuoteAsset, DepositAsset>()) {
+        option::none()
+    } else if (type_name::with_defining_ids<DepositAsset>() == type_name::with_defining_ids<BaseAsset>()) {
+        option::some(read_price_unsafe<BaseAsset>(base_oracle, registry))
+    } else {
+        option::some(read_price_unsafe<QuoteAsset>(quote_oracle, registry))
+    };
+
     deposit_core<BaseAsset, QuoteAsset, DepositAsset>(
         self,
         registry,
-        read_price<BaseAsset>(base_oracle, registry, clock),
-        read_price<QuoteAsset>(quote_oracle, registry, clock),
+        event_reading,
         coin,
         clock,
         ctx,
@@ -473,13 +480,36 @@ public fun withdraw<BaseAsset, QuoteAsset, WithdrawAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ): Coin<WithdrawAsset> {
+    let (risk_base_reading, risk_quote_reading) = if (
+        self.withdraw_needs_risk_check(base_margin_pool, quote_margin_pool)
+    ) {
+        (
+            option::some(read_price<BaseAsset>(base_oracle, registry, clock)),
+            option::some(read_price<QuoteAsset>(quote_oracle, registry, clock)),
+        )
+    } else {
+        (option::none(), option::none())
+    };
+    let (event_base_reading, event_quote_reading) = if (
+        emits_collateral_event<BaseAsset, QuoteAsset, WithdrawAsset>()
+    ) {
+        (
+            option::some(read_price_unsafe<BaseAsset>(base_oracle, registry)),
+            option::some(read_price_unsafe<QuoteAsset>(quote_oracle, registry)),
+        )
+    } else {
+        (option::none(), option::none())
+    };
+
     withdraw_core<BaseAsset, QuoteAsset, WithdrawAsset>(
         self,
         registry,
         base_margin_pool,
         quote_margin_pool,
-        read_price<BaseAsset>(base_oracle, registry, clock),
-        read_price<QuoteAsset>(quote_oracle, registry, clock),
+        risk_base_reading,
+        risk_quote_reading,
+        event_base_reading,
+        event_quote_reading,
         pool,
         withdraw_amount,
         clock,
@@ -617,6 +647,11 @@ public fun risk_ratio<BaseAsset, QuoteAsset>(
     quote_margin_pool: &MarginPool<QuoteAsset>,
     clock: &Clock,
 ): u64 {
+    // No debt means no oracle is needed: `assets_in_debt_unit` short-circuits and the
+    // ratio is MAX regardless of price. Returning here keeps a stale feed from
+    // breaking a read-only query, as it did before Pyth Pro.
+    if (self.margin_pool_id.is_none()) return margin_constants::max_risk_ratio();
+
     risk_ratio_core<BaseAsset, QuoteAsset>(
         self,
         registry,
@@ -641,7 +676,12 @@ public fun risk_ratio_unsafe<BaseAsset, QuoteAsset>(
     quote_margin_pool: &MarginPool<QuoteAsset>,
     clock: &Clock,
 ): u64 {
-    risk_ratio_unsafe_core<BaseAsset, QuoteAsset>(
+    // No debt means no oracle is needed: `assets_in_debt_unit` short-circuits and the
+    // ratio is MAX regardless of price. Returning here keeps a stale feed from
+    // breaking a read-only query, as it did before Pyth Pro.
+    if (self.margin_pool_id.is_none()) return margin_constants::max_risk_ratio();
+
+    risk_ratio_core<BaseAsset, QuoteAsset>(
         self,
         registry,
         read_price_unsafe<BaseAsset>(base_oracle, registry),
@@ -1740,6 +1780,34 @@ fun balance_manager_unsafe_mut<BaseAsset, QuoteAsset>(
     &mut self.balance_manager
 }
 
+/// True when the manager holds no borrow position, so `risk_ratio` is MAX without
+/// consulting the oracle.
+public(package) fun has_no_margin_pool<BaseAsset, QuoteAsset>(
+    self: &MarginManager<BaseAsset, QuoteAsset>,
+): bool {
+    self.margin_pool_id.is_none()
+}
+
+/// True when `withdraw` runs a risk check - the manager has debt in one of the two
+/// pools. Kept beside the core so the wrapper's lazy read and the core's branch
+/// cannot disagree.
+public(package) fun withdraw_needs_risk_check<BaseAsset, QuoteAsset>(
+    self: &MarginManager<BaseAsset, QuoteAsset>,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+): bool {
+    self.margin_pool_id.contains(&base_margin_pool.id())
+        || self.margin_pool_id.contains(&quote_margin_pool.id())
+}
+
+/// True when a deposit/withdraw of `Asset` emits a collateral event. A DEEP move in a
+/// base/quote pool emits nothing and needs no oracle read at all.
+public(package) fun emits_collateral_event<BaseAsset, QuoteAsset, Asset>(): bool {
+    let asset_type = type_name::with_defining_ids<Asset>();
+    asset_type == type_name::with_defining_ids<BaseAsset>()
+        || asset_type == type_name::with_defining_ids<QuoteAsset>()
+}
+
 // === Shared cores ===
 // Bodies factored out so the legacy and Pyth Pro entrypoints run identical logic;
 // only the reader that produced the `PythReading` differs.
@@ -1900,8 +1968,11 @@ public(package) fun execute_conditional_orders_v3_core<BaseAsset, QuoteAsset>(
 public(package) fun deposit_core<BaseAsset, QuoteAsset, DepositAsset>(
     self: &mut MarginManager<BaseAsset, QuoteAsset>,
     registry: &MarginRegistry,
-    base_reading: PythReading,
-    quote_reading: PythReading,
+    /// Unvalidated read of the deposited asset's own feed, used only for the
+    /// telemetry event. `none` for a DEEP deposit, which emits nothing - so adding
+    /// collateral never depends on the oracle, and cannot be blocked by a stale or
+    /// wide-confidence feed on the asset being deposited or the other side.
+    event_reading: Option<PythReading>,
     coin: Coin<DepositAsset>,
     clock: &Clock,
     ctx: &mut TxContext,
@@ -1920,11 +1991,7 @@ public(package) fun deposit_core<BaseAsset, QuoteAsset, DepositAsset>(
     // or quote assets.
     if (!deposit_base_asset && !deposit_quote_asset) return;
 
-    let reading = if (deposit_base_asset) {
-        base_reading
-    } else {
-        quote_reading
-    };
+    let reading = event_reading.borrow();
     let (pyth_price, pyth_decimals) = (reading.price(), reading.decimals());
 
     event::emit(DepositCollateralEvent {
@@ -1937,13 +2004,20 @@ public(package) fun deposit_core<BaseAsset, QuoteAsset, DepositAsset>(
     });
 }
 
+/// `risk_*_reading` are validated reads, needed only when the manager carries debt.
+/// `event_*_reading` are unvalidated reads used solely for the telemetry event, and
+/// only when a base/quote asset is withdrawn. Both are `none` otherwise, so a
+/// debt-free withdrawal never touches the oracle - matching the pre-Pyth-Pro
+/// behaviour, where a stale feed could not block a user reclaiming collateral.
 public(package) fun withdraw_core<BaseAsset, QuoteAsset, WithdrawAsset>(
     self: &mut MarginManager<BaseAsset, QuoteAsset>,
     registry: &MarginRegistry,
     base_margin_pool: &MarginPool<BaseAsset>,
     quote_margin_pool: &MarginPool<QuoteAsset>,
-    base_reading: PythReading,
-    quote_reading: PythReading,
+    risk_base_reading: Option<PythReading>,
+    risk_quote_reading: Option<PythReading>,
+    event_base_reading: Option<PythReading>,
+    event_quote_reading: Option<PythReading>,
     pool: &Pool<BaseAsset, QuoteAsset>,
     withdraw_amount: u64,
     clock: &Clock,
@@ -1965,8 +2039,8 @@ public(package) fun withdraw_core<BaseAsset, QuoteAsset, WithdrawAsset>(
     if (self.margin_pool_id.contains(&base_margin_pool.id())) {
         let risk_ratio = self.risk_ratio_int(
             registry,
-            base_reading,
-            quote_reading,
+            *risk_base_reading.borrow(),
+            *risk_quote_reading.borrow(),
             pool,
             base_margin_pool,
             clock,
@@ -1975,8 +2049,8 @@ public(package) fun withdraw_core<BaseAsset, QuoteAsset, WithdrawAsset>(
     } else if (self.margin_pool_id.contains(&quote_margin_pool.id())) {
         let risk_ratio = self.risk_ratio_int(
             registry,
-            base_reading,
-            quote_reading,
+            *risk_base_reading.borrow(),
+            *risk_quote_reading.borrow(),
             pool,
             quote_margin_pool,
             clock,
@@ -2009,8 +2083,8 @@ public(package) fun withdraw_core<BaseAsset, QuoteAsset, WithdrawAsset>(
         _,
     ) = self.manager_state_core(
         registry,
-        base_reading,
-        quote_reading,
+        *event_base_reading.borrow(),
+        *event_quote_reading.borrow(),
         pool,
         base_margin_pool,
         quote_margin_pool,
@@ -2329,38 +2403,6 @@ public(package) fun risk_ratio_core<BaseAsset, QuoteAsset>(
     }
 }
 
-public(package) fun risk_ratio_unsafe_core<BaseAsset, QuoteAsset>(
-    self: &MarginManager<BaseAsset, QuoteAsset>,
-    registry: &MarginRegistry,
-    base_reading: PythReading,
-    quote_reading: PythReading,
-    pool: &Pool<BaseAsset, QuoteAsset>,
-    base_margin_pool: &MarginPool<BaseAsset>,
-    quote_margin_pool: &MarginPool<QuoteAsset>,
-    clock: &Clock,
-): u64 {
-    let debt_is_base = self.borrowed_base_shares > 0;
-    if (debt_is_base) {
-        self.risk_ratio_int(
-            registry,
-            base_reading,
-            quote_reading,
-            pool,
-            base_margin_pool,
-            clock,
-        )
-    } else {
-        self.risk_ratio_int(
-            registry,
-            base_reading,
-            quote_reading,
-            pool,
-            quote_margin_pool,
-            clock,
-        )
-    }
-}
-
 public(package) fun manager_state_core<BaseAsset, QuoteAsset>(
     self: &MarginManager<BaseAsset, QuoteAsset>,
     registry: &MarginRegistry,
@@ -2383,7 +2425,7 @@ public(package) fun manager_state_core<BaseAsset, QuoteAsset>(
     } else {
         (0, 0)
     };
-    let risk_ratio = self.risk_ratio_unsafe_core(
+    let risk_ratio = self.risk_ratio_core(
         registry,
         base_reading,
         quote_reading,

--- a/packages/deepbook_margin/sources/margin_manager.move
+++ b/packages/deepbook_margin/sources/margin_manager.move
@@ -1771,10 +1771,13 @@ fun balance_manager_unsafe_mut<BaseAsset, QuoteAsset>(
 
 /// True when the manager holds no borrow position, so `risk_ratio` is MAX without
 /// consulting the oracle.
-public(package) fun has_no_margin_pool<BaseAsset, QuoteAsset>(
+/// True when the manager owes anything on either leg. The entrypoints that read the
+/// oracle lazily are all gated on exactly this, so it lives here rather than being
+/// spelled out at each call site.
+public(package) fun has_debt<BaseAsset, QuoteAsset>(
     self: &MarginManager<BaseAsset, QuoteAsset>,
 ): bool {
-    self.margin_pool_id.is_none()
+    self.borrowed_base_shares > 0 || self.borrowed_quote_shares > 0
 }
 
 /// True when `withdraw` runs a risk check - the manager has debt in one of the two

--- a/packages/deepbook_margin/sources/margin_manager.move
+++ b/packages/deepbook_margin/sources/margin_manager.move
@@ -197,8 +197,7 @@ public fun add_conditional_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    add_conditional_order_core<BaseAsset, QuoteAsset>(
-        self,
+    self.add_conditional_order_core(
         pool,
         read_price<BaseAsset>(base_price_info_object, registry, clock),
         read_price<QuoteAsset>(quote_price_info_object, registry, clock),
@@ -273,8 +272,7 @@ public fun execute_conditional_orders_v2<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &TxContext,
 ): vector<OrderInfo> {
-    execute_conditional_orders_v2_core<BaseAsset, QuoteAsset>(
-        self,
+    self.execute_conditional_orders_v2_core(
         pool,
         base_margin_pool,
         quote_margin_pool,
@@ -310,8 +308,7 @@ public fun execute_conditional_orders_v3<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ): vector<OrderInfo> {
-    execute_conditional_orders_v3_core<BaseAsset, QuoteAsset>(
-        self,
+    self.execute_conditional_orders_v3_core(
         pool,
         base_margin_pool,
         quote_margin_pool,
@@ -456,8 +453,7 @@ public fun deposit<BaseAsset, QuoteAsset, DepositAsset>(
         option::some(read_price<QuoteAsset>(quote_oracle, registry, clock))
     };
 
-    deposit_core<BaseAsset, QuoteAsset, DepositAsset>(
-        self,
+    self.deposit_core(
         registry,
         event_reading,
         coin,
@@ -501,8 +497,7 @@ public fun withdraw<BaseAsset, QuoteAsset, WithdrawAsset>(
         (option::none(), option::none())
     };
 
-    withdraw_core<BaseAsset, QuoteAsset, WithdrawAsset>(
-        self,
+    self.withdraw_core(
         registry,
         base_margin_pool,
         quote_margin_pool,
@@ -529,8 +524,7 @@ public fun borrow_base<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    borrow_base_core<BaseAsset, QuoteAsset>(
-        self,
+    self.borrow_base_core(
         registry,
         base_margin_pool,
         read_price<BaseAsset>(base_oracle, registry, clock),
@@ -554,8 +548,7 @@ public fun borrow_quote<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    borrow_quote_core<BaseAsset, QuoteAsset>(
-        self,
+    self.borrow_quote_core(
         registry,
         quote_margin_pool,
         read_price<BaseAsset>(base_oracle, registry, clock),
@@ -623,8 +616,7 @@ public fun liquidate<BaseAsset, QuoteAsset, DebtAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ): (Coin<BaseAsset>, Coin<QuoteAsset>, Coin<DebtAsset>) {
-    liquidate_core<BaseAsset, QuoteAsset, DebtAsset>(
-        self,
+    self.liquidate_core(
         registry,
         read_price<BaseAsset>(base_oracle, registry, clock),
         read_price<QuoteAsset>(quote_oracle, registry, clock),
@@ -652,8 +644,7 @@ public fun risk_ratio<BaseAsset, QuoteAsset>(
     // breaking a read-only query, as it did before Pyth Pro.
     if (self.margin_pool_id.is_none()) return margin_constants::max_risk_ratio();
 
-    risk_ratio_core<BaseAsset, QuoteAsset>(
-        self,
+    self.risk_ratio_core(
         registry,
         read_price<BaseAsset>(base_oracle, registry, clock),
         read_price<QuoteAsset>(quote_oracle, registry, clock),
@@ -681,8 +672,7 @@ public fun risk_ratio_unsafe<BaseAsset, QuoteAsset>(
     // breaking a read-only query, as it did before Pyth Pro.
     if (self.margin_pool_id.is_none()) return margin_constants::max_risk_ratio();
 
-    risk_ratio_core<BaseAsset, QuoteAsset>(
-        self,
+    self.risk_ratio_core(
         registry,
         read_price_unsafe<BaseAsset>(base_oracle, registry),
         read_price_unsafe<QuoteAsset>(quote_oracle, registry),
@@ -777,8 +767,7 @@ public fun manager_state<BaseAsset, QuoteAsset>(
     quote_margin_pool: &MarginPool<QuoteAsset>,
     clock: &Clock,
 ): (ID, ID, u64, u64, u64, u64, u64, u64, u8, u64, u8, u64, u64, u64) {
-    manager_state_core<BaseAsset, QuoteAsset>(
-        self,
+    self.manager_state_core(
         registry,
         read_price_unsafe<BaseAsset>(base_oracle, registry),
         read_price_unsafe<QuoteAsset>(quote_oracle, registry),

--- a/packages/deepbook_margin/sources/margin_manager.move
+++ b/packages/deepbook_margin/sources/margin_manager.move
@@ -451,9 +451,9 @@ public fun deposit<BaseAsset, QuoteAsset, DepositAsset>(
     let event_reading = if (!emits_collateral_event<BaseAsset, QuoteAsset, DepositAsset>()) {
         option::none()
     } else if (type_name::with_defining_ids<DepositAsset>() == type_name::with_defining_ids<BaseAsset>()) {
-        option::some(read_price_unsafe<BaseAsset>(base_oracle, registry))
+        option::some(read_price<BaseAsset>(base_oracle, registry, clock))
     } else {
-        option::some(read_price_unsafe<QuoteAsset>(quote_oracle, registry))
+        option::some(read_price<QuoteAsset>(quote_oracle, registry, clock))
     };
 
     deposit_core<BaseAsset, QuoteAsset, DepositAsset>(
@@ -1968,10 +1968,11 @@ public(package) fun execute_conditional_orders_v3_core<BaseAsset, QuoteAsset>(
 public(package) fun deposit_core<BaseAsset, QuoteAsset, DepositAsset>(
     self: &mut MarginManager<BaseAsset, QuoteAsset>,
     registry: &MarginRegistry,
-    /// Unvalidated read of the deposited asset's own feed, used only for the
-    /// telemetry event. `none` for a DEEP deposit, which emits nothing - so adding
-    /// collateral never depends on the oracle, and cannot be blocked by a stale or
-    /// wide-confidence feed on the asset being deposited or the other side.
+    // Validated read of the deposited asset's own feed, for the telemetry event.
+    // `none` for a DEEP deposit, which emits no event. Only the deposited side is
+    // read, so the other feed being stale cannot block a collateral top-up, and the
+    // confidence bound does not apply to a read that never reaches `price_config` -
+    // both matching the behaviour before Pyth Pro.
     event_reading: Option<PythReading>,
     coin: Coin<DepositAsset>,
     clock: &Clock,

--- a/packages/deepbook_margin/sources/margin_manager.move
+++ b/packages/deepbook_margin/sources/margin_manager.move
@@ -197,23 +197,18 @@ public fun add_conditional_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    registry.load_inner();
-    self.validate_owner(ctx);
-    let manager_id = self.id();
-    assert!(pool.id() == self.deepbook_pool(), EIncorrectDeepBookPool);
-    self
-        .take_profit_stop_loss
-        .add_conditional_order<BaseAsset, QuoteAsset>(
-            pool,
-            manager_id,
-            base_price_info_object,
-            quote_price_info_object,
-            registry,
-            conditional_order_id,
-            condition,
-            pending_order,
-            clock,
-        );
+    add_conditional_order_core<BaseAsset, QuoteAsset>(
+        self,
+        pool,
+        read_price<BaseAsset>(base_price_info_object, registry, clock),
+        read_price<QuoteAsset>(quote_price_info_object, registry, clock),
+        registry,
+        conditional_order_id,
+        condition,
+        pending_order,
+        clock,
+        ctx,
+    )
 }
 
 /// Cancel all conditional orders.
@@ -278,53 +273,18 @@ public fun execute_conditional_orders_v2<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &TxContext,
 ): vector<OrderInfo> {
-    registry.load_inner();
-    assert!(pool.id() == self.deepbook_pool(), EIncorrectDeepBookPool);
-    let current_price = calculate_price<BaseAsset, QuoteAsset>(
-        registry,
-        read_price<BaseAsset>(base_price_info_object, registry, clock),
-        read_price<QuoteAsset>(quote_price_info_object, registry, clock),
-    );
-
-    let orders_to_process = self.collect_triggered_orders(current_price);
-
-    let mut order_infos = vector[];
-    let mut executed_ids = vector[];
-    let mut expired_ids = vector[];
-    let mut insufficient_funds_ids = vector[];
-    let mut out_of_bounds_ids = vector[];
-    let mut below_liquidation_ids = vector[];
-
-    self.process_collected_orders_v2(
+    execute_conditional_orders_v2_core<BaseAsset, QuoteAsset>(
+        self,
         pool,
-        registry,
         base_margin_pool,
         quote_margin_pool,
-        base_price_info_object,
-        quote_price_info_object,
-        orders_to_process,
-        &mut order_infos,
-        &mut executed_ids,
-        &mut expired_ids,
-        &mut insufficient_funds_ids,
-        &mut out_of_bounds_ids,
-        &mut below_liquidation_ids,
+        read_price<BaseAsset>(base_price_info_object, registry, clock),
+        read_price<QuoteAsset>(quote_price_info_object, registry, clock),
+        registry,
         max_orders_to_execute,
         clock,
         ctx,
-    );
-
-    self.finalize_conditional_execution(
-        pool.id(),
-        expired_ids,
-        insufficient_funds_ids,
-        out_of_bounds_ids,
-        below_liquidation_ids,
-        executed_ids,
-        clock,
-    );
-
-    order_infos
+    )
 }
 
 /// Execute conditional orders, deleveraging on each market-type fill.
@@ -350,53 +310,18 @@ public fun execute_conditional_orders_v3<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ): vector<OrderInfo> {
-    registry.load_inner();
-    assert!(pool.id() == self.deepbook_pool(), EIncorrectDeepBookPool);
-    let current_price = calculate_price<BaseAsset, QuoteAsset>(
-        registry,
-        read_price<BaseAsset>(base_price_info_object, registry, clock),
-        read_price<QuoteAsset>(quote_price_info_object, registry, clock),
-    );
-
-    let orders_to_process = self.collect_triggered_orders(current_price);
-
-    let mut order_infos = vector[];
-    let mut executed_ids = vector[];
-    let mut expired_ids = vector[];
-    let mut insufficient_funds_ids = vector[];
-    let mut out_of_bounds_ids = vector[];
-    let mut below_liquidation_ids = vector[];
-
-    self.process_collected_orders_v3(
+    execute_conditional_orders_v3_core<BaseAsset, QuoteAsset>(
+        self,
         pool,
-        registry,
         base_margin_pool,
         quote_margin_pool,
-        base_price_info_object,
-        quote_price_info_object,
-        orders_to_process,
-        &mut order_infos,
-        &mut executed_ids,
-        &mut expired_ids,
-        &mut insufficient_funds_ids,
-        &mut out_of_bounds_ids,
-        &mut below_liquidation_ids,
+        read_price<BaseAsset>(base_price_info_object, registry, clock),
+        read_price<QuoteAsset>(quote_price_info_object, registry, clock),
+        registry,
         max_orders_to_execute,
         clock,
         ctx,
-    );
-
-    self.finalize_conditional_execution(
-        pool.id(),
-        expired_ids,
-        insufficient_funds_ids,
-        out_of_bounds_ids,
-        below_liquidation_ids,
-        executed_ids,
-        clock,
-    );
-
-    order_infos
+    )
 }
 
 // === Public Functions - Margin Manager ===
@@ -523,35 +448,15 @@ public fun deposit<BaseAsset, QuoteAsset, DepositAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    registry.load_inner();
-    self.validate_owner(ctx);
-
-    let deposit_amount = coin.value();
-    self.deposit_int<BaseAsset, QuoteAsset, DepositAsset>(coin, ctx);
-
-    let deposit_asset_type = type_name::with_defining_ids<DepositAsset>();
-    let deposit_base_asset = deposit_asset_type == type_name::with_defining_ids<BaseAsset>();
-    let deposit_quote_asset = deposit_asset_type == type_name::with_defining_ids<QuoteAsset>();
-    // We return early here, because there is no need to emit a deposit collateral event if neither the base asset
-    // nor the quote asset is deposited. This handles the case for DEEP deposits, when DEEP is not part of the base
-    // or quote assets.
-    if (!deposit_base_asset && !deposit_quote_asset) return;
-
-    let reading = if (deposit_base_asset) {
-        read_price<BaseAsset>(base_oracle, registry, clock)
-    } else {
-        read_price<QuoteAsset>(quote_oracle, registry, clock)
-    };
-    let (pyth_price, pyth_decimals) = (reading.price(), reading.decimals());
-
-    event::emit(DepositCollateralEvent {
-        margin_manager_id: self.id(),
-        amount: deposit_amount,
-        asset: deposit_asset_type,
-        pyth_price,
-        pyth_decimals,
-        timestamp: clock.timestamp_ms(),
-    });
+    deposit_core<BaseAsset, QuoteAsset, DepositAsset>(
+        self,
+        registry,
+        read_price<BaseAsset>(base_oracle, registry, clock),
+        read_price<QuoteAsset>(quote_oracle, registry, clock),
+        coin,
+        clock,
+        ctx,
+    )
 }
 
 /// Withdraw a specified amount of an asset from the margin manager. The asset must be of the same type as either the base, quote, or DEEP.
@@ -568,91 +473,18 @@ public fun withdraw<BaseAsset, QuoteAsset, WithdrawAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ): Coin<WithdrawAsset> {
-    registry.load_inner();
-    self.validate_owner(ctx);
-    assert!(pool.id() == self.deepbook_pool(), EIncorrectDeepBookPool);
-
-    let balance_manager = &mut self.balance_manager;
-    let withdraw_cap = &self.withdraw_cap;
-
-    let coin = balance_manager.withdraw_with_cap<WithdrawAsset>(
-        withdraw_cap,
-        withdraw_amount,
-        ctx,
-    );
-
-    if (self.margin_pool_id.contains(&base_margin_pool.id())) {
-        let risk_ratio = self.risk_ratio_int(
-            registry,
-            read_price<BaseAsset>(base_oracle, registry, clock),
-            read_price<QuoteAsset>(quote_oracle, registry, clock),
-            pool,
-            base_margin_pool,
-            clock,
-        );
-        assert!(registry.can_withdraw(pool.id(), risk_ratio), EWithdrawRiskRatioExceeded);
-    } else if (self.margin_pool_id.contains(&quote_margin_pool.id())) {
-        let risk_ratio = self.risk_ratio_int(
-            registry,
-            read_price<BaseAsset>(base_oracle, registry, clock),
-            read_price<QuoteAsset>(quote_oracle, registry, clock),
-            pool,
-            quote_margin_pool,
-            clock,
-        );
-        assert!(registry.can_withdraw(pool.id(), risk_ratio), EWithdrawRiskRatioExceeded);
-    };
-
-    let withdraw_asset_type = type_name::with_defining_ids<WithdrawAsset>();
-    let withdraw_base_asset = withdraw_asset_type == type_name::with_defining_ids<BaseAsset>();
-    let withdraw_quote_asset = withdraw_asset_type == type_name::with_defining_ids<QuoteAsset>();
-    // We return early here, because there is no need to emit a withdraw collateral event if neither the base asset
-    // nor the quote asset is withdrawn. This handles the case for DEEP withdrawals, when DEEP is not part of the base
-    // or quote assets.
-    if (!withdraw_base_asset && !withdraw_quote_asset) return coin;
-
-    let (
-        _,
-        _,
-        _,
-        remaining_base_asset,
-        remaining_quote_asset,
-        remaining_base_debt,
-        remaining_quote_debt,
-        base_pyth_price,
-        base_pyth_decimals,
-        quote_pyth_price,
-        quote_pyth_decimals,
-        _,
-        _,
-        _,
-    ) = self.manager_state(
+    withdraw_core<BaseAsset, QuoteAsset, WithdrawAsset>(
+        self,
         registry,
-        base_oracle,
-        quote_oracle,
-        pool,
         base_margin_pool,
         quote_margin_pool,
+        read_price<BaseAsset>(base_oracle, registry, clock),
+        read_price<QuoteAsset>(quote_oracle, registry, clock),
+        pool,
+        withdraw_amount,
         clock,
-    );
-
-    event::emit(WithdrawCollateralEvent {
-        margin_manager_id: self.id(),
-        amount: withdraw_amount,
-        asset: withdraw_asset_type,
-        withdraw_base_asset,
-        remaining_base_asset,
-        remaining_quote_asset,
-        remaining_base_debt,
-        remaining_quote_debt,
-        base_pyth_price,
-        base_pyth_decimals,
-        quote_pyth_price,
-        quote_pyth_decimals,
-        timestamp: clock.timestamp_ms(),
-    });
-
-    coin
+        ctx,
+    )
 }
 
 /// Borrow the base asset using the margin manager.
@@ -667,36 +499,17 @@ public fun borrow_base<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    registry.load_inner();
-    self.validate_owner(ctx);
-    assert!(registry.pool_enabled(pool), EPoolNotEnabledForMarginTrading);
-    assert!(pool.id() == self.deepbook_pool, EIncorrectDeepBookPool);
-    assert!(self.can_borrow(base_margin_pool), ECannotHaveLoanInMoreThanOneMarginPool);
-    assert!(
-        base_margin_pool.deepbook_pool_allowed(self.deepbook_pool),
-        EDeepbookPoolNotAllowedForLoan,
-    );
-    let (coin, borrowed_shares) = base_margin_pool.borrow(loan_amount, clock, ctx);
-    self.borrowed_base_shares = self.borrowed_base_shares + borrowed_shares;
-    self.margin_pool_id = option::some(base_margin_pool.id());
-    self.deposit_int<BaseAsset, QuoteAsset, BaseAsset>(coin, ctx);
-    let risk_ratio = self.risk_ratio_int(
+    borrow_base_core<BaseAsset, QuoteAsset>(
+        self,
         registry,
+        base_margin_pool,
         read_price<BaseAsset>(base_oracle, registry, clock),
         read_price<QuoteAsset>(quote_oracle, registry, clock),
         pool,
-        base_margin_pool,
-        clock,
-    );
-    assert!(registry.can_borrow(pool.id(), risk_ratio), EBorrowRiskRatioExceeded);
-
-    event::emit(LoanBorrowedEvent {
-        margin_manager_id: self.id(),
-        margin_pool_id: base_margin_pool.id(),
         loan_amount,
-        loan_shares: borrowed_shares,
-        timestamp: clock.timestamp_ms(),
-    });
+        clock,
+        ctx,
+    )
 }
 
 /// Borrow the quote asset using the margin manager.
@@ -711,36 +524,17 @@ public fun borrow_quote<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    registry.load_inner();
-    self.validate_owner(ctx);
-    assert!(registry.pool_enabled(pool), EPoolNotEnabledForMarginTrading);
-    assert!(pool.id() == self.deepbook_pool, EIncorrectDeepBookPool);
-    assert!(self.can_borrow(quote_margin_pool), ECannotHaveLoanInMoreThanOneMarginPool);
-    assert!(
-        quote_margin_pool.deepbook_pool_allowed(self.deepbook_pool),
-        EDeepbookPoolNotAllowedForLoan,
-    );
-    let (coin, borrowed_shares) = quote_margin_pool.borrow(loan_amount, clock, ctx);
-    self.borrowed_quote_shares = self.borrowed_quote_shares + borrowed_shares;
-    self.margin_pool_id = option::some(quote_margin_pool.id());
-    self.deposit_int<BaseAsset, QuoteAsset, QuoteAsset>(coin, ctx);
-    let risk_ratio = self.risk_ratio_int(
+    borrow_quote_core<BaseAsset, QuoteAsset>(
+        self,
         registry,
+        quote_margin_pool,
         read_price<BaseAsset>(base_oracle, registry, clock),
         read_price<QuoteAsset>(quote_oracle, registry, clock),
         pool,
-        quote_margin_pool,
-        clock,
-    );
-    assert!(registry.can_borrow(pool.id(), risk_ratio), EBorrowRiskRatioExceeded);
-
-    event::emit(LoanBorrowedEvent {
-        margin_manager_id: self.id(),
-        margin_pool_id: quote_margin_pool.id(),
         loan_amount,
-        loan_shares: borrowed_shares,
-        timestamp: clock.timestamp_ms(),
-    });
+        clock,
+        ctx,
+    )
 }
 
 /// Repay the base asset loan using the margin manager.
@@ -799,170 +593,17 @@ public fun liquidate<BaseAsset, QuoteAsset, DebtAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ): (Coin<BaseAsset>, Coin<QuoteAsset>, Coin<DebtAsset>) {
-    // 1. Check that we can liquidate, cancel all open orders.
-    assert!(self.deepbook_pool == pool.id(), EIncorrectDeepBookPool);
-    assert!(self.margin_pool_id.contains(&margin_pool.id()), EIncorrectMarginPool);
-    let risk_ratio = self.risk_ratio_int(
+    liquidate_core<BaseAsset, QuoteAsset, DebtAsset>(
+        self,
         registry,
         read_price<BaseAsset>(base_oracle, registry, clock),
         read_price<QuoteAsset>(quote_oracle, registry, clock),
-        pool,
         margin_pool,
-        clock,
-    );
-    assert!(registry.can_liquidate(pool.id(), risk_ratio), ECannotLiquidate);
-    assert!(repay_coin.value() >= margin_constants::min_liquidation_repay(), ERepayAmountTooLow);
-    let trade_proof = self.trade_proof(ctx);
-    pool.withdraw_settled_amounts(&mut self.balance_manager, &trade_proof);
-    pool.cancel_all_orders(&mut self.balance_manager, &trade_proof, clock, ctx);
-
-    // 2. Calculate the maximum debt that can be repaid. The margin manager can be in three scenarios:
-    // a) Assets <= Debt + user_reward: Full liquidation, repay as much debt as possible, lending pool may incur bad debt.
-    // b) Debt + user_reward < Assets <= Debt + user_reward + pool_reward: There are enough assets to cover the debt, but pool may not get full rewards.
-    // c) Debt + user_reward + pool_reward < Assets: There are enough assets to cover everything. We may not need to liquidate the full position.
-    let borrowed_shares = self.borrowed_base_shares.max(self.borrowed_quote_shares);
-    let debt = margin_pool.borrow_shares_to_amount(borrowed_shares, clock); // 350 USDC debt
-    let debt_is_base =
-        type_name::with_defining_ids<DebtAsset>() == type_name::with_defining_ids<BaseAsset>();
-    let base_reading = read_price<BaseAsset>(base_oracle, registry, clock);
-    let quote_reading = read_price<QuoteAsset>(quote_oracle, registry, clock);
-    let (assets_in_debt_unit, base_asset, quote_asset) = self.assets_in_debt_unit(
-        registry,
         pool,
-        base_reading,
-        quote_reading,
-    ); // SUI/USDC pool. We have 90 SUI and 40 USDC, 350 USDC debt. This should be 400 USDC. (assume 1 SUI = 4 USDC)
-
-    let liquidation_reward_with_user_pool =
-        constants::float_scaling() + registry.user_liquidation_reward(pool.id()) + registry.pool_liquidation_reward(pool.id()); // 1.05
-
-    let target_ratio = registry.target_liquidation_risk_ratio(pool.id()); // 1.25
-    let numerator = math::mul(target_ratio, debt) - assets_in_debt_unit; // 1.25 * 350 - 400 = 437.5 - 400 = 37.5
-    let denominator = target_ratio - liquidation_reward_with_user_pool; // 1.25 - 1.05 = 0.2
-    let debt_repay = math::div(numerator, denominator); // 37.5 / 0.2 = 187.5
-    // We have to pay the minimum between our current debt and the debt required to reach the target ratio.
-    // In other words, if our assets are low, we pay off all debt (full liquidation)
-    // if our assets are high, we pay off some of the debt (partial liquidation)
-    let debt_repay = debt_repay.min(debt); // 187.5
-    let debt_with_reward = math::mul(debt_repay, liquidation_reward_with_user_pool); // 187.5 * 1.05 = 196.875
-    let debt_can_repay_with_rewards = debt_with_reward.min(assets_in_debt_unit); // 196.875
-    let max_repay = math::div(debt_can_repay_with_rewards, liquidation_reward_with_user_pool); // 196.875 / 1.05 = 187.5
-    let liquidation_reward_with_pool =
-        constants::float_scaling() + registry.pool_liquidation_reward(pool.id()); // 1.03 (assume 3% pool reward, 2% user reward)
-
-    let input_coin_without_pool_reward = math::div(
-        repay_coin.value(),
-        liquidation_reward_with_pool,
-    ); // 100 / 1.03 = 97.087
-    let repay_amount = max_repay.min(input_coin_without_pool_reward); // 97.087
-    let repay_amount_with_pool_reward = math::mul(repay_amount, liquidation_reward_with_pool); // 97.087 * 1.03 = 100
-
-    // If assets are insufficient to cover full debt + reward, the manager's collateral is
-    // fully withdrawn at `max_repay`. Clear every borrow share so the shortfall is recorded
-    // as `pool_default` rather than left as silent residual debt on an empty manager.
-    let assets_exhausted = assets_in_debt_unit <= debt_with_reward;
-    let repay_shares = if (assets_exhausted && repay_amount == max_repay) {
-        borrowed_shares
-    } else {
-        math::mul(
-            borrowed_shares,
-            math::div(repay_amount, debt),
-        )
-    }; // Assume index 2, so borrowed_shares = 350/2 = 175. 97.087 / 350 = 0.2774 * 175 = 48.545 shares being repaid (97.087 USDC is repayment)
-    assert!(repay_shares > 0, ERepaySharesTooLow);
-    let (debt_repaid, pool_reward, pool_default) = margin_pool.repay_liquidation(
-        repay_shares,
-        repay_coin.split(repay_amount_with_pool_reward, ctx),
+        repay_coin,
         clock,
-    );
-    // 97.087 debt repaid, pool reward is 100 - 97.087 = 2.913 (3%), pool_default is 0
-    // We only default if this is a full liquidation
-
-    if (debt_is_base) {
-        self.borrowed_base_shares = self.borrowed_base_shares - repay_shares;
-    } else {
-        self.borrowed_quote_shares = self.borrowed_quote_shares - repay_shares;
-    };
-
-    // Clear margin_pool_id if fully liquidated
-    if (self.borrowed_base_shares == 0 && self.borrowed_quote_shares == 0) {
-        self.margin_pool_id = option::none();
-    };
-
-    // repay_amount * 1.05 is what the user should receive back, since the user provided both the repayment and pool reward
-    // user should receive as much assets possible in the debt asset first, then the collateral asset
-
-    let mut out_amount = math::mul(repay_amount, liquidation_reward_with_user_pool); // 97.087 * 1.05 = 101.941
-
-    let (base_coin, quote_coin) = if (debt_is_base) {
-        let base_out = out_amount.min(base_asset);
-        out_amount = out_amount - base_out;
-        let max_quote_out = calculate_target_currency<BaseAsset, QuoteAsset>(
-            registry,
-            base_reading,
-            quote_reading,
-            out_amount,
-        );
-        let quote_out = max_quote_out.min(quote_asset);
-        let base_coin = self.withdraw_without_owner_check(
-            base_out,
-            ctx,
-        );
-        let quote_coin = self.withdraw_without_owner_check(
-            quote_out,
-            ctx,
-        );
-        (base_coin, quote_coin)
-    } else {
-        let quote_out = out_amount.min(quote_asset);
-        out_amount = out_amount - quote_out; // 101.941 - 40 = 61.941
-        let max_base_out = calculate_target_currency<QuoteAsset, BaseAsset>(
-            registry,
-            quote_reading,
-            base_reading,
-            out_amount,
-        );
-        let base_out = max_base_out.min(base_asset);
-        let base_coin = self.withdraw_without_owner_check(
-            base_out,
-            ctx,
-        );
-        let quote_coin = self.withdraw_without_owner_check(
-            quote_out,
-            ctx,
-        );
-        (base_coin, quote_coin)
-    };
-    // We have 40 USDC which is used first in the second loop. Then SUI to reach the total of 101.941 USDC.
-
-    let (remaining_base_asset, remaining_quote_asset) = self.calculate_assets(pool);
-    let (remaining_base_debt, remaining_quote_debt) = if (self.margin_pool_id.is_some()) {
-        self.calculate_debts(margin_pool, clock)
-    } else {
-        (0, 0)
-    };
-    let (base_pyth_price, base_pyth_decimals) = (base_reading.price(), base_reading.decimals());
-    let (quote_pyth_price, quote_pyth_decimals) = (quote_reading.price(), quote_reading.decimals());
-
-    event::emit(LiquidationEvent {
-        margin_manager_id: self.id(),
-        margin_pool_id: margin_pool.id(),
-        liquidation_amount: debt_repaid,
-        pool_reward,
-        pool_default,
-        risk_ratio,
-        remaining_base_asset,
-        remaining_quote_asset,
-        remaining_base_debt,
-        remaining_quote_debt,
-        base_pyth_price,
-        base_pyth_decimals,
-        quote_pyth_price,
-        quote_pyth_decimals,
-        timestamp: clock.timestamp_ms(),
-    });
-
-    (base_coin, quote_coin, repay_coin)
+        ctx,
+    )
 }
 
 // Returns the risk ratio of the margin manager given the corresponding margin pools.
@@ -976,26 +617,16 @@ public fun risk_ratio<BaseAsset, QuoteAsset>(
     quote_margin_pool: &MarginPool<QuoteAsset>,
     clock: &Clock,
 ): u64 {
-    let debt_is_base = self.borrowed_base_shares > 0;
-    if (debt_is_base) {
-        self.risk_ratio_int(
-            registry,
-            read_price<BaseAsset>(base_oracle, registry, clock),
-            read_price<QuoteAsset>(quote_oracle, registry, clock),
-            pool,
-            base_margin_pool,
-            clock,
-        )
-    } else {
-        self.risk_ratio_int(
-            registry,
-            read_price<BaseAsset>(base_oracle, registry, clock),
-            read_price<QuoteAsset>(quote_oracle, registry, clock),
-            pool,
-            quote_margin_pool,
-            clock,
-        )
-    }
+    risk_ratio_core<BaseAsset, QuoteAsset>(
+        self,
+        registry,
+        read_price<BaseAsset>(base_oracle, registry, clock),
+        read_price<QuoteAsset>(quote_oracle, registry, clock),
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        clock,
+    )
 }
 
 /// Returns the risk ratio without validating oracle price staleness or confidence.
@@ -1010,26 +641,16 @@ public fun risk_ratio_unsafe<BaseAsset, QuoteAsset>(
     quote_margin_pool: &MarginPool<QuoteAsset>,
     clock: &Clock,
 ): u64 {
-    let debt_is_base = self.borrowed_base_shares > 0;
-    if (debt_is_base) {
-        self.risk_ratio_int(
-            registry,
-            read_price_unsafe<BaseAsset>(base_oracle, registry),
-            read_price_unsafe<QuoteAsset>(quote_oracle, registry),
-            pool,
-            base_margin_pool,
-            clock,
-        )
-    } else {
-        self.risk_ratio_int(
-            registry,
-            read_price_unsafe<BaseAsset>(base_oracle, registry),
-            read_price_unsafe<QuoteAsset>(quote_oracle, registry),
-            pool,
-            quote_margin_pool,
-            clock,
-        )
-    }
+    risk_ratio_unsafe_core<BaseAsset, QuoteAsset>(
+        self,
+        registry,
+        read_price_unsafe<BaseAsset>(base_oracle, registry),
+        read_price_unsafe<QuoteAsset>(quote_oracle, registry),
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        clock,
+    )
 }
 
 // === Public Functions - Read Only ===
@@ -1116,58 +737,15 @@ public fun manager_state<BaseAsset, QuoteAsset>(
     quote_margin_pool: &MarginPool<QuoteAsset>,
     clock: &Clock,
 ): (ID, ID, u64, u64, u64, u64, u64, u64, u8, u64, u8, u64, u64, u64) {
-    let manager_id = self.id();
-    let deepbook_pool_id = self.deepbook_pool;
-    let (base_asset, quote_asset) = self.calculate_assets(pool);
-    let (base_debt, quote_debt) = if (self.margin_pool_id.is_some()) {
-        if (self.has_base_debt()) {
-            self.calculate_debts(base_margin_pool, clock)
-        } else {
-            self.calculate_debts(quote_margin_pool, clock)
-        }
-    } else {
-        (0, 0)
-    };
-    let risk_ratio = self.risk_ratio_unsafe(
+    manager_state_core<BaseAsset, QuoteAsset>(
+        self,
         registry,
-        base_oracle,
-        quote_oracle,
+        read_price_unsafe<BaseAsset>(base_oracle, registry),
+        read_price_unsafe<QuoteAsset>(quote_oracle, registry),
         pool,
         base_margin_pool,
         quote_margin_pool,
         clock,
-    );
-
-    let base_reading = read_price_unsafe<BaseAsset>(base_oracle, registry);
-    let quote_reading = read_price_unsafe<QuoteAsset>(quote_oracle, registry);
-    let (base_pyth_price, base_pyth_decimals) = (base_reading.price(), base_reading.decimals());
-    let (quote_pyth_price, quote_pyth_decimals) = (quote_reading.price(), quote_reading.decimals());
-
-    let current_price = calculate_price<BaseAsset, QuoteAsset>(
-        registry,
-        base_reading,
-        quote_reading,
-    );
-
-    // Get the lowest trigger above price and highest trigger below price
-    let lowest_trigger_above_price = self.lowest_trigger_above_price();
-    let highest_trigger_below_price = self.highest_trigger_below_price();
-
-    (
-        manager_id,
-        deepbook_pool_id,
-        risk_ratio,
-        base_asset,
-        quote_asset,
-        base_debt,
-        quote_debt,
-        base_pyth_price,
-        base_pyth_decimals,
-        quote_pyth_price,
-        quote_pyth_decimals,
-        current_price,
-        lowest_trigger_above_price,
-        highest_trigger_below_price,
     )
 }
 
@@ -1199,78 +777,15 @@ public fun manager_states<BaseAsset, QuoteAsset>(
     vector<u64>,
     vector<u64>,
 ) {
-    let mut manager_ids = vector[];
-    let mut deepbook_pool_ids = vector[];
-    let mut risk_ratios = vector[];
-    let mut base_assets = vector[];
-    let mut quote_assets = vector[];
-    let mut base_debts = vector[];
-    let mut quote_debts = vector[];
-    let mut base_pyth_prices = vector[];
-    let mut base_pyth_decimals_vec = vector[];
-    let mut quote_pyth_prices = vector[];
-    let mut quote_pyth_decimals_vec = vector[];
-    let mut current_prices = vector[];
-    let mut lowest_trigger_above_prices = vector[];
-    let mut highest_trigger_below_prices = vector[];
-
-    margin_managers.do_ref!(|manager| {
-        let (
-            manager_id,
-            deepbook_pool_id,
-            risk_ratio,
-            base_asset,
-            quote_asset,
-            base_debt,
-            quote_debt,
-            base_pyth_price,
-            base_pyth_decimals,
-            quote_pyth_price,
-            quote_pyth_decimals,
-            current_price,
-            lowest_trigger_above_price,
-            highest_trigger_below_price,
-        ) = manager.manager_state(
-            registry,
-            base_oracle,
-            quote_oracle,
-            pool,
-            base_margin_pool,
-            quote_margin_pool,
-            clock,
-        );
-
-        manager_ids.push_back(manager_id);
-        deepbook_pool_ids.push_back(deepbook_pool_id);
-        risk_ratios.push_back(risk_ratio);
-        base_assets.push_back(base_asset);
-        quote_assets.push_back(quote_asset);
-        base_debts.push_back(base_debt);
-        quote_debts.push_back(quote_debt);
-        base_pyth_prices.push_back(base_pyth_price);
-        base_pyth_decimals_vec.push_back(base_pyth_decimals);
-        quote_pyth_prices.push_back(quote_pyth_price);
-        quote_pyth_decimals_vec.push_back(quote_pyth_decimals);
-        current_prices.push_back(current_price);
-        lowest_trigger_above_prices.push_back(lowest_trigger_above_price);
-        highest_trigger_below_prices.push_back(highest_trigger_below_price);
-    });
-
-    (
-        manager_ids,
-        deepbook_pool_ids,
-        risk_ratios,
-        base_assets,
-        quote_assets,
-        base_debts,
-        quote_debts,
-        base_pyth_prices,
-        base_pyth_decimals_vec,
-        quote_pyth_prices,
-        quote_pyth_decimals_vec,
-        current_prices,
-        lowest_trigger_above_prices,
-        highest_trigger_below_prices,
+    manager_states_core<BaseAsset, QuoteAsset>(
+        margin_managers,
+        registry,
+        read_price_unsafe<BaseAsset>(base_oracle, registry),
+        read_price_unsafe<QuoteAsset>(quote_oracle, registry),
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        clock,
     )
 }
 
@@ -2063,8 +1578,8 @@ fun process_collected_orders_v2<BaseAsset, QuoteAsset>(
     registry: &MarginRegistry,
     base_margin_pool: &MarginPool<BaseAsset>,
     quote_margin_pool: &MarginPool<QuoteAsset>,
-    base_oracle: &PriceInfoObject,
-    quote_oracle: &PriceInfoObject,
+    base_reading: PythReading,
+    quote_reading: PythReading,
     orders: vector<ConditionalOrder>,
     order_infos: &mut vector<OrderInfo>,
     executed_ids: &mut vector<u64>,
@@ -2098,10 +1613,10 @@ fun process_collected_orders_v2<BaseAsset, QuoteAsset>(
         !executed_ids.is_empty()
         && (self.borrowed_base_shares > 0 || self.borrowed_quote_shares > 0)
     ) {
-        let risk_ratio_after = self.risk_ratio(
+        let risk_ratio_after = self.risk_ratio_core(
             registry,
-            base_oracle,
-            quote_oracle,
+            base_reading,
+            quote_reading,
             pool,
             base_margin_pool,
             quote_margin_pool,
@@ -2129,8 +1644,8 @@ fun process_collected_orders_v3<BaseAsset, QuoteAsset>(
     registry: &MarginRegistry,
     base_margin_pool: &mut MarginPool<BaseAsset>,
     quote_margin_pool: &mut MarginPool<QuoteAsset>,
-    base_oracle: &PriceInfoObject,
-    quote_oracle: &PriceInfoObject,
+    base_reading: PythReading,
+    quote_reading: PythReading,
     orders: vector<ConditionalOrder>,
     order_infos: &mut vector<OrderInfo>,
     executed_ids: &mut vector<u64>,
@@ -2144,10 +1659,10 @@ fun process_collected_orders_v3<BaseAsset, QuoteAsset>(
 ) {
     let has_debt = self.borrowed_base_shares > 0 || self.borrowed_quote_shares > 0;
     let risk_ratio_before = if (has_debt) {
-        self.risk_ratio(
+        self.risk_ratio_core(
             registry,
-            base_oracle,
-            quote_oracle,
+            base_reading,
+            quote_reading,
             pool,
             base_margin_pool,
             quote_margin_pool,
@@ -2206,10 +1721,10 @@ fun process_collected_orders_v3<BaseAsset, QuoteAsset>(
     };
 
     if (has_debt && !executed_ids.is_empty()) {
-        let risk_ratio_after = self.risk_ratio(
+        let risk_ratio_after = self.risk_ratio_core(
             registry,
-            base_oracle,
-            quote_oracle,
+            base_reading,
+            quote_reading,
             pool,
             base_margin_pool,
             quote_margin_pool,
@@ -2223,4 +1738,787 @@ fun balance_manager_unsafe_mut<BaseAsset, QuoteAsset>(
     self: &mut MarginManager<BaseAsset, QuoteAsset>,
 ): &mut BalanceManager {
     &mut self.balance_manager
+}
+
+// === Shared cores ===
+// Bodies factored out so the legacy and Pyth Pro entrypoints run identical logic;
+// only the reader that produced the `PythReading` differs.
+
+public(package) fun add_conditional_order_core<BaseAsset, QuoteAsset>(
+    self: &mut MarginManager<BaseAsset, QuoteAsset>,
+    pool: &Pool<BaseAsset, QuoteAsset>,
+    base_reading: PythReading,
+    quote_reading: PythReading,
+    registry: &MarginRegistry,
+    conditional_order_id: u64,
+    condition: Condition,
+    pending_order: PendingOrder,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    registry.load_inner();
+    self.validate_owner(ctx);
+    let manager_id = self.id();
+    assert!(pool.id() == self.deepbook_pool(), EIncorrectDeepBookPool);
+    self
+        .take_profit_stop_loss
+        .add_conditional_order<BaseAsset, QuoteAsset>(
+            pool,
+            manager_id,
+            base_reading,
+            quote_reading,
+            registry,
+            conditional_order_id,
+            condition,
+            pending_order,
+            clock,
+        );
+}
+
+public(package) fun execute_conditional_orders_v2_core<BaseAsset, QuoteAsset>(
+    self: &mut MarginManager<BaseAsset, QuoteAsset>,
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    base_reading: PythReading,
+    quote_reading: PythReading,
+    registry: &MarginRegistry,
+    max_orders_to_execute: u64,
+    clock: &Clock,
+    ctx: &TxContext,
+): vector<OrderInfo> {
+    registry.load_inner();
+    assert!(pool.id() == self.deepbook_pool(), EIncorrectDeepBookPool);
+    let current_price = calculate_price<BaseAsset, QuoteAsset>(
+        registry,
+        base_reading,
+        quote_reading,
+    );
+
+    let orders_to_process = self.collect_triggered_orders(current_price);
+
+    let mut order_infos = vector[];
+    let mut executed_ids = vector[];
+    let mut expired_ids = vector[];
+    let mut insufficient_funds_ids = vector[];
+    let mut out_of_bounds_ids = vector[];
+    let mut below_liquidation_ids = vector[];
+
+    self.process_collected_orders_v2(
+        pool,
+        registry,
+        base_margin_pool,
+        quote_margin_pool,
+        base_reading,
+        quote_reading,
+        orders_to_process,
+        &mut order_infos,
+        &mut executed_ids,
+        &mut expired_ids,
+        &mut insufficient_funds_ids,
+        &mut out_of_bounds_ids,
+        &mut below_liquidation_ids,
+        max_orders_to_execute,
+        clock,
+        ctx,
+    );
+
+    self.finalize_conditional_execution(
+        pool.id(),
+        expired_ids,
+        insufficient_funds_ids,
+        out_of_bounds_ids,
+        below_liquidation_ids,
+        executed_ids,
+        clock,
+    );
+
+    order_infos
+}
+
+public(package) fun execute_conditional_orders_v3_core<BaseAsset, QuoteAsset>(
+    self: &mut MarginManager<BaseAsset, QuoteAsset>,
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &mut MarginPool<BaseAsset>,
+    quote_margin_pool: &mut MarginPool<QuoteAsset>,
+    base_reading: PythReading,
+    quote_reading: PythReading,
+    registry: &MarginRegistry,
+    max_orders_to_execute: u64,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): vector<OrderInfo> {
+    registry.load_inner();
+    assert!(pool.id() == self.deepbook_pool(), EIncorrectDeepBookPool);
+    let current_price = calculate_price<BaseAsset, QuoteAsset>(
+        registry,
+        base_reading,
+        quote_reading,
+    );
+
+    let orders_to_process = self.collect_triggered_orders(current_price);
+
+    let mut order_infos = vector[];
+    let mut executed_ids = vector[];
+    let mut expired_ids = vector[];
+    let mut insufficient_funds_ids = vector[];
+    let mut out_of_bounds_ids = vector[];
+    let mut below_liquidation_ids = vector[];
+
+    self.process_collected_orders_v3(
+        pool,
+        registry,
+        base_margin_pool,
+        quote_margin_pool,
+        base_reading,
+        quote_reading,
+        orders_to_process,
+        &mut order_infos,
+        &mut executed_ids,
+        &mut expired_ids,
+        &mut insufficient_funds_ids,
+        &mut out_of_bounds_ids,
+        &mut below_liquidation_ids,
+        max_orders_to_execute,
+        clock,
+        ctx,
+    );
+
+    self.finalize_conditional_execution(
+        pool.id(),
+        expired_ids,
+        insufficient_funds_ids,
+        out_of_bounds_ids,
+        below_liquidation_ids,
+        executed_ids,
+        clock,
+    );
+
+    order_infos
+}
+
+public(package) fun deposit_core<BaseAsset, QuoteAsset, DepositAsset>(
+    self: &mut MarginManager<BaseAsset, QuoteAsset>,
+    registry: &MarginRegistry,
+    base_reading: PythReading,
+    quote_reading: PythReading,
+    coin: Coin<DepositAsset>,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    registry.load_inner();
+    self.validate_owner(ctx);
+
+    let deposit_amount = coin.value();
+    self.deposit_int<BaseAsset, QuoteAsset, DepositAsset>(coin, ctx);
+
+    let deposit_asset_type = type_name::with_defining_ids<DepositAsset>();
+    let deposit_base_asset = deposit_asset_type == type_name::with_defining_ids<BaseAsset>();
+    let deposit_quote_asset = deposit_asset_type == type_name::with_defining_ids<QuoteAsset>();
+    // We return early here, because there is no need to emit a deposit collateral event if neither the base asset
+    // nor the quote asset is deposited. This handles the case for DEEP deposits, when DEEP is not part of the base
+    // or quote assets.
+    if (!deposit_base_asset && !deposit_quote_asset) return;
+
+    let reading = if (deposit_base_asset) {
+        base_reading
+    } else {
+        quote_reading
+    };
+    let (pyth_price, pyth_decimals) = (reading.price(), reading.decimals());
+
+    event::emit(DepositCollateralEvent {
+        margin_manager_id: self.id(),
+        amount: deposit_amount,
+        asset: deposit_asset_type,
+        pyth_price,
+        pyth_decimals,
+        timestamp: clock.timestamp_ms(),
+    });
+}
+
+public(package) fun withdraw_core<BaseAsset, QuoteAsset, WithdrawAsset>(
+    self: &mut MarginManager<BaseAsset, QuoteAsset>,
+    registry: &MarginRegistry,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    base_reading: PythReading,
+    quote_reading: PythReading,
+    pool: &Pool<BaseAsset, QuoteAsset>,
+    withdraw_amount: u64,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): Coin<WithdrawAsset> {
+    registry.load_inner();
+    self.validate_owner(ctx);
+    assert!(pool.id() == self.deepbook_pool(), EIncorrectDeepBookPool);
+
+    let balance_manager = &mut self.balance_manager;
+    let withdraw_cap = &self.withdraw_cap;
+
+    let coin = balance_manager.withdraw_with_cap<WithdrawAsset>(
+        withdraw_cap,
+        withdraw_amount,
+        ctx,
+    );
+
+    if (self.margin_pool_id.contains(&base_margin_pool.id())) {
+        let risk_ratio = self.risk_ratio_int(
+            registry,
+            base_reading,
+            quote_reading,
+            pool,
+            base_margin_pool,
+            clock,
+        );
+        assert!(registry.can_withdraw(pool.id(), risk_ratio), EWithdrawRiskRatioExceeded);
+    } else if (self.margin_pool_id.contains(&quote_margin_pool.id())) {
+        let risk_ratio = self.risk_ratio_int(
+            registry,
+            base_reading,
+            quote_reading,
+            pool,
+            quote_margin_pool,
+            clock,
+        );
+        assert!(registry.can_withdraw(pool.id(), risk_ratio), EWithdrawRiskRatioExceeded);
+    };
+
+    let withdraw_asset_type = type_name::with_defining_ids<WithdrawAsset>();
+    let withdraw_base_asset = withdraw_asset_type == type_name::with_defining_ids<BaseAsset>();
+    let withdraw_quote_asset = withdraw_asset_type == type_name::with_defining_ids<QuoteAsset>();
+    // We return early here, because there is no need to emit a withdraw collateral event if neither the base asset
+    // nor the quote asset is withdrawn. This handles the case for DEEP withdrawals, when DEEP is not part of the base
+    // or quote assets.
+    if (!withdraw_base_asset && !withdraw_quote_asset) return coin;
+
+    let (
+        _,
+        _,
+        _,
+        remaining_base_asset,
+        remaining_quote_asset,
+        remaining_base_debt,
+        remaining_quote_debt,
+        base_pyth_price,
+        base_pyth_decimals,
+        quote_pyth_price,
+        quote_pyth_decimals,
+        _,
+        _,
+        _,
+    ) = self.manager_state_core(
+        registry,
+        base_reading,
+        quote_reading,
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        clock,
+    );
+
+    event::emit(WithdrawCollateralEvent {
+        margin_manager_id: self.id(),
+        amount: withdraw_amount,
+        asset: withdraw_asset_type,
+        withdraw_base_asset,
+        remaining_base_asset,
+        remaining_quote_asset,
+        remaining_base_debt,
+        remaining_quote_debt,
+        base_pyth_price,
+        base_pyth_decimals,
+        quote_pyth_price,
+        quote_pyth_decimals,
+        timestamp: clock.timestamp_ms(),
+    });
+
+    coin
+}
+
+public(package) fun borrow_base_core<BaseAsset, QuoteAsset>(
+    self: &mut MarginManager<BaseAsset, QuoteAsset>,
+    registry: &MarginRegistry,
+    base_margin_pool: &mut MarginPool<BaseAsset>,
+    base_reading: PythReading,
+    quote_reading: PythReading,
+    pool: &Pool<BaseAsset, QuoteAsset>,
+    loan_amount: u64,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    registry.load_inner();
+    self.validate_owner(ctx);
+    assert!(registry.pool_enabled(pool), EPoolNotEnabledForMarginTrading);
+    assert!(pool.id() == self.deepbook_pool, EIncorrectDeepBookPool);
+    assert!(self.can_borrow(base_margin_pool), ECannotHaveLoanInMoreThanOneMarginPool);
+    assert!(
+        base_margin_pool.deepbook_pool_allowed(self.deepbook_pool),
+        EDeepbookPoolNotAllowedForLoan,
+    );
+    let (coin, borrowed_shares) = base_margin_pool.borrow(loan_amount, clock, ctx);
+    self.borrowed_base_shares = self.borrowed_base_shares + borrowed_shares;
+    self.margin_pool_id = option::some(base_margin_pool.id());
+    self.deposit_int<BaseAsset, QuoteAsset, BaseAsset>(coin, ctx);
+    let risk_ratio = self.risk_ratio_int(
+        registry,
+        base_reading,
+        quote_reading,
+        pool,
+        base_margin_pool,
+        clock,
+    );
+    assert!(registry.can_borrow(pool.id(), risk_ratio), EBorrowRiskRatioExceeded);
+
+    event::emit(LoanBorrowedEvent {
+        margin_manager_id: self.id(),
+        margin_pool_id: base_margin_pool.id(),
+        loan_amount,
+        loan_shares: borrowed_shares,
+        timestamp: clock.timestamp_ms(),
+    });
+}
+
+public(package) fun borrow_quote_core<BaseAsset, QuoteAsset>(
+    self: &mut MarginManager<BaseAsset, QuoteAsset>,
+    registry: &MarginRegistry,
+    quote_margin_pool: &mut MarginPool<QuoteAsset>,
+    base_reading: PythReading,
+    quote_reading: PythReading,
+    pool: &Pool<BaseAsset, QuoteAsset>,
+    loan_amount: u64,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    registry.load_inner();
+    self.validate_owner(ctx);
+    assert!(registry.pool_enabled(pool), EPoolNotEnabledForMarginTrading);
+    assert!(pool.id() == self.deepbook_pool, EIncorrectDeepBookPool);
+    assert!(self.can_borrow(quote_margin_pool), ECannotHaveLoanInMoreThanOneMarginPool);
+    assert!(
+        quote_margin_pool.deepbook_pool_allowed(self.deepbook_pool),
+        EDeepbookPoolNotAllowedForLoan,
+    );
+    let (coin, borrowed_shares) = quote_margin_pool.borrow(loan_amount, clock, ctx);
+    self.borrowed_quote_shares = self.borrowed_quote_shares + borrowed_shares;
+    self.margin_pool_id = option::some(quote_margin_pool.id());
+    self.deposit_int<BaseAsset, QuoteAsset, QuoteAsset>(coin, ctx);
+    let risk_ratio = self.risk_ratio_int(
+        registry,
+        base_reading,
+        quote_reading,
+        pool,
+        quote_margin_pool,
+        clock,
+    );
+    assert!(registry.can_borrow(pool.id(), risk_ratio), EBorrowRiskRatioExceeded);
+
+    event::emit(LoanBorrowedEvent {
+        margin_manager_id: self.id(),
+        margin_pool_id: quote_margin_pool.id(),
+        loan_amount,
+        loan_shares: borrowed_shares,
+        timestamp: clock.timestamp_ms(),
+    });
+}
+
+public(package) fun liquidate_core<BaseAsset, QuoteAsset, DebtAsset>(
+    self: &mut MarginManager<BaseAsset, QuoteAsset>,
+    registry: &MarginRegistry,
+    base_reading: PythReading,
+    quote_reading: PythReading,
+    margin_pool: &mut MarginPool<DebtAsset>,
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    mut repay_coin: Coin<DebtAsset>,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): (Coin<BaseAsset>, Coin<QuoteAsset>, Coin<DebtAsset>) {
+    // 1. Check that we can liquidate, cancel all open orders.
+    assert!(self.deepbook_pool == pool.id(), EIncorrectDeepBookPool);
+    assert!(self.margin_pool_id.contains(&margin_pool.id()), EIncorrectMarginPool);
+    let risk_ratio = self.risk_ratio_int(
+        registry,
+        base_reading,
+        quote_reading,
+        pool,
+        margin_pool,
+        clock,
+    );
+    assert!(registry.can_liquidate(pool.id(), risk_ratio), ECannotLiquidate);
+    assert!(repay_coin.value() >= margin_constants::min_liquidation_repay(), ERepayAmountTooLow);
+    let trade_proof = self.trade_proof(ctx);
+    pool.withdraw_settled_amounts(&mut self.balance_manager, &trade_proof);
+    pool.cancel_all_orders(&mut self.balance_manager, &trade_proof, clock, ctx);
+
+    // 2. Calculate the maximum debt that can be repaid. The margin manager can be in three scenarios:
+    // a) Assets <= Debt + user_reward: Full liquidation, repay as much debt as possible, lending pool may incur bad debt.
+    // b) Debt + user_reward < Assets <= Debt + user_reward + pool_reward: There are enough assets to cover the debt, but pool may not get full rewards.
+    // c) Debt + user_reward + pool_reward < Assets: There are enough assets to cover everything. We may not need to liquidate the full position.
+    let borrowed_shares = self.borrowed_base_shares.max(self.borrowed_quote_shares);
+    let debt = margin_pool.borrow_shares_to_amount(borrowed_shares, clock); // 350 USDC debt
+    let debt_is_base =
+        type_name::with_defining_ids<DebtAsset>() == type_name::with_defining_ids<BaseAsset>();
+    let (assets_in_debt_unit, base_asset, quote_asset) = self.assets_in_debt_unit(
+        registry,
+        pool,
+        base_reading,
+        quote_reading,
+    ); // SUI/USDC pool. We have 90 SUI and 40 USDC, 350 USDC debt. This should be 400 USDC. (assume 1 SUI = 4 USDC)
+
+    let liquidation_reward_with_user_pool =
+        constants::float_scaling() + registry.user_liquidation_reward(pool.id()) + registry.pool_liquidation_reward(pool.id()); // 1.05
+
+    let target_ratio = registry.target_liquidation_risk_ratio(pool.id()); // 1.25
+    let numerator = math::mul(target_ratio, debt) - assets_in_debt_unit; // 1.25 * 350 - 400 = 437.5 - 400 = 37.5
+    let denominator = target_ratio - liquidation_reward_with_user_pool; // 1.25 - 1.05 = 0.2
+    let debt_repay = math::div(numerator, denominator); // 37.5 / 0.2 = 187.5
+    // We have to pay the minimum between our current debt and the debt required to reach the target ratio.
+    // In other words, if our assets are low, we pay off all debt (full liquidation)
+    // if our assets are high, we pay off some of the debt (partial liquidation)
+    let debt_repay = debt_repay.min(debt); // 187.5
+    let debt_with_reward = math::mul(debt_repay, liquidation_reward_with_user_pool); // 187.5 * 1.05 = 196.875
+    let debt_can_repay_with_rewards = debt_with_reward.min(assets_in_debt_unit); // 196.875
+    let max_repay = math::div(debt_can_repay_with_rewards, liquidation_reward_with_user_pool); // 196.875 / 1.05 = 187.5
+    let liquidation_reward_with_pool =
+        constants::float_scaling() + registry.pool_liquidation_reward(pool.id()); // 1.03 (assume 3% pool reward, 2% user reward)
+
+    let input_coin_without_pool_reward = math::div(
+        repay_coin.value(),
+        liquidation_reward_with_pool,
+    ); // 100 / 1.03 = 97.087
+    let repay_amount = max_repay.min(input_coin_without_pool_reward); // 97.087
+    let repay_amount_with_pool_reward = math::mul(repay_amount, liquidation_reward_with_pool); // 97.087 * 1.03 = 100
+
+    // If assets are insufficient to cover full debt + reward, the manager's collateral is
+    // fully withdrawn at `max_repay`. Clear every borrow share so the shortfall is recorded
+    // as `pool_default` rather than left as silent residual debt on an empty manager.
+    let assets_exhausted = assets_in_debt_unit <= debt_with_reward;
+    let repay_shares = if (assets_exhausted && repay_amount == max_repay) {
+        borrowed_shares
+    } else {
+        math::mul(
+            borrowed_shares,
+            math::div(repay_amount, debt),
+        )
+    }; // Assume index 2, so borrowed_shares = 350/2 = 175. 97.087 / 350 = 0.2774 * 175 = 48.545 shares being repaid (97.087 USDC is repayment)
+    assert!(repay_shares > 0, ERepaySharesTooLow);
+    let (debt_repaid, pool_reward, pool_default) = margin_pool.repay_liquidation(
+        repay_shares,
+        repay_coin.split(repay_amount_with_pool_reward, ctx),
+        clock,
+    );
+    // 97.087 debt repaid, pool reward is 100 - 97.087 = 2.913 (3%), pool_default is 0
+    // We only default if this is a full liquidation
+
+    if (debt_is_base) {
+        self.borrowed_base_shares = self.borrowed_base_shares - repay_shares;
+    } else {
+        self.borrowed_quote_shares = self.borrowed_quote_shares - repay_shares;
+    };
+
+    // Clear margin_pool_id if fully liquidated
+    if (self.borrowed_base_shares == 0 && self.borrowed_quote_shares == 0) {
+        self.margin_pool_id = option::none();
+    };
+
+    // repay_amount * 1.05 is what the user should receive back, since the user provided both the repayment and pool reward
+    // user should receive as much assets possible in the debt asset first, then the collateral asset
+
+    let mut out_amount = math::mul(repay_amount, liquidation_reward_with_user_pool); // 97.087 * 1.05 = 101.941
+
+    let (base_coin, quote_coin) = if (debt_is_base) {
+        let base_out = out_amount.min(base_asset);
+        out_amount = out_amount - base_out;
+        let max_quote_out = calculate_target_currency<BaseAsset, QuoteAsset>(
+            registry,
+            base_reading,
+            quote_reading,
+            out_amount,
+        );
+        let quote_out = max_quote_out.min(quote_asset);
+        let base_coin = self.withdraw_without_owner_check(
+            base_out,
+            ctx,
+        );
+        let quote_coin = self.withdraw_without_owner_check(
+            quote_out,
+            ctx,
+        );
+        (base_coin, quote_coin)
+    } else {
+        let quote_out = out_amount.min(quote_asset);
+        out_amount = out_amount - quote_out; // 101.941 - 40 = 61.941
+        let max_base_out = calculate_target_currency<QuoteAsset, BaseAsset>(
+            registry,
+            quote_reading,
+            base_reading,
+            out_amount,
+        );
+        let base_out = max_base_out.min(base_asset);
+        let base_coin = self.withdraw_without_owner_check(
+            base_out,
+            ctx,
+        );
+        let quote_coin = self.withdraw_without_owner_check(
+            quote_out,
+            ctx,
+        );
+        (base_coin, quote_coin)
+    };
+    // We have 40 USDC which is used first in the second loop. Then SUI to reach the total of 101.941 USDC.
+
+    let (remaining_base_asset, remaining_quote_asset) = self.calculate_assets(pool);
+    let (remaining_base_debt, remaining_quote_debt) = if (self.margin_pool_id.is_some()) {
+        self.calculate_debts(margin_pool, clock)
+    } else {
+        (0, 0)
+    };
+    let (base_pyth_price, base_pyth_decimals) = (base_reading.price(), base_reading.decimals());
+    let (quote_pyth_price, quote_pyth_decimals) = (quote_reading.price(), quote_reading.decimals());
+
+    event::emit(LiquidationEvent {
+        margin_manager_id: self.id(),
+        margin_pool_id: margin_pool.id(),
+        liquidation_amount: debt_repaid,
+        pool_reward,
+        pool_default,
+        risk_ratio,
+        remaining_base_asset,
+        remaining_quote_asset,
+        remaining_base_debt,
+        remaining_quote_debt,
+        base_pyth_price,
+        base_pyth_decimals,
+        quote_pyth_price,
+        quote_pyth_decimals,
+        timestamp: clock.timestamp_ms(),
+    });
+
+    (base_coin, quote_coin, repay_coin)
+}
+
+public(package) fun risk_ratio_core<BaseAsset, QuoteAsset>(
+    self: &MarginManager<BaseAsset, QuoteAsset>,
+    registry: &MarginRegistry,
+    base_reading: PythReading,
+    quote_reading: PythReading,
+    pool: &Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    clock: &Clock,
+): u64 {
+    let debt_is_base = self.borrowed_base_shares > 0;
+    if (debt_is_base) {
+        self.risk_ratio_int(
+            registry,
+            base_reading,
+            quote_reading,
+            pool,
+            base_margin_pool,
+            clock,
+        )
+    } else {
+        self.risk_ratio_int(
+            registry,
+            base_reading,
+            quote_reading,
+            pool,
+            quote_margin_pool,
+            clock,
+        )
+    }
+}
+
+public(package) fun risk_ratio_unsafe_core<BaseAsset, QuoteAsset>(
+    self: &MarginManager<BaseAsset, QuoteAsset>,
+    registry: &MarginRegistry,
+    base_reading: PythReading,
+    quote_reading: PythReading,
+    pool: &Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    clock: &Clock,
+): u64 {
+    let debt_is_base = self.borrowed_base_shares > 0;
+    if (debt_is_base) {
+        self.risk_ratio_int(
+            registry,
+            base_reading,
+            quote_reading,
+            pool,
+            base_margin_pool,
+            clock,
+        )
+    } else {
+        self.risk_ratio_int(
+            registry,
+            base_reading,
+            quote_reading,
+            pool,
+            quote_margin_pool,
+            clock,
+        )
+    }
+}
+
+public(package) fun manager_state_core<BaseAsset, QuoteAsset>(
+    self: &MarginManager<BaseAsset, QuoteAsset>,
+    registry: &MarginRegistry,
+    base_reading: PythReading,
+    quote_reading: PythReading,
+    pool: &Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    clock: &Clock,
+): (ID, ID, u64, u64, u64, u64, u64, u64, u8, u64, u8, u64, u64, u64) {
+    let manager_id = self.id();
+    let deepbook_pool_id = self.deepbook_pool;
+    let (base_asset, quote_asset) = self.calculate_assets(pool);
+    let (base_debt, quote_debt) = if (self.margin_pool_id.is_some()) {
+        if (self.has_base_debt()) {
+            self.calculate_debts(base_margin_pool, clock)
+        } else {
+            self.calculate_debts(quote_margin_pool, clock)
+        }
+    } else {
+        (0, 0)
+    };
+    let risk_ratio = self.risk_ratio_unsafe_core(
+        registry,
+        base_reading,
+        quote_reading,
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        clock,
+    );
+    let (base_pyth_price, base_pyth_decimals) = (base_reading.price(), base_reading.decimals());
+    let (quote_pyth_price, quote_pyth_decimals) = (quote_reading.price(), quote_reading.decimals());
+
+    let current_price = calculate_price<BaseAsset, QuoteAsset>(
+        registry,
+        base_reading,
+        quote_reading,
+    );
+
+    // Get the lowest trigger above price and highest trigger below price
+    let lowest_trigger_above_price = self.lowest_trigger_above_price();
+    let highest_trigger_below_price = self.highest_trigger_below_price();
+
+    (
+        manager_id,
+        deepbook_pool_id,
+        risk_ratio,
+        base_asset,
+        quote_asset,
+        base_debt,
+        quote_debt,
+        base_pyth_price,
+        base_pyth_decimals,
+        quote_pyth_price,
+        quote_pyth_decimals,
+        current_price,
+        lowest_trigger_above_price,
+        highest_trigger_below_price,
+    )
+}
+
+public(package) fun manager_states_core<BaseAsset, QuoteAsset>(
+    margin_managers: &vector<MarginManager<BaseAsset, QuoteAsset>>,
+    registry: &MarginRegistry,
+    base_reading: PythReading,
+    quote_reading: PythReading,
+    pool: &Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    clock: &Clock,
+): (
+    vector<ID>,
+    vector<ID>,
+    vector<u64>,
+    vector<u64>,
+    vector<u64>,
+    vector<u64>,
+    vector<u64>,
+    vector<u64>,
+    vector<u8>,
+    vector<u64>,
+    vector<u8>,
+    vector<u64>,
+    vector<u64>,
+    vector<u64>,
+) {
+    let mut manager_ids = vector[];
+    let mut deepbook_pool_ids = vector[];
+    let mut risk_ratios = vector[];
+    let mut base_assets = vector[];
+    let mut quote_assets = vector[];
+    let mut base_debts = vector[];
+    let mut quote_debts = vector[];
+    let mut base_pyth_prices = vector[];
+    let mut base_pyth_decimals_vec = vector[];
+    let mut quote_pyth_prices = vector[];
+    let mut quote_pyth_decimals_vec = vector[];
+    let mut current_prices = vector[];
+    let mut lowest_trigger_above_prices = vector[];
+    let mut highest_trigger_below_prices = vector[];
+
+    margin_managers.do_ref!(|manager| {
+        let (
+            manager_id,
+            deepbook_pool_id,
+            risk_ratio,
+            base_asset,
+            quote_asset,
+            base_debt,
+            quote_debt,
+            base_pyth_price,
+            base_pyth_decimals,
+            quote_pyth_price,
+            quote_pyth_decimals,
+            current_price,
+            lowest_trigger_above_price,
+            highest_trigger_below_price,
+        ) = manager.manager_state_core(
+            registry,
+            base_reading,
+            quote_reading,
+            pool,
+            base_margin_pool,
+            quote_margin_pool,
+            clock,
+        );
+
+        manager_ids.push_back(manager_id);
+        deepbook_pool_ids.push_back(deepbook_pool_id);
+        risk_ratios.push_back(risk_ratio);
+        base_assets.push_back(base_asset);
+        quote_assets.push_back(quote_asset);
+        base_debts.push_back(base_debt);
+        quote_debts.push_back(quote_debt);
+        base_pyth_prices.push_back(base_pyth_price);
+        base_pyth_decimals_vec.push_back(base_pyth_decimals);
+        quote_pyth_prices.push_back(quote_pyth_price);
+        quote_pyth_decimals_vec.push_back(quote_pyth_decimals);
+        current_prices.push_back(current_price);
+        lowest_trigger_above_prices.push_back(lowest_trigger_above_price);
+        highest_trigger_below_prices.push_back(highest_trigger_below_price);
+    });
+
+    (
+        manager_ids,
+        deepbook_pool_ids,
+        risk_ratios,
+        base_assets,
+        quote_assets,
+        base_debts,
+        quote_debts,
+        base_pyth_prices,
+        base_pyth_decimals_vec,
+        quote_pyth_prices,
+        quote_pyth_decimals_vec,
+        current_prices,
+        lowest_trigger_above_prices,
+        highest_trigger_below_prices,
+    )
 }

--- a/packages/deepbook_margin/sources/margin_manager_pro.move
+++ b/packages/deepbook_margin/sources/margin_manager_pro.move
@@ -1,0 +1,321 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Pyth Pro entrypoints for `margin_manager`.
+///
+/// Pyth Core is being replaced by a separately published package, so its
+/// `PriceInfoObject` is a distinct Move type from the legacy one and the frozen
+/// signatures in `margin_manager` can never accept it. The Pyth Pro surface therefore lives
+/// here, under the same function names. Each entry reads the Pro feed and delegates
+/// to the shared core in `margin_manager`, so both feeds run identical logic.
+module deepbook_margin::margin_manager_pro;
+
+use deepbook::{order_info::OrderInfo, pool::Pool};
+use deepbook_margin::{
+    margin_manager::{Self, MarginManager},
+    margin_pool::MarginPool,
+    margin_registry::MarginRegistry,
+    oracle,
+    tpsl::{Condition, PendingOrder}
+};
+use pyth_pro::price_info::PriceInfoObject as PriceInfoObjectPro;
+use sui::{clock::Clock, coin::Coin};
+
+public fun add_conditional_order<BaseAsset, QuoteAsset>(
+    self: &mut MarginManager<BaseAsset, QuoteAsset>,
+    pool: &Pool<BaseAsset, QuoteAsset>,
+    base_price_info_object: &PriceInfoObjectPro,
+    quote_price_info_object: &PriceInfoObjectPro,
+    registry: &MarginRegistry,
+    conditional_order_id: u64,
+    condition: Condition,
+    pending_order: PendingOrder,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    margin_manager::add_conditional_order_core<BaseAsset, QuoteAsset>(
+        self,
+        pool,
+        oracle::read_price_pro<BaseAsset>(base_price_info_object, registry, clock),
+        oracle::read_price_pro<QuoteAsset>(quote_price_info_object, registry, clock),
+        registry,
+        conditional_order_id,
+        condition,
+        pending_order,
+        clock,
+        ctx,
+    )
+}
+
+public fun execute_conditional_orders_v2<BaseAsset, QuoteAsset>(
+    self: &mut MarginManager<BaseAsset, QuoteAsset>,
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    base_price_info_object: &PriceInfoObjectPro,
+    quote_price_info_object: &PriceInfoObjectPro,
+    registry: &MarginRegistry,
+    max_orders_to_execute: u64,
+    clock: &Clock,
+    ctx: &TxContext,
+): vector<OrderInfo> {
+    margin_manager::execute_conditional_orders_v2_core<BaseAsset, QuoteAsset>(
+        self,
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        oracle::read_price_pro<BaseAsset>(base_price_info_object, registry, clock),
+        oracle::read_price_pro<QuoteAsset>(quote_price_info_object, registry, clock),
+        registry,
+        max_orders_to_execute,
+        clock,
+        ctx,
+    )
+}
+
+public fun execute_conditional_orders_v3<BaseAsset, QuoteAsset>(
+    self: &mut MarginManager<BaseAsset, QuoteAsset>,
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &mut MarginPool<BaseAsset>,
+    quote_margin_pool: &mut MarginPool<QuoteAsset>,
+    base_price_info_object: &PriceInfoObjectPro,
+    quote_price_info_object: &PriceInfoObjectPro,
+    registry: &MarginRegistry,
+    max_orders_to_execute: u64,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): vector<OrderInfo> {
+    margin_manager::execute_conditional_orders_v3_core<BaseAsset, QuoteAsset>(
+        self,
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        oracle::read_price_pro<BaseAsset>(base_price_info_object, registry, clock),
+        oracle::read_price_pro<QuoteAsset>(quote_price_info_object, registry, clock),
+        registry,
+        max_orders_to_execute,
+        clock,
+        ctx,
+    )
+}
+
+public fun deposit<BaseAsset, QuoteAsset, DepositAsset>(
+    self: &mut MarginManager<BaseAsset, QuoteAsset>,
+    registry: &MarginRegistry,
+    base_oracle: &PriceInfoObjectPro,
+    quote_oracle: &PriceInfoObjectPro,
+    coin: Coin<DepositAsset>,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    margin_manager::deposit_core<BaseAsset, QuoteAsset, DepositAsset>(
+        self,
+        registry,
+        oracle::read_price_pro<BaseAsset>(base_oracle, registry, clock),
+        oracle::read_price_pro<QuoteAsset>(quote_oracle, registry, clock),
+        coin,
+        clock,
+        ctx,
+    )
+}
+
+public fun withdraw<BaseAsset, QuoteAsset, WithdrawAsset>(
+    self: &mut MarginManager<BaseAsset, QuoteAsset>,
+    registry: &MarginRegistry,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    base_oracle: &PriceInfoObjectPro,
+    quote_oracle: &PriceInfoObjectPro,
+    pool: &Pool<BaseAsset, QuoteAsset>,
+    withdraw_amount: u64,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): Coin<WithdrawAsset> {
+    margin_manager::withdraw_core<BaseAsset, QuoteAsset, WithdrawAsset>(
+        self,
+        registry,
+        base_margin_pool,
+        quote_margin_pool,
+        oracle::read_price_pro<BaseAsset>(base_oracle, registry, clock),
+        oracle::read_price_pro<QuoteAsset>(quote_oracle, registry, clock),
+        pool,
+        withdraw_amount,
+        clock,
+        ctx,
+    )
+}
+
+public fun borrow_base<BaseAsset, QuoteAsset>(
+    self: &mut MarginManager<BaseAsset, QuoteAsset>,
+    registry: &MarginRegistry,
+    base_margin_pool: &mut MarginPool<BaseAsset>,
+    base_oracle: &PriceInfoObjectPro,
+    quote_oracle: &PriceInfoObjectPro,
+    pool: &Pool<BaseAsset, QuoteAsset>,
+    loan_amount: u64,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    margin_manager::borrow_base_core<BaseAsset, QuoteAsset>(
+        self,
+        registry,
+        base_margin_pool,
+        oracle::read_price_pro<BaseAsset>(base_oracle, registry, clock),
+        oracle::read_price_pro<QuoteAsset>(quote_oracle, registry, clock),
+        pool,
+        loan_amount,
+        clock,
+        ctx,
+    )
+}
+
+public fun borrow_quote<BaseAsset, QuoteAsset>(
+    self: &mut MarginManager<BaseAsset, QuoteAsset>,
+    registry: &MarginRegistry,
+    quote_margin_pool: &mut MarginPool<QuoteAsset>,
+    base_oracle: &PriceInfoObjectPro,
+    quote_oracle: &PriceInfoObjectPro,
+    pool: &Pool<BaseAsset, QuoteAsset>,
+    loan_amount: u64,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    margin_manager::borrow_quote_core<BaseAsset, QuoteAsset>(
+        self,
+        registry,
+        quote_margin_pool,
+        oracle::read_price_pro<BaseAsset>(base_oracle, registry, clock),
+        oracle::read_price_pro<QuoteAsset>(quote_oracle, registry, clock),
+        pool,
+        loan_amount,
+        clock,
+        ctx,
+    )
+}
+
+public fun liquidate<BaseAsset, QuoteAsset, DebtAsset>(
+    self: &mut MarginManager<BaseAsset, QuoteAsset>,
+    registry: &MarginRegistry,
+    base_oracle: &PriceInfoObjectPro,
+    quote_oracle: &PriceInfoObjectPro,
+    margin_pool: &mut MarginPool<DebtAsset>,
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    mut repay_coin: Coin<DebtAsset>,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): (Coin<BaseAsset>, Coin<QuoteAsset>, Coin<DebtAsset>) {
+    margin_manager::liquidate_core<BaseAsset, QuoteAsset, DebtAsset>(
+        self,
+        registry,
+        oracle::read_price_pro<BaseAsset>(base_oracle, registry, clock),
+        oracle::read_price_pro<QuoteAsset>(quote_oracle, registry, clock),
+        margin_pool,
+        pool,
+        repay_coin,
+        clock,
+        ctx,
+    )
+}
+
+public fun risk_ratio<BaseAsset, QuoteAsset>(
+    self: &MarginManager<BaseAsset, QuoteAsset>,
+    registry: &MarginRegistry,
+    base_oracle: &PriceInfoObjectPro,
+    quote_oracle: &PriceInfoObjectPro,
+    pool: &Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    clock: &Clock,
+): u64 {
+    margin_manager::risk_ratio_core<BaseAsset, QuoteAsset>(
+        self,
+        registry,
+        oracle::read_price_pro<BaseAsset>(base_oracle, registry, clock),
+        oracle::read_price_pro<QuoteAsset>(quote_oracle, registry, clock),
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        clock,
+    )
+}
+
+public fun risk_ratio_unsafe<BaseAsset, QuoteAsset>(
+    self: &MarginManager<BaseAsset, QuoteAsset>,
+    registry: &MarginRegistry,
+    base_oracle: &PriceInfoObjectPro,
+    quote_oracle: &PriceInfoObjectPro,
+    pool: &Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    clock: &Clock,
+): u64 {
+    margin_manager::risk_ratio_unsafe_core<BaseAsset, QuoteAsset>(
+        self,
+        registry,
+        oracle::read_price_pro_unsafe<BaseAsset>(base_oracle, registry),
+        oracle::read_price_pro_unsafe<QuoteAsset>(quote_oracle, registry),
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        clock,
+    )
+}
+
+public fun manager_state<BaseAsset, QuoteAsset>(
+    self: &MarginManager<BaseAsset, QuoteAsset>,
+    registry: &MarginRegistry,
+    base_oracle: &PriceInfoObjectPro,
+    quote_oracle: &PriceInfoObjectPro,
+    pool: &Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    clock: &Clock,
+): (ID, ID, u64, u64, u64, u64, u64, u64, u8, u64, u8, u64, u64, u64) {
+    margin_manager::manager_state_core<BaseAsset, QuoteAsset>(
+        self,
+        registry,
+        oracle::read_price_pro_unsafe<BaseAsset>(base_oracle, registry),
+        oracle::read_price_pro_unsafe<QuoteAsset>(quote_oracle, registry),
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        clock,
+    )
+}
+
+public fun manager_states<BaseAsset, QuoteAsset>(
+    margin_managers: &vector<MarginManager<BaseAsset, QuoteAsset>>,
+    registry: &MarginRegistry,
+    base_oracle: &PriceInfoObjectPro,
+    quote_oracle: &PriceInfoObjectPro,
+    pool: &Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    clock: &Clock,
+): (
+    vector<ID>,
+    vector<ID>,
+    vector<u64>,
+    vector<u64>,
+    vector<u64>,
+    vector<u64>,
+    vector<u64>,
+    vector<u64>,
+    vector<u8>,
+    vector<u64>,
+    vector<u8>,
+    vector<u64>,
+    vector<u64>,
+    vector<u64>,
+) {
+    margin_manager::manager_states_core<BaseAsset, QuoteAsset>(
+        margin_managers,
+        registry,
+        oracle::read_price_pro_unsafe<BaseAsset>(base_oracle, registry),
+        oracle::read_price_pro_unsafe<QuoteAsset>(quote_oracle, registry),
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        clock,
+    )
+}

--- a/packages/deepbook_margin/sources/margin_manager_pro.move
+++ b/packages/deepbook_margin/sources/margin_manager_pro.move
@@ -117,9 +117,9 @@ public fun deposit<BaseAsset, QuoteAsset, DepositAsset>(
     } else if (
         type_name::with_defining_ids<DepositAsset>() == type_name::with_defining_ids<BaseAsset>()
     ) {
-        option::some(oracle::read_price_pro_unsafe<BaseAsset>(base_oracle, registry))
+        option::some(oracle::read_price_pro<BaseAsset>(base_oracle, registry, clock))
     } else {
-        option::some(oracle::read_price_pro_unsafe<QuoteAsset>(quote_oracle, registry))
+        option::some(oracle::read_price_pro<QuoteAsset>(quote_oracle, registry, clock))
     };
 
     margin_manager::deposit_core<BaseAsset, QuoteAsset, DepositAsset>(

--- a/packages/deepbook_margin/sources/margin_manager_pro.move
+++ b/packages/deepbook_margin/sources/margin_manager_pro.move
@@ -12,6 +12,7 @@ module deepbook_margin::margin_manager_pro;
 
 use deepbook::{order_info::OrderInfo, pool::Pool};
 use deepbook_margin::{
+    margin_constants,
     margin_manager::{Self, MarginManager},
     margin_pool::MarginPool,
     margin_registry::MarginRegistry,
@@ -19,6 +20,7 @@ use deepbook_margin::{
     tpsl::{Condition, PendingOrder}
 };
 use pyth_pro::price_info::PriceInfoObject as PriceInfoObjectPro;
+use std::type_name;
 use sui::{clock::Clock, coin::Coin};
 
 public fun add_conditional_order<BaseAsset, QuoteAsset>(
@@ -108,11 +110,22 @@ public fun deposit<BaseAsset, QuoteAsset, DepositAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
+    let event_reading = if (
+        !margin_manager::emits_collateral_event<BaseAsset, QuoteAsset, DepositAsset>()
+    ) {
+        option::none()
+    } else if (
+        type_name::with_defining_ids<DepositAsset>() == type_name::with_defining_ids<BaseAsset>()
+    ) {
+        option::some(oracle::read_price_pro_unsafe<BaseAsset>(base_oracle, registry))
+    } else {
+        option::some(oracle::read_price_pro_unsafe<QuoteAsset>(quote_oracle, registry))
+    };
+
     margin_manager::deposit_core<BaseAsset, QuoteAsset, DepositAsset>(
         self,
         registry,
-        oracle::read_price_pro<BaseAsset>(base_oracle, registry, clock),
-        oracle::read_price_pro<QuoteAsset>(quote_oracle, registry, clock),
+        event_reading,
         coin,
         clock,
         ctx,
@@ -131,13 +144,36 @@ public fun withdraw<BaseAsset, QuoteAsset, WithdrawAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ): Coin<WithdrawAsset> {
+    let (risk_base_reading, risk_quote_reading) = if (
+        self.withdraw_needs_risk_check(base_margin_pool, quote_margin_pool)
+    ) {
+        (
+            option::some(oracle::read_price_pro<BaseAsset>(base_oracle, registry, clock)),
+            option::some(oracle::read_price_pro<QuoteAsset>(quote_oracle, registry, clock)),
+        )
+    } else {
+        (option::none(), option::none())
+    };
+    let (event_base_reading, event_quote_reading) = if (
+        margin_manager::emits_collateral_event<BaseAsset, QuoteAsset, WithdrawAsset>()
+    ) {
+        (
+            option::some(oracle::read_price_pro_unsafe<BaseAsset>(base_oracle, registry)),
+            option::some(oracle::read_price_pro_unsafe<QuoteAsset>(quote_oracle, registry)),
+        )
+    } else {
+        (option::none(), option::none())
+    };
+
     margin_manager::withdraw_core<BaseAsset, QuoteAsset, WithdrawAsset>(
         self,
         registry,
         base_margin_pool,
         quote_margin_pool,
-        oracle::read_price_pro<BaseAsset>(base_oracle, registry, clock),
-        oracle::read_price_pro<QuoteAsset>(quote_oracle, registry, clock),
+        risk_base_reading,
+        risk_quote_reading,
+        event_base_reading,
+        event_quote_reading,
         pool,
         withdraw_amount,
         clock,
@@ -227,6 +263,11 @@ public fun risk_ratio<BaseAsset, QuoteAsset>(
     quote_margin_pool: &MarginPool<QuoteAsset>,
     clock: &Clock,
 ): u64 {
+    // No debt means no oracle is needed: `assets_in_debt_unit` short-circuits and the
+    // ratio is MAX regardless of price. Returning here keeps a stale feed from
+    // breaking a read-only query, as it did before Pyth Pro.
+    if (self.has_no_margin_pool()) return margin_constants::max_risk_ratio();
+
     margin_manager::risk_ratio_core<BaseAsset, QuoteAsset>(
         self,
         registry,
@@ -249,7 +290,12 @@ public fun risk_ratio_unsafe<BaseAsset, QuoteAsset>(
     quote_margin_pool: &MarginPool<QuoteAsset>,
     clock: &Clock,
 ): u64 {
-    margin_manager::risk_ratio_unsafe_core<BaseAsset, QuoteAsset>(
+    // No debt means no oracle is needed: `assets_in_debt_unit` short-circuits and the
+    // ratio is MAX regardless of price. Returning here keeps a stale feed from
+    // breaking a read-only query, as it did before Pyth Pro.
+    if (self.has_no_margin_pool()) return margin_constants::max_risk_ratio();
+
+    margin_manager::risk_ratio_core<BaseAsset, QuoteAsset>(
         self,
         registry,
         oracle::read_price_pro_unsafe<BaseAsset>(base_oracle, registry),

--- a/packages/deepbook_margin/sources/margin_manager_pro.move
+++ b/packages/deepbook_margin/sources/margin_manager_pro.move
@@ -35,8 +35,7 @@ public fun add_conditional_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    margin_manager::add_conditional_order_core<BaseAsset, QuoteAsset>(
-        self,
+    self.add_conditional_order_core(
         pool,
         oracle::read_price_pro<BaseAsset>(base_price_info_object, registry, clock),
         oracle::read_price_pro<QuoteAsset>(quote_price_info_object, registry, clock),
@@ -61,8 +60,7 @@ public fun execute_conditional_orders_v2<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &TxContext,
 ): vector<OrderInfo> {
-    margin_manager::execute_conditional_orders_v2_core<BaseAsset, QuoteAsset>(
-        self,
+    self.execute_conditional_orders_v2_core(
         pool,
         base_margin_pool,
         quote_margin_pool,
@@ -87,8 +85,7 @@ public fun execute_conditional_orders_v3<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ): vector<OrderInfo> {
-    margin_manager::execute_conditional_orders_v3_core<BaseAsset, QuoteAsset>(
-        self,
+    self.execute_conditional_orders_v3_core(
         pool,
         base_margin_pool,
         quote_margin_pool,
@@ -122,8 +119,7 @@ public fun deposit<BaseAsset, QuoteAsset, DepositAsset>(
         option::some(oracle::read_price_pro<QuoteAsset>(quote_oracle, registry, clock))
     };
 
-    margin_manager::deposit_core<BaseAsset, QuoteAsset, DepositAsset>(
-        self,
+    self.deposit_core(
         registry,
         event_reading,
         coin,
@@ -165,8 +161,7 @@ public fun withdraw<BaseAsset, QuoteAsset, WithdrawAsset>(
         (option::none(), option::none())
     };
 
-    margin_manager::withdraw_core<BaseAsset, QuoteAsset, WithdrawAsset>(
-        self,
+    self.withdraw_core(
         registry,
         base_margin_pool,
         quote_margin_pool,
@@ -192,8 +187,7 @@ public fun borrow_base<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    margin_manager::borrow_base_core<BaseAsset, QuoteAsset>(
-        self,
+    self.borrow_base_core(
         registry,
         base_margin_pool,
         oracle::read_price_pro<BaseAsset>(base_oracle, registry, clock),
@@ -216,8 +210,7 @@ public fun borrow_quote<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    margin_manager::borrow_quote_core<BaseAsset, QuoteAsset>(
-        self,
+    self.borrow_quote_core(
         registry,
         quote_margin_pool,
         oracle::read_price_pro<BaseAsset>(base_oracle, registry, clock),
@@ -240,8 +233,7 @@ public fun liquidate<BaseAsset, QuoteAsset, DebtAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ): (Coin<BaseAsset>, Coin<QuoteAsset>, Coin<DebtAsset>) {
-    margin_manager::liquidate_core<BaseAsset, QuoteAsset, DebtAsset>(
-        self,
+    self.liquidate_core(
         registry,
         oracle::read_price_pro<BaseAsset>(base_oracle, registry, clock),
         oracle::read_price_pro<QuoteAsset>(quote_oracle, registry, clock),
@@ -268,8 +260,7 @@ public fun risk_ratio<BaseAsset, QuoteAsset>(
     // breaking a read-only query, as it did before Pyth Pro.
     if (self.has_no_margin_pool()) return margin_constants::max_risk_ratio();
 
-    margin_manager::risk_ratio_core<BaseAsset, QuoteAsset>(
-        self,
+    self.risk_ratio_core(
         registry,
         oracle::read_price_pro<BaseAsset>(base_oracle, registry, clock),
         oracle::read_price_pro<QuoteAsset>(quote_oracle, registry, clock),
@@ -295,8 +286,7 @@ public fun risk_ratio_unsafe<BaseAsset, QuoteAsset>(
     // breaking a read-only query, as it did before Pyth Pro.
     if (self.has_no_margin_pool()) return margin_constants::max_risk_ratio();
 
-    margin_manager::risk_ratio_core<BaseAsset, QuoteAsset>(
-        self,
+    self.risk_ratio_core(
         registry,
         oracle::read_price_pro_unsafe<BaseAsset>(base_oracle, registry),
         oracle::read_price_pro_unsafe<QuoteAsset>(quote_oracle, registry),
@@ -317,8 +307,7 @@ public fun manager_state<BaseAsset, QuoteAsset>(
     quote_margin_pool: &MarginPool<QuoteAsset>,
     clock: &Clock,
 ): (ID, ID, u64, u64, u64, u64, u64, u64, u8, u64, u8, u64, u64, u64) {
-    margin_manager::manager_state_core<BaseAsset, QuoteAsset>(
-        self,
+    self.manager_state_core(
         registry,
         oracle::read_price_pro_unsafe<BaseAsset>(base_oracle, registry),
         oracle::read_price_pro_unsafe<QuoteAsset>(quote_oracle, registry),

--- a/packages/deepbook_margin/sources/margin_manager_pro.move
+++ b/packages/deepbook_margin/sources/margin_manager_pro.move
@@ -258,7 +258,7 @@ public fun risk_ratio<BaseAsset, QuoteAsset>(
     // No debt means no oracle is needed: `assets_in_debt_unit` short-circuits and the
     // ratio is MAX regardless of price. Returning here keeps a stale feed from
     // breaking a read-only query, as it did before Pyth Pro.
-    if (self.has_no_margin_pool()) return margin_constants::max_risk_ratio();
+    if (self.margin_pool_id().is_none()) return margin_constants::max_risk_ratio();
 
     self.risk_ratio_core(
         registry,
@@ -284,7 +284,7 @@ public fun risk_ratio_unsafe<BaseAsset, QuoteAsset>(
     // No debt means no oracle is needed: `assets_in_debt_unit` short-circuits and the
     // ratio is MAX regardless of price. Returning here keeps a stale feed from
     // breaking a read-only query, as it did before Pyth Pro.
-    if (self.has_no_margin_pool()) return margin_constants::max_risk_ratio();
+    if (self.margin_pool_id().is_none()) return margin_constants::max_risk_ratio();
 
     self.risk_ratio_core(
         registry,

--- a/packages/deepbook_margin/sources/pool_proxy.move
+++ b/packages/deepbook_margin/sources/pool_proxy.move
@@ -183,8 +183,8 @@ public(package) fun place_limit_order_v2_core<BaseAsset, QuoteAsset>(
     pool: &mut Pool<BaseAsset, QuoteAsset>,
     base_margin_pool: &MarginPool<BaseAsset>,
     quote_margin_pool: &MarginPool<QuoteAsset>,
-    base_reading: PythReading,
-    quote_reading: PythReading,
+    base_reading: Option<PythReading>,
+    quote_reading: Option<PythReading>,
     client_order_id: u64,
     order_type: u8,
     self_matching_option: u8,
@@ -241,8 +241,8 @@ public(package) fun place_market_order_v2_core<BaseAsset, QuoteAsset>(
     pool: &mut Pool<BaseAsset, QuoteAsset>,
     base_margin_pool: &MarginPool<BaseAsset>,
     quote_margin_pool: &MarginPool<QuoteAsset>,
-    base_reading: PythReading,
-    quote_reading: PythReading,
+    base_reading: Option<PythReading>,
+    quote_reading: Option<PythReading>,
     client_order_id: u64,
     self_matching_option: u8,
     quantity: u64,
@@ -586,14 +586,16 @@ public(package) fun place_reduce_only_market_order_and_repay_loan_core<BaseAsset
     // place_market_order settles the taker fill into the manager's balance, so
     // the proceeds are drawable: repay the settled proceeds (+ idle balance) into
     // the debt side, then gate on the net (post-repay) monotonic ratio.
+    // Reduce-only requires debt (`ENotReduceOnlyOrder`), so readings are always
+    // present here, unlike the non-reduce-only entries which may pass `none`.
     repay_debt_then_assert_monotonic(
         registry,
         margin_manager,
         pool,
         base_margin_pool,
         quote_margin_pool,
-        base_reading,
-        quote_reading,
+        option::some(base_reading),
+        option::some(quote_reading),
         risk_ratio_before,
         clock,
         ctx,
@@ -696,14 +698,16 @@ public(package) fun place_reduce_only_limit_order_and_repay_loan_core<BaseAsset,
     // Repay the settled taker fills (+ idle balance) before the monotonic gate,
     // so a crossing reduce-only limit deleverages instead of aborting; a
     // fully-resting order has no taker proceeds, so this repays nothing.
+    // Reduce-only requires debt (`ENotReduceOnlyOrder`), so readings are always
+    // present here, unlike the non-reduce-only entries which may pass `none`.
     repay_debt_then_assert_monotonic(
         registry,
         margin_manager,
         pool,
         base_margin_pool,
         quote_margin_pool,
-        base_reading,
-        quote_reading,
+        option::some(base_reading),
+        option::some(quote_reading),
         risk_ratio_before,
         clock,
         ctx,
@@ -737,8 +741,8 @@ public(package) fun place_market_order_and_repay_loan_core<BaseAsset, QuoteAsset
     pool: &mut Pool<BaseAsset, QuoteAsset>,
     base_margin_pool: &mut MarginPool<BaseAsset>,
     quote_margin_pool: &mut MarginPool<QuoteAsset>,
-    base_reading: PythReading,
-    quote_reading: PythReading,
+    base_reading: Option<PythReading>,
+    quote_reading: Option<PythReading>,
     client_order_id: u64,
     self_matching_option: u8,
     quantity: u64,
@@ -768,8 +772,8 @@ public(package) fun place_market_order_and_repay_loan_core<BaseAsset, QuoteAsset
     ) {
         margin_manager.risk_ratio_core(
             registry,
-            base_reading,
-            quote_reading,
+            *base_reading.borrow(),
+            *quote_reading.borrow(),
             pool,
             base_margin_pool,
             quote_margin_pool,
@@ -1079,8 +1083,10 @@ fun assert_post_trade_solvent<BaseAsset, QuoteAsset>(
     pool: &Pool<BaseAsset, QuoteAsset>,
     base_margin_pool: &MarginPool<BaseAsset>,
     quote_margin_pool: &MarginPool<QuoteAsset>,
-    base_reading: PythReading,
-    quote_reading: PythReading,
+    // `none` when the manager is debt-free: the gate below returns before any price
+    // is needed, so an order from a debt-free manager must not require a fresh feed.
+    base_reading: Option<PythReading>,
+    quote_reading: Option<PythReading>,
     clock: &Clock,
 ) {
     if (
@@ -1092,8 +1098,8 @@ fun assert_post_trade_solvent<BaseAsset, QuoteAsset>(
 
     let risk_ratio_after = margin_manager.risk_ratio_core(
         registry,
-        base_reading,
-        quote_reading,
+        *base_reading.borrow(),
+        *quote_reading.borrow(),
         pool,
         base_margin_pool,
         quote_margin_pool,
@@ -1147,8 +1153,8 @@ fun repay_debt_then_assert_monotonic<BaseAsset, QuoteAsset>(
     pool: &Pool<BaseAsset, QuoteAsset>,
     base_margin_pool: &mut MarginPool<BaseAsset>,
     quote_margin_pool: &mut MarginPool<QuoteAsset>,
-    base_reading: PythReading,
-    quote_reading: PythReading,
+    base_reading: Option<PythReading>,
+    quote_reading: Option<PythReading>,
     risk_ratio_before: u64,
     clock: &Clock,
     ctx: &mut TxContext,
@@ -1169,8 +1175,8 @@ fun repay_debt_then_assert_monotonic<BaseAsset, QuoteAsset>(
             pool,
             base_margin_pool,
             quote_margin_pool,
-            base_reading,
-            quote_reading,
+            *base_reading.borrow(),
+            *quote_reading.borrow(),
             clock,
             risk_ratio_before,
         );
@@ -1199,14 +1205,28 @@ public fun place_limit_order_v2<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &TxContext,
 ): OrderInfo {
+    // A debt-free manager needs no price: every consumer below is debt-gated, so
+    // reading eagerly would let a stale feed block an order that used to succeed.
+    let (base_reading, quote_reading) = if (
+        margin_manager.borrowed_base_shares() > 0
+        || margin_manager.borrowed_quote_shares() > 0
+    ) {
+        (
+            option::some(oracle::read_price<BaseAsset>(base_oracle, registry, clock)),
+            option::some(oracle::read_price<QuoteAsset>(quote_oracle, registry, clock)),
+        )
+    } else {
+        (option::none(), option::none())
+    };
+
     place_limit_order_v2_core<BaseAsset, QuoteAsset>(
         registry,
         margin_manager,
         pool,
         base_margin_pool,
         quote_margin_pool,
-        oracle::read_price<BaseAsset>(base_oracle, registry, clock),
-        oracle::read_price<QuoteAsset>(quote_oracle, registry, clock),
+        base_reading,
+        quote_reading,
         client_order_id,
         order_type,
         self_matching_option,
@@ -1236,14 +1256,28 @@ public fun place_market_order_v2<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &TxContext,
 ): OrderInfo {
+    // A debt-free manager needs no price: every consumer below is debt-gated, so
+    // reading eagerly would let a stale feed block an order that used to succeed.
+    let (base_reading, quote_reading) = if (
+        margin_manager.borrowed_base_shares() > 0
+        || margin_manager.borrowed_quote_shares() > 0
+    ) {
+        (
+            option::some(oracle::read_price<BaseAsset>(base_oracle, registry, clock)),
+            option::some(oracle::read_price<QuoteAsset>(quote_oracle, registry, clock)),
+        )
+    } else {
+        (option::none(), option::none())
+    };
+
     place_market_order_v2_core<BaseAsset, QuoteAsset>(
         registry,
         margin_manager,
         pool,
         base_margin_pool,
         quote_margin_pool,
-        oracle::read_price<BaseAsset>(base_oracle, registry, clock),
-        oracle::read_price<QuoteAsset>(quote_oracle, registry, clock),
+        base_reading,
+        quote_reading,
         client_order_id,
         self_matching_option,
         quantity,
@@ -1418,14 +1452,28 @@ public fun place_market_order_and_repay_loan<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ): OrderInfo {
+    // A debt-free manager needs no price: every consumer below is debt-gated, so
+    // reading eagerly would let a stale feed block an order that used to succeed.
+    let (base_reading, quote_reading) = if (
+        margin_manager.borrowed_base_shares() > 0
+        || margin_manager.borrowed_quote_shares() > 0
+    ) {
+        (
+            option::some(oracle::read_price<BaseAsset>(base_oracle, registry, clock)),
+            option::some(oracle::read_price<QuoteAsset>(quote_oracle, registry, clock)),
+        )
+    } else {
+        (option::none(), option::none())
+    };
+
     place_market_order_and_repay_loan_core<BaseAsset, QuoteAsset>(
         registry,
         margin_manager,
         pool,
         base_margin_pool,
         quote_margin_pool,
-        oracle::read_price<BaseAsset>(base_oracle, registry, clock),
-        oracle::read_price<QuoteAsset>(quote_oracle, registry, clock),
+        base_reading,
+        quote_reading,
         client_order_id,
         self_matching_option,
         quantity,

--- a/packages/deepbook_margin/sources/pool_proxy.move
+++ b/packages/deepbook_margin/sources/pool_proxy.move
@@ -766,10 +766,7 @@ public(package) fun place_market_order_and_repay_loan_core<BaseAsset, QuoteAsset
 
     // Capture the pre-trade ratio for the monotonic gate, but only while the
     // manager has debt — `risk_ratio` is only meaningful against a debt.
-    let risk_ratio_before = if (
-        margin_manager.borrowed_base_shares() > 0
-        || margin_manager.borrowed_quote_shares() > 0
-    ) {
+    let risk_ratio_before = if (margin_manager.has_debt()) {
         margin_manager.risk_ratio_core(
             registry,
             *base_reading.borrow(),
@@ -1165,10 +1162,7 @@ fun repay_debt_then_assert_monotonic<BaseAsset, QuoteAsset>(
         margin_manager.repay_quote(registry, quote_margin_pool, option::none(), clock, ctx);
     };
 
-    if (
-        margin_manager.borrowed_base_shares() > 0
-        || margin_manager.borrowed_quote_shares() > 0
-    ) {
+    if (margin_manager.has_debt()) {
         assert_reduce_only_monotonic(
             margin_manager,
             registry,
@@ -1207,10 +1201,7 @@ public fun place_limit_order_v2<BaseAsset, QuoteAsset>(
 ): OrderInfo {
     // A debt-free manager needs no price: every consumer below is debt-gated, so
     // reading eagerly would let a stale feed block an order that used to succeed.
-    let (base_reading, quote_reading) = if (
-        margin_manager.borrowed_base_shares() > 0
-        || margin_manager.borrowed_quote_shares() > 0
-    ) {
+    let (base_reading, quote_reading) = if (margin_manager.has_debt()) {
         (
             option::some(oracle::read_price<BaseAsset>(base_oracle, registry, clock)),
             option::some(oracle::read_price<QuoteAsset>(quote_oracle, registry, clock)),
@@ -1258,10 +1249,7 @@ public fun place_market_order_v2<BaseAsset, QuoteAsset>(
 ): OrderInfo {
     // A debt-free manager needs no price: every consumer below is debt-gated, so
     // reading eagerly would let a stale feed block an order that used to succeed.
-    let (base_reading, quote_reading) = if (
-        margin_manager.borrowed_base_shares() > 0
-        || margin_manager.borrowed_quote_shares() > 0
-    ) {
+    let (base_reading, quote_reading) = if (margin_manager.has_debt()) {
         (
             option::some(oracle::read_price<BaseAsset>(base_oracle, registry, clock)),
             option::some(oracle::read_price<QuoteAsset>(quote_oracle, registry, clock)),
@@ -1454,10 +1442,7 @@ public fun place_market_order_and_repay_loan<BaseAsset, QuoteAsset>(
 ): OrderInfo {
     // A debt-free manager needs no price: every consumer below is debt-gated, so
     // reading eagerly would let a stale feed block an order that used to succeed.
-    let (base_reading, quote_reading) = if (
-        margin_manager.borrowed_base_shares() > 0
-        || margin_manager.borrowed_quote_shares() > 0
-    ) {
+    let (base_reading, quote_reading) = if (margin_manager.has_debt()) {
         (
             option::some(oracle::read_price<BaseAsset>(base_oracle, registry, clock)),
             option::some(oracle::read_price<QuoteAsset>(quote_oracle, registry, clock)),

--- a/packages/deepbook_margin/sources/pool_proxy.move
+++ b/packages/deepbook_margin/sources/pool_proxy.move
@@ -8,7 +8,7 @@ use deepbook_margin::{
     margin_manager::MarginManager,
     margin_pool::MarginPool,
     margin_registry::MarginRegistry,
-    oracle
+    oracle::{Self, PythReading}
 };
 use pyth::price_info::PriceInfoObject;
 use std::type_name;
@@ -48,11 +48,30 @@ public fun update_current_price<BaseAsset, QuoteAsset>(
     quote_price_info_object: &PriceInfoObject,
     clock: &Clock,
 ) {
-    // Calculate current price using safe oracle (with staleness, confidence, EWMA checks)
+    // Safe reads: staleness, feed id, confidence and EWMA are all enforced here.
+    let base_reading = oracle::read_price<BaseAsset>(base_price_info_object, registry, clock);
+    let quote_reading = oracle::read_price<QuoteAsset>(quote_price_info_object, registry, clock);
+
+    update_current_price_core<BaseAsset, QuoteAsset>(
+        registry,
+        pool,
+        base_reading,
+        quote_reading,
+        clock,
+    )
+}
+
+public(package) fun update_current_price_core<BaseAsset, QuoteAsset>(
+    registry: &mut MarginRegistry,
+    pool: &Pool<BaseAsset, QuoteAsset>,
+    base_reading: PythReading,
+    quote_reading: PythReading,
+    clock: &Clock,
+) {
     let price = oracle::calculate_price<BaseAsset, QuoteAsset>(
         registry,
-        oracle::read_price<BaseAsset>(base_price_info_object, registry, clock),
-        oracle::read_price<QuoteAsset>(quote_price_info_object, registry, clock),
+        base_reading,
+        quote_reading,
     );
 
     registry.update_current_price(pool.id(), price, clock);
@@ -158,14 +177,14 @@ public fun place_reduce_only_market_order<BaseAsset, QuoteAsset, DebtAsset>(
 // borrow-floor check allows.
 
 /// Places a limit order in the pool.
-public fun place_limit_order_v2<BaseAsset, QuoteAsset>(
+public(package) fun place_limit_order_v2_core<BaseAsset, QuoteAsset>(
     registry: &MarginRegistry,
     margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
     pool: &mut Pool<BaseAsset, QuoteAsset>,
     base_margin_pool: &MarginPool<BaseAsset>,
     quote_margin_pool: &MarginPool<QuoteAsset>,
-    base_oracle: &PriceInfoObject,
-    quote_oracle: &PriceInfoObject,
+    base_reading: PythReading,
+    quote_reading: PythReading,
     client_order_id: u64,
     order_type: u8,
     self_matching_option: u8,
@@ -207,8 +226,8 @@ public fun place_limit_order_v2<BaseAsset, QuoteAsset>(
         pool,
         base_margin_pool,
         quote_margin_pool,
-        base_oracle,
-        quote_oracle,
+        base_reading,
+        quote_reading,
         clock,
     );
 
@@ -216,14 +235,14 @@ public fun place_limit_order_v2<BaseAsset, QuoteAsset>(
 }
 
 /// Places a market order in the pool.
-public fun place_market_order_v2<BaseAsset, QuoteAsset>(
+public(package) fun place_market_order_v2_core<BaseAsset, QuoteAsset>(
     registry: &MarginRegistry,
     margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
     pool: &mut Pool<BaseAsset, QuoteAsset>,
     base_margin_pool: &MarginPool<BaseAsset>,
     quote_margin_pool: &MarginPool<QuoteAsset>,
-    base_oracle: &PriceInfoObject,
-    quote_oracle: &PriceInfoObject,
+    base_reading: PythReading,
+    quote_reading: PythReading,
     client_order_id: u64,
     self_matching_option: u8,
     quantity: u64,
@@ -265,8 +284,8 @@ public fun place_market_order_v2<BaseAsset, QuoteAsset>(
         pool,
         base_margin_pool,
         quote_margin_pool,
-        base_oracle,
-        quote_oracle,
+        base_reading,
+        quote_reading,
         clock,
     );
 
@@ -274,14 +293,14 @@ public fun place_market_order_v2<BaseAsset, QuoteAsset>(
 }
 
 /// Places a reduce-only order in the pool. Used when margin trading is disabled.
-public fun place_reduce_only_limit_order_v2<BaseAsset, QuoteAsset>(
+public(package) fun place_reduce_only_limit_order_v2_core<BaseAsset, QuoteAsset>(
     registry: &MarginRegistry,
     margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
     pool: &mut Pool<BaseAsset, QuoteAsset>,
     base_margin_pool: &MarginPool<BaseAsset>,
     quote_margin_pool: &MarginPool<QuoteAsset>,
-    base_oracle: &PriceInfoObject,
-    quote_oracle: &PriceInfoObject,
+    base_reading: PythReading,
+    quote_reading: PythReading,
     client_order_id: u64,
     order_type: u8,
     self_matching_option: u8,
@@ -322,10 +341,10 @@ public fun place_reduce_only_limit_order_v2<BaseAsset, QuoteAsset>(
     // The reduce-only quantity predicate above already guarantees the manager
     // has debt on the relevant side, so `risk_ratio` is safe to compute (no
     // divide-by-zero in `risk_ratio_int`).
-    let risk_ratio_before = margin_manager.risk_ratio(
+    let risk_ratio_before = margin_manager.risk_ratio_core(
         registry,
-        base_oracle,
-        quote_oracle,
+        base_reading,
+        quote_reading,
         pool,
         base_margin_pool,
         quote_margin_pool,
@@ -371,8 +390,8 @@ public fun place_reduce_only_limit_order_v2<BaseAsset, QuoteAsset>(
         pool,
         base_margin_pool,
         quote_margin_pool,
-        base_oracle,
-        quote_oracle,
+        base_reading,
+        quote_reading,
         clock,
         risk_ratio_before,
     );
@@ -391,14 +410,14 @@ public fun place_reduce_only_limit_order_v2<BaseAsset, QuoteAsset>(
 /// callable for existing integrators; its reduce-only *direction* guard matches
 /// the other entries — a bid needs base (short-side) debt, the ask needs quote
 /// (long-side) debt and sells up to gross base held — with no size cap.
-public fun place_reduce_only_market_order_v2<BaseAsset, QuoteAsset>(
+public(package) fun place_reduce_only_market_order_v2_core<BaseAsset, QuoteAsset>(
     registry: &MarginRegistry,
     margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
     pool: &mut Pool<BaseAsset, QuoteAsset>,
     base_margin_pool: &MarginPool<BaseAsset>,
     quote_margin_pool: &MarginPool<QuoteAsset>,
-    base_oracle: &PriceInfoObject,
-    quote_oracle: &PriceInfoObject,
+    base_reading: PythReading,
+    quote_reading: PythReading,
     client_order_id: u64,
     self_matching_option: u8,
     quantity: u64,
@@ -441,10 +460,10 @@ public fun place_reduce_only_market_order_v2<BaseAsset, QuoteAsset>(
     // The reduce-only quantity predicate above already guarantees the manager
     // has debt on the relevant side, so `risk_ratio` is safe to compute (no
     // divide-by-zero in `risk_ratio_int`).
-    let risk_ratio_before = margin_manager.risk_ratio(
+    let risk_ratio_before = margin_manager.risk_ratio_core(
         registry,
-        base_oracle,
-        quote_oracle,
+        base_reading,
+        quote_reading,
         pool,
         base_margin_pool,
         quote_margin_pool,
@@ -472,8 +491,8 @@ public fun place_reduce_only_market_order_v2<BaseAsset, QuoteAsset>(
         pool,
         base_margin_pool,
         quote_margin_pool,
-        base_oracle,
-        quote_oracle,
+        base_reading,
+        quote_reading,
         clock,
         risk_ratio_before,
     );
@@ -491,14 +510,14 @@ public fun place_reduce_only_market_order_v2<BaseAsset, QuoteAsset>(
 /// absorbs the slippage (still bounded by the `assert_price` band), and lets a
 /// manager in the `liquidation..min_borrow` band climb out — it cannot reach
 /// the borrow floor in a single swap.
-public fun place_reduce_only_market_order_and_repay_loan<BaseAsset, QuoteAsset>(
+public(package) fun place_reduce_only_market_order_and_repay_loan_core<BaseAsset, QuoteAsset>(
     registry: &MarginRegistry,
     margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
     pool: &mut Pool<BaseAsset, QuoteAsset>,
     base_margin_pool: &mut MarginPool<BaseAsset>,
     quote_margin_pool: &mut MarginPool<QuoteAsset>,
-    base_oracle: &PriceInfoObject,
-    quote_oracle: &PriceInfoObject,
+    base_reading: PythReading,
+    quote_reading: PythReading,
     client_order_id: u64,
     self_matching_option: u8,
     quantity: u64,
@@ -540,10 +559,10 @@ public fun place_reduce_only_market_order_and_repay_loan<BaseAsset, QuoteAsset>(
 
     registry.assert_price(pool.id(), effective_price, is_bid, clock);
 
-    let risk_ratio_before = margin_manager.risk_ratio(
+    let risk_ratio_before = margin_manager.risk_ratio_core(
         registry,
-        base_oracle,
-        quote_oracle,
+        base_reading,
+        quote_reading,
         pool,
         base_margin_pool,
         quote_margin_pool,
@@ -573,8 +592,8 @@ public fun place_reduce_only_market_order_and_repay_loan<BaseAsset, QuoteAsset>(
         pool,
         base_margin_pool,
         quote_margin_pool,
-        base_oracle,
-        quote_oracle,
+        base_reading,
+        quote_reading,
         risk_ratio_before,
         clock,
         ctx,
@@ -597,14 +616,14 @@ public fun place_reduce_only_market_order_and_repay_loan<BaseAsset, QuoteAsset>(
 /// deleverages so the net ratio holds. The resting remainder only locks balance
 /// (counted in assets), so it doesn't move the ratio. Unfilled-and-resting
 /// behaves exactly like `place_reduce_only_limit_order_v2` (nothing to repay).
-public fun place_reduce_only_limit_order_and_repay_loan<BaseAsset, QuoteAsset>(
+public(package) fun place_reduce_only_limit_order_and_repay_loan_core<BaseAsset, QuoteAsset>(
     registry: &MarginRegistry,
     margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
     pool: &mut Pool<BaseAsset, QuoteAsset>,
     base_margin_pool: &mut MarginPool<BaseAsset>,
     quote_margin_pool: &mut MarginPool<QuoteAsset>,
-    base_oracle: &PriceInfoObject,
-    quote_oracle: &PriceInfoObject,
+    base_reading: PythReading,
+    quote_reading: PythReading,
     client_order_id: u64,
     order_type: u8,
     self_matching_option: u8,
@@ -639,10 +658,10 @@ public fun place_reduce_only_limit_order_and_repay_loan<BaseAsset, QuoteAsset>(
         ENotReduceOnlyOrder,
     );
 
-    let risk_ratio_before = margin_manager.risk_ratio(
+    let risk_ratio_before = margin_manager.risk_ratio_core(
         registry,
-        base_oracle,
-        quote_oracle,
+        base_reading,
+        quote_reading,
         pool,
         base_margin_pool,
         quote_margin_pool,
@@ -683,8 +702,8 @@ public fun place_reduce_only_limit_order_and_repay_loan<BaseAsset, QuoteAsset>(
         pool,
         base_margin_pool,
         quote_margin_pool,
-        base_oracle,
-        quote_oracle,
+        base_reading,
+        quote_reading,
         risk_ratio_before,
         clock,
         ctx,
@@ -712,14 +731,14 @@ public fun place_reduce_only_limit_order_and_repay_loan<BaseAsset, QuoteAsset>(
 /// (surplus is the manager's own holding) and `assert_price` still bounds
 /// slippage. Requires margin trading enabled; in reduce-only mode use
 /// `place_reduce_only_market_order_and_repay_loan`.
-public fun place_market_order_and_repay_loan<BaseAsset, QuoteAsset>(
+public(package) fun place_market_order_and_repay_loan_core<BaseAsset, QuoteAsset>(
     registry: &MarginRegistry,
     margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
     pool: &mut Pool<BaseAsset, QuoteAsset>,
     base_margin_pool: &mut MarginPool<BaseAsset>,
     quote_margin_pool: &mut MarginPool<QuoteAsset>,
-    base_oracle: &PriceInfoObject,
-    quote_oracle: &PriceInfoObject,
+    base_reading: PythReading,
+    quote_reading: PythReading,
     client_order_id: u64,
     self_matching_option: u8,
     quantity: u64,
@@ -747,10 +766,10 @@ public fun place_market_order_and_repay_loan<BaseAsset, QuoteAsset>(
         margin_manager.borrowed_base_shares() > 0
         || margin_manager.borrowed_quote_shares() > 0
     ) {
-        margin_manager.risk_ratio(
+        margin_manager.risk_ratio_core(
             registry,
-            base_oracle,
-            quote_oracle,
+            base_reading,
+            quote_reading,
             pool,
             base_margin_pool,
             quote_margin_pool,
@@ -786,8 +805,8 @@ public fun place_market_order_and_repay_loan<BaseAsset, QuoteAsset>(
         pool,
         base_margin_pool,
         quote_margin_pool,
-        base_oracle,
-        quote_oracle,
+        base_reading,
+        quote_reading,
         risk_ratio_before,
         clock,
         ctx,
@@ -1060,8 +1079,8 @@ fun assert_post_trade_solvent<BaseAsset, QuoteAsset>(
     pool: &Pool<BaseAsset, QuoteAsset>,
     base_margin_pool: &MarginPool<BaseAsset>,
     quote_margin_pool: &MarginPool<QuoteAsset>,
-    base_oracle: &PriceInfoObject,
-    quote_oracle: &PriceInfoObject,
+    base_reading: PythReading,
+    quote_reading: PythReading,
     clock: &Clock,
 ) {
     if (
@@ -1071,10 +1090,10 @@ fun assert_post_trade_solvent<BaseAsset, QuoteAsset>(
         return
     };
 
-    let risk_ratio_after = margin_manager.risk_ratio(
+    let risk_ratio_after = margin_manager.risk_ratio_core(
         registry,
-        base_oracle,
-        quote_oracle,
+        base_reading,
+        quote_reading,
         pool,
         base_margin_pool,
         quote_margin_pool,
@@ -1097,15 +1116,15 @@ fun assert_reduce_only_monotonic<BaseAsset, QuoteAsset>(
     pool: &Pool<BaseAsset, QuoteAsset>,
     base_margin_pool: &MarginPool<BaseAsset>,
     quote_margin_pool: &MarginPool<QuoteAsset>,
-    base_oracle: &PriceInfoObject,
-    quote_oracle: &PriceInfoObject,
+    base_reading: PythReading,
+    quote_reading: PythReading,
     clock: &Clock,
     risk_ratio_before: u64,
 ) {
-    let risk_ratio_after = margin_manager.risk_ratio(
+    let risk_ratio_after = margin_manager.risk_ratio_core(
         registry,
-        base_oracle,
-        quote_oracle,
+        base_reading,
+        quote_reading,
         pool,
         base_margin_pool,
         quote_margin_pool,
@@ -1128,8 +1147,8 @@ fun repay_debt_then_assert_monotonic<BaseAsset, QuoteAsset>(
     pool: &Pool<BaseAsset, QuoteAsset>,
     base_margin_pool: &mut MarginPool<BaseAsset>,
     quote_margin_pool: &mut MarginPool<QuoteAsset>,
-    base_oracle: &PriceInfoObject,
-    quote_oracle: &PriceInfoObject,
+    base_reading: PythReading,
+    quote_reading: PythReading,
     risk_ratio_before: u64,
     clock: &Clock,
     ctx: &mut TxContext,
@@ -1150,10 +1169,269 @@ fun repay_debt_then_assert_monotonic<BaseAsset, QuoteAsset>(
             pool,
             base_margin_pool,
             quote_margin_pool,
-            base_oracle,
-            quote_oracle,
+            base_reading,
+            quote_reading,
             clock,
             risk_ratio_before,
         );
     };
+}
+
+// === Legacy Pyth entrypoints ===
+// Frozen signatures. Bodies delegate to the shared cores above.
+
+public fun place_limit_order_v2<BaseAsset, QuoteAsset>(
+    registry: &MarginRegistry,
+    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    base_oracle: &PriceInfoObject,
+    quote_oracle: &PriceInfoObject,
+    client_order_id: u64,
+    order_type: u8,
+    self_matching_option: u8,
+    price: u64,
+    quantity: u64,
+    is_bid: bool,
+    pay_with_deep: bool,
+    expire_timestamp: u64,
+    clock: &Clock,
+    ctx: &TxContext,
+): OrderInfo {
+    place_limit_order_v2_core<BaseAsset, QuoteAsset>(
+        registry,
+        margin_manager,
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        oracle::read_price<BaseAsset>(base_oracle, registry, clock),
+        oracle::read_price<QuoteAsset>(quote_oracle, registry, clock),
+        client_order_id,
+        order_type,
+        self_matching_option,
+        price,
+        quantity,
+        is_bid,
+        pay_with_deep,
+        expire_timestamp,
+        clock,
+        ctx,
+    )
+}
+
+public fun place_market_order_v2<BaseAsset, QuoteAsset>(
+    registry: &MarginRegistry,
+    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    base_oracle: &PriceInfoObject,
+    quote_oracle: &PriceInfoObject,
+    client_order_id: u64,
+    self_matching_option: u8,
+    quantity: u64,
+    is_bid: bool,
+    pay_with_deep: bool,
+    clock: &Clock,
+    ctx: &TxContext,
+): OrderInfo {
+    place_market_order_v2_core<BaseAsset, QuoteAsset>(
+        registry,
+        margin_manager,
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        oracle::read_price<BaseAsset>(base_oracle, registry, clock),
+        oracle::read_price<QuoteAsset>(quote_oracle, registry, clock),
+        client_order_id,
+        self_matching_option,
+        quantity,
+        is_bid,
+        pay_with_deep,
+        clock,
+        ctx,
+    )
+}
+
+public fun place_reduce_only_limit_order_v2<BaseAsset, QuoteAsset>(
+    registry: &MarginRegistry,
+    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    base_oracle: &PriceInfoObject,
+    quote_oracle: &PriceInfoObject,
+    client_order_id: u64,
+    order_type: u8,
+    self_matching_option: u8,
+    price: u64,
+    quantity: u64,
+    is_bid: bool,
+    pay_with_deep: bool,
+    expire_timestamp: u64,
+    clock: &Clock,
+    ctx: &TxContext,
+): OrderInfo {
+    place_reduce_only_limit_order_v2_core<BaseAsset, QuoteAsset>(
+        registry,
+        margin_manager,
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        oracle::read_price<BaseAsset>(base_oracle, registry, clock),
+        oracle::read_price<QuoteAsset>(quote_oracle, registry, clock),
+        client_order_id,
+        order_type,
+        self_matching_option,
+        price,
+        quantity,
+        is_bid,
+        pay_with_deep,
+        expire_timestamp,
+        clock,
+        ctx,
+    )
+}
+
+public fun place_reduce_only_market_order_v2<BaseAsset, QuoteAsset>(
+    registry: &MarginRegistry,
+    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    base_oracle: &PriceInfoObject,
+    quote_oracle: &PriceInfoObject,
+    client_order_id: u64,
+    self_matching_option: u8,
+    quantity: u64,
+    is_bid: bool,
+    pay_with_deep: bool,
+    clock: &Clock,
+    ctx: &TxContext,
+): OrderInfo {
+    place_reduce_only_market_order_v2_core<BaseAsset, QuoteAsset>(
+        registry,
+        margin_manager,
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        oracle::read_price<BaseAsset>(base_oracle, registry, clock),
+        oracle::read_price<QuoteAsset>(quote_oracle, registry, clock),
+        client_order_id,
+        self_matching_option,
+        quantity,
+        is_bid,
+        pay_with_deep,
+        clock,
+        ctx,
+    )
+}
+
+public fun place_reduce_only_market_order_and_repay_loan<BaseAsset, QuoteAsset>(
+    registry: &MarginRegistry,
+    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &mut MarginPool<BaseAsset>,
+    quote_margin_pool: &mut MarginPool<QuoteAsset>,
+    base_oracle: &PriceInfoObject,
+    quote_oracle: &PriceInfoObject,
+    client_order_id: u64,
+    self_matching_option: u8,
+    quantity: u64,
+    is_bid: bool,
+    pay_with_deep: bool,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): OrderInfo {
+    place_reduce_only_market_order_and_repay_loan_core<BaseAsset, QuoteAsset>(
+        registry,
+        margin_manager,
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        oracle::read_price<BaseAsset>(base_oracle, registry, clock),
+        oracle::read_price<QuoteAsset>(quote_oracle, registry, clock),
+        client_order_id,
+        self_matching_option,
+        quantity,
+        is_bid,
+        pay_with_deep,
+        clock,
+        ctx,
+    )
+}
+
+public fun place_reduce_only_limit_order_and_repay_loan<BaseAsset, QuoteAsset>(
+    registry: &MarginRegistry,
+    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &mut MarginPool<BaseAsset>,
+    quote_margin_pool: &mut MarginPool<QuoteAsset>,
+    base_oracle: &PriceInfoObject,
+    quote_oracle: &PriceInfoObject,
+    client_order_id: u64,
+    order_type: u8,
+    self_matching_option: u8,
+    price: u64,
+    quantity: u64,
+    is_bid: bool,
+    pay_with_deep: bool,
+    expire_timestamp: u64,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): OrderInfo {
+    place_reduce_only_limit_order_and_repay_loan_core<BaseAsset, QuoteAsset>(
+        registry,
+        margin_manager,
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        oracle::read_price<BaseAsset>(base_oracle, registry, clock),
+        oracle::read_price<QuoteAsset>(quote_oracle, registry, clock),
+        client_order_id,
+        order_type,
+        self_matching_option,
+        price,
+        quantity,
+        is_bid,
+        pay_with_deep,
+        expire_timestamp,
+        clock,
+        ctx,
+    )
+}
+
+public fun place_market_order_and_repay_loan<BaseAsset, QuoteAsset>(
+    registry: &MarginRegistry,
+    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &mut MarginPool<BaseAsset>,
+    quote_margin_pool: &mut MarginPool<QuoteAsset>,
+    base_oracle: &PriceInfoObject,
+    quote_oracle: &PriceInfoObject,
+    client_order_id: u64,
+    self_matching_option: u8,
+    quantity: u64,
+    is_bid: bool,
+    pay_with_deep: bool,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): OrderInfo {
+    place_market_order_and_repay_loan_core<BaseAsset, QuoteAsset>(
+        registry,
+        margin_manager,
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        oracle::read_price<BaseAsset>(base_oracle, registry, clock),
+        oracle::read_price<QuoteAsset>(quote_oracle, registry, clock),
+        client_order_id,
+        self_matching_option,
+        quantity,
+        is_bid,
+        pay_with_deep,
+        clock,
+        ctx,
+    )
 }

--- a/packages/deepbook_margin/sources/pool_proxy.move
+++ b/packages/deepbook_margin/sources/pool_proxy.move
@@ -162,7 +162,7 @@ public fun place_reduce_only_market_order<BaseAsset, QuoteAsset, DebtAsset>(
 //
 // Each v2 entry mirrors its v1 counterpart and additionally recomputes
 // `risk_ratio` after the order settles (using Pyth via the public
-// `MarginManager::risk_ratio` helper). For non-reduce-only entries the
+// `margin_manager::risk_ratio_core` helper). For non-reduce-only entries the
 // post-trade ratio must be at least `min_open_risk_ratio` — a floor between
 // liquidation and the borrow floor, so a max-leverage open can absorb the
 // opening trade's spread (which lands the ratio just under `min_borrow`)

--- a/packages/deepbook_margin/sources/pool_proxy_pro.move
+++ b/packages/deepbook_margin/sources/pool_proxy_pro.move
@@ -65,10 +65,7 @@ public fun place_limit_order_v2<BaseAsset, QuoteAsset>(
 ): OrderInfo {
     // A debt-free manager needs no price: every consumer below is debt-gated, so
     // reading eagerly would let a stale feed block an order that used to succeed.
-    let (base_reading, quote_reading) = if (
-        margin_manager.borrowed_base_shares() > 0
-        || margin_manager.borrowed_quote_shares() > 0
-    ) {
+    let (base_reading, quote_reading) = if (margin_manager.has_debt()) {
         (
             option::some(oracle::read_price_pro<BaseAsset>(base_oracle, registry, clock)),
             option::some(oracle::read_price_pro<QuoteAsset>(quote_oracle, registry, clock)),
@@ -116,10 +113,7 @@ public fun place_market_order_v2<BaseAsset, QuoteAsset>(
 ): OrderInfo {
     // A debt-free manager needs no price: every consumer below is debt-gated, so
     // reading eagerly would let a stale feed block an order that used to succeed.
-    let (base_reading, quote_reading) = if (
-        margin_manager.borrowed_base_shares() > 0
-        || margin_manager.borrowed_quote_shares() > 0
-    ) {
+    let (base_reading, quote_reading) = if (margin_manager.has_debt()) {
         (
             option::some(oracle::read_price_pro<BaseAsset>(base_oracle, registry, clock)),
             option::some(oracle::read_price_pro<QuoteAsset>(quote_oracle, registry, clock)),
@@ -312,10 +306,7 @@ public fun place_market_order_and_repay_loan<BaseAsset, QuoteAsset>(
 ): OrderInfo {
     // A debt-free manager needs no price: every consumer below is debt-gated, so
     // reading eagerly would let a stale feed block an order that used to succeed.
-    let (base_reading, quote_reading) = if (
-        margin_manager.borrowed_base_shares() > 0
-        || margin_manager.borrowed_quote_shares() > 0
-    ) {
+    let (base_reading, quote_reading) = if (margin_manager.has_debt()) {
         (
             option::some(oracle::read_price_pro<BaseAsset>(base_oracle, registry, clock)),
             option::some(oracle::read_price_pro<QuoteAsset>(quote_oracle, registry, clock)),

--- a/packages/deepbook_margin/sources/pool_proxy_pro.move
+++ b/packages/deepbook_margin/sources/pool_proxy_pro.move
@@ -63,14 +63,28 @@ public fun place_limit_order_v2<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &TxContext,
 ): OrderInfo {
+    // A debt-free manager needs no price: every consumer below is debt-gated, so
+    // reading eagerly would let a stale feed block an order that used to succeed.
+    let (base_reading, quote_reading) = if (
+        margin_manager.borrowed_base_shares() > 0
+        || margin_manager.borrowed_quote_shares() > 0
+    ) {
+        (
+            option::some(oracle::read_price_pro<BaseAsset>(base_oracle, registry, clock)),
+            option::some(oracle::read_price_pro<QuoteAsset>(quote_oracle, registry, clock)),
+        )
+    } else {
+        (option::none(), option::none())
+    };
+
     pool_proxy::place_limit_order_v2_core<BaseAsset, QuoteAsset>(
         registry,
         margin_manager,
         pool,
         base_margin_pool,
         quote_margin_pool,
-        oracle::read_price_pro<BaseAsset>(base_oracle, registry, clock),
-        oracle::read_price_pro<QuoteAsset>(quote_oracle, registry, clock),
+        base_reading,
+        quote_reading,
         client_order_id,
         order_type,
         self_matching_option,
@@ -100,14 +114,28 @@ public fun place_market_order_v2<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &TxContext,
 ): OrderInfo {
+    // A debt-free manager needs no price: every consumer below is debt-gated, so
+    // reading eagerly would let a stale feed block an order that used to succeed.
+    let (base_reading, quote_reading) = if (
+        margin_manager.borrowed_base_shares() > 0
+        || margin_manager.borrowed_quote_shares() > 0
+    ) {
+        (
+            option::some(oracle::read_price_pro<BaseAsset>(base_oracle, registry, clock)),
+            option::some(oracle::read_price_pro<QuoteAsset>(quote_oracle, registry, clock)),
+        )
+    } else {
+        (option::none(), option::none())
+    };
+
     pool_proxy::place_market_order_v2_core<BaseAsset, QuoteAsset>(
         registry,
         margin_manager,
         pool,
         base_margin_pool,
         quote_margin_pool,
-        oracle::read_price_pro<BaseAsset>(base_oracle, registry, clock),
-        oracle::read_price_pro<QuoteAsset>(quote_oracle, registry, clock),
+        base_reading,
+        quote_reading,
         client_order_id,
         self_matching_option,
         quantity,
@@ -282,14 +310,28 @@ public fun place_market_order_and_repay_loan<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ): OrderInfo {
+    // A debt-free manager needs no price: every consumer below is debt-gated, so
+    // reading eagerly would let a stale feed block an order that used to succeed.
+    let (base_reading, quote_reading) = if (
+        margin_manager.borrowed_base_shares() > 0
+        || margin_manager.borrowed_quote_shares() > 0
+    ) {
+        (
+            option::some(oracle::read_price_pro<BaseAsset>(base_oracle, registry, clock)),
+            option::some(oracle::read_price_pro<QuoteAsset>(quote_oracle, registry, clock)),
+        )
+    } else {
+        (option::none(), option::none())
+    };
+
     pool_proxy::place_market_order_and_repay_loan_core<BaseAsset, QuoteAsset>(
         registry,
         margin_manager,
         pool,
         base_margin_pool,
         quote_margin_pool,
-        oracle::read_price_pro<BaseAsset>(base_oracle, registry, clock),
-        oracle::read_price_pro<QuoteAsset>(quote_oracle, registry, clock),
+        base_reading,
+        quote_reading,
         client_order_id,
         self_matching_option,
         quantity,

--- a/packages/deepbook_margin/sources/pool_proxy_pro.move
+++ b/packages/deepbook_margin/sources/pool_proxy_pro.move
@@ -1,0 +1,301 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Pyth Pro entrypoints for `pool_proxy`.
+///
+/// Pyth Core is being replaced by a separately published package, so its
+/// `PriceInfoObject` is a distinct Move type from the legacy one and the frozen
+/// signatures in `pool_proxy` can never accept it. The Pyth Pro surface therefore lives
+/// here, under the same function names. Each entry reads the Pro feed and delegates
+/// to the shared core in `pool_proxy`, so both feeds run identical logic.
+module deepbook_margin::pool_proxy_pro;
+
+use deepbook::{order_info::OrderInfo, pool::Pool};
+use deepbook_margin::{
+    margin_manager::MarginManager,
+    margin_pool::MarginPool,
+    margin_registry::MarginRegistry,
+    oracle,
+    pool_proxy
+};
+use pyth_pro::price_info::PriceInfoObject as PriceInfoObjectPro;
+use sui::clock::Clock;
+
+public fun update_current_price<BaseAsset, QuoteAsset>(
+    registry: &mut MarginRegistry,
+    pool: &Pool<BaseAsset, QuoteAsset>,
+    base_price_info_object: &PriceInfoObjectPro,
+    quote_price_info_object: &PriceInfoObjectPro,
+    clock: &Clock,
+) {
+    let base_reading = oracle::read_price_pro<BaseAsset>(base_price_info_object, registry, clock);
+    let quote_reading = oracle::read_price_pro<QuoteAsset>(
+        quote_price_info_object,
+        registry,
+        clock,
+    );
+
+    pool_proxy::update_current_price_core<BaseAsset, QuoteAsset>(
+        registry,
+        pool,
+        base_reading,
+        quote_reading,
+        clock,
+    )
+}
+
+public fun place_limit_order_v2<BaseAsset, QuoteAsset>(
+    registry: &MarginRegistry,
+    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    base_oracle: &PriceInfoObjectPro,
+    quote_oracle: &PriceInfoObjectPro,
+    client_order_id: u64,
+    order_type: u8,
+    self_matching_option: u8,
+    price: u64,
+    quantity: u64,
+    is_bid: bool,
+    pay_with_deep: bool,
+    expire_timestamp: u64,
+    clock: &Clock,
+    ctx: &TxContext,
+): OrderInfo {
+    pool_proxy::place_limit_order_v2_core<BaseAsset, QuoteAsset>(
+        registry,
+        margin_manager,
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        oracle::read_price_pro<BaseAsset>(base_oracle, registry, clock),
+        oracle::read_price_pro<QuoteAsset>(quote_oracle, registry, clock),
+        client_order_id,
+        order_type,
+        self_matching_option,
+        price,
+        quantity,
+        is_bid,
+        pay_with_deep,
+        expire_timestamp,
+        clock,
+        ctx,
+    )
+}
+
+public fun place_market_order_v2<BaseAsset, QuoteAsset>(
+    registry: &MarginRegistry,
+    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    base_oracle: &PriceInfoObjectPro,
+    quote_oracle: &PriceInfoObjectPro,
+    client_order_id: u64,
+    self_matching_option: u8,
+    quantity: u64,
+    is_bid: bool,
+    pay_with_deep: bool,
+    clock: &Clock,
+    ctx: &TxContext,
+): OrderInfo {
+    pool_proxy::place_market_order_v2_core<BaseAsset, QuoteAsset>(
+        registry,
+        margin_manager,
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        oracle::read_price_pro<BaseAsset>(base_oracle, registry, clock),
+        oracle::read_price_pro<QuoteAsset>(quote_oracle, registry, clock),
+        client_order_id,
+        self_matching_option,
+        quantity,
+        is_bid,
+        pay_with_deep,
+        clock,
+        ctx,
+    )
+}
+
+public fun place_reduce_only_limit_order_v2<BaseAsset, QuoteAsset>(
+    registry: &MarginRegistry,
+    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    base_oracle: &PriceInfoObjectPro,
+    quote_oracle: &PriceInfoObjectPro,
+    client_order_id: u64,
+    order_type: u8,
+    self_matching_option: u8,
+    price: u64,
+    quantity: u64,
+    is_bid: bool,
+    pay_with_deep: bool,
+    expire_timestamp: u64,
+    clock: &Clock,
+    ctx: &TxContext,
+): OrderInfo {
+    pool_proxy::place_reduce_only_limit_order_v2_core<BaseAsset, QuoteAsset>(
+        registry,
+        margin_manager,
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        oracle::read_price_pro<BaseAsset>(base_oracle, registry, clock),
+        oracle::read_price_pro<QuoteAsset>(quote_oracle, registry, clock),
+        client_order_id,
+        order_type,
+        self_matching_option,
+        price,
+        quantity,
+        is_bid,
+        pay_with_deep,
+        expire_timestamp,
+        clock,
+        ctx,
+    )
+}
+
+public fun place_reduce_only_market_order_v2<BaseAsset, QuoteAsset>(
+    registry: &MarginRegistry,
+    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &MarginPool<BaseAsset>,
+    quote_margin_pool: &MarginPool<QuoteAsset>,
+    base_oracle: &PriceInfoObjectPro,
+    quote_oracle: &PriceInfoObjectPro,
+    client_order_id: u64,
+    self_matching_option: u8,
+    quantity: u64,
+    is_bid: bool,
+    pay_with_deep: bool,
+    clock: &Clock,
+    ctx: &TxContext,
+): OrderInfo {
+    pool_proxy::place_reduce_only_market_order_v2_core<BaseAsset, QuoteAsset>(
+        registry,
+        margin_manager,
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        oracle::read_price_pro<BaseAsset>(base_oracle, registry, clock),
+        oracle::read_price_pro<QuoteAsset>(quote_oracle, registry, clock),
+        client_order_id,
+        self_matching_option,
+        quantity,
+        is_bid,
+        pay_with_deep,
+        clock,
+        ctx,
+    )
+}
+
+public fun place_reduce_only_market_order_and_repay_loan<BaseAsset, QuoteAsset>(
+    registry: &MarginRegistry,
+    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &mut MarginPool<BaseAsset>,
+    quote_margin_pool: &mut MarginPool<QuoteAsset>,
+    base_oracle: &PriceInfoObjectPro,
+    quote_oracle: &PriceInfoObjectPro,
+    client_order_id: u64,
+    self_matching_option: u8,
+    quantity: u64,
+    is_bid: bool,
+    pay_with_deep: bool,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): OrderInfo {
+    pool_proxy::place_reduce_only_market_order_and_repay_loan_core<BaseAsset, QuoteAsset>(
+        registry,
+        margin_manager,
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        oracle::read_price_pro<BaseAsset>(base_oracle, registry, clock),
+        oracle::read_price_pro<QuoteAsset>(quote_oracle, registry, clock),
+        client_order_id,
+        self_matching_option,
+        quantity,
+        is_bid,
+        pay_with_deep,
+        clock,
+        ctx,
+    )
+}
+
+public fun place_reduce_only_limit_order_and_repay_loan<BaseAsset, QuoteAsset>(
+    registry: &MarginRegistry,
+    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &mut MarginPool<BaseAsset>,
+    quote_margin_pool: &mut MarginPool<QuoteAsset>,
+    base_oracle: &PriceInfoObjectPro,
+    quote_oracle: &PriceInfoObjectPro,
+    client_order_id: u64,
+    order_type: u8,
+    self_matching_option: u8,
+    price: u64,
+    quantity: u64,
+    is_bid: bool,
+    pay_with_deep: bool,
+    expire_timestamp: u64,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): OrderInfo {
+    pool_proxy::place_reduce_only_limit_order_and_repay_loan_core<BaseAsset, QuoteAsset>(
+        registry,
+        margin_manager,
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        oracle::read_price_pro<BaseAsset>(base_oracle, registry, clock),
+        oracle::read_price_pro<QuoteAsset>(quote_oracle, registry, clock),
+        client_order_id,
+        order_type,
+        self_matching_option,
+        price,
+        quantity,
+        is_bid,
+        pay_with_deep,
+        expire_timestamp,
+        clock,
+        ctx,
+    )
+}
+
+public fun place_market_order_and_repay_loan<BaseAsset, QuoteAsset>(
+    registry: &MarginRegistry,
+    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    base_margin_pool: &mut MarginPool<BaseAsset>,
+    quote_margin_pool: &mut MarginPool<QuoteAsset>,
+    base_oracle: &PriceInfoObjectPro,
+    quote_oracle: &PriceInfoObjectPro,
+    client_order_id: u64,
+    self_matching_option: u8,
+    quantity: u64,
+    is_bid: bool,
+    pay_with_deep: bool,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): OrderInfo {
+    pool_proxy::place_market_order_and_repay_loan_core<BaseAsset, QuoteAsset>(
+        registry,
+        margin_manager,
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        oracle::read_price_pro<BaseAsset>(base_oracle, registry, clock),
+        oracle::read_price_pro<QuoteAsset>(quote_oracle, registry, clock),
+        client_order_id,
+        self_matching_option,
+        quantity,
+        is_bid,
+        pay_with_deep,
+        clock,
+        ctx,
+    )
+}

--- a/packages/deepbook_margin/sources/tpsl.move
+++ b/packages/deepbook_margin/sources/tpsl.move
@@ -7,9 +7,8 @@ use deepbook::{constants, pool::Pool};
 use deepbook_margin::{
     margin_constants,
     margin_registry::MarginRegistry,
-    oracle::{calculate_price, read_price}
+    oracle::{PythReading, calculate_price}
 };
-use pyth::price_info::PriceInfoObject;
 use sui::{clock::Clock, event};
 
 // === Errors ===
@@ -260,8 +259,8 @@ public(package) fun add_conditional_order<BaseAsset, QuoteAsset>(
     self: &mut TakeProfitStopLoss,
     pool: &Pool<BaseAsset, QuoteAsset>,
     manager_id: ID,
-    base_price_info_object: &PriceInfoObject,
-    quote_price_info_object: &PriceInfoObject,
+    base_reading: PythReading,
+    quote_reading: PythReading,
     registry: &MarginRegistry,
     conditional_order_id: u64,
     condition: Condition,
@@ -282,8 +281,8 @@ public(package) fun add_conditional_order<BaseAsset, QuoteAsset>(
 
     let current_price = calculate_price<BaseAsset, QuoteAsset>(
         registry,
-        read_price<BaseAsset>(base_price_info_object, registry, clock),
-        read_price<QuoteAsset>(quote_price_info_object, registry, clock),
+        base_reading,
+        quote_reading,
     );
 
     let trigger_below_price = condition.trigger_below_price;

--- a/packages/deepbook_margin/tests/helper/oracle_tests.move
+++ b/packages/deepbook_margin/tests/helper/oracle_tests.move
@@ -21,6 +21,7 @@ use deepbook_margin::{
     test_helpers::{
         build_pyth_price_info_object,
         build_pyth_pro_price_info_object,
+        build_pyth_pro_price_info_with_ewma,
         create_test_pyth_config,
     }
 };
@@ -645,7 +646,10 @@ fun test_read_price_pro_matches_legacy_reader() {
     let pyth_config = create_test_pyth_config(); // max_conf_bps = 1000 (10%)
     registry.add_config(&admin_cap, pyth_config);
 
-    let price_info = build_pyth_pro_price_info_object(
+    // Same feed id, price, conf, exponent and timestamp through both packages. The
+    // two readers must produce an identical `PythReading`, or the Pro entrypoints
+    // price differently from the legacy ones they shadow.
+    let legacy_info = build_pyth_price_info_object(
         &mut scenario,
         test_constants::usdc_price_feed_id(),
         10000000000, // $100
@@ -653,16 +657,28 @@ fun test_read_price_pro_matches_legacy_reader() {
         8,
         clock.timestamp_ms() / 1000,
     );
-
-    let usd_price = calculate_usd_price<USDC>(
-        read_price_pro<USDC>(&price_info, &registry, &clock),
-        &registry,
-        1000000, // 1 USDC
+    let pro_info = build_pyth_pro_price_info_object(
+        &mut scenario,
+        test_constants::usdc_price_feed_id(),
+        10000000000,
+        1000000,
+        8,
+        clock.timestamp_ms() / 1000,
     );
-    assert!(usd_price == 100_000_000_000);
+
+    let legacy_reading = read_price<USDC>(&legacy_info, &registry, &clock);
+    let pro_reading = read_price_pro<USDC>(&pro_info, &registry, &clock);
+    assert!(pro_reading.price() == legacy_reading.price());
+    assert!(pro_reading.decimals() == legacy_reading.decimals());
+
+    let legacy_usd = calculate_usd_price<USDC>(legacy_reading, &registry, 1000000);
+    let pro_usd = calculate_usd_price<USDC>(pro_reading, &registry, 1000000); // 1 USDC
+    assert!(pro_usd == legacy_usd);
+    assert!(pro_usd == 100_000_000_000);
 
     destroy(admin_cap);
-    destroy(price_info);
+    destroy(legacy_info);
+    destroy(pro_info);
     test_scenario::return_shared(registry);
     test_scenario::return_shared(clock);
     scenario.end();
@@ -801,8 +817,132 @@ fun test_unvalidated_reading_skips_confidence_bound() {
         clock.timestamp_ms() / 1000,
     );
 
+    // Reaching `price_config` is the whole point: the identical conf through the
+    // validated reader aborts `EInvalidPythPriceConf`
+    // (`test_read_price_pro_confidence_enforced_when_pricing`). Asserting only on
+    // `reading.price()` would never execute the bound at all.
     let reading = read_price_pro_unsafe<USDC>(&price_info, &registry);
     assert!(reading.price() == 10000000000);
+
+    let usd_price = calculate_usd_price<USDC>(reading, &registry, 1000000);
+    assert!(usd_price == 100_000_000_000);
+
+    destroy(admin_cap);
+    destroy(price_info);
+    test_scenario::return_shared(registry);
+    test_scenario::return_shared(clock);
+    scenario.end();
+}
+
+// === Pyth Pro EWMA divergence ===
+// `build_pyth_pro_price_info_object` sets `ema == spot`, so every other Pro test
+// leaves the divergence guard a tautology. These are the only tests that execute it,
+// and the only thing standing between a mutated `read_price_pro` ewma argument and a
+// green CI run.
+
+#[test, expected_failure(abort_code = ::deepbook_margin::oracle::EInvalidPythPrice)]
+fun test_read_price_pro_rejects_ewma_divergence_high() {
+    let mut scenario = test_scenario::begin(test_constants::admin());
+
+    scenario.next_tx(test_constants::admin());
+    let admin_cap = margin_registry::new_for_testing(scenario.ctx());
+    let mut clock = clock::create_for_testing(scenario.ctx());
+    clock.set_for_testing(1000000);
+    clock.share_for_testing();
+
+    scenario.next_tx(test_constants::admin());
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let clock = scenario.take_shared<Clock>();
+    let pyth_config = create_test_pyth_config(); // max_ewma_difference_bps = 1500 (15%)
+    registry.add_config(&admin_cap, pyth_config);
+
+    // Spot $120 against a $100 EWMA: 20% above, past the 15% bound.
+    let price_info = build_pyth_pro_price_info_with_ewma(
+        &mut scenario,
+        test_constants::usdc_price_feed_id(),
+        12000000000,
+        10000000000,
+        50000,
+        8,
+        clock.timestamp_ms() / 1000,
+    );
+
+    let _ = read_price_pro<USDC>(&price_info, &registry, &clock);
+
+    destroy(admin_cap);
+    destroy(price_info);
+    test_scenario::return_shared(registry);
+    test_scenario::return_shared(clock);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = ::deepbook_margin::oracle::EInvalidPythPrice)]
+fun test_read_price_pro_rejects_ewma_divergence_low() {
+    let mut scenario = test_scenario::begin(test_constants::admin());
+
+    scenario.next_tx(test_constants::admin());
+    let admin_cap = margin_registry::new_for_testing(scenario.ctx());
+    let mut clock = clock::create_for_testing(scenario.ctx());
+    clock.set_for_testing(1000000);
+    clock.share_for_testing();
+
+    scenario.next_tx(test_constants::admin());
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let clock = scenario.take_shared<Clock>();
+    let pyth_config = create_test_pyth_config(); // max_ewma_difference_bps = 1500 (15%)
+    registry.add_config(&admin_cap, pyth_config);
+
+    // Spot $80 against a $100 EWMA: 20% below the bound in the other direction.
+    let price_info = build_pyth_pro_price_info_with_ewma(
+        &mut scenario,
+        test_constants::usdc_price_feed_id(),
+        8000000000,
+        10000000000,
+        50000,
+        8,
+        clock.timestamp_ms() / 1000,
+    );
+
+    let _ = read_price_pro<USDC>(&price_info, &registry, &clock);
+
+    destroy(admin_cap);
+    destroy(price_info);
+    test_scenario::return_shared(registry);
+    test_scenario::return_shared(clock);
+    scenario.end();
+}
+
+/// The guard must not be an unconditional abort: a divergence inside the bound reads
+/// normally, and the reading carries the spot price rather than the EWMA.
+#[test]
+fun test_read_price_pro_accepts_ewma_divergence_within_bound() {
+    let mut scenario = test_scenario::begin(test_constants::admin());
+
+    scenario.next_tx(test_constants::admin());
+    let admin_cap = margin_registry::new_for_testing(scenario.ctx());
+    let mut clock = clock::create_for_testing(scenario.ctx());
+    clock.set_for_testing(1000000);
+    clock.share_for_testing();
+
+    scenario.next_tx(test_constants::admin());
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let clock = scenario.take_shared<Clock>();
+    let pyth_config = create_test_pyth_config(); // max_ewma_difference_bps = 1500 (15%)
+    registry.add_config(&admin_cap, pyth_config);
+
+    // Spot $110 against a $100 EWMA: 10% divergence, inside the 15% bound.
+    let price_info = build_pyth_pro_price_info_with_ewma(
+        &mut scenario,
+        test_constants::usdc_price_feed_id(),
+        11000000000,
+        10000000000,
+        50000,
+        8,
+        clock.timestamp_ms() / 1000,
+    );
+
+    let reading = read_price_pro<USDC>(&price_info, &registry, &clock);
+    assert!(reading.price() == 11000000000);
 
     destroy(admin_cap);
     destroy(price_info);

--- a/packages/deepbook_margin/tests/helper/oracle_tests.move
+++ b/packages/deepbook_margin/tests/helper/oracle_tests.move
@@ -17,7 +17,7 @@ use deepbook_margin::{
         calculate_target_amount,
         test_conversion_config,
     },
-    test_constants::{Self, USDC},
+    test_constants::{Self, SUI, USDC},
     test_helpers::{
         build_pyth_price_info_object,
         build_pyth_pro_price_info_object,
@@ -943,6 +943,86 @@ fun test_read_price_pro_accepts_ewma_divergence_within_bound() {
 
     let reading = read_price_pro<USDC>(&price_info, &registry, &clock);
     assert!(reading.price() == 11000000000);
+
+    destroy(admin_cap);
+    destroy(price_info);
+    test_scenario::return_shared(registry);
+    test_scenario::return_shared(clock);
+    scenario.end();
+}
+
+// === The asset tag itself ===
+// `PythReading.coin_type` is a regression barrier: it converts a reading routed to the
+// wrong leg from a silent mis-price into an abort. A barrier with no test protecting it
+// is not a barrier - deleting the assert in `price_config` left the whole suite green.
+// These two stand on it, in both directions.
+
+#[test, expected_failure(abort_code = ::deepbook_margin::oracle::EReadingAssetMismatch)]
+fun test_reading_consumed_as_the_wrong_asset_aborts() {
+    let mut scenario = test_scenario::begin(test_constants::admin());
+
+    scenario.next_tx(test_constants::admin());
+    let admin_cap = margin_registry::new_for_testing(scenario.ctx());
+    let mut clock = clock::create_for_testing(scenario.ctx());
+    clock.set_for_testing(1000000);
+    clock.share_for_testing();
+
+    scenario.next_tx(test_constants::admin());
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let clock = scenario.take_shared<Clock>();
+    registry.add_config(&admin_cap, create_test_pyth_config());
+
+    // A completely valid SUI reading: right feed id, fresh, tight confidence, EWMA in
+    // band. Nothing about it is malformed - it is simply not a USDC price.
+    let price_info = build_pyth_price_info_object(
+        &mut scenario,
+        test_constants::sui_price_feed_id(),
+        10000000000,
+        1000000,
+        8,
+        clock.timestamp_ms() / 1000,
+    );
+    let sui_reading = read_price<SUI>(&price_info, &registry, &clock);
+
+    let _ = calculate_usd_price<USDC>(sui_reading, &registry, 1000000);
+
+    destroy(admin_cap);
+    destroy(price_info);
+    test_scenario::return_shared(registry);
+    test_scenario::return_shared(clock);
+    scenario.end();
+}
+
+/// The control: the identical reading consumed as the asset it is actually for prices
+/// normally. Without this, an assert that always aborted would pass the test above.
+#[test]
+fun test_reading_consumed_as_its_own_asset_prices_normally() {
+    let mut scenario = test_scenario::begin(test_constants::admin());
+
+    scenario.next_tx(test_constants::admin());
+    let admin_cap = margin_registry::new_for_testing(scenario.ctx());
+    let mut clock = clock::create_for_testing(scenario.ctx());
+    clock.set_for_testing(1000000);
+    clock.share_for_testing();
+
+    scenario.next_tx(test_constants::admin());
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let clock = scenario.take_shared<Clock>();
+    registry.add_config(&admin_cap, create_test_pyth_config());
+
+    let price_info = build_pyth_price_info_object(
+        &mut scenario,
+        test_constants::sui_price_feed_id(),
+        10000000000, // $100
+        1000000,
+        8,
+        clock.timestamp_ms() / 1000,
+    );
+    let sui_reading = read_price<SUI>(&price_info, &registry, &clock);
+
+    // SUI carries 9 decimals in the test config, so 1 SUI is 1_000_000_000.
+    let usd = calculate_usd_price<SUI>(sui_reading, &registry, 1_000_000_000);
+    assert!(usd == 100_000_000_000);
 
     destroy(admin_cap);
     destroy(price_info);

--- a/packages/deepbook_margin/tests/helper/oracle_tests.move
+++ b/packages/deepbook_margin/tests/helper/oracle_tests.move
@@ -7,7 +7,10 @@ module deepbook_margin::oracle_tests;
 use deepbook_margin::{
     margin_registry::{Self, MarginRegistry},
     oracle::{
+        Self,
         read_price,
+        read_price_pro,
+        read_price_pro_unsafe,
         calculate_usd_currency_amount,
         calculate_target_currency_amount,
         calculate_usd_price,
@@ -15,7 +18,11 @@ use deepbook_margin::{
         test_conversion_config,
     },
     test_constants::{Self, USDC},
-    test_helpers::{build_pyth_price_info_object, create_test_pyth_config}
+    test_helpers::{
+        build_pyth_price_info_object,
+        build_pyth_pro_price_info_object,
+        create_test_pyth_config,
+    }
 };
 use pyth::{i64, price, price_feed, price_identifier, price_info::{Self, PriceInfoObject}};
 use std::unit_test::destroy;
@@ -610,6 +617,192 @@ fun test_ewma_check_with_high_price_no_overflow() {
 
     // 1 USDC at $1.1M = $1.1M (with 9 decimals for USD representation)
     assert!(usd_price == 1_100_000_000_000_000);
+
+    destroy(admin_cap);
+    destroy(price_info);
+    test_scenario::return_shared(registry);
+    test_scenario::return_shared(clock);
+    scenario.end();
+}
+
+// === Pyth Pro reader parity ===
+// Pyth Pro is a separate published package, so its feed is a distinct Move type.
+// These pin that `read_price_pro` enforces exactly the policy `read_price` does.
+
+#[test]
+fun test_read_price_pro_matches_legacy_reader() {
+    let mut scenario = test_scenario::begin(test_constants::admin());
+
+    scenario.next_tx(test_constants::admin());
+    let admin_cap = margin_registry::new_for_testing(scenario.ctx());
+    let mut clock = clock::create_for_testing(scenario.ctx());
+    clock.set_for_testing(1000000);
+    clock.share_for_testing();
+
+    scenario.next_tx(test_constants::admin());
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let clock = scenario.take_shared<Clock>();
+    let pyth_config = create_test_pyth_config(); // max_conf_bps = 1000 (10%)
+    registry.add_config(&admin_cap, pyth_config);
+
+    let price_info = build_pyth_pro_price_info_object(
+        &mut scenario,
+        test_constants::usdc_price_feed_id(),
+        10000000000, // $100
+        1000000, // well inside the confidence bound
+        8,
+        clock.timestamp_ms() / 1000,
+    );
+
+    let usd_price = calculate_usd_price<USDC>(
+        read_price_pro<USDC>(&price_info, &registry, &clock),
+        &registry,
+        1000000, // 1 USDC
+    );
+    assert!(usd_price == 100_000_000_000);
+
+    destroy(admin_cap);
+    destroy(price_info);
+    test_scenario::return_shared(registry);
+    test_scenario::return_shared(clock);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = pyth_pro::pyth::E_STALE_PRICE_UPDATE)]
+fun test_read_price_pro_rejects_stale_price() {
+    let mut scenario = test_scenario::begin(test_constants::admin());
+
+    scenario.next_tx(test_constants::admin());
+    let admin_cap = margin_registry::new_for_testing(scenario.ctx());
+    let mut clock = clock::create_for_testing(scenario.ctx());
+    clock.set_for_testing(1000000);
+    clock.share_for_testing();
+
+    scenario.next_tx(test_constants::admin());
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let clock = scenario.take_shared<Clock>();
+    let pyth_config = create_test_pyth_config(); // max_conf_bps = 1000 (10%)
+    registry.add_config(&admin_cap, pyth_config);
+
+    let price_info = build_pyth_pro_price_info_object(
+        &mut scenario,
+        test_constants::usdc_price_feed_id(),
+        10000000000,
+        1000000,
+        8,
+        (clock.timestamp_ms() / 1000) - 65, // beyond max_age_secs
+    );
+
+    let _ = read_price_pro<USDC>(&price_info, &registry, &clock);
+
+    destroy(admin_cap);
+    destroy(price_info);
+    test_scenario::return_shared(registry);
+    test_scenario::return_shared(clock);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = oracle::EPriceFeedIdMismatch)]
+fun test_read_price_pro_rejects_wrong_feed_id() {
+    let mut scenario = test_scenario::begin(test_constants::admin());
+
+    scenario.next_tx(test_constants::admin());
+    let admin_cap = margin_registry::new_for_testing(scenario.ctx());
+    let mut clock = clock::create_for_testing(scenario.ctx());
+    clock.set_for_testing(1000000);
+    clock.share_for_testing();
+
+    scenario.next_tx(test_constants::admin());
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let clock = scenario.take_shared<Clock>();
+    let pyth_config = create_test_pyth_config(); // max_conf_bps = 1000 (10%)
+    registry.add_config(&admin_cap, pyth_config);
+
+    let price_info = build_pyth_pro_price_info_object(
+        &mut scenario,
+        test_constants::sui_price_feed_id(), // not USDC's feed
+        10000000000,
+        1000000,
+        8,
+        clock.timestamp_ms() / 1000,
+    );
+
+    let _ = read_price_pro<USDC>(&price_info, &registry, &clock);
+
+    destroy(admin_cap);
+    destroy(price_info);
+    test_scenario::return_shared(registry);
+    test_scenario::return_shared(clock);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = oracle::EInvalidPythPriceConf)]
+fun test_read_price_pro_confidence_enforced_when_pricing() {
+    let mut scenario = test_scenario::begin(test_constants::admin());
+
+    scenario.next_tx(test_constants::admin());
+    let admin_cap = margin_registry::new_for_testing(scenario.ctx());
+    let mut clock = clock::create_for_testing(scenario.ctx());
+    clock.set_for_testing(1000000);
+    clock.share_for_testing();
+
+    scenario.next_tx(test_constants::admin());
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let clock = scenario.take_shared<Clock>();
+    let pyth_config = create_test_pyth_config(); // max_conf_bps = 1000 (10%)
+    registry.add_config(&admin_cap, pyth_config);
+
+    let price_info = build_pyth_pro_price_info_object(
+        &mut scenario,
+        test_constants::usdc_price_feed_id(),
+        10000000000,
+        1500000000, // 15% conf, above the 10% bound
+        8,
+        clock.timestamp_ms() / 1000,
+    );
+
+    let _ = calculate_usd_price<USDC>(
+        read_price_pro<USDC>(&price_info, &registry, &clock),
+        &registry,
+        1000000,
+    );
+
+    destroy(admin_cap);
+    destroy(price_info);
+    test_scenario::return_shared(registry);
+    test_scenario::return_shared(clock);
+    scenario.end();
+}
+
+#[test]
+fun test_unvalidated_reading_skips_confidence_bound() {
+    let mut scenario = test_scenario::begin(test_constants::admin());
+
+    scenario.next_tx(test_constants::admin());
+    let admin_cap = margin_registry::new_for_testing(scenario.ctx());
+    let mut clock = clock::create_for_testing(scenario.ctx());
+    clock.set_for_testing(1000000);
+    clock.share_for_testing();
+
+    scenario.next_tx(test_constants::admin());
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let clock = scenario.take_shared<Clock>();
+    let pyth_config = create_test_pyth_config(); // max_conf_bps = 1000 (10%)
+    registry.add_config(&admin_cap, pyth_config);
+
+    // A telemetry read (deposit event) must not be blocked by a wide confidence
+    // interval - the bound is a pricing guard, and unvalidated readings carry none.
+    let price_info = build_pyth_pro_price_info_object(
+        &mut scenario,
+        test_constants::usdc_price_feed_id(),
+        10000000000,
+        1500000000, // 15% conf, above the bound
+        8,
+        clock.timestamp_ms() / 1000,
+    );
+
+    let reading = read_price_pro_unsafe<USDC>(&price_info, &registry);
+    assert!(reading.price() == 10000000000);
 
     destroy(admin_cap);
     destroy(price_info);

--- a/packages/deepbook_margin/tests/helper/test_helpers.move
+++ b/packages/deepbook_margin/tests/helper/test_helpers.move
@@ -562,6 +562,27 @@ public fun build_stale_btc_price_info_object(
 }
 
 /// Build a stale USDC price info object (timestamp is stale_seconds before clock time)
+public fun build_stale_usdt_price_info_object(
+    scenario: &mut Scenario,
+    clock: &Clock,
+    stale_seconds: u64,
+): PriceInfoObject {
+    let current_timestamp = clock.timestamp_ms() / 1000;
+    let stale_timestamp = if (current_timestamp > stale_seconds) {
+        current_timestamp - stale_seconds
+    } else {
+        0
+    };
+    build_pyth_price_info_object(
+        scenario,
+        test_constants::usdt_price_feed_id(),
+        1 * test_constants::pyth_multiplier(),
+        50000,
+        test_constants::pyth_decimals(),
+        stale_timestamp,
+    )
+}
+
 public fun build_stale_usdc_price_info_object(
     scenario: &mut Scenario,
     clock: &Clock,
@@ -1777,6 +1798,21 @@ public fun build_stale_usdc_price_info_object_pro(
     build_pyth_pro_price_info_object(
         scenario,
         test_constants::usdc_price_feed_id(),
+        1 * test_constants::pyth_multiplier(),
+        50000,
+        test_constants::pyth_decimals(),
+        (clock.timestamp_ms() / 1000) - stale_seconds,
+    )
+}
+
+public fun build_stale_usdt_price_info_object_pro(
+    scenario: &mut Scenario,
+    stale_seconds: u64,
+    clock: &Clock,
+): PriceInfoObjectPro {
+    build_pyth_pro_price_info_object(
+        scenario,
+        test_constants::usdt_price_feed_id(),
         1 * test_constants::pyth_multiplier(),
         50000,
         test_constants::pyth_decimals(),

--- a/packages/deepbook_margin/tests/helper/test_helpers.move
+++ b/packages/deepbook_margin/tests/helper/test_helpers.move
@@ -1653,3 +1653,99 @@ public fun build_pyth_pro_price_info_object(
     );
     price_info_pro::new_price_info_object_for_test(price_info, scenario.ctx())
 }
+
+// === Pyth Pro price object builders ===
+// Twins of the legacy builders above. Pyth Pro is a separately published package, so
+// its `PriceInfoObject` is a distinct Move type and the Pro entrypoints cannot be
+// exercised with the legacy objects.
+
+public fun build_demo_usdc_price_info_object_pro(
+    scenario: &mut Scenario,
+    clock: &Clock,
+): PriceInfoObjectPro {
+    build_pyth_pro_price_info_object(
+        scenario,
+        test_constants::usdc_price_feed_id(),
+        1 * test_constants::pyth_multiplier(),
+        50000,
+        test_constants::pyth_decimals(),
+        clock.timestamp_ms() / 1000,
+    )
+}
+
+public fun build_demo_usdt_price_info_object_pro(
+    scenario: &mut Scenario,
+    clock: &Clock,
+): PriceInfoObjectPro {
+    build_pyth_pro_price_info_object(
+        scenario,
+        test_constants::usdt_price_feed_id(),
+        1 * test_constants::pyth_multiplier(),
+        50000,
+        test_constants::pyth_decimals(),
+        clock.timestamp_ms() / 1000,
+    )
+}
+
+public fun build_btc_price_info_object_pro(
+    scenario: &mut Scenario,
+    price_usd: u64,
+    clock: &Clock,
+): PriceInfoObjectPro {
+    build_pyth_pro_price_info_object(
+        scenario,
+        test_constants::btc_price_feed_id(),
+        price_usd * test_constants::pyth_multiplier(),
+        1000000,
+        test_constants::pyth_decimals(),
+        clock.timestamp_ms() / 1000,
+    )
+}
+
+public fun build_sui_price_info_object_pro(
+    scenario: &mut Scenario,
+    price_usd: u64,
+    clock: &Clock,
+): PriceInfoObjectPro {
+    build_pyth_pro_price_info_object(
+        scenario,
+        test_constants::sui_price_feed_id(),
+        price_usd * test_constants::pyth_multiplier(),
+        100000,
+        test_constants::pyth_decimals(),
+        clock.timestamp_ms() / 1000,
+    )
+}
+
+/// Stale by `stale_seconds`, for asserting that the Pro readers still enforce
+/// staleness on the paths that validated it before the migration.
+public fun build_stale_btc_price_info_object_pro(
+    scenario: &mut Scenario,
+    price_usd: u64,
+    stale_seconds: u64,
+    clock: &Clock,
+): PriceInfoObjectPro {
+    build_pyth_pro_price_info_object(
+        scenario,
+        test_constants::btc_price_feed_id(),
+        price_usd * test_constants::pyth_multiplier(),
+        1000000,
+        test_constants::pyth_decimals(),
+        (clock.timestamp_ms() / 1000) - stale_seconds,
+    )
+}
+
+public fun build_stale_usdc_price_info_object_pro(
+    scenario: &mut Scenario,
+    stale_seconds: u64,
+    clock: &Clock,
+): PriceInfoObjectPro {
+    build_pyth_pro_price_info_object(
+        scenario,
+        test_constants::usdc_price_feed_id(),
+        1 * test_constants::pyth_multiplier(),
+        50000,
+        test_constants::pyth_decimals(),
+        (clock.timestamp_ms() / 1000) - stale_seconds,
+    )
+}

--- a/packages/deepbook_margin/tests/helper/test_helpers.move
+++ b/packages/deepbook_margin/tests/helper/test_helpers.move
@@ -1654,6 +1654,40 @@ public fun build_pyth_pro_price_info_object(
     price_info_pro::new_price_info_object_for_test(price_info, scenario.ctx())
 }
 
+/// Pro object whose EWMA price differs from the spot price. The builder above sets
+/// `ema == spot`, which makes the divergence guard a tautology; every test that means
+/// to exercise `max_ewma_difference_bps` on a Pro feed must come through here.
+public fun build_pyth_pro_price_info_with_ewma(
+    scenario: &mut Scenario,
+    id: vector<u8>,
+    price_value: u64,
+    ewma_price_value: u64,
+    conf_value: u64,
+    exp_value: u64,
+    timestamp: u64,
+): PriceInfoObjectPro {
+    let price_id = price_identifier_pro::from_byte_vec(id);
+    let price = price_pro::new(
+        i64_pro::new(price_value, false),
+        conf_value,
+        i64_pro::new(exp_value, true),
+        timestamp,
+    );
+    let ewma_price = price_pro::new(
+        i64_pro::new(ewma_price_value, false),
+        conf_value,
+        i64_pro::new(exp_value, true),
+        timestamp,
+    );
+    let price_feed = price_feed_pro::new(price_id, price, ewma_price);
+    let price_info = price_info_pro::new_price_info(
+        timestamp - 2,
+        timestamp - 1,
+        price_feed,
+    );
+    price_info_pro::new_price_info_object_for_test(price_info, scenario.ctx())
+}
+
 // === Pyth Pro price object builders ===
 // Twins of the legacy builders above. Pyth Pro is a separately published package, so
 // its `PriceInfoObject` is a distinct Move type and the Pro entrypoints cannot be
@@ -1747,5 +1781,24 @@ public fun build_stale_usdc_price_info_object_pro(
         50000,
         test_constants::pyth_decimals(),
         (clock.timestamp_ms() / 1000) - stale_seconds,
+    )
+}
+
+/// Fresh BTC feed carrying an arbitrarily wide confidence interval. The confidence
+/// bound is a *pricing* guard asserted in `price_config`, not a read guard, so a
+/// reading taken for telemetry must survive a `conf` this wide.
+public fun build_wide_conf_btc_price_info_object_pro(
+    scenario: &mut Scenario,
+    price_usd: u64,
+    conf_value: u64,
+    clock: &Clock,
+): PriceInfoObjectPro {
+    build_pyth_pro_price_info_object(
+        scenario,
+        test_constants::btc_price_feed_id(),
+        price_usd * test_constants::pyth_multiplier(),
+        conf_value,
+        test_constants::pyth_decimals(),
+        clock.timestamp_ms() / 1000,
     )
 }

--- a/packages/deepbook_margin/tests/helper/test_helpers.move
+++ b/packages/deepbook_margin/tests/helper/test_helpers.move
@@ -22,6 +22,13 @@ use deepbook_margin::{
     test_constants::{Self, USDC, USDT, BTC, SUI}
 };
 use pyth::{i64, price, price_feed, price_identifier, price_info::{Self, PriceInfoObject}};
+use pyth_pro::{
+    i64 as i64_pro,
+    price as price_pro,
+    price_feed as price_feed_pro,
+    price_identifier as price_identifier_pro,
+    price_info::{Self as price_info_pro, PriceInfoObject as PriceInfoObjectPro}
+};
 use std::unit_test::destroy;
 use sui::{
     clock::{Self, Clock},
@@ -1618,4 +1625,31 @@ public fun execute_conditional_orders_v3_for_test<BaseAsset, QuoteAsset>(
         clock,
         scenario.ctx(),
     )
+}
+
+/// Pyth Pro twin of `build_pyth_price_info_object`. Pyth Pro is a separately
+/// published package, so its `PriceInfoObject` is a distinct Move type and needs its
+/// own constructor even though the shape is identical.
+public fun build_pyth_pro_price_info_object(
+    scenario: &mut Scenario,
+    id: vector<u8>,
+    price_value: u64,
+    conf_value: u64,
+    exp_value: u64,
+    timestamp: u64,
+): PriceInfoObjectPro {
+    let price_id = price_identifier_pro::from_byte_vec(id);
+    let price = price_pro::new(
+        i64_pro::new(price_value, false),
+        conf_value,
+        i64_pro::new(exp_value, true),
+        timestamp,
+    );
+    let price_feed = price_feed_pro::new(price_id, price, price);
+    let price_info = price_info_pro::new_price_info(
+        timestamp - 2,
+        timestamp - 1,
+        price_feed,
+    );
+    price_info_pro::new_price_info_object_for_test(price_info, scenario.ctx())
 }

--- a/packages/deepbook_margin/tests/margin_manager_pro_tests.move
+++ b/packages/deepbook_margin/tests/margin_manager_pro_tests.move
@@ -1,0 +1,402 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Behavioural coverage for `margin_manager_pro`.
+///
+/// Pyth Pro is a separately published package, so its `PriceInfoObject` is a distinct
+/// Move type and no legacy test reaches these entrypoints. Each test drives the same
+/// flow as its legacy twin through the Pro feed, so a wrong `_core` target, a swapped
+/// base/quote argument, or a downgraded reader fails here rather than merely
+/// compiling.
+#[test_only]
+module deepbook_margin::margin_manager_pro_tests;
+
+use deepbook::{pool::Pool, registry::Registry};
+use deepbook_margin::{
+    margin_constants,
+    margin_manager::{Self, MarginManager},
+    margin_manager_pro,
+    margin_pool::MarginPool,
+    margin_registry::MarginRegistry,
+    test_constants::{Self, USDC, BTC, btc_multiplier},
+    test_helpers::{
+        cleanup_margin_test,
+        mint_coin,
+        build_demo_usdc_price_info_object_pro,
+        build_btc_price_info_object_pro,
+        build_stale_btc_price_info_object_pro,
+        setup_btc_usd_deepbook_margin,
+        return_shared_2,
+        destroy_2,
+    }
+};
+use sui::test_scenario::{Self as test, return_shared};
+
+/// Deposits USDC collateral through the Pro entrypoint and asserts it landed.
+#[test]
+fun deposit_pro_credits_collateral() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        _btc_pool_id,
+        _usdc_pool_id,
+        _pool_id,
+        registry_id,
+    ) = setup_btc_usd_deepbook_margin();
+
+    let btc_price = build_btc_price_info_object_pro(&mut scenario, 100000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<BTC, USDC>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+
+    margin_manager_pro::deposit<BTC, USDC, USDC>(
+        &mut mm,
+        &registry,
+        &btc_price,
+        &usdc_price,
+        mint_coin<USDC>(100_000 * test_constants::usdc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+
+    assert!(mm.quote_balance() == 100_000 * test_constants::usdc_multiplier());
+
+    return_shared_2!(mm, pool);
+    destroy_2!(btc_price, usdc_price);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+/// Borrows base through the Pro entrypoint, then reads the position back through the
+/// Pro `risk_ratio`, `manager_state` and `manager_states` views.
+#[test]
+fun borrow_base_pro_and_pro_views_agree() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        btc_pool_id,
+        _usdc_pool_id,
+        _pool_id,
+        registry_id,
+    ) = setup_btc_usd_deepbook_margin();
+
+    let btc_price = build_btc_price_info_object_pro(&mut scenario, 100000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<BTC, USDC>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
+    let usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(_usdc_pool_id);
+
+    margin_manager_pro::deposit<BTC, USDC, USDC>(
+        &mut mm,
+        &registry,
+        &btc_price,
+        &usdc_price,
+        mint_coin<USDC>(100_000 * test_constants::usdc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+
+    margin_manager_pro::borrow_base<BTC, USDC>(
+        &mut mm,
+        &registry,
+        &mut btc_pool,
+        &btc_price,
+        &usdc_price,
+        &pool,
+        1 * btc_multiplier(),
+        &clock,
+        scenario.ctx(),
+    );
+    assert!(mm.borrowed_base_shares() > 0);
+
+    // Pro views must return a real ratio, not the debt-free MAX short-circuit.
+    let ratio = margin_manager_pro::risk_ratio<BTC, USDC>(
+        &mm,
+        &registry,
+        &btc_price,
+        &usdc_price,
+        &pool,
+        &btc_pool,
+        &usdc_pool,
+        &clock,
+    );
+    assert!(ratio > 0 && ratio < margin_constants::max_risk_ratio());
+
+    let ratio_unsafe = margin_manager_pro::risk_ratio_unsafe<BTC, USDC>(
+        &mm,
+        &registry,
+        &btc_price,
+        &usdc_price,
+        &pool,
+        &btc_pool,
+        &usdc_pool,
+        &clock,
+    );
+    assert!(ratio_unsafe == ratio);
+
+    let (_, _, state_ratio, _, _, _, _, _, _, _, _, _, _, _) = margin_manager_pro::manager_state<
+        BTC,
+        USDC,
+    >(&mm, &registry, &btc_price, &usdc_price, &pool, &btc_pool, &usdc_pool, &clock);
+    assert!(state_ratio == ratio);
+
+    // `MarginManager` has no `drop`, so the batch input is built and destroyed
+    // explicitly. An empty batch still exercises the delegation into the shared core.
+    let managers = vector<MarginManager<BTC, USDC>>[];
+    let (ids, _, ratios, _, _, _, _, _, _, _, _, _, _, _) = margin_manager_pro::manager_states<
+        BTC,
+        USDC,
+    >(
+        &managers,
+        &registry,
+        &btc_price,
+        &usdc_price,
+        &pool,
+        &btc_pool,
+        &usdc_pool,
+        &clock,
+    );
+    assert!(ids.is_empty() && ratios.is_empty());
+    managers.destroy_empty();
+
+    test::return_shared(btc_pool);
+    test::return_shared(usdc_pool);
+    return_shared_2!(mm, pool);
+    destroy_2!(btc_price, usdc_price);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+/// A debt-free manager must be able to withdraw with a stale Pro feed: the risk check
+/// does not run, so no price is needed. Pins the lazy-read fix on the Pro path.
+#[test]
+fun withdraw_pro_no_debt_tolerates_stale_feed() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        btc_pool_id,
+        usdc_pool_id,
+        _pool_id,
+        registry_id,
+    ) = setup_btc_usd_deepbook_margin();
+
+    let btc_price = build_btc_price_info_object_pro(&mut scenario, 100000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<BTC, USDC>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
+    let usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+
+    margin_manager_pro::deposit<BTC, USDC, USDC>(
+        &mut mm,
+        &registry,
+        &btc_price,
+        &usdc_price,
+        mint_coin<USDC>(100_000 * test_constants::usdc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+
+    // Both feeds far beyond max_age_secs; no debt, so no validated read happens.
+    let stale_btc = build_stale_btc_price_info_object_pro(&mut scenario, 100000, 600, &clock);
+    let stale_usdc = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+
+    let coin = margin_manager_pro::withdraw<BTC, USDC, USDC>(
+        &mut mm,
+        &registry,
+        &btc_pool,
+        &usdc_pool,
+        &stale_btc,
+        &stale_usdc,
+        &pool,
+        1_000 * test_constants::usdc_multiplier(),
+        &clock,
+        scenario.ctx(),
+    );
+    assert!(coin.value() == 1_000 * test_constants::usdc_multiplier());
+
+    sui::coin::burn_for_testing(coin);
+    test::return_shared(btc_pool);
+    test::return_shared(usdc_pool);
+    return_shared_2!(mm, pool);
+    destroy_2!(btc_price, usdc_price);
+    destroy_2!(stale_btc, stale_usdc);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+/// A debt-free manager's Pro `risk_ratio` view returns MAX without touching the feed.
+#[test]
+fun risk_ratio_pro_no_debt_returns_max_with_stale_feed() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        btc_pool_id,
+        usdc_pool_id,
+        _pool_id,
+        registry_id,
+    ) = setup_btc_usd_deepbook_margin();
+
+    let stale_btc = build_stale_btc_price_info_object_pro(&mut scenario, 100000, 600, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<BTC, USDC>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
+    let usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+
+    let ratio = margin_manager_pro::risk_ratio<BTC, USDC>(
+        &mm,
+        &registry,
+        &stale_btc,
+        &usdc_price,
+        &pool,
+        &btc_pool,
+        &usdc_pool,
+        &clock,
+    );
+    assert!(ratio == margin_constants::max_risk_ratio());
+
+    let ratio_unsafe = margin_manager_pro::risk_ratio_unsafe<BTC, USDC>(
+        &mm,
+        &registry,
+        &stale_btc,
+        &usdc_price,
+        &pool,
+        &btc_pool,
+        &usdc_pool,
+        &clock,
+    );
+    assert!(ratio_unsafe == margin_constants::max_risk_ratio());
+
+    test::return_shared(btc_pool);
+    test::return_shared(usdc_pool);
+    return_shared_2!(mm, pool);
+    destroy_2!(stale_btc, usdc_price);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+/// Borrows quote through the Pro entrypoint. Mirrors `borrow_base_pro`, on the other
+/// side of the pair, so a base/quote transposition in either wrapper is caught.
+#[test]
+fun borrow_quote_pro_takes_a_loan() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        _btc_pool_id,
+        usdc_pool_id,
+        _pool_id,
+        registry_id,
+    ) = setup_btc_usd_deepbook_margin();
+
+    let btc_price = build_btc_price_info_object_pro(&mut scenario, 100000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<BTC, USDC>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+
+    margin_manager_pro::deposit<BTC, USDC, USDC>(
+        &mut mm,
+        &registry,
+        &btc_price,
+        &usdc_price,
+        mint_coin<USDC>(100_000 * test_constants::usdc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+
+    margin_manager_pro::borrow_quote<BTC, USDC>(
+        &mut mm,
+        &registry,
+        &mut usdc_pool,
+        &btc_price,
+        &usdc_price,
+        &pool,
+        10_000 * test_constants::usdc_multiplier(),
+        &clock,
+        scenario.ctx(),
+    );
+    assert!(mm.borrowed_quote_shares() > 0);
+
+    test::return_shared(usdc_pool);
+    return_shared_2!(mm, pool);
+    destroy_2!(btc_price, usdc_price);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}

--- a/packages/deepbook_margin/tests/margin_manager_pro_tests.move
+++ b/packages/deepbook_margin/tests/margin_manager_pro_tests.move
@@ -24,6 +24,7 @@ use deepbook_margin::{
         mint_coin,
         build_demo_usdc_price_info_object_pro,
         build_btc_price_info_object_pro,
+        build_wide_conf_btc_price_info_object_pro,
         build_stale_btc_price_info_object_pro,
         setup_btc_usd_deepbook_margin,
         return_shared_2,
@@ -142,7 +143,10 @@ fun borrow_base_pro_and_pro_views_agree() {
     );
     assert!(mm.borrowed_base_shares() > 0);
 
-    // Pro views must return a real ratio, not the debt-free MAX short-circuit.
+    // Pro views must return a real ratio, not the debt-free MAX short-circuit, and it
+    // must be the *right* ratio: $100k USDC collateral plus the 1 BTC drawn at $100k
+    // is $200k of assets against $100k of debt, exactly 2.0. A range assertion would
+    // sit still while the two feeds were transposed; this does not.
     let ratio = margin_manager_pro::risk_ratio<BTC, USDC>(
         &mm,
         &registry,
@@ -153,7 +157,7 @@ fun borrow_base_pro_and_pro_views_agree() {
         &usdc_pool,
         &clock,
     );
-    assert!(ratio > 0 && ratio < margin_constants::max_risk_ratio());
+    assert!(ratio == 2_000_000_000);
 
     let ratio_unsafe = margin_manager_pro::risk_ratio_unsafe<BTC, USDC>(
         &mm,
@@ -612,5 +616,140 @@ fun add_conditional_order_pro_registers_the_order() {
 
     return_shared_2!(mm, pool);
     destroy_2!(btc_price, usdc_price);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+/// `deposit` prices the collateral event through the *validated* reader, exactly as
+/// the legacy entry does. Depositing base with a stale base feed must therefore abort.
+///
+/// This is the pin for a regression that already happened once: swapping this reader
+/// for `read_price_pro_unsafe` silently drops staleness, feed-id and EWMA enforcement
+/// from every deposit, and without this test nothing in the suite notices.
+#[test, expected_failure(abort_code = pyth_pro::pyth::E_STALE_PRICE_UPDATE)]
+fun deposit_pro_rejects_stale_feed() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        _btc_pool_id,
+        _usdc_pool_id,
+        _pool_id,
+        registry_id,
+    ) = setup_btc_usd_deepbook_margin();
+
+    let btc_price = build_btc_price_info_object_pro(&mut scenario, 100000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<BTC, USDC>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+
+    let stale_btc = build_stale_btc_price_info_object_pro(&mut scenario, 100000, 600, &clock);
+    margin_manager_pro::deposit<BTC, USDC, BTC>(
+        &mut mm,
+        &registry,
+        &stale_btc,
+        &usdc_price,
+        mint_coin<BTC>(1 * btc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+
+    return_shared_2!(mm, pool);
+    destroy_2!(btc_price, usdc_price);
+    std::unit_test::destroy(stale_btc);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+/// A withdrawal's collateral event is priced through the *unvalidated* reader, whose
+/// `PythReading` carries no confidence bound. An arbitrarily wide interval must
+/// therefore still emit rather than abort - the bound is a pricing guard, and the
+/// event is telemetry. Routing this through the validated reader would break
+/// withdrawals whenever a feed widened.
+#[test]
+fun withdraw_pro_with_wide_confidence_still_emits() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        btc_pool_id,
+        usdc_pool_id,
+        _pool_id,
+        registry_id,
+    ) = setup_btc_usd_deepbook_margin();
+
+    let btc_price = build_btc_price_info_object_pro(&mut scenario, 100000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<BTC, USDC>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
+    let usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+
+    margin_manager_pro::deposit<BTC, USDC, USDC>(
+        &mut mm,
+        &registry,
+        &btc_price,
+        &usdc_price,
+        mint_coin<USDC>(100_000 * test_constants::usdc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+
+    // 50% of the price, far outside any sane `max_conf_bps`.
+    let wide_btc = build_wide_conf_btc_price_info_object_pro(
+        &mut scenario,
+        100000,
+        50000 * test_constants::pyth_multiplier(),
+        &clock,
+    );
+
+    let coin = margin_manager_pro::withdraw<BTC, USDC, USDC>(
+        &mut mm,
+        &registry,
+        &btc_pool,
+        &usdc_pool,
+        &wide_btc,
+        &usdc_price,
+        &pool,
+        1_000 * test_constants::usdc_multiplier(),
+        &clock,
+        scenario.ctx(),
+    );
+    assert!(coin.value() == 1_000 * test_constants::usdc_multiplier());
+
+    sui::coin::burn_for_testing(coin);
+    test::return_shared(btc_pool);
+    test::return_shared(usdc_pool);
+    return_shared_2!(mm, pool);
+    destroy_2!(btc_price, usdc_price);
+    std::unit_test::destroy(wide_btc);
     cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
 }

--- a/packages/deepbook_margin/tests/margin_manager_pro_tests.move
+++ b/packages/deepbook_margin/tests/margin_manager_pro_tests.move
@@ -26,6 +26,7 @@ use deepbook_margin::{
         build_btc_price_info_object_pro,
         build_wide_conf_btc_price_info_object_pro,
         build_stale_btc_price_info_object_pro,
+        build_stale_usdc_price_info_object_pro,
         setup_btc_usd_deepbook_margin,
         return_shared_2,
         destroy_2,
@@ -249,9 +250,10 @@ fun withdraw_pro_no_debt_tolerates_stale_feed() {
         scenario.ctx(),
     );
 
-    // Both feeds far beyond max_age_secs; no debt, so no validated read happens.
+    // Both feeds genuinely beyond max_age_secs; no debt, so neither is read. A fresh
+    // second leg here would let that leg's read be hoisted back out unnoticed.
     let stale_btc = build_stale_btc_price_info_object_pro(&mut scenario, 100000, 600, &clock);
-    let stale_usdc = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+    let stale_usdc = build_stale_usdc_price_info_object_pro(&mut scenario, 600, &clock);
 
     let coin = margin_manager_pro::withdraw<BTC, USDC, USDC>(
         &mut mm,
@@ -751,5 +753,808 @@ fun withdraw_pro_with_wide_confidence_still_emits() {
     return_shared_2!(mm, pool);
     destroy_2!(btc_price, usdc_price);
     std::unit_test::destroy(wide_btc);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+// === `withdraw` with debt: the solvency gate on the Pro path ===
+// Both shipped Pro withdraw tests deposit and never borrow, so `withdraw_needs_risk_check`
+// is false and the entire risk branch - the gate deciding whether value may leave a
+// leveraged manager - never executes. These three run it, either side of the floor.
+
+#[test]
+fun withdraw_pro_with_debt_succeeds_within_the_ratio() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        btc_pool_id,
+        usdc_pool_id,
+        _pool_id,
+        registry_id,
+    ) = setup_btc_usd_deepbook_margin();
+
+    let btc_price = build_btc_price_info_object_pro(&mut scenario, 100000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<BTC, USDC>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
+    let usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+
+    // $100k USDC collateral, then draw 0.5 BTC ($50k): $150k of assets against $50k of
+    // debt, a ratio of 3.0. `min_withdraw_risk_ratio` is 2.0, so there is real room
+    // both above and below it - drawing a full 1 BTC would sit exactly on the floor and
+    // every withdrawal, however small, would abort.
+    margin_manager_pro::deposit<BTC, USDC, USDC>(
+        &mut mm,
+        &registry,
+        &btc_price,
+        &usdc_price,
+        mint_coin<USDC>(100_000 * test_constants::usdc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    margin_manager_pro::borrow_base<BTC, USDC>(
+        &mut mm,
+        &registry,
+        &mut btc_pool,
+        &btc_price,
+        &usdc_price,
+        &pool,
+        btc_multiplier() / 2,
+        &clock,
+        scenario.ctx(),
+    );
+
+    let coin = margin_manager_pro::withdraw<BTC, USDC, USDC>(
+        &mut mm,
+        &registry,
+        &btc_pool,
+        &usdc_pool,
+        &btc_price,
+        &usdc_price,
+        &pool,
+        10_000 * test_constants::usdc_multiplier(),
+        &clock,
+        scenario.ctx(),
+    );
+    assert!(coin.value() == 10_000 * test_constants::usdc_multiplier());
+
+    // $140k of assets over $50k of debt.
+    let ratio = margin_manager_pro::risk_ratio<BTC, USDC>(
+        &mm,
+        &registry,
+        &btc_price,
+        &usdc_price,
+        &pool,
+        &btc_pool,
+        &usdc_pool,
+        &clock,
+    );
+    assert!(ratio == 2_800_000_000);
+
+    sui::coin::burn_for_testing(coin);
+    test::return_shared(btc_pool);
+    test::return_shared(usdc_pool);
+    return_shared_2!(mm, pool);
+    destroy_2!(btc_price, usdc_price);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+#[test, expected_failure(abort_code = deepbook_margin::margin_manager::EWithdrawRiskRatioExceeded)]
+fun withdraw_pro_with_debt_rejects_an_unsafe_withdrawal() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        btc_pool_id,
+        usdc_pool_id,
+        _pool_id,
+        registry_id,
+    ) = setup_btc_usd_deepbook_margin();
+
+    let btc_price = build_btc_price_info_object_pro(&mut scenario, 100000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<BTC, USDC>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
+    let usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+
+    // $100k USDC collateral, then draw 0.5 BTC ($50k): $150k of assets against $50k of
+    // debt, a ratio of 3.0. `min_withdraw_risk_ratio` is 2.0, so there is real room
+    // both above and below it - drawing a full 1 BTC would sit exactly on the floor and
+    // every withdrawal, however small, would abort.
+    margin_manager_pro::deposit<BTC, USDC, USDC>(
+        &mut mm,
+        &registry,
+        &btc_price,
+        &usdc_price,
+        mint_coin<USDC>(100_000 * test_constants::usdc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    margin_manager_pro::borrow_base<BTC, USDC>(
+        &mut mm,
+        &registry,
+        &mut btc_pool,
+        &btc_price,
+        &usdc_price,
+        &pool,
+        btc_multiplier() / 2,
+        &clock,
+        scenario.ctx(),
+    );
+
+    // Would leave $90k of assets against $50k of debt - a ratio of 1.8, under the 2.0 floor.
+    let coin = margin_manager_pro::withdraw<BTC, USDC, USDC>(
+        &mut mm,
+        &registry,
+        &btc_pool,
+        &usdc_pool,
+        &btc_price,
+        &usdc_price,
+        &pool,
+        60_000 * test_constants::usdc_multiplier(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    sui::coin::burn_for_testing(coin);
+    test::return_shared(btc_pool);
+    test::return_shared(usdc_pool);
+    return_shared_2!(mm, pool);
+    destroy_2!(btc_price, usdc_price);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+#[test, expected_failure(abort_code = pyth_pro::pyth::E_STALE_PRICE_UPDATE)]
+fun withdraw_pro_with_debt_rejects_stale_feed() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        btc_pool_id,
+        usdc_pool_id,
+        _pool_id,
+        registry_id,
+    ) = setup_btc_usd_deepbook_margin();
+
+    let btc_price = build_btc_price_info_object_pro(&mut scenario, 100000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<BTC, USDC>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
+    let usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+
+    // $100k USDC collateral, then draw 0.5 BTC ($50k): $150k of assets against $50k of
+    // debt, a ratio of 3.0. `min_withdraw_risk_ratio` is 2.0, so there is real room
+    // both above and below it - drawing a full 1 BTC would sit exactly on the floor and
+    // every withdrawal, however small, would abort.
+    margin_manager_pro::deposit<BTC, USDC, USDC>(
+        &mut mm,
+        &registry,
+        &btc_price,
+        &usdc_price,
+        mint_coin<USDC>(100_000 * test_constants::usdc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    margin_manager_pro::borrow_base<BTC, USDC>(
+        &mut mm,
+        &registry,
+        &mut btc_pool,
+        &btc_price,
+        &usdc_price,
+        &pool,
+        btc_multiplier() / 2,
+        &clock,
+        scenario.ctx(),
+    );
+
+    let stale_btc = build_stale_btc_price_info_object_pro(&mut scenario, 100000, 600, &clock);
+    let coin = margin_manager_pro::withdraw<BTC, USDC, USDC>(
+        &mut mm,
+        &registry,
+        &btc_pool,
+        &usdc_pool,
+        &stale_btc,
+        &usdc_price,
+        &pool,
+        10_000 * test_constants::usdc_multiplier(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    sui::coin::burn_for_testing(coin);
+    std::unit_test::destroy(stale_btc);
+    test::return_shared(btc_pool);
+    test::return_shared(usdc_pool);
+    return_shared_2!(mm, pool);
+    destroy_2!(btc_price, usdc_price);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+// === Reader-choice pins for the remaining Pro entrypoints ===
+// Each of these reads the oracle unconditionally through the *validated* reader. With
+// no test standing on that choice, swapping in `read_price_pro_unsafe` silently drops
+// staleness, EWMA-divergence and confidence enforcement and leaves CI green - on
+// `liquidate`, that is enough to seize collateral at an arbitrarily old price. One
+// stale-feed rejection per entrypoint closes it.
+
+#[test, expected_failure(abort_code = pyth_pro::pyth::E_STALE_PRICE_UPDATE)]
+fun risk_ratio_pro_with_debt_rejects_stale_feed() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        btc_pool_id,
+        usdc_pool_id,
+        _pool_id,
+        registry_id,
+    ) = setup_btc_usd_deepbook_margin();
+
+    let btc_price = build_btc_price_info_object_pro(&mut scenario, 100000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<BTC, USDC>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
+    let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+
+    margin_manager_pro::deposit<BTC, USDC, USDC>(
+        &mut mm,
+        &registry,
+        &btc_price,
+        &usdc_price,
+        mint_coin<USDC>(100_000 * test_constants::usdc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    margin_manager_pro::borrow_base<BTC, USDC>(
+        &mut mm,
+        &registry,
+        &mut btc_pool,
+        &btc_price,
+        &usdc_price,
+        &pool,
+        btc_multiplier() / 2,
+        &clock,
+        scenario.ctx(),
+    );
+
+    let stale_btc = build_stale_btc_price_info_object_pro(&mut scenario, 100000, 600, &clock);
+
+    let _ = margin_manager_pro::risk_ratio<BTC, USDC>(
+        &mm,
+        &registry,
+        &stale_btc,
+        &usdc_price,
+        &pool,
+        &btc_pool,
+        &usdc_pool,
+        &clock,
+    );
+
+    test::return_shared(btc_pool);
+    test::return_shared(usdc_pool);
+    return_shared_2!(mm, pool);
+    destroy_2!(btc_price, usdc_price);
+    std::unit_test::destroy(stale_btc);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+#[test, expected_failure(abort_code = pyth_pro::pyth::E_STALE_PRICE_UPDATE)]
+fun borrow_base_pro_rejects_stale_feed() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        btc_pool_id,
+        usdc_pool_id,
+        _pool_id,
+        registry_id,
+    ) = setup_btc_usd_deepbook_margin();
+
+    let btc_price = build_btc_price_info_object_pro(&mut scenario, 100000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<BTC, USDC>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
+    let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+
+    margin_manager_pro::deposit<BTC, USDC, USDC>(
+        &mut mm,
+        &registry,
+        &btc_price,
+        &usdc_price,
+        mint_coin<USDC>(100_000 * test_constants::usdc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    margin_manager_pro::borrow_base<BTC, USDC>(
+        &mut mm,
+        &registry,
+        &mut btc_pool,
+        &btc_price,
+        &usdc_price,
+        &pool,
+        btc_multiplier() / 2,
+        &clock,
+        scenario.ctx(),
+    );
+
+    let stale_btc = build_stale_btc_price_info_object_pro(&mut scenario, 100000, 600, &clock);
+
+    margin_manager_pro::borrow_base<BTC, USDC>(
+        &mut mm,
+        &registry,
+        &mut btc_pool,
+        &stale_btc,
+        &usdc_price,
+        &pool,
+        btc_multiplier() / 10,
+        &clock,
+        scenario.ctx(),
+    );
+
+    test::return_shared(btc_pool);
+    test::return_shared(usdc_pool);
+    return_shared_2!(mm, pool);
+    destroy_2!(btc_price, usdc_price);
+    std::unit_test::destroy(stale_btc);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+#[test, expected_failure(abort_code = pyth_pro::pyth::E_STALE_PRICE_UPDATE)]
+fun borrow_quote_pro_rejects_stale_feed() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        btc_pool_id,
+        usdc_pool_id,
+        _pool_id,
+        registry_id,
+    ) = setup_btc_usd_deepbook_margin();
+
+    let btc_price = build_btc_price_info_object_pro(&mut scenario, 100000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<BTC, USDC>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
+    let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+
+    margin_manager_pro::deposit<BTC, USDC, USDC>(
+        &mut mm,
+        &registry,
+        &btc_price,
+        &usdc_price,
+        mint_coin<USDC>(100_000 * test_constants::usdc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    margin_manager_pro::borrow_base<BTC, USDC>(
+        &mut mm,
+        &registry,
+        &mut btc_pool,
+        &btc_price,
+        &usdc_price,
+        &pool,
+        btc_multiplier() / 2,
+        &clock,
+        scenario.ctx(),
+    );
+
+    let stale_btc = build_stale_btc_price_info_object_pro(&mut scenario, 100000, 600, &clock);
+
+    margin_manager_pro::borrow_quote<BTC, USDC>(
+        &mut mm,
+        &registry,
+        &mut usdc_pool,
+        &stale_btc,
+        &usdc_price,
+        &pool,
+        1_000 * test_constants::usdc_multiplier(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    test::return_shared(btc_pool);
+    test::return_shared(usdc_pool);
+    return_shared_2!(mm, pool);
+    destroy_2!(btc_price, usdc_price);
+    std::unit_test::destroy(stale_btc);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+#[test, expected_failure(abort_code = pyth_pro::pyth::E_STALE_PRICE_UPDATE)]
+fun liquidate_pro_rejects_stale_feed() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        btc_pool_id,
+        usdc_pool_id,
+        _pool_id,
+        registry_id,
+    ) = setup_btc_usd_deepbook_margin();
+
+    let btc_price = build_btc_price_info_object_pro(&mut scenario, 100000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<BTC, USDC>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
+    let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+
+    margin_manager_pro::deposit<BTC, USDC, USDC>(
+        &mut mm,
+        &registry,
+        &btc_price,
+        &usdc_price,
+        mint_coin<USDC>(100_000 * test_constants::usdc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    margin_manager_pro::borrow_base<BTC, USDC>(
+        &mut mm,
+        &registry,
+        &mut btc_pool,
+        &btc_price,
+        &usdc_price,
+        &pool,
+        btc_multiplier() / 2,
+        &clock,
+        scenario.ctx(),
+    );
+
+    let stale_btc = build_stale_btc_price_info_object_pro(&mut scenario, 100000, 600, &clock);
+
+    // The read happens before the health check, so a healthy manager still aborts on
+    // staleness rather than on `ECannotLiquidate`.
+    let (b, q, r) = margin_manager_pro::liquidate<BTC, USDC, USDC>(
+        &mut mm,
+        &registry,
+        &stale_btc,
+        &usdc_price,
+        &mut usdc_pool,
+        &mut pool,
+        mint_coin<USDC>(1_000 * test_constants::usdc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    sui::coin::burn_for_testing(b);
+    sui::coin::burn_for_testing(q);
+    sui::coin::burn_for_testing(r);
+
+    test::return_shared(btc_pool);
+    test::return_shared(usdc_pool);
+    return_shared_2!(mm, pool);
+    destroy_2!(btc_price, usdc_price);
+    std::unit_test::destroy(stale_btc);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+#[test, expected_failure(abort_code = pyth_pro::pyth::E_STALE_PRICE_UPDATE)]
+fun execute_conditional_orders_v2_pro_rejects_stale_feed() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        btc_pool_id,
+        usdc_pool_id,
+        _pool_id,
+        registry_id,
+    ) = setup_btc_usd_deepbook_margin();
+
+    let btc_price = build_btc_price_info_object_pro(&mut scenario, 100000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<BTC, USDC>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
+    let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+
+    margin_manager_pro::deposit<BTC, USDC, USDC>(
+        &mut mm,
+        &registry,
+        &btc_price,
+        &usdc_price,
+        mint_coin<USDC>(100_000 * test_constants::usdc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    margin_manager_pro::borrow_base<BTC, USDC>(
+        &mut mm,
+        &registry,
+        &mut btc_pool,
+        &btc_price,
+        &usdc_price,
+        &pool,
+        btc_multiplier() / 2,
+        &clock,
+        scenario.ctx(),
+    );
+
+    let stale_btc = build_stale_btc_price_info_object_pro(&mut scenario, 100000, 600, &clock);
+
+    let v2: vector<OrderInfo> = margin_manager_pro::execute_conditional_orders_v2<BTC, USDC>(
+        &mut mm,
+        &mut pool,
+        &btc_pool,
+        &usdc_pool,
+        &stale_btc,
+        &usdc_price,
+        &registry,
+        10,
+        &clock,
+        scenario.ctx(),
+    );
+    assert!(v2.is_empty());
+
+    test::return_shared(btc_pool);
+    test::return_shared(usdc_pool);
+    return_shared_2!(mm, pool);
+    destroy_2!(btc_price, usdc_price);
+    std::unit_test::destroy(stale_btc);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+#[test, expected_failure(abort_code = pyth_pro::pyth::E_STALE_PRICE_UPDATE)]
+fun execute_conditional_orders_v3_pro_rejects_stale_feed() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        btc_pool_id,
+        usdc_pool_id,
+        _pool_id,
+        registry_id,
+    ) = setup_btc_usd_deepbook_margin();
+
+    let btc_price = build_btc_price_info_object_pro(&mut scenario, 100000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<BTC, USDC>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
+    let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+
+    margin_manager_pro::deposit<BTC, USDC, USDC>(
+        &mut mm,
+        &registry,
+        &btc_price,
+        &usdc_price,
+        mint_coin<USDC>(100_000 * test_constants::usdc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    margin_manager_pro::borrow_base<BTC, USDC>(
+        &mut mm,
+        &registry,
+        &mut btc_pool,
+        &btc_price,
+        &usdc_price,
+        &pool,
+        btc_multiplier() / 2,
+        &clock,
+        scenario.ctx(),
+    );
+
+    let stale_btc = build_stale_btc_price_info_object_pro(&mut scenario, 100000, 600, &clock);
+
+    let v3: vector<OrderInfo> = margin_manager_pro::execute_conditional_orders_v3<BTC, USDC>(
+        &mut mm,
+        &mut pool,
+        &mut btc_pool,
+        &mut usdc_pool,
+        &stale_btc,
+        &usdc_price,
+        &registry,
+        10,
+        &clock,
+        scenario.ctx(),
+    );
+    assert!(v3.is_empty());
+
+    test::return_shared(btc_pool);
+    test::return_shared(usdc_pool);
+    return_shared_2!(mm, pool);
+    destroy_2!(btc_price, usdc_price);
+    std::unit_test::destroy(stale_btc);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+#[test, expected_failure(abort_code = pyth_pro::pyth::E_STALE_PRICE_UPDATE)]
+fun add_conditional_order_pro_rejects_stale_feed() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        _btc_pool_id,
+        _usdc_pool_id,
+        _pool_id,
+        registry_id,
+    ) = setup_btc_usd_deepbook_margin();
+
+    let btc_price = build_btc_price_info_object_pro(&mut scenario, 100000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<BTC, USDC>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+
+    let condition = tpsl::new_condition(true, 90_000_000_000);
+    let pending_order = tpsl::new_pending_limit_order(
+        1,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        100_000_000_000,
+        1 * btc_multiplier(),
+        false,
+        false,
+        constants::max_u64(),
+    );
+
+    let stale_btc = build_stale_btc_price_info_object_pro(&mut scenario, 100000, 600, &clock);
+    margin_manager_pro::add_conditional_order<BTC, USDC>(
+        &mut mm,
+        &pool,
+        &stale_btc,
+        &usdc_price,
+        &registry,
+        1,
+        condition,
+        pending_order,
+        &clock,
+        scenario.ctx(),
+    );
+
+    std::unit_test::destroy(stale_btc);
+    return_shared_2!(mm, pool);
+    destroy_2!(btc_price, usdc_price);
     cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
 }

--- a/packages/deepbook_margin/tests/margin_manager_pro_tests.move
+++ b/packages/deepbook_margin/tests/margin_manager_pro_tests.move
@@ -11,7 +11,7 @@
 #[test_only]
 module deepbook_margin::margin_manager_pro_tests;
 
-use deepbook::{pool::Pool, registry::Registry};
+use deepbook::{constants, order_info::OrderInfo, pool::Pool, registry::Registry};
 use deepbook_margin::{
     margin_constants,
     margin_manager::{Self, MarginManager},
@@ -28,7 +28,8 @@ use deepbook_margin::{
         setup_btc_usd_deepbook_margin,
         return_shared_2,
         destroy_2,
-    }
+    },
+    tpsl
 };
 use sui::test_scenario::{Self as test, return_shared};
 
@@ -396,6 +397,219 @@ fun borrow_quote_pro_takes_a_loan() {
     assert!(mm.borrowed_quote_shares() > 0);
 
     test::return_shared(usdc_pool);
+    return_shared_2!(mm, pool);
+    destroy_2!(btc_price, usdc_price);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+/// A healthy manager cannot be liquidated. Asserts the Pro `liquidate` reaches the
+/// shared core's solvency gate rather than some other path.
+#[test, expected_failure(abort_code = deepbook_margin::margin_manager::ECannotLiquidate)]
+fun liquidate_pro_rejects_a_healthy_manager() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        _btc_pool_id,
+        usdc_pool_id,
+        _pool_id,
+        registry_id,
+    ) = setup_btc_usd_deepbook_margin();
+
+    let btc_price = build_btc_price_info_object_pro(&mut scenario, 100000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<BTC, USDC>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+
+    margin_manager_pro::deposit<BTC, USDC, USDC>(
+        &mut mm,
+        &registry,
+        &btc_price,
+        &usdc_price,
+        mint_coin<USDC>(100_000 * test_constants::usdc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    margin_manager_pro::borrow_quote<BTC, USDC>(
+        &mut mm,
+        &registry,
+        &mut usdc_pool,
+        &btc_price,
+        &usdc_price,
+        &pool,
+        10_000 * test_constants::usdc_multiplier(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    let (b, q, r) = margin_manager_pro::liquidate<BTC, USDC, USDC>(
+        &mut mm,
+        &registry,
+        &btc_price,
+        &usdc_price,
+        &mut usdc_pool,
+        &mut pool,
+        mint_coin<USDC>(1_000 * test_constants::usdc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+
+    sui::coin::burn_for_testing(b);
+    sui::coin::burn_for_testing(q);
+    sui::coin::burn_for_testing(r);
+    test::return_shared(usdc_pool);
+    return_shared_2!(mm, pool);
+    destroy_2!(btc_price, usdc_price);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+/// With no conditional orders registered, both Pro executors return an empty batch.
+/// Exercises the delegation into the shared cores for v2 and v3.
+#[test]
+fun execute_conditional_orders_pro_with_no_orders_returns_empty() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        btc_pool_id,
+        usdc_pool_id,
+        _pool_id,
+        registry_id,
+    ) = setup_btc_usd_deepbook_margin();
+
+    let btc_price = build_btc_price_info_object_pro(&mut scenario, 100000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<BTC, USDC>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
+    let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+
+    let v2: vector<OrderInfo> = margin_manager_pro::execute_conditional_orders_v2<BTC, USDC>(
+        &mut mm,
+        &mut pool,
+        &btc_pool,
+        &usdc_pool,
+        &btc_price,
+        &usdc_price,
+        &registry,
+        10,
+        &clock,
+        scenario.ctx(),
+    );
+    assert!(v2.is_empty());
+
+    let v3: vector<OrderInfo> = margin_manager_pro::execute_conditional_orders_v3<BTC, USDC>(
+        &mut mm,
+        &mut pool,
+        &mut btc_pool,
+        &mut usdc_pool,
+        &btc_price,
+        &usdc_price,
+        &registry,
+        10,
+        &clock,
+        scenario.ctx(),
+    );
+    assert!(v3.is_empty());
+
+    test::return_shared(btc_pool);
+    test::return_shared(usdc_pool);
+    return_shared_2!(mm, pool);
+    destroy_2!(btc_price, usdc_price);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+/// Registers a conditional order through the Pro entrypoint and reads it back.
+#[test]
+fun add_conditional_order_pro_registers_the_order() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        _btc_pool_id,
+        _usdc_pool_id,
+        _pool_id,
+        registry_id,
+    ) = setup_btc_usd_deepbook_margin();
+
+    let btc_price = build_btc_price_info_object_pro(&mut scenario, 100000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<BTC, USDC>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+
+    let condition = tpsl::new_condition(true, 90_000_000_000);
+    let pending_order = tpsl::new_pending_limit_order(
+        1,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        100_000_000_000,
+        1 * btc_multiplier(),
+        false,
+        false,
+        constants::max_u64(),
+    );
+
+    margin_manager_pro::add_conditional_order<BTC, USDC>(
+        &mut mm,
+        &pool,
+        &btc_price,
+        &usdc_price,
+        &registry,
+        1,
+        condition,
+        pending_order,
+        &clock,
+        scenario.ctx(),
+    );
+
+    assert!(mm.conditional_order_ids().length() == 1);
+
     return_shared_2!(mm, pool);
     destroy_2!(btc_price, usdc_price);
     cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);

--- a/packages/deepbook_margin/tests/margin_manager_tests.move
+++ b/packages/deepbook_margin/tests/margin_manager_tests.move
@@ -4688,3 +4688,83 @@ fun test_liquidate_repay_just_below_max_does_not_clear_all() {
     return_shared(mm);
     cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
 }
+
+/// `risk_ratio_unsafe` is the view the off-chain risk and liquidation paths read, and
+/// nothing exercised it with debt: readings only reach `price_config` once the manager
+/// owes something, so with a debt-free manager the whole pricing path is skipped and a
+/// transposed base/quote pair is invisible. Asserting the exact ratio pins the pairing.
+#[test]
+fun risk_ratio_unsafe_with_debt_prices_both_legs() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        btc_pool_id,
+        usdc_pool_id,
+        _pool_id,
+        registry_id,
+    ) = setup_btc_usd_deepbook_margin();
+
+    let btc_price = build_btc_price_info_object(&mut scenario, 100000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<BTC, USDC>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
+    let usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+
+    margin_manager::deposit<BTC, USDC, USDC>(
+        &mut mm,
+        &registry,
+        &btc_price,
+        &usdc_price,
+        mint_coin<USDC>(100_000 * test_constants::usdc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    margin_manager::borrow_base<BTC, USDC>(
+        &mut mm,
+        &registry,
+        &mut btc_pool,
+        &btc_price,
+        &usdc_price,
+        &pool,
+        test_constants::btc_multiplier() / 2,
+        &clock,
+        scenario.ctx(),
+    );
+
+    // $100k USDC plus the 0.5 BTC drawn at $100k is $150k of assets against $50k of
+    // debt: exactly 3.0. Transposed, BTC would price at $1 and USDC at $100k.
+    let ratio = margin_manager::risk_ratio_unsafe<BTC, USDC>(
+        &mm,
+        &registry,
+        &btc_price,
+        &usdc_price,
+        &pool,
+        &btc_pool,
+        &usdc_pool,
+        &clock,
+    );
+    assert!(ratio == 3_000_000_000);
+
+    return_shared(btc_pool);
+    return_shared(usdc_pool);
+    return_shared_2!(mm, pool);
+    destroy_2!(btc_price, usdc_price);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}

--- a/packages/deepbook_margin/tests/pool_proxy_pro_tests.move
+++ b/packages/deepbook_margin/tests/pool_proxy_pro_tests.move
@@ -1,0 +1,393 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Behavioural coverage for `pool_proxy_pro`.
+///
+/// Mirrors the legacy `pool_proxy_tests` happy paths through the Pyth Pro feed. The
+/// Pro entrypoints are a distinct Move type surface, so nothing in the legacy suite
+/// reaches them; without these, a wrong `_core` target or a downgraded reader would
+/// still compile and still pass CI.
+#[test_only]
+module deepbook_margin::pool_proxy_pro_tests;
+
+use deepbook::{constants, pool::Pool, registry::Registry};
+use deepbook_margin::{
+    margin_manager::{Self, MarginManager},
+    margin_manager_pro,
+    margin_pool::MarginPool,
+    margin_registry::MarginRegistry,
+    pool_proxy_pro,
+    test_constants::{Self, USDC, USDT},
+    test_helpers::{
+        setup_pool_proxy_test_env,
+        cleanup_margin_test,
+        mint_coin,
+        destroy_2,
+        return_shared_2,
+        build_demo_usdc_price_info_object_pro,
+        build_demo_usdt_price_info_object_pro,
+        build_stale_usdc_price_info_object_pro,
+        setup_orderbook_liquidity_stablecoin,
+    }
+};
+use std::unit_test::destroy;
+use sui::test_scenario::return_shared;
+
+/// `update_current_price` is the permissionless refresh the order-validation path
+/// depends on. Without a Pro twin, price updates would stop at the cutover.
+#[test]
+fun update_current_price_pro_refreshes_the_registry() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        _b,
+        _q,
+        pool_id,
+        _r,
+    ) = setup_pool_proxy_test_env<USDC, USDT>();
+
+    scenario.next_tx(test_constants::user1());
+    let pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_pro(&mut scenario, &clock);
+
+    pool_proxy_pro::update_current_price<USDC, USDT>(
+        &mut registry,
+        &pool,
+        &usdc_price,
+        &usdt_price,
+        &clock,
+    );
+
+    destroy_2!(usdc_price, usdt_price);
+    return_shared(pool);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+/// A debt-free manager places a limit order through the Pro entrypoint. Also pins the
+/// lazy-read fix: the feeds here are stale, and a debt-free manager must not need
+/// them, exactly as before the migration.
+#[test]
+fun place_limit_order_v2_pro_no_debt_tolerates_stale_feed() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+        registry_id,
+    ) = setup_pool_proxy_test_env<USDC, USDT>();
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<USDC, USDT>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_pro(&mut scenario, &clock);
+
+    margin_manager_pro::deposit<USDC, USDT, USDC>(
+        &mut mm,
+        &registry,
+        &usdc_price,
+        &usdt_price,
+        mint_coin<USDC>(10000 * test_constants::usdc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+
+    // Stale feeds: with no debt the solvency gate short-circuits, so no read happens.
+    let stale_usdc = build_stale_usdc_price_info_object_pro(&mut scenario, 600, &clock);
+    let stale_usdt = build_demo_usdt_price_info_object_pro(&mut scenario, &clock);
+
+    let order_info = pool_proxy_pro::place_limit_order_v2<USDC, USDT>(
+        &registry,
+        &mut mm,
+        &mut pool,
+        &base_pool,
+        &quote_pool,
+        &stale_usdc,
+        &stale_usdt,
+        1,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        1_000_000_000,
+        100 * test_constants::usdc_multiplier(),
+        false,
+        false,
+        2000000,
+        &clock,
+        scenario.ctx(),
+    );
+    destroy(order_info);
+
+    return_shared(base_pool);
+    return_shared(quote_pool);
+    destroy_2!(usdc_price, usdt_price);
+    destroy_2!(stale_usdc, stale_usdt);
+    return_shared_2!(mm, pool);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+/// Market order through the Pro entrypoint, debt-free, with a fresh feed.
+#[test]
+fun place_market_order_v2_pro_places_an_order() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+        registry_id,
+    ) = setup_pool_proxy_test_env<USDC, USDT>();
+
+    // A market order needs a resting book to cross against.
+    setup_orderbook_liquidity_stablecoin<USDC, USDT>(&mut scenario, pool_id, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<USDC, USDT>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_pro(&mut scenario, &clock);
+
+    margin_manager_pro::deposit<USDC, USDT, USDC>(
+        &mut mm,
+        &registry,
+        &usdc_price,
+        &usdt_price,
+        mint_coin<USDC>(10000 * test_constants::usdc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+
+    let order_info = pool_proxy_pro::place_market_order_v2<USDC, USDT>(
+        &registry,
+        &mut mm,
+        &mut pool,
+        &base_pool,
+        &quote_pool,
+        &usdc_price,
+        &usdt_price,
+        2,
+        constants::self_matching_allowed(),
+        50 * test_constants::usdc_multiplier(),
+        false,
+        false,
+        &clock,
+        scenario.ctx(),
+    );
+    destroy(order_info);
+
+    return_shared(base_pool);
+    return_shared(quote_pool);
+    destroy_2!(usdc_price, usdt_price);
+    return_shared_2!(mm, pool);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+/// Reduce-only limit order through the Pro entrypoint. A bid requires base debt, so
+/// these entries always read the oracle - unlike the plain v2 entries.
+#[test]
+fun place_reduce_only_limit_order_v2_pro_places_an_order() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+        registry_id,
+    ) = setup_pool_proxy_test_env<USDC, USDT>();
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<USDC, USDT>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_pro(&mut scenario, &clock);
+    let mut base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+
+    // Collateral in quote, debt in base: the shape every reduce-only bid needs.
+    margin_manager_pro::deposit<USDC, USDT, USDT>(
+        &mut mm,
+        &registry,
+        &usdc_price,
+        &usdt_price,
+        mint_coin<USDT>(10000 * test_constants::usdt_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    margin_manager_pro::borrow_base<USDC, USDT>(
+        &mut mm,
+        &registry,
+        &mut base_pool,
+        &usdc_price,
+        &usdt_price,
+        &pool,
+        500 * test_constants::usdc_multiplier(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    let order_info = pool_proxy_pro::place_reduce_only_limit_order_v2<USDC, USDT>(
+        &registry,
+        &mut mm,
+        &mut pool,
+        &base_pool,
+        &quote_pool,
+        &usdc_price,
+        &usdt_price,
+        1,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        1_000_000_000,
+        100 * test_constants::usdc_multiplier(),
+        true,
+        false,
+        2000000,
+        &clock,
+        scenario.ctx(),
+    );
+    destroy(order_info);
+
+    return_shared(base_pool);
+    return_shared(quote_pool);
+    destroy_2!(usdc_price, usdt_price);
+    return_shared_2!(mm, pool);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+/// Reduce-only market order through the Pro entrypoint. Like its legacy twin
+/// (`pool_proxy_tests::test_place_reduce_only_market_order_ok`), this is an
+/// `expected_failure`: a market close pays the spread, and the monotonic gate fires on
+/// the swap-only intermediate state before any repay. Documented in `move.md`.
+#[test, expected_failure(abort_code = deepbook_margin::pool_proxy::ERiskRatioMustNotWorsen)]
+fun place_reduce_only_market_order_v2_pro_aborts_on_worsened_ratio() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+        registry_id,
+    ) = setup_pool_proxy_test_env<USDC, USDT>();
+
+    setup_orderbook_liquidity_stablecoin<USDC, USDT>(&mut scenario, pool_id, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<USDC, USDT>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_pro(&mut scenario, &clock);
+    let mut base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+
+    // Collateral in quote, debt in base: the shape every reduce-only bid needs.
+    margin_manager_pro::deposit<USDC, USDT, USDT>(
+        &mut mm,
+        &registry,
+        &usdc_price,
+        &usdt_price,
+        mint_coin<USDT>(10000 * test_constants::usdt_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    margin_manager_pro::borrow_base<USDC, USDT>(
+        &mut mm,
+        &registry,
+        &mut base_pool,
+        &usdc_price,
+        &usdt_price,
+        &pool,
+        500 * test_constants::usdc_multiplier(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    let order_info = pool_proxy_pro::place_reduce_only_market_order_v2<USDC, USDT>(
+        &registry,
+        &mut mm,
+        &mut pool,
+        &base_pool,
+        &quote_pool,
+        &usdc_price,
+        &usdt_price,
+        2,
+        constants::self_matching_allowed(),
+        10 * test_constants::usdc_multiplier(),
+        true,
+        false,
+        &clock,
+        scenario.ctx(),
+    );
+    destroy(order_info);
+
+    return_shared(base_pool);
+    return_shared(quote_pool);
+    destroy_2!(usdc_price, usdt_price);
+    return_shared_2!(mm, pool);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}

--- a/packages/deepbook_margin/tests/pool_proxy_pro_tests.move
+++ b/packages/deepbook_margin/tests/pool_proxy_pro_tests.move
@@ -391,3 +391,257 @@ fun place_reduce_only_market_order_v2_pro_aborts_on_worsened_ratio() {
     return_shared_2!(mm, pool);
     cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
 }
+
+/// Reduce-only limit close + repay through the Pro entrypoint. A bid requires base
+/// debt, which the setup establishes.
+#[test]
+fun place_reduce_only_limit_order_and_repay_loan_pro_places_an_order() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+        registry_id,
+    ) = setup_pool_proxy_test_env<USDC, USDT>();
+
+    setup_orderbook_liquidity_stablecoin<USDC, USDT>(&mut scenario, pool_id, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<USDC, USDT>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_pro(&mut scenario, &clock);
+    let mut base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let mut quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+
+    margin_manager_pro::deposit<USDC, USDT, USDT>(
+        &mut mm,
+        &registry,
+        &usdc_price,
+        &usdt_price,
+        mint_coin<USDT>(10000 * test_constants::usdt_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    margin_manager_pro::borrow_base<USDC, USDT>(
+        &mut mm,
+        &registry,
+        &mut base_pool,
+        &usdc_price,
+        &usdt_price,
+        &pool,
+        500 * test_constants::usdc_multiplier(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    let order_info = pool_proxy_pro::place_reduce_only_limit_order_and_repay_loan<USDC, USDT>(
+        &registry,
+        &mut mm,
+        &mut pool,
+        &mut base_pool,
+        &mut quote_pool,
+        &usdc_price,
+        &usdt_price,
+        1,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        1_000_000_000,
+        100 * test_constants::usdc_multiplier(),
+        true,
+        false,
+        2000000,
+        &clock,
+        scenario.ctx(),
+    );
+    destroy(order_info);
+
+    return_shared(base_pool);
+    return_shared(quote_pool);
+    destroy_2!(usdc_price, usdt_price);
+    return_shared_2!(mm, pool);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+/// Reduce-only market close *with* the repay included. Unlike the swap-only
+/// `place_reduce_only_market_order_v2` above - which trips the monotonic gate on the
+/// spread - including the repay lifts the ratio, so this succeeds. That contrast is
+/// the behaviour `move.md` documents, and it holds on the Pro path too.
+#[test]
+fun place_reduce_only_market_order_and_repay_loan_pro_closes_and_repays() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+        registry_id,
+    ) = setup_pool_proxy_test_env<USDC, USDT>();
+
+    setup_orderbook_liquidity_stablecoin<USDC, USDT>(&mut scenario, pool_id, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<USDC, USDT>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_pro(&mut scenario, &clock);
+    let mut base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let mut quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+
+    margin_manager_pro::deposit<USDC, USDT, USDT>(
+        &mut mm,
+        &registry,
+        &usdc_price,
+        &usdt_price,
+        mint_coin<USDT>(10000 * test_constants::usdt_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    margin_manager_pro::borrow_base<USDC, USDT>(
+        &mut mm,
+        &registry,
+        &mut base_pool,
+        &usdc_price,
+        &usdt_price,
+        &pool,
+        500 * test_constants::usdc_multiplier(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    let order_info = pool_proxy_pro::place_reduce_only_market_order_and_repay_loan<USDC, USDT>(
+        &registry,
+        &mut mm,
+        &mut pool,
+        &mut base_pool,
+        &mut quote_pool,
+        &usdc_price,
+        &usdt_price,
+        2,
+        constants::self_matching_allowed(),
+        10 * test_constants::usdc_multiplier(),
+        true,
+        false,
+        &clock,
+        scenario.ctx(),
+    );
+    destroy(order_info);
+
+    return_shared(base_pool);
+    return_shared(quote_pool);
+    destroy_2!(usdc_price, usdt_price);
+    return_shared_2!(mm, pool);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+/// Non-reduce-only market close + repay through the Pro entrypoint. Shares the
+/// monotonic gate with the reduce-only entries; the repay carries it.
+#[test]
+fun place_market_order_and_repay_loan_pro_closes_and_repays() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+        registry_id,
+    ) = setup_pool_proxy_test_env<USDC, USDT>();
+
+    setup_orderbook_liquidity_stablecoin<USDC, USDT>(&mut scenario, pool_id, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<USDC, USDT>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_pro(&mut scenario, &clock);
+    let mut base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let mut quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+
+    margin_manager_pro::deposit<USDC, USDT, USDT>(
+        &mut mm,
+        &registry,
+        &usdc_price,
+        &usdt_price,
+        mint_coin<USDT>(10000 * test_constants::usdt_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    margin_manager_pro::borrow_base<USDC, USDT>(
+        &mut mm,
+        &registry,
+        &mut base_pool,
+        &usdc_price,
+        &usdt_price,
+        &pool,
+        500 * test_constants::usdc_multiplier(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    let order_info = pool_proxy_pro::place_market_order_and_repay_loan<USDC, USDT>(
+        &registry,
+        &mut mm,
+        &mut pool,
+        &mut base_pool,
+        &mut quote_pool,
+        &usdc_price,
+        &usdt_price,
+        3,
+        constants::self_matching_allowed(),
+        10 * test_constants::usdc_multiplier(),
+        true,
+        false,
+        &clock,
+        scenario.ctx(),
+    );
+    destroy(order_info);
+
+    return_shared(base_pool);
+    return_shared(quote_pool);
+    destroy_2!(usdc_price, usdt_price);
+    return_shared_2!(mm, pool);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}

--- a/packages/deepbook_margin/tests/pool_proxy_pro_tests.move
+++ b/packages/deepbook_margin/tests/pool_proxy_pro_tests.move
@@ -29,6 +29,7 @@ use deepbook_margin::{
         build_demo_usdc_price_info_object_pro,
         build_demo_usdt_price_info_object_pro,
         build_stale_usdc_price_info_object_pro,
+        build_stale_usdt_price_info_object_pro,
         setup_orderbook_liquidity_stablecoin,
     }
 };
@@ -169,9 +170,11 @@ fun place_limit_order_v2_pro_no_debt_tolerates_stale_feed() {
     let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
     let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
 
-    // Stale feeds: with no debt the solvency gate short-circuits, so no read happens.
+    // BOTH legs stale: with no debt the solvency gate short-circuits, so neither is
+    // read. Staling only one leg would leave the other's read free to be hoisted back
+    // out of the conditional unnoticed.
     let stale_usdc = build_stale_usdc_price_info_object_pro(&mut scenario, 600, &clock);
-    let stale_usdt = build_demo_usdt_price_info_object_pro(&mut scenario, &clock);
+    let stale_usdt = build_stale_usdt_price_info_object_pro(&mut scenario, 600, &clock);
 
     let order_info = pool_proxy_pro::place_limit_order_v2<USDC, USDT>(
         &registry,
@@ -993,5 +996,381 @@ fun place_market_order_and_repay_loan_pro_with_debt_rejects_stale_feed() {
     destroy_2!(usdc_price, usdt_price);
     destroy(stale_usdc);
     return_shared_2!(mm, pool);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+// === Reader-choice pins for the always-reading `pool_proxy_pro` entries ===
+// The four reduce-only entries read unconditionally - a reduce-only bid needs base
+// debt, so there is no debt-free short circuit to take. Nothing stood on their choice
+// of the validated reader, so a downgrade to `read_price_pro_unsafe` passed CI.
+
+#[test, expected_failure(abort_code = pyth_pro::pyth::E_STALE_PRICE_UPDATE)]
+fun place_reduce_only_limit_order_v2_pro_rejects_stale_feed() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+        registry_id,
+    ) = setup_pool_proxy_test_env<USDC, USDT>();
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<USDC, USDT>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_pro(&mut scenario, &clock);
+    let mut base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let mut quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+
+    // Collateral in quote, debt in base: the shape every reduce-only bid needs.
+    margin_manager_pro::deposit<USDC, USDT, USDT>(
+        &mut mm,
+        &registry,
+        &usdc_price,
+        &usdt_price,
+        mint_coin<USDT>(10000 * test_constants::usdt_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    margin_manager_pro::borrow_base<USDC, USDT>(
+        &mut mm,
+        &registry,
+        &mut base_pool,
+        &usdc_price,
+        &usdt_price,
+        &pool,
+        500 * test_constants::usdc_multiplier(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    let stale_usdc = build_stale_usdc_price_info_object_pro(&mut scenario, 600, &clock);
+
+    let order_info = pool_proxy_pro::place_reduce_only_limit_order_v2<USDC, USDT>(
+        &registry,
+        &mut mm,
+        &mut pool,
+        &base_pool,
+        &quote_pool,
+        &stale_usdc,
+        &usdt_price,
+        1,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        1_000_000_000,
+        100 * test_constants::usdc_multiplier(),
+        true,
+        false,
+        2000000,
+        &clock,
+        scenario.ctx(),
+    );
+    destroy(order_info);
+
+    return_shared(base_pool);
+    return_shared(quote_pool);
+    destroy_2!(usdc_price, usdt_price);
+    destroy(stale_usdc);
+    return_shared_2!(mm, pool);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+#[test, expected_failure(abort_code = pyth_pro::pyth::E_STALE_PRICE_UPDATE)]
+fun place_reduce_only_market_order_v2_pro_rejects_stale_feed() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+        registry_id,
+    ) = setup_pool_proxy_test_env<USDC, USDT>();
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<USDC, USDT>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_pro(&mut scenario, &clock);
+    let mut base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let mut quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+
+    // Collateral in quote, debt in base: the shape every reduce-only bid needs.
+    margin_manager_pro::deposit<USDC, USDT, USDT>(
+        &mut mm,
+        &registry,
+        &usdc_price,
+        &usdt_price,
+        mint_coin<USDT>(10000 * test_constants::usdt_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    margin_manager_pro::borrow_base<USDC, USDT>(
+        &mut mm,
+        &registry,
+        &mut base_pool,
+        &usdc_price,
+        &usdt_price,
+        &pool,
+        500 * test_constants::usdc_multiplier(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    let stale_usdc = build_stale_usdc_price_info_object_pro(&mut scenario, 600, &clock);
+
+    let order_info = pool_proxy_pro::place_reduce_only_market_order_v2<USDC, USDT>(
+        &registry,
+        &mut mm,
+        &mut pool,
+        &base_pool,
+        &quote_pool,
+        &stale_usdc,
+        &usdt_price,
+        2,
+        constants::self_matching_allowed(),
+        10 * test_constants::usdc_multiplier(),
+        true,
+        false,
+        &clock,
+        scenario.ctx(),
+    );
+    destroy(order_info);
+
+    return_shared(base_pool);
+    return_shared(quote_pool);
+    destroy_2!(usdc_price, usdt_price);
+    destroy(stale_usdc);
+    return_shared_2!(mm, pool);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+#[test, expected_failure(abort_code = pyth_pro::pyth::E_STALE_PRICE_UPDATE)]
+fun place_reduce_only_limit_order_and_repay_loan_pro_rejects_stale_feed() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+        registry_id,
+    ) = setup_pool_proxy_test_env<USDC, USDT>();
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<USDC, USDT>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_pro(&mut scenario, &clock);
+    let mut base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let mut quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+
+    // Collateral in quote, debt in base: the shape every reduce-only bid needs.
+    margin_manager_pro::deposit<USDC, USDT, USDT>(
+        &mut mm,
+        &registry,
+        &usdc_price,
+        &usdt_price,
+        mint_coin<USDT>(10000 * test_constants::usdt_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    margin_manager_pro::borrow_base<USDC, USDT>(
+        &mut mm,
+        &registry,
+        &mut base_pool,
+        &usdc_price,
+        &usdt_price,
+        &pool,
+        500 * test_constants::usdc_multiplier(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    let stale_usdc = build_stale_usdc_price_info_object_pro(&mut scenario, 600, &clock);
+
+    let order_info = pool_proxy_pro::place_reduce_only_limit_order_and_repay_loan<USDC, USDT>(
+        &registry,
+        &mut mm,
+        &mut pool,
+        &mut base_pool,
+        &mut quote_pool,
+        &stale_usdc,
+        &usdt_price,
+        1,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        1_000_000_000,
+        100 * test_constants::usdc_multiplier(),
+        true,
+        false,
+        2000000,
+        &clock,
+        scenario.ctx(),
+    );
+    destroy(order_info);
+
+    return_shared(base_pool);
+    return_shared(quote_pool);
+    destroy_2!(usdc_price, usdt_price);
+    destroy(stale_usdc);
+    return_shared_2!(mm, pool);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+#[test, expected_failure(abort_code = pyth_pro::pyth::E_STALE_PRICE_UPDATE)]
+fun place_reduce_only_market_order_and_repay_loan_pro_rejects_stale_feed() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+        registry_id,
+    ) = setup_pool_proxy_test_env<USDC, USDT>();
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<USDC, USDT>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_pro(&mut scenario, &clock);
+    let mut base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let mut quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+
+    // Collateral in quote, debt in base: the shape every reduce-only bid needs.
+    margin_manager_pro::deposit<USDC, USDT, USDT>(
+        &mut mm,
+        &registry,
+        &usdc_price,
+        &usdt_price,
+        mint_coin<USDT>(10000 * test_constants::usdt_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    margin_manager_pro::borrow_base<USDC, USDT>(
+        &mut mm,
+        &registry,
+        &mut base_pool,
+        &usdc_price,
+        &usdt_price,
+        &pool,
+        500 * test_constants::usdc_multiplier(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    let stale_usdc = build_stale_usdc_price_info_object_pro(&mut scenario, 600, &clock);
+
+    let order_info = pool_proxy_pro::place_reduce_only_market_order_and_repay_loan<USDC, USDT>(
+        &registry,
+        &mut mm,
+        &mut pool,
+        &mut base_pool,
+        &mut quote_pool,
+        &stale_usdc,
+        &usdt_price,
+        2,
+        constants::self_matching_allowed(),
+        10 * test_constants::usdc_multiplier(),
+        true,
+        false,
+        &clock,
+        scenario.ctx(),
+    );
+    destroy(order_info);
+
+    return_shared(base_pool);
+    return_shared(quote_pool);
+    destroy_2!(usdc_price, usdt_price);
+    destroy(stale_usdc);
+    return_shared_2!(mm, pool);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+#[test, expected_failure(abort_code = pyth_pro::pyth::E_STALE_PRICE_UPDATE)]
+fun update_current_price_pro_rejects_stale_feed() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        _b,
+        _q,
+        pool_id,
+        _r,
+    ) = setup_pool_proxy_test_env<USDC, USDT>();
+
+    scenario.next_tx(test_constants::user1());
+    let pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+
+    let stale_usdc = build_stale_usdc_price_info_object_pro(&mut scenario, 600, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_pro(&mut scenario, &clock);
+
+    pool_proxy_pro::update_current_price<USDC, USDT>(
+        &mut registry,
+        &pool,
+        &stale_usdc,
+        &usdt_price,
+        &clock,
+    );
+
+    destroy_2!(stale_usdc, usdt_price);
+    return_shared(pool);
     cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
 }

--- a/packages/deepbook_margin/tests/pool_proxy_pro_tests.move
+++ b/packages/deepbook_margin/tests/pool_proxy_pro_tests.move
@@ -1374,3 +1374,185 @@ fun update_current_price_pro_rejects_stale_feed() {
     return_shared(pool);
     cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
 }
+
+// === With debt, fresh feeds: the readings are actually consumed ===
+// The `*_with_debt_rejects_stale_feed` tests above abort inside the reader, so the
+// `PythReading`s they produce never reach `price_config`. The debt-free tests pass
+// `none`. Between them, nothing drives these two entrypoints down the path where the
+// readings are used - which is exactly where transposing them would show up.
+
+#[test]
+fun place_limit_order_v2_pro_with_debt_places_an_order() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+        registry_id,
+    ) = setup_pool_proxy_test_env<USDC, USDT>();
+
+    setup_orderbook_liquidity_stablecoin<USDC, USDT>(&mut scenario, pool_id, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<USDC, USDT>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_pro(&mut scenario, &clock);
+    let mut base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+
+    margin_manager_pro::deposit<USDC, USDT, USDT>(
+        &mut mm,
+        &registry,
+        &usdc_price,
+        &usdt_price,
+        mint_coin<USDT>(10000 * test_constants::usdt_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    margin_manager_pro::borrow_base<USDC, USDT>(
+        &mut mm,
+        &registry,
+        &mut base_pool,
+        &usdc_price,
+        &usdt_price,
+        &pool,
+        500 * test_constants::usdc_multiplier(),
+        &clock,
+        scenario.ctx(),
+    );
+    assert!(mm.borrowed_base_shares() > 0);
+
+    let order_info = pool_proxy_pro::place_limit_order_v2<USDC, USDT>(
+        &registry,
+        &mut mm,
+        &mut pool,
+        &base_pool,
+        &quote_pool,
+        &usdc_price,
+        &usdt_price,
+        7,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        1_000_000_000,
+        100 * test_constants::usdc_multiplier(),
+        true,
+        false,
+        2000000,
+        &clock,
+        scenario.ctx(),
+    );
+    assert!(order_info.client_order_id() == 7);
+    assert!(order_info.price() == 1_000_000_000);
+    assert!(order_info.original_quantity() == 100 * test_constants::usdc_multiplier());
+    assert!(order_info.is_bid());
+    assert!(mm.borrowed_base_shares() > 0);
+    destroy(order_info);
+
+    return_shared(base_pool);
+    return_shared(quote_pool);
+    destroy_2!(usdc_price, usdt_price);
+    return_shared_2!(mm, pool);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+#[test]
+fun place_market_order_v2_pro_with_debt_places_an_order() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+        registry_id,
+    ) = setup_pool_proxy_test_env<USDC, USDT>();
+
+    setup_orderbook_liquidity_stablecoin<USDC, USDT>(&mut scenario, pool_id, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<USDC, USDT>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_pro(&mut scenario, &clock);
+    let mut base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+
+    margin_manager_pro::deposit<USDC, USDT, USDT>(
+        &mut mm,
+        &registry,
+        &usdc_price,
+        &usdt_price,
+        mint_coin<USDT>(10000 * test_constants::usdt_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    margin_manager_pro::borrow_base<USDC, USDT>(
+        &mut mm,
+        &registry,
+        &mut base_pool,
+        &usdc_price,
+        &usdt_price,
+        &pool,
+        500 * test_constants::usdc_multiplier(),
+        &clock,
+        scenario.ctx(),
+    );
+    assert!(mm.borrowed_base_shares() > 0);
+
+    let order_info = pool_proxy_pro::place_market_order_v2<USDC, USDT>(
+        &registry,
+        &mut mm,
+        &mut pool,
+        &base_pool,
+        &quote_pool,
+        &usdc_price,
+        &usdt_price,
+        8,
+        constants::self_matching_allowed(),
+        10 * test_constants::usdc_multiplier(),
+        true,
+        false,
+        &clock,
+        scenario.ctx(),
+    );
+    assert!(order_info.client_order_id() == 8);
+    assert!(order_info.executed_quantity() == 10 * test_constants::usdc_multiplier());
+    assert!(order_info.is_bid());
+    assert!(mm.borrowed_base_shares() > 0);
+    destroy(order_info);
+
+    return_shared(base_pool);
+    return_shared(quote_pool);
+    destroy_2!(usdc_price, usdt_price);
+    return_shared_2!(mm, pool);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}

--- a/packages/deepbook_margin/tests/pool_proxy_pro_tests.move
+++ b/packages/deepbook_margin/tests/pool_proxy_pro_tests.move
@@ -17,13 +17,15 @@ use deepbook_margin::{
     margin_pool::MarginPool,
     margin_registry::MarginRegistry,
     pool_proxy_pro,
-    test_constants::{Self, USDC, USDT},
+    test_constants::{Self, BTC, USDC, USDT},
     test_helpers::{
         setup_pool_proxy_test_env,
+        setup_btc_usd_deepbook_margin,
         cleanup_margin_test,
         mint_coin,
         destroy_2,
         return_shared_2,
+        build_btc_price_info_object_pro,
         build_demo_usdc_price_info_object_pro,
         build_demo_usdt_price_info_object_pro,
         build_stale_usdc_price_info_object_pro,
@@ -63,7 +65,59 @@ fun update_current_price_pro_refreshes_the_registry() {
         &clock,
     );
 
+    // $1.00 base over $1.00 quote is a pool price of 1e9; the default tolerance is 5%.
+    // Without this the call could write nothing at all and the test would still pass.
+    let (lower_bound, upper_bound) = registry.get_price_bounds(pool_id, &clock);
+    assert!(lower_bound == 950_000_000);
+    assert!(upper_bound == 1_050_000_000);
+
     destroy_2!(usdc_price, usdt_price);
+    return_shared(pool);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+/// The same refresh on a pair whose legs have *different* prices.
+///
+/// Every other test in this file runs USDC/USDT, both pinned at $1.00, so base and
+/// quote are numerically interchangeable and transposing the two readings on the way
+/// into the shared core is undetectable. At BTC/USDC the transposition is a factor of
+/// 1e10, so this is the test that actually holds the argument order.
+#[test]
+fun update_current_price_pro_holds_base_quote_order() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        _b,
+        _q,
+        pool_id,
+        _r,
+    ) = setup_btc_usd_deepbook_margin();
+
+    scenario.next_tx(test_constants::user1());
+    let pool = scenario.take_shared_by_id<Pool<BTC, USDC>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+
+    let btc_price = build_btc_price_info_object_pro(&mut scenario, 100000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+
+    pool_proxy_pro::update_current_price<BTC, USDC>(
+        &mut registry,
+        &pool,
+        &btc_price,
+        &usdc_price,
+        &clock,
+    );
+
+    // $100,000 base over $1.00 quote, carried through BTC's 8 decimals against USDC's
+    // 6, is a pool price of 1e12 with 5% tolerance either side. Transposed the price
+    // would be ~1e6 and neither bound would come close.
+    let (lower_bound, upper_bound) = registry.get_price_bounds(pool_id, &clock);
+    assert!(lower_bound == 950_000_000_000);
+    assert!(upper_bound == 1_050_000_000_000);
+
+    destroy_2!(btc_price, usdc_price);
     return_shared(pool);
     cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
 }
@@ -138,6 +192,13 @@ fun place_limit_order_v2_pro_no_debt_tolerates_stale_feed() {
         &clock,
         scenario.ctx(),
     );
+    assert!(order_info.client_order_id() == 1);
+    assert!(order_info.price() == 1_000_000_000);
+    assert!(order_info.original_quantity() == 100 * test_constants::usdc_multiplier());
+    assert!(!order_info.is_bid());
+    // Still debt-free, which is what let the stale feed through.
+    assert!(mm.borrowed_base_shares() == 0);
+    assert!(mm.borrowed_quote_shares() == 0);
     destroy(order_info);
 
     return_shared(base_pool);
@@ -212,6 +273,12 @@ fun place_market_order_v2_pro_places_an_order() {
         &clock,
         scenario.ctx(),
     );
+    // A market order that crosses the seeded book must actually execute; asserting
+    // only that the call returned would not distinguish a fill from a no-op.
+    assert!(order_info.client_order_id() == 2);
+    assert!(order_info.executed_quantity() == 50 * test_constants::usdc_multiplier());
+    assert!(order_info.status() == constants::filled());
+    assert!(!order_info.is_bid());
     destroy(order_info);
 
     return_shared(base_pool);
@@ -297,6 +364,12 @@ fun place_reduce_only_limit_order_v2_pro_places_an_order() {
         &clock,
         scenario.ctx(),
     );
+    assert!(order_info.client_order_id() == 1);
+    assert!(order_info.price() == 1_000_000_000);
+    assert!(order_info.original_quantity() == 100 * test_constants::usdc_multiplier());
+    assert!(order_info.is_bid());
+    // The base debt that makes a reduce-only bid legal in the first place.
+    assert!(mm.borrowed_base_shares() > 0);
     destroy(order_info);
 
     return_shared(base_pool);
@@ -450,6 +523,7 @@ fun place_reduce_only_limit_order_and_repay_loan_pro_places_an_order() {
         scenario.ctx(),
     );
 
+    let shares_before = mm.borrowed_base_shares();
     let order_info = pool_proxy_pro::place_reduce_only_limit_order_and_repay_loan<USDC, USDT>(
         &registry,
         &mut mm,
@@ -469,6 +543,14 @@ fun place_reduce_only_limit_order_and_repay_loan_pro_places_an_order() {
         &clock,
         scenario.ctx(),
     );
+    // The bid rests rather than crossing, but the repay leg still runs against the
+    // manager's own balance and clears the whole 500-base loan. Asserting the exact
+    // outcome is the point: a repay that silently no-ops would leave `shares_before`.
+    assert!(order_info.client_order_id() == 1);
+    assert!(order_info.price() == 1_000_000_000);
+    assert!(order_info.is_bid());
+    assert!(shares_before > 0);
+    assert!(mm.borrowed_base_shares() == 0);
     destroy(order_info);
 
     return_shared(base_pool);
@@ -538,6 +620,7 @@ fun place_reduce_only_market_order_and_repay_loan_pro_closes_and_repays() {
         scenario.ctx(),
     );
 
+    let shares_before = mm.borrowed_base_shares();
     let order_info = pool_proxy_pro::place_reduce_only_market_order_and_repay_loan<USDC, USDT>(
         &registry,
         &mut mm,
@@ -554,6 +637,11 @@ fun place_reduce_only_market_order_and_repay_loan_pro_closes_and_repays() {
         &clock,
         scenario.ctx(),
     );
+    // The repay is the whole difference between this entry and the swap-only one that
+    // aborts above. If it silently no-ops, the debt never moves.
+    assert!(order_info.client_order_id() == 2);
+    assert!(order_info.executed_quantity() == 10 * test_constants::usdc_multiplier());
+    assert!(mm.borrowed_base_shares() < shares_before);
     destroy(order_info);
 
     return_shared(base_pool);
@@ -621,6 +709,7 @@ fun place_market_order_and_repay_loan_pro_closes_and_repays() {
         scenario.ctx(),
     );
 
+    let shares_before = mm.borrowed_base_shares();
     let order_info = pool_proxy_pro::place_market_order_and_repay_loan<USDC, USDT>(
         &registry,
         &mut mm,
@@ -637,11 +726,272 @@ fun place_market_order_and_repay_loan_pro_closes_and_repays() {
         &clock,
         scenario.ctx(),
     );
+    assert!(order_info.client_order_id() == 3);
+    assert!(order_info.executed_quantity() == 10 * test_constants::usdc_multiplier());
+    assert!(mm.borrowed_base_shares() < shares_before);
     destroy(order_info);
 
     return_shared(base_pool);
     return_shared(quote_pool);
     destroy_2!(usdc_price, usdt_price);
+    return_shared_2!(mm, pool);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+// === Lazy-read pins: the "must read" direction ===
+// `place_limit_order_v2`, `place_market_order_v2` and `place_market_order_and_repay_loan`
+// read the oracle only when the manager carries debt. The tests above cover the
+// debt-free half - a stale feed is tolerated. These cover the other half: with debt,
+// the read is mandatory, so a stale feed must abort. Without them, a mutation that
+// drops the read entirely and always passes `none` would still be green.
+
+#[test, expected_failure(abort_code = pyth_pro::pyth::E_STALE_PRICE_UPDATE)]
+fun place_limit_order_v2_pro_with_debt_rejects_stale_feed() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+        registry_id,
+    ) = setup_pool_proxy_test_env<USDC, USDT>();
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<USDC, USDT>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_pro(&mut scenario, &clock);
+    let mut base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+
+    // Establish debt on fresh feeds, so only the entry under test sees a stale one.
+    margin_manager_pro::deposit<USDC, USDT, USDT>(
+        &mut mm,
+        &registry,
+        &usdc_price,
+        &usdt_price,
+        mint_coin<USDT>(10000 * test_constants::usdt_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    margin_manager_pro::borrow_base<USDC, USDT>(
+        &mut mm,
+        &registry,
+        &mut base_pool,
+        &usdc_price,
+        &usdt_price,
+        &pool,
+        500 * test_constants::usdc_multiplier(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    let stale_usdc = build_stale_usdc_price_info_object_pro(&mut scenario, 600, &clock);
+    let order_info = pool_proxy_pro::place_limit_order_v2<USDC, USDT>(
+        &registry,
+        &mut mm,
+        &mut pool,
+        &base_pool,
+        &quote_pool,
+        &stale_usdc,
+        &usdt_price,
+        1,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        1_000_000_000,
+        100 * test_constants::usdc_multiplier(),
+        false,
+        false,
+        2000000,
+        &clock,
+        scenario.ctx(),
+    );
+    destroy(order_info);
+
+    return_shared(base_pool);
+    return_shared(quote_pool);
+    destroy_2!(usdc_price, usdt_price);
+    destroy(stale_usdc);
+    return_shared_2!(mm, pool);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+#[test, expected_failure(abort_code = pyth_pro::pyth::E_STALE_PRICE_UPDATE)]
+fun place_market_order_v2_pro_with_debt_rejects_stale_feed() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+        registry_id,
+    ) = setup_pool_proxy_test_env<USDC, USDT>();
+
+    setup_orderbook_liquidity_stablecoin<USDC, USDT>(&mut scenario, pool_id, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<USDC, USDT>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_pro(&mut scenario, &clock);
+    let mut base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+
+    margin_manager_pro::deposit<USDC, USDT, USDT>(
+        &mut mm,
+        &registry,
+        &usdc_price,
+        &usdt_price,
+        mint_coin<USDT>(10000 * test_constants::usdt_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    margin_manager_pro::borrow_base<USDC, USDT>(
+        &mut mm,
+        &registry,
+        &mut base_pool,
+        &usdc_price,
+        &usdt_price,
+        &pool,
+        500 * test_constants::usdc_multiplier(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    let stale_usdc = build_stale_usdc_price_info_object_pro(&mut scenario, 600, &clock);
+    let order_info = pool_proxy_pro::place_market_order_v2<USDC, USDT>(
+        &registry,
+        &mut mm,
+        &mut pool,
+        &base_pool,
+        &quote_pool,
+        &stale_usdc,
+        &usdt_price,
+        2,
+        constants::self_matching_allowed(),
+        50 * test_constants::usdc_multiplier(),
+        false,
+        false,
+        &clock,
+        scenario.ctx(),
+    );
+    destroy(order_info);
+
+    return_shared(base_pool);
+    return_shared(quote_pool);
+    destroy_2!(usdc_price, usdt_price);
+    destroy(stale_usdc);
+    return_shared_2!(mm, pool);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+#[test, expected_failure(abort_code = pyth_pro::pyth::E_STALE_PRICE_UPDATE)]
+fun place_market_order_and_repay_loan_pro_with_debt_rejects_stale_feed() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+        registry_id,
+    ) = setup_pool_proxy_test_env<USDC, USDT>();
+
+    setup_orderbook_liquidity_stablecoin<USDC, USDT>(&mut scenario, pool_id, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<USDC, USDT>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let usdc_price = build_demo_usdc_price_info_object_pro(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_pro(&mut scenario, &clock);
+    let mut base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let mut quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+
+    margin_manager_pro::deposit<USDC, USDT, USDT>(
+        &mut mm,
+        &registry,
+        &usdc_price,
+        &usdt_price,
+        mint_coin<USDT>(10000 * test_constants::usdt_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    margin_manager_pro::borrow_base<USDC, USDT>(
+        &mut mm,
+        &registry,
+        &mut base_pool,
+        &usdc_price,
+        &usdt_price,
+        &pool,
+        500 * test_constants::usdc_multiplier(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    let stale_usdc = build_stale_usdc_price_info_object_pro(&mut scenario, 600, &clock);
+    let order_info = pool_proxy_pro::place_market_order_and_repay_loan<USDC, USDT>(
+        &registry,
+        &mut mm,
+        &mut pool,
+        &mut base_pool,
+        &mut quote_pool,
+        &stale_usdc,
+        &usdt_price,
+        3,
+        constants::self_matching_allowed(),
+        10 * test_constants::usdc_multiplier(),
+        true,
+        false,
+        &clock,
+        scenario.ctx(),
+    );
+    destroy(order_info);
+
+    return_shared(base_pool);
+    return_shared(quote_pool);
+    destroy_2!(usdc_price, usdt_price);
+    destroy(stale_usdc);
     return_shared_2!(mm, pool);
     cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
 }

--- a/packages/deepbook_margin/tests/pool_proxy_tests.move
+++ b/packages/deepbook_margin/tests/pool_proxy_tests.move
@@ -29,6 +29,7 @@ use deepbook_margin::{
         return_shared_3,
         build_demo_usdc_price_info_object,
         build_stale_usdc_price_info_object,
+        build_stale_usdt_price_info_object,
         build_demo_usdt_price_info_object,
         build_demo_usdc_price_info_object_with_price,
         setup_orderbook_liquidity_stablecoin,
@@ -8821,6 +8822,7 @@ fun place_limit_order_v2_no_debt_tolerates_stale_feed() {
     let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
 
     let stale_usdc = build_stale_usdc_price_info_object(&mut scenario, &clock, 600);
+    let stale_usdt = build_stale_usdt_price_info_object(&mut scenario, &clock, 600);
     let order_info = pool_proxy::place_limit_order_v2<USDC, USDT>(
         &registry,
         &mut mm,
@@ -8828,7 +8830,7 @@ fun place_limit_order_v2_no_debt_tolerates_stale_feed() {
         &base_pool,
         &quote_pool,
         &stale_usdc,
-        &usdt_price,
+        &stale_usdt,
         1,
         constants::no_restriction(),
         constants::self_matching_allowed(),
@@ -8848,7 +8850,7 @@ fun place_limit_order_v2_no_debt_tolerates_stale_feed() {
     return_shared(base_pool);
     return_shared(quote_pool);
     destroy_2!(usdc_price, usdt_price);
-    destroy(stale_usdc);
+    destroy_2!(stale_usdc, stale_usdt);
     return_shared_2!(mm, pool);
     cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
 }
@@ -8900,6 +8902,7 @@ fun place_market_order_v2_no_debt_tolerates_stale_feed() {
     let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
 
     let stale_usdc = build_stale_usdc_price_info_object(&mut scenario, &clock, 600);
+    let stale_usdt = build_stale_usdt_price_info_object(&mut scenario, &clock, 600);
     let order_info = pool_proxy::place_market_order_v2<USDC, USDT>(
         &registry,
         &mut mm,
@@ -8907,7 +8910,7 @@ fun place_market_order_v2_no_debt_tolerates_stale_feed() {
         &base_pool,
         &quote_pool,
         &stale_usdc,
-        &usdt_price,
+        &stale_usdt,
         2,
         constants::self_matching_allowed(),
         50 * test_constants::usdc_multiplier(),
@@ -8924,7 +8927,7 @@ fun place_market_order_v2_no_debt_tolerates_stale_feed() {
     return_shared(base_pool);
     return_shared(quote_pool);
     destroy_2!(usdc_price, usdt_price);
-    destroy(stale_usdc);
+    destroy_2!(stale_usdc, stale_usdt);
     return_shared_2!(mm, pool);
     cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
 }

--- a/packages/deepbook_margin/tests/pool_proxy_tests.move
+++ b/packages/deepbook_margin/tests/pool_proxy_tests.move
@@ -28,6 +28,7 @@ use deepbook_margin::{
         return_shared_2,
         return_shared_3,
         build_demo_usdc_price_info_object,
+        build_stale_usdc_price_info_object,
         build_demo_usdt_price_info_object,
         build_demo_usdc_price_info_object_with_price,
         setup_orderbook_liquidity_stablecoin,
@@ -8767,4 +8768,163 @@ fun reduce_only_limit_v2_taker_fill_aborts() {
     );
 
     abort 999
+}
+
+// === Lazy-read pins: a debt-free manager must not need a fresh feed ===
+// `place_limit_order_v2`, `place_market_order_v2` and `place_market_order_and_repay_loan`
+// read the oracle only when the manager carries debt. Every other test here carries
+// debt, so hoisting the read back out of the conditional - the regression this
+// behaviour was introduced to fix - passes the whole rest of the suite untouched.
+
+#[test]
+fun place_limit_order_v2_no_debt_tolerates_stale_feed() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+        registry_id,
+    ) = setup_pool_proxy_test_env<USDC, USDT>();
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<USDC, USDT>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+
+    margin_manager::deposit<USDC, USDT, USDC>(
+        &mut mm,
+        &registry,
+        &usdc_price,
+        &usdt_price,
+        mint_coin<USDC>(10000 * test_constants::usdc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+
+    let stale_usdc = build_stale_usdc_price_info_object(&mut scenario, &clock, 600);
+    let order_info = pool_proxy::place_limit_order_v2<USDC, USDT>(
+        &registry,
+        &mut mm,
+        &mut pool,
+        &base_pool,
+        &quote_pool,
+        &stale_usdc,
+        &usdt_price,
+        1,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        1_000_000_000,
+        100 * test_constants::usdc_multiplier(),
+        false,
+        false,
+        2000000,
+        &clock,
+        scenario.ctx(),
+    );
+    assert!(order_info.client_order_id() == 1);
+    assert!(mm.borrowed_base_shares() == 0);
+    assert!(mm.borrowed_quote_shares() == 0);
+    destroy(order_info);
+
+    return_shared(base_pool);
+    return_shared(quote_pool);
+    destroy_2!(usdc_price, usdt_price);
+    destroy(stale_usdc);
+    return_shared_2!(mm, pool);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
+}
+
+#[test]
+fun place_market_order_v2_no_debt_tolerates_stale_feed() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+        registry_id,
+    ) = setup_pool_proxy_test_env<USDC, USDT>();
+
+    setup_orderbook_liquidity_stablecoin<USDC, USDT>(&mut scenario, pool_id, &clock);
+
+    scenario.next_tx(test_constants::user1());
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<USDC, USDT>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+
+    margin_manager::deposit<USDC, USDT, USDC>(
+        &mut mm,
+        &registry,
+        &usdc_price,
+        &usdt_price,
+        mint_coin<USDC>(10000 * test_constants::usdc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+
+    let stale_usdc = build_stale_usdc_price_info_object(&mut scenario, &clock, 600);
+    let order_info = pool_proxy::place_market_order_v2<USDC, USDT>(
+        &registry,
+        &mut mm,
+        &mut pool,
+        &base_pool,
+        &quote_pool,
+        &stale_usdc,
+        &usdt_price,
+        2,
+        constants::self_matching_allowed(),
+        50 * test_constants::usdc_multiplier(),
+        false,
+        false,
+        &clock,
+        scenario.ctx(),
+    );
+    assert!(order_info.client_order_id() == 2);
+    assert!(order_info.executed_quantity() == 50 * test_constants::usdc_multiplier());
+    assert!(mm.borrowed_base_shares() == 0);
+    destroy(order_info);
+
+    return_shared(base_pool);
+    return_shared(quote_pool);
+    destroy_2!(usdc_price, usdt_price);
+    destroy(stale_usdc);
+    return_shared_2!(mm, pool);
+    cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
 }

--- a/packages/margin_liquidation/Move.lock
+++ b/packages/margin_liquidation/Move.lock
@@ -65,7 +65,7 @@ manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5E
 deps = { std = "MoveStdlib", sui = "Sui" }
 
 [pinned.testnet.MoveStdlib]
-source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "73dd2c2ba6f9fdb21d7ffde2b50a3f2f0ac39bc1" }
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "85400e2bd37b490fcd057776e700d3fdca643396" }
 use_environment = "testnet"
 manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
 deps = {}
@@ -77,13 +77,19 @@ manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05
 deps = {}
 
 [pinned.testnet.Pyth]
-source = { git = "https://github.com/pyth-network/pyth-crosschain.git", subdir = "target_chains/sui/contracts", rev = "3bd1262dcba9518a6901aa6a15f04072799bfb37" }
+source = { git = "https://github.com/pyth-network/pyth-crosschain.git", subdir = "target_chains/sui/contracts", rev = "62c7a5bc0fc857ba6417ad780190552d4919ceca" }
 use_environment = "testnet"
-manifest_digest = "9942AAB3725BC51DADB046B4440A3D008E554C9286ECC72B3DE5CC0309C0D63D"
+manifest_digest = "EE442EEB0E1F71B244DBB1E016B1D0D8F67061BDAFA606B6C86F093D15CA0755"
 deps = { Sui = "Sui_1", Wormhole = "Wormhole" }
 
+[pinned.testnet.PythProCompatible]
+source = { git = "https://github.com/pyth-network/pyth-crosschain.git", subdir = "target_chains/sui/contracts", rev = "6c78a4d882daf4d91457ad5142cb58fc7e376f98" }
+use_environment = "testnet"
+manifest_digest = "AEAC3FAD5DCF925755E55B4498F4CED3B564F87B638049EF0A7C4E9F2EA7E9EC"
+deps = { Sui = "Sui_1", WormholeSimpleMajority = "WormholeSimpleMajority" }
+
 [pinned.testnet.Sui]
-source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "73dd2c2ba6f9fdb21d7ffde2b50a3f2f0ac39bc1" }
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "85400e2bd37b490fcd057776e700d3fdca643396" }
 use_environment = "testnet"
 manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
 deps = { MoveStdlib = "MoveStdlib" }
@@ -95,7 +101,13 @@ manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D
 deps = { MoveStdlib = "MoveStdlib_1" }
 
 [pinned.testnet.Wormhole]
-source = { git = "https://github.com/wormhole-foundation/wormhole.git", subdir = "sui/wormhole", rev = "b71be5cbb9537c4aac8e23e74371affa3825efcd" }
+source = { git = "https://github.com/wormhole-foundation/wormhole.git", subdir = "sui/wormhole", rev = "1b1cb69e809e0e7081cf1bf9b2779c41c14fc7f0" }
+use_environment = "testnet"
+manifest_digest = "6996F1AB8CD448FFBA142C085C488FE8A46B485E61E38A1891EFA52B30D9C12E"
+deps = { Sui = "Sui_1" }
+
+[pinned.testnet.WormholeSimpleMajority]
+source = { git = "https://github.com/pyth-network/pyth-crosschain.git", subdir = "target_chains/sui/vendor/wormhole_simple_majority/wormhole", rev = "6c78a4d882daf4d91457ad5142cb58fc7e376f98" }
 use_environment = "testnet"
 manifest_digest = "6996F1AB8CD448FFBA142C085C488FE8A46B485E61E38A1891EFA52B30D9C12E"
 deps = { Sui = "Sui_1" }
@@ -109,17 +121,17 @@ deps = { std = "MoveStdlib", sui = "Sui", token = "token" }
 [pinned.testnet.deepbook_margin]
 source = { local = "../deepbook_margin" }
 use_environment = "testnet"
-manifest_digest = "0399AA4FC0023475DA450CD4E893FAA707F2D974710687B551D39BD9679B288E"
-deps = { deepbook = "deepbook", pyth = "Pyth", std = "MoveStdlib", sui = "Sui", token = "token" }
+manifest_digest = "55032D0F8CAAAF41FE80CB3AB9E13122BDE117CDAB8D2EF91114C583232A3058"
+deps = { deepbook = "deepbook", pyth = "Pyth", pyth_pro = "PythProCompatible", std = "MoveStdlib", sui = "Sui", token = "token" }
 
 [pinned.testnet.margin_liquidation]
 source = { root = true }
 use_environment = "testnet"
-manifest_digest = "16A636F6775B8A491DBDA7196CE56B690C31E02802533981158A49510686B093"
-deps = { deepbook = "deepbook", deepbook_margin = "deepbook_margin", std = "MoveStdlib", sui = "Sui" }
+manifest_digest = "56AC82023B117F89A629BF2EB76AAF63841990AE835AC41AB35CC5AF466AC876"
+deps = { deepbook = "deepbook", deepbook_margin = "deepbook_margin", pyth = "Pyth", std = "MoveStdlib", sui = "Sui", token = "token" }
 
 [pinned.testnet.token]
-source = { git = "https://github.com/MystenLabs/deepbookv3.git", subdir = "packages/token", rev = "8b024db118f0f1b8d76e78f469574c82d5b0b2ad" }
+source = { git = "https://github.com/MystenLabs/deepbookv3.git", subdir = "packages/token", rev = "2e0a88f860f1ae64f709b3978f1e206a91771169" }
 use_environment = "testnet"
 manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
 deps = { std = "MoveStdlib", sui = "Sui" }

--- a/packages/margin_liquidation/Move.lock
+++ b/packages/margin_liquidation/Move.lock
@@ -22,6 +22,12 @@ use_environment = "mainnet"
 manifest_digest = "F2C5AF85C4B72C8F6A8132D05DE4F787F4EB80DBFF812331ED65AE599E7DF92A"
 deps = { Sui = "Sui_1", Wormhole = "Wormhole" }
 
+[pinned.mainnet.PythProCompatible]
+source = { git = "https://github.com/pyth-network/pyth-crosschain.git", subdir = "target_chains/sui/contracts", rev = "aa291266173173480efef77b9454f2dbc2b4fd62" }
+use_environment = "mainnet"
+manifest_digest = "3D2B5BBF2058F3C9DCA3527CC2486C518124687B60479CA9875E5475652B7BBC"
+deps = { Sui = "Sui_1", WormholeSimpleMajority = "WormholeSimpleMajority" }
+
 [pinned.mainnet.Sui]
 source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "73dd2c2ba6f9fdb21d7ffde2b50a3f2f0ac39bc1" }
 use_environment = "mainnet"
@@ -40,6 +46,12 @@ use_environment = "mainnet"
 manifest_digest = "0D766A0380B75080707CFA6099AF469A2E502B0D9DC334A9E9983B391C5555D9"
 deps = { Sui = "Sui_1" }
 
+[pinned.mainnet.WormholeSimpleMajority]
+source = { git = "https://github.com/pyth-network/pyth-crosschain.git", subdir = "target_chains/sui/vendor/wormhole_simple_majority/wormhole", rev = "aa291266173173480efef77b9454f2dbc2b4fd62" }
+use_environment = "mainnet"
+manifest_digest = "0D766A0380B75080707CFA6099AF469A2E502B0D9DC334A9E9983B391C5555D9"
+deps = { Sui = "Sui_1" }
+
 [pinned.mainnet.deepbook]
 source = { local = "../deepbook" }
 use_environment = "mainnet"
@@ -49,17 +61,17 @@ deps = { std = "MoveStdlib", sui = "Sui", token = "token" }
 [pinned.mainnet.deepbook_margin]
 source = { local = "../deepbook_margin" }
 use_environment = "mainnet"
-manifest_digest = "CB667B820C1B23DAA461D4276F8B16B13DE45132636E1E65E65D553C4DF5D716"
-deps = { deepbook = "deepbook", pyth = "Pyth", std = "MoveStdlib", sui = "Sui", token = "token" }
+manifest_digest = "E968042AE197611B52E36277EC7F179E2D242F5AC9C381BC26476601EF5001D4"
+deps = { deepbook = "deepbook", pyth = "Pyth", pyth_pro = "PythProCompatible", std = "MoveStdlib", sui = "Sui", token = "token" }
 
 [pinned.mainnet.margin_liquidation]
 source = { root = true }
 use_environment = "mainnet"
-manifest_digest = "5CC277B067409F5523A5A79F4FB51C732BA239CE7C95D5B713BA137AAD727F30"
-deps = { deepbook = "deepbook", deepbook_margin = "deepbook_margin", std = "MoveStdlib", sui = "Sui" }
+manifest_digest = "7721CC3A1C8F05A632ACD9BCC88A257DEB2909BBD46126F9270D7CD67E401731"
+deps = { deepbook = "deepbook", deepbook_margin = "deepbook_margin", pyth = "Pyth", std = "MoveStdlib", sui = "Sui", token = "token" }
 
 [pinned.mainnet.token]
-source = { git = "https://github.com/MystenLabs/deepbookv3.git", subdir = "packages/token", rev = "8b024db118f0f1b8d76e78f469574c82d5b0b2ad" }
+source = { git = "https://github.com/MystenLabs/deepbookv3.git", subdir = "packages/token", rev = "2e0a88f860f1ae64f709b3978f1e206a91771169" }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }


### PR DESCRIPTION
Second of two PRs migrating margin to Pyth Pro. **Stacked on #1170** — review that first; this PR's diff is against it. The two are one shippable unit: this PR fixes #1170's known availability regressions and carries every test for the Pro readers it introduces.

## Summary
- New `deepbook_margin::margin_manager_pro` (12 entrypoints) and `deepbook_margin::pool_proxy_pro` (8 entrypoints), exposing the Pyth Pro surface **under the same function names**. Callers change module, not function.
- Every existing entrypoint keeps its exact signature and now delegates to a `public(package)` `_core` taking `PythReading` values.
- The Pro entrypoint reads the Pro feed and calls the *same* core, so both feeds run byte-identical logic.
- Internals that threaded feed objects now thread readings: `tpsl::add_conditional_order`, `process_collected_orders_v2/v3`, and `pool_proxy`'s solvency/monotonicity helpers.
- Reads are **lazy** where the value is only needed conditionally, which is what fixes #1170's regressions.
- `PythReading` carries a `coin_type` tag asserted in `price_config`, so a reading routed to the wrong leg aborts instead of mis-pricing. This covers every reading **used for pricing**; the deposit collateral event reads `.price()`/`.decimals()` directly and is out of its reach.
- `MARGIN_VERSION` 6 → 7.

## Why
- Pyth Pro's `PriceInfoObject` is a different Move type (new package, fresh `original-id`). The frozen signatures can never accept it — verified: a straight repoint fails with 21 × `Compatibility E03001`.
- Adding entrypoints alongside is the only route that keeps the package upgradeable. A fresh publish would strand the existing `MarginManager` objects and force a full re-wire.

## Key decisions
- **Separate modules, same function names.** `_pro` suffixes would stack badly on margin's existing `_v2`/`_v3` behaviour-version idiom (`place_limit_order_v2_pro`). Module-scoping keeps call sites readable.
- **Shared cores, not duplicated bodies.** Two copies of liquidation and borrow logic drifting is a worse failure mode than one delegation refactor. There is exactly one implementation of each path.
- **A separate module forces the core split** — Move scopes field access and private helpers to the defining module, so `margin_manager_pro` cannot touch `MarginManager` internals. The cores are what make it possible at all.
- **Lazy reads restore `main`'s availability.** `withdraw_needs_risk_check` and `emits_collateral_event` gate the reads so a debt-free manager still transacts during a feed outage, exactly as before the migration. This is the fix for #1170's two known regressions.
- **`PythReading` is tagged with the asset it prices.** The struct carried a price with no record of which asset it was for, so transposing the base and quote readings at a `_core` call site was undetectable — a probe showed `calculate_price<BTC, USDC>` with the two swapped returns `100` instead of `1000000000000`, a 10^10 mis-price with no abort. Every one of the 40 shipped call sites pairs correctly today; this is a regression barrier, not a fix. The field can only be added before the first deploy, since a `compatible` upgrade cannot add one afterwards.
- **No teardown.** Both feeds go through `get_price_no_older_than(…, max_age)`, so the legacy entrypoints fail closed by themselves once the legacy feeds stop. Nothing to remove at the cutover; the eventual cleanup is turning the legacy bodies into aborting stubs, since Sui never permits deleting a public function.
- **`update_current_price` included.** It is the permissionless price-refresh entry the order-validation path depends on; without a Pro twin, price updates would stop at the cutover.

## Scope / Descoped
- `margin_liquidation` migrates in a follow-up (2 entrypoints, no oracle logic of its own).
- No SDK changes here. The SDK should take a major bump onto the Pro entrypoints rather than carry a per-environment switch that becomes dead weight within a month.
- Off-chain cutover work is tracked separately.

## Test plan

`sui move test --path packages/deepbook_margin --gas-limit 100000000000` — **424/424**.

- [x] `sui move build --build-env mainnet` and `--build-env testnet`, for both `deepbook_margin` and `margin_liquidation` — all four exit 0, lockfiles unchanged.
- [x] `sui client --client.env testnet upgrade --dry-run` — **execution status: success**. Proves the 20 new entrypoints are additive and every frozen signature is intact.
- [x] Public surface diffed against the *deployed bytecode* of both baselines (mainnet `margin-v6.0.0`, testnet `margin-testnet-v15.0.0`) via `sui move summary --package-id`: purely additive, **0 public functions removed and 0 changed** against either. All 70 structs identical in fields and abilities. The `coin_type` commit adds and removes zero public functions on top of that.
- [x] `checks/format-move.sh` clean.

Coverage was measured by mutation testing rather than asserted, since a delegation layer is exactly where a migration goes wrong silently:

- [x] **Reader choice.** Downgrading `read_price_pro` to `read_price_pro_unsafe` — which drops staleness, EWMA-divergence and confidence — swept across every entrypoint in turn: **0 of 17 survive** (16 of 17 survived before this work). Each previously-unpinned entrypoint now has a stale-feed rejection test.
- [x] **Base/quote transposition.** Swapping the two readings at each entrypoint: **0 of 25 survive** (2 of 25 before, under this mutation operator; an independent sweep using a different operator over a 13-site sample measured 7/13 caught before and 12/13 after). Two entrypoints needed a with-debt happy path as well, because their readings were otherwise never consumed.
- [x] **The asset-tag guard itself.** Deleting the `price_config` assert fails CI: a valid SUI reading consumed as `calculate_usd_price<USDC>` must abort `EReadingAssetMismatch`, and the identical reading consumed as SUI must price normally.
- [x] **Lazy reads, both directions.** Dropping the read entirely and always passing `none` is caught; so is re-hoisting it back to an eager read — the regression this behaviour exists to prevent, which previously passed 110/110 on the legacy suite.
- [x] **EWMA divergence** now actually executes on the Pro readers. The Pro fixture set `ema == spot`, making the divergence assert a tautology on every Pro test; passing spot in place of the EWMA is now caught.
- [x] **`withdraw`'s solvency gate** is exercised with debt on the Pro path either side of the 2.0 floor. It previously had no coverage at all — both Pro withdraw tests deposited and never borrowed, so the branch never ran.

## Review

Reviewed by independent agents for upgrade compatibility, security against the deployed `margin-v6.0.0` baseline, and test quality.

- **Security: no way to lose or steal funds, mis-price collateral, bypass a guard, or brick an entrypoint that did not exist at v6.** Per-function diffs of all 17 `_core` bodies against v6 show the only deltas are oracle plumbing, with the guard inventory matching one-for-one. `PythReading` is `copy, drop` only, appears in no `public fun` signature, and cannot cross a PTB boundary.
- Pyth Pro's `pyth.move`, `price_feed.move` and `price_identifier.move` are **byte-identical to Core** (`diff -q`); the packages differ only in test-only helpers, a doc typo, and the vendored Wormhole. Both readers therefore run literally the same staleness and EMA code.
- The `coin_type` guard was reviewed separately. No false-abort path: `PythConfig.currencies` is keyed by the value's own `type_name` field via its sole constructor, and both sides of the assert read the same row through the same accessor, so the comparison is reflexive and cannot fire on legitimate traffic. Gas cost measured over the full suite at **+0.36%**, worst single real path +1.25%.
- **Dependency-level risk, not a defect in this diff:** Pyth Pro's Wormhole uses a simple-majority guardian quorum (`n/2+1`) rather than the canonical `2/3`. That is a new and weaker trust root on every solvency decision, and wants an explicit risk acceptance before Pro is enabled on mainnet.

## Risk / Rollout
- Purely additive on-chain. No existing entrypoint changes signature or behaviour.
- The refactor rewrites the *bodies* of live borrow/withdraw/liquidate/order entrypoints into delegations — that is the part worth reviewing closely.
- **`enable_version(7)` must be called on the live `MarginRegistry` immediately after each upgrade**, or every entrypoint aborts `EPackageVersionDisabled`. Both registries currently allow `{6}`.
- **Merge and deploy as a stack with #1170.** Deploying #1170 alone would ship its two availability regressions and freeze `PythReading` without its `coin_type` tag, which a `compatible` upgrade could then never add.
- Deploy order after merge: upgrade testnet, cut the off-chain price and liquidation paths over to the new `PriceInfoObject` ids, then mainnet via the UpgradeCap multisig, which has human signer latency — start it early.
