### PR TITLE
Add DeepBook dashboard service manifest

### DIFF
--- a/crates/dashboard.yaml
+++ b/crates/dashboard.yaml
@@ -1,0 +1,62 @@
+apiVersion: dashboard.mysten.io/v1alpha1
+kind: Service
+metadata:
+  id: deepbook
+  displayName: DeepBook Core
+  description: DeepBook core indexer and API server deployments.
+spec:
+  sourcePath: crates
+  components:
+    - id: deepbook-indexer
+      displayName: DeepBook Indexer
+      sourcePath: crates/indexer
+      dockerfile: docker/deepbook-indexer/Dockerfile
+    - id: deepbook-server
+      displayName: DeepBook API Server
+      sourcePath: crates/server
+      dockerfile: docker/deepbook-server/Dockerfile
+  pulumi:
+    repoUrl: https://github.com/MystenLabs/sui-operations.git
+    projectPath: pulumi/apps/deepbook
+    defaultRef: main
+    environments:
+      - name: mainnet
+        displayName: Mainnet
+        stackName: mysten/deepbook/mainnet
+        replicaControls:
+          - componentId: deepbook-server
+            pulumiConfigPath: /config/deepbook:serverReplicas
+            minReplicas: 0
+            maxReplicas: 10
+        imagePins:
+          - componentId: deepbook-indexer
+            imageConfigPath: /config/deepbook:indexerImage
+          - componentId: deepbook-server
+            imageConfigPath: /config/deepbook:serverImage
+        observability:
+          cluster: gke-workloads-primary-use4
+          namespace: deepbook-mainnet
+          containers:
+            - deepbook-indexer
+            - deepbook-server
+          logsDatasource: mysten-logs-workloads-primary
+      - name: testnet
+        displayName: Testnet
+        stackName: mysten/deepbook/testnet
+        replicaControls:
+          - componentId: deepbook-server
+            pulumiConfigPath: /config/deepbook:serverReplicas
+            minReplicas: 0
+            maxReplicas: 10
+        imagePins:
+          - componentId: deepbook-indexer
+            imageConfigPath: /config/deepbook:indexerImage
+          - componentId: deepbook-server
+            imageConfigPath: /config/deepbook:serverImage
+        observability:
+          cluster: gke-workloads-secondary-use4
+          namespace: deepbook-testnet
+          containers:
+            - deepbook-indexer
+            - deepbook-server
+          logsDatasource: mysten-logs-workloads-secondary

--- a/crates/dashboard.yaml
+++ b/crates/dashboard.yaml
@@ -26,7 +26,7 @@ spec:
         replicaControls:
           - componentId: deepbook-server
             pulumiConfigPath: /config/deepbook:serverReplicas
-            minReplicas: 0
+            minReplicas: 1
             maxReplicas: 10
         imagePins:
           - componentId: deepbook-indexer


### PR DESCRIPTION
## Summary
- add a dashboard service manifest for the DeepBook core indexer and API server
- map mainnet and testnet deployments to `sui-operations/pulumi/apps/deepbook`
- expose server replica controls, image pins, and runtime observability targets

## Why
- DeepBook core deployments are not currently discoverable or manageable through the DeFi management dashboard
- the deployable Rust crates and Dockerfiles live in `deepbookv3`, so their manifest must live with this source repository

## Key decisions
- model indexer and server as one Pulumi deployment unit
- omit `crates/schema` because it is a shared library rather than an independently deployed runtime
- allow server scaling while keeping the singleton indexer outside replica controls

## Test plan
- [x] validate manifest YAML
- [x] verify component source paths and Dockerfiles exist
- [x] verify the Pulumi project and mainnet/testnet stack files exist
- [x] `git diff --check`

## Dependencies
- Dashboard multi-repository support: https://github.com/MystenLabs/deepbook-services/pull/100
- Production catalog configuration: https://github.com/MystenLabs/sui-operations/pull/8545
