### PR TITLE
predict: weight the trading fee by the pool's directional inventory (DBU-627)

### DIFF
--- a/packages/predict/sources/config/config_constants.move
+++ b/packages/predict/sources/config/config_constants.move
@@ -33,6 +33,8 @@ const EMarketTickSizeTooLarge: u64 = 22;
 const EInvalidNoLeverageWindowMs: u64 = 23;
 const EInvalidLpRequestLimitFlushAttempts: u64 = 24;
 const EInvalidMaxLpPoolValue: u64 = 25;
+const EInvalidInventoryCapitalFraction: u64 = 26;
+const EInvalidInventoryFeeSensitivity: u64 = 27;
 
 // === Fees ===
 
@@ -190,6 +192,60 @@ public(package) fun assert_no_leverage_window_ms(value: u64) {
     assert!(
         value >= min_no_leverage_window_ms!() && value <= max_no_leverage_window_ms!(),
         EInvalidNoLeverageWindowMs,
+    );
+}
+
+// === Inventory Fee Weight ===
+
+/// Fraction of an expiry's own allocated capital at which the inventory fee
+/// weight reaches full strength.
+///
+/// The normalizing depth is derived, not configured in absolute size: an expiry
+/// funded with twice the capital absorbs twice the directional position before
+/// weighting the fee by the same amount. Half the expiry's allocation by default.
+public(package) macro fun default_inventory_capital_fraction(): u64 { 500_000_000 }
+
+/// Nonzero: a zero fraction would make any position at all reach full weight.
+/// Disable the weight with `inventory_fee_sensitivity = 0` instead.
+public(package) macro fun min_inventory_capital_fraction(): u64 { 1 }
+
+/// The pool cannot take more one-sided directional risk on an expiry than that
+/// expiry's whole capital budget, so normalizing past 100% of it is unreachable.
+public(package) macro fun max_inventory_capital_fraction(): u64 {
+    fixed_math::math::float_scaling!()
+}
+
+public(package) fun assert_inventory_capital_fraction(value: u64) {
+    assert!(
+        value >= min_inventory_capital_fraction!()
+            && value <= max_inventory_capital_fraction!(),
+        EInvalidInventoryCapitalFraction,
+    );
+}
+
+/// How far the inventory weight may move the trading fee, as a fraction of the
+/// unweighted fee. The weight is `1 ± sensitivity·loading`, so `0.5` means a
+/// trade into a fully-loaded book pays 1.5x and one that offsets it pays 0.5x.
+///
+/// Ships at `0`, which pins the weight at exactly `1` and reproduces today's fee
+/// for every trade. Whether leaning the fee on inventory improves LP outcomes is
+/// an open question that wants live flow to answer, so it is enabled per expiry
+/// by an admin rather than at launch.
+public(package) macro fun default_inventory_fee_sensitivity(): u64 { 0 }
+
+public(package) macro fun min_inventory_fee_sensitivity(): u64 { 0 }
+
+/// Strictly below 1.0: at `1.0` a fully-offsetting trade would pay exactly zero
+/// fee, and anything above it would owe the trader a rebate — which makes a
+/// round trip through the vault profitable and is a drain, not an inducement.
+/// The ceiling is what lets the weight subtract without underflowing.
+public(package) macro fun max_inventory_fee_sensitivity(): u64 { 500_000_000 }
+
+public(package) fun assert_inventory_fee_sensitivity(value: u64) {
+    assert!(
+        value >= min_inventory_fee_sensitivity!()
+            && value <= max_inventory_fee_sensitivity!(),
+        EInvalidInventoryFeeSensitivity,
     );
 }
 

--- a/packages/predict/sources/config/protocol_config.move
+++ b/packages/predict/sources/config/protocol_config.move
@@ -191,6 +191,28 @@ public fun set_template_max_entry_probability(
     config.strike_exposure_template_config.set_max_entry_probability(value);
 }
 
+/// Set the fraction of an expiry's allocated capital at which the inventory fee
+/// weight reaches full strength, snapshotted by newly created expiry markets.
+public fun set_template_inventory_capital_fraction(
+    config: &mut ProtocolConfig,
+    _admin_cap: &AdminCap,
+    value: u64,
+) {
+    config.assert_version();
+    config.strike_exposure_template_config.set_inventory_capital_fraction(value);
+}
+
+/// Set how far the inventory weight may move the trading fee, snapshotted by
+/// newly created expiry markets. `0` snapshots the weight off.
+public fun set_template_inventory_fee_sensitivity(
+    config: &mut ProtocolConfig,
+    _admin_cap: &AdminCap,
+    value: u64,
+) {
+    config.assert_version();
+    config.strike_exposure_template_config.set_inventory_fee_sensitivity(value);
+}
+
 /// Select which source the live forward is built from: `true` carries the Block
 /// Scholes basis on a fresh Pyth spot, `false` uses the Block Scholes forward
 /// directly. Locked during valuation so one flush marks every market on one formula.

--- a/packages/predict/sources/config/strike_exposure_config.move
+++ b/packages/predict/sources/config/strike_exposure_config.move
@@ -10,7 +10,7 @@
 module deepbook_predict::strike_exposure_config;
 
 use deepbook_predict::{config_constants, constants};
-use fixed_math::math;
+use fixed_math::{i64::I64, math};
 
 const EOrderBelowLiquidationThreshold: u64 = 0;
 const EEntryProbabilityOutOfBounds: u64 = 1;
@@ -50,6 +50,14 @@ public struct StrikeExposureConfig has store {
     /// Window before expiry within which mint admission caps leverage at 1x, in ms.
     /// `0` disables the block.
     no_leverage_window_ms: u64,
+    /// Fraction of the expiry's own allocated capital at which the inventory fee
+    /// weight reaches full strength. The normalizing depth is derived per expiry
+    /// (`inventory_depth_lots`), so a bigger market absorbs a proportionally
+    /// bigger position before its fee moves by the same amount.
+    inventory_capital_fraction: u64,
+    /// How far the inventory weight may move the fee, as a fraction of the
+    /// unweighted fee. `0` pins the weight at 1 and disables the mechanism.
+    inventory_fee_sensitivity: u64,
 }
 
 /// Mint admission outcome: the net premium charged for the order and the static
@@ -99,6 +107,84 @@ public(package) fun expiry_fee_max_multiplier(config: &StrikeExposureConfig): u6
 
 public(package) fun no_leverage_window_ms(config: &StrikeExposureConfig): u64 {
     config.no_leverage_window_ms
+}
+
+public(package) fun inventory_fee_sensitivity(config: &StrikeExposureConfig): u64 {
+    config.inventory_fee_sensitivity
+}
+
+/// Net one-sided directional position, in position lots, at which the inventory
+/// fee weight reaches full strength for an expiry funded with `allocated_capital`.
+///
+/// Derived rather than configured, so the weight self-scales with the market and
+/// no operator has to hand-size a depth per expiry. The conversion to lots is
+/// exact: `allocated_capital` is DUSDC base units, and one lot of a one-sided
+/// position is `position_lot_size` base units of max payout — what the pool
+/// actually has at risk against it.
+///
+/// Returns `0` when the expiry's share of the fraction is under one lot; callers
+/// treat that as full strength, since any position at all exceeds the depth.
+public(package) fun inventory_depth_lots(
+    config: &StrikeExposureConfig,
+    allocated_capital: u64,
+): u64 {
+    math::mul_down(config.inventory_capital_fraction, allocated_capital)
+        / constants::position_lot_size!()
+}
+
+/// Multiplier applied to the unweighted trading fee for a trade that leaves the
+/// pool holding `post_trade_aggregate`, in FLOAT_SCALING.
+///
+/// `1 ± sensitivity · min(1, |aggregate| / depth)`, where the depth is
+/// `inventory_depth_lots(allocated_capital)`: dearer when the trade
+/// deepens the pool's existing directional lean, cheaper when it offsets one.
+/// Exactly `1.0` — today's fee, unchanged — whenever the mechanism is disabled,
+/// the book ends flat, or the trade is directionally neutral (a two-sided range,
+/// where the pool is short one boundary and long the other).
+///
+/// The weight multiplies the assembled fee, so it scales a rate that `min_fee`
+/// has already floored: a discounted trade can settle below `min_fee · quantity`.
+/// That is deliberate — `min_fee` floors the unweighted rate, and the weight is a
+/// policy multiplier on top of it, bounded strictly positive by
+/// `max_inventory_fee_sensitivity`.
+///
+/// Reading the POST-trade aggregate is what makes the weight undodgeable by
+/// sequencing: a trade is always charged against the position it leaves behind,
+/// so an order that overshoots from one lean into the opposite one pays for the
+/// exposure it just created rather than being rewarded for the one it cleared.
+public(package) fun inventory_fee_weight(
+    config: &StrikeExposureConfig,
+    post_trade_aggregate: &I64,
+    trade_delta: &I64,
+    allocated_capital: u64,
+): u64 {
+    let float_scaling = math::float_scaling!();
+    if (
+        config.inventory_fee_sensitivity == 0
+            || trade_delta.is_zero()
+            || post_trade_aggregate.is_zero()
+    ) return float_scaling;
+
+    // Checked, and `None` means full strength: a zero depth (an expiry funded
+    // below one lot) or a ratio too large for `u64` both mean the position
+    // dwarfs the depth. Aborting here would brick an under-funded expiry's
+    // trade path.
+    let loading = math::try_mul_div_down(
+        post_trade_aggregate.magnitude(),
+        float_scaling,
+        config.inventory_depth_lots(allocated_capital),
+    )
+        .destroy_or!(float_scaling)
+        .min(float_scaling);
+    // Bounded by `max_inventory_fee_sensitivity < 1.0`, so the subtraction
+    // cannot underflow and the weight stays strictly positive.
+    let swing = math::mul_down(config.inventory_fee_sensitivity, loading);
+
+    if (trade_delta.is_negative() == post_trade_aggregate.is_negative()) {
+        float_scaling + swing
+    } else {
+        float_scaling - swing
+    }
 }
 
 /// Returns the raw trade fee for a live probability and quantity, rounded down so the trader keeps sub-unit dust.
@@ -196,6 +282,8 @@ public(package) fun new(): StrikeExposureConfig {
         expiry_fee_window_ms: config_constants::default_expiry_fee_window_ms!(),
         expiry_fee_max_multiplier: config_constants::default_expiry_fee_max_multiplier!(),
         no_leverage_window_ms: config_constants::default_no_leverage_window_ms!(),
+        inventory_capital_fraction: config_constants::default_inventory_capital_fraction!(),
+        inventory_fee_sensitivity: config_constants::default_inventory_fee_sensitivity!(),
     }
 }
 
@@ -212,6 +300,8 @@ public(package) fun snapshot(config: &StrikeExposureConfig): StrikeExposureConfi
         expiry_fee_window_ms: config.expiry_fee_window_ms,
         expiry_fee_max_multiplier: config.expiry_fee_max_multiplier,
         no_leverage_window_ms: config.no_leverage_window_ms,
+        inventory_capital_fraction: config.inventory_capital_fraction,
+        inventory_fee_sensitivity: config.inventory_fee_sensitivity,
     }
 }
 
@@ -265,6 +355,16 @@ public(package) fun set_expiry_fee_max_multiplier(config: &mut StrikeExposureCon
 public(package) fun set_no_leverage_window_ms(config: &mut StrikeExposureConfig, window_ms: u64) {
     config_constants::assert_no_leverage_window_ms(window_ms);
     config.no_leverage_window_ms = window_ms;
+}
+
+public(package) fun set_inventory_capital_fraction(config: &mut StrikeExposureConfig, value: u64) {
+    config_constants::assert_inventory_capital_fraction(value);
+    config.inventory_capital_fraction = value;
+}
+
+public(package) fun set_inventory_fee_sensitivity(config: &mut StrikeExposureConfig, value: u64) {
+    config_constants::assert_inventory_fee_sensitivity(value);
+    config.inventory_fee_sensitivity = value;
 }
 
 /// Return the 1e9-scaled per-unit trade fee.

--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -29,7 +29,7 @@ use deepbook_predict::{
     strike_exposure_config
 };
 use dusdc::dusdc::DUSDC;
-use fixed_math::math;
+use fixed_math::{i64::I64, math};
 use propbook::{
     block_scholes_store::{BlockScholesSVIStore, BlockScholesValueStore},
     pyth_feed::PythFeed,
@@ -181,6 +181,15 @@ public fun tick_size(market: &ExpiryMarket): u64 {
 /// Return the admission-grid step for SDK and devInspect range construction.
 public fun admission_tick_size(market: &ExpiryMarket): u64 {
     market.strike_exposure.admission_tick_size()
+}
+
+/// Return the pool's net directional position against this expiry, in position
+/// lots, signed in UP-probability space: negative means the pool is net short
+/// UP, so trades that deepen that lean pay a weighted-up fee. Public for SDK and
+/// devInspect reads — this is the state that explains a fee sitting off its
+/// unweighted value.
+public fun directional_aggregate(market: &ExpiryMarket): I64 {
+    market.strike_exposure.directional_aggregate()
 }
 
 /// Return the admitted reference tick for SDK and devInspect range construction.
@@ -858,6 +867,7 @@ public(package) fun create_and_share(
     tick_size: u64,
     admission_tick_size: u64,
     reference_tick_source_timestamp_ms: u64,
+    allocated_capital: u64,
     ctx: &mut TxContext,
 ): ID {
     let id = object::new(ctx);
@@ -876,6 +886,7 @@ public(package) fun create_and_share(
             tick_size,
             admission_tick_size,
             reference_tick_source_timestamp_ms,
+            allocated_capital,
             strike_exposure_config,
             ctx,
         ),
@@ -989,7 +1000,7 @@ fun compute_mint_quote(
 ): MintQuote {
     let entry_probability = terms.entry_probability();
     let quantity = terms.quantity();
-    let raw_fee_amount = market.strike_exposure.trading_fee(entry_probability, quantity, clock);
+    let raw_fee_amount = market.strike_exposure.mint_trading_fee(terms, clock);
     let trading_fee = config.stake_config().fee_amount_after_discount(raw_fee_amount, active_stake);
     let fee_incentive_subsidy = market.fee_incentive_subsidy_amount(trading_fee);
     let builder_fee = builder_fee_amount(builder_code_id, trading_fee, quantity);
@@ -1136,14 +1147,7 @@ fun redeem(
         // the stake discount always leaves a discounted staker a positive net
         // even when the raw fee exceeds the payout (discount-then-clamp could
         // net them exactly zero).
-        let fee_amount = market
-            .strike_exposure
-            .trading_fee(
-                range_probability,
-                close_quantity,
-                clock,
-            )
-            .min(redeem_amount);
+        let fee_amount = market.strike_exposure.close_trading_fee(&terms, clock).min(redeem_amount);
         let fee_amount = config.stake_config().fee_amount_after_discount(fee_amount, active_stake);
 
         // The redeem payment decomposition, computed in full before any cash moves:

--- a/packages/predict/sources/registry/registry.move
+++ b/packages/predict/sources/registry/registry.move
@@ -261,6 +261,7 @@ public fun create_and_share_expiry_market(
         tick_size,
         admission_tick_size,
         reference_tick_source_timestamp_ms,
+        max_expiry_allocation,
         ctx,
     );
     pool_vault.register_expiry(

--- a/packages/predict/sources/strike_exposure/strike_exposure.move
+++ b/packages/predict/sources/strike_exposure/strike_exposure.move
@@ -23,7 +23,7 @@ use deepbook_predict::{
     strike_exposure_config::StrikeExposureConfig,
     strike_payout_tree::{Self, StrikePayoutTree}
 };
-use fixed_math::math;
+use fixed_math::{i64::{Self, I64}, math};
 use sui::clock::Clock;
 
 const EInvalidCloseQuantity: u64 = 0;
@@ -59,6 +59,19 @@ public struct StrikeExposure has store {
     liquidation: LiquidationBook,
     /// Sparse payout tree for live cash backing and settled liability.
     payout: StrikePayoutTree,
+    /// Net directional position the pool holds against this expiry's traders, in
+    /// position lots, signed in UP-probability space: negative means the pool is
+    /// net short UP. Maintained by `directional_lots` at every book mutation —
+    /// mint adds, and live close, liquidation, and settled close all release — so
+    /// it is the net live one-sided position in every phase. Read only to weight
+    /// the trading fee.
+    directional_aggregate: I64,
+    /// Pool capital budgeted to this expiry at creation (`max_expiry_allocation`),
+    /// in DUSDC base units. Normalizes the directional aggregate, so the fee
+    /// weight scales with the market rather than a hand-set constant.
+    /// Snapshotted and immutable: a depth that moved with LP flows would reprice
+    /// open interest with no trade occurring.
+    allocated_capital: u64,
 }
 
 /// Pure mint terms for one prospective live mint: the priced tick range,
@@ -268,24 +281,52 @@ public(package) fun reference_tick(exposure: &StrikeExposure): Option<u64> {
     exposure.reference_tick
 }
 
-/// Return the raw per-trade fee for a live price and quantity.
+/// Return the pool's net directional position against this expiry, in position
+/// lots. Negative means the pool is net short UP.
+public(package) fun directional_aggregate(exposure: &StrikeExposure): I64 {
+    exposure.directional_aggregate
+}
+
+/// Return the raw per-trade fee for a prospective mint, weighted by the
+/// directional position the mint would leave the pool holding.
 ///
-/// Fee collection is expiry-market payment accounting; exposure only owns the
-/// snapshotted config needed to price it.
-public(package) fun trading_fee(
+/// Fee collection is expiry-market payment accounting; exposure owns the
+/// snapshotted config that prices it and the inventory the weight reads.
+public(package) fun mint_trading_fee(
     exposure: &StrikeExposure,
-    probability: u64,
-    quantity: u64,
+    terms: &MintTerms,
     clock: &Clock,
 ): u64 {
-    exposure
-        .config
-        .trading_fee(
-            exposure.expiry_ms,
-            probability,
-            quantity,
-            clock.timestamp_ms(),
-        )
+    exposure.weighted_trading_fee(
+        &directional_lots(terms.lower_tick, terms.higher_tick, terms.quantity),
+        terms.entry_probability,
+        terms.quantity,
+        clock,
+    )
+}
+
+/// Return the raw per-trade fee for a prospective live close, weighted by the
+/// directional position the close would leave the pool holding. A close releases
+/// the slice's own weight, so flow that flattens the book is charged less.
+///
+/// Aborts unless the outcome is `Live`; only a live close pays a trading fee.
+public(package) fun close_trading_fee(
+    exposure: &StrikeExposure,
+    terms: &CloseTerms,
+    clock: &Clock,
+): u64 {
+    let live = terms.live_terms();
+    let released = directional_lots(
+        terms.order.lower_tick(),
+        terms.order.higher_tick(),
+        live.close_quantity,
+    ).neg();
+    exposure.weighted_trading_fee(
+        &released,
+        live.range_probability,
+        live.close_quantity,
+        clock,
+    )
 }
 
 /// Return whether a leveraged order remains in the liquidation index. One-x
@@ -385,6 +426,7 @@ public(package) fun allocate_mint_order(exposure: &mut StrikeExposure, terms: Mi
 
     exposure.liquidation.insert_order(&allocated_order);
     exposure.payout.insert_range(lower_tick, higher_tick, quantity, floor_shares);
+    exposure.apply_directional_delta(&directional_lots(lower_tick, higher_tick, quantity));
 
     allocated_order
 }
@@ -531,6 +573,7 @@ public(package) fun new(
     tick_size: u64,
     admission_tick_size: u64,
     reference_tick_source_timestamp_ms: u64,
+    allocated_capital: u64,
     config: StrikeExposureConfig,
     ctx: &mut TxContext,
 ): StrikeExposure {
@@ -547,6 +590,8 @@ public(package) fun new(
         settled_payout_liability: 0,
         liquidation: liquidation_book::new(ctx),
         payout: strike_payout_tree::new(ctx),
+        directional_aggregate: i64::zero(),
+        allocated_capital,
     }
 }
 
@@ -651,6 +696,7 @@ fun quote_live_close(order: &Order, close_quantity: u64, range_probability: u64)
 /// index and release its quoted payout from the settled liability.
 fun process_settled_close(exposure: &mut StrikeExposure, order: &Order, payout: u64) {
     exposure.liquidation.remove_order(order);
+    exposure.release_directional_delta(order, order.quantity());
     // Settlement liability and individual payouts use the same integer quantity
     // and floor atoms, so the subtraction is additive without rounding dust.
     exposure.settled_payout_liability = exposure.settled_payout_liability - payout;
@@ -675,6 +721,7 @@ fun process_live_close(
             remove_floor_shares,
         );
     exposure.liquidation.remove_order(order);
+    exposure.release_directional_delta(order, close_quantity);
 
     // The survivor keeps exactly what the closed slice did not remove:
     // conservation by construction, with `order::replacement` re-validating
@@ -734,6 +781,7 @@ fun apply_liquidation(
             order.quantity(),
             order.floor_shares(),
         );
+    exposure.release_directional_delta(order, order.quantity());
 
     order_events::emit_order_liquidated(
         exposure.expiry_market_id,
@@ -753,6 +801,67 @@ fun gross_order_value(exposure: &StrikeExposure, pricer: &Pricer, order: &Order)
 /// static floor. The reserve independently backs the order's full net payout.
 fun under_liquidation_floor(exposure: &StrikeExposure, gross_value: u64, floor_amount: u64): bool {
     gross_value <= math::div_down(floor_amount, exposure.config.liquidation_ltv())
+}
+
+/// Price the unweighted fee from the snapshotted config, then apply the
+/// inventory weight for the position this trade leaves behind.
+fun weighted_trading_fee(
+    exposure: &StrikeExposure,
+    delta: &I64,
+    probability: u64,
+    quantity: u64,
+    clock: &Clock,
+): u64 {
+    let fee = exposure
+        .config
+        .trading_fee(
+            exposure.expiry_ms,
+            probability,
+            quantity,
+            clock.timestamp_ms(),
+        );
+    let weight = exposure
+        .config
+        .inventory_fee_weight(
+            &exposure.directional_aggregate.add(delta),
+            delta,
+            exposure.allocated_capital,
+        );
+
+    math::mul_down(fee, weight)
+}
+
+/// Return `quantity` of `order`'s range to the pool, undoing exactly the
+/// directional weight the mint of that slice added.
+fun release_directional_delta(exposure: &mut StrikeExposure, order: &Order, quantity: u64) {
+    let released = directional_lots(order.lower_tick(), order.higher_tick(), quantity).neg();
+    exposure.apply_directional_delta(&released);
+}
+
+fun apply_directional_delta(exposure: &mut StrikeExposure, delta: &I64) {
+    exposure.directional_aggregate = exposure.directional_aggregate.add(delta);
+}
+
+/// Net directional position, in position lots, that the pool takes on when a
+/// trader buys `quantity` of `(lower_tick, higher_tick]`.
+///
+/// The pool is short what the trader is long: short `P(lower)`, long `P(higher)`.
+/// Only finite boundaries carry directional risk, because `P(-inf) = 1` and
+/// `P(+inf) = 0` are constants — so a one-sided binary moves the aggregate by its
+/// full size, while a two-sided range is directionally flat and leaves it alone.
+///
+/// This is the single owned evaluator for the aggregate: mint, live close, and
+/// liquidation all route through it, so a removal subtracts bit-equal what the
+/// insert added. It reads only atoms that round-trip losslessly through the
+/// packed order id (the boundary ticks and a whole number of lots) and no oracle
+/// state whatsoever, so the aggregate cannot drift as the surface moves. Any
+/// price-dependent weighting belongs at read time.
+fun directional_lots(lower_tick: u64, higher_tick: u64, quantity: u64): I64 {
+    let lots = quantity / constants::position_lot_size!();
+    let long_leg = if (higher_tick == constants::pos_inf_tick!()) 0 else lots;
+    let short_leg = if (lower_tick == 0) 0 else lots;
+
+    i64::from_u64(long_leg).sub(&i64::from_u64(short_leg))
 }
 
 fun order_range_price(exposure: &StrikeExposure, pricer: &Pricer, order: &Order): u64 {

--- a/packages/predict/tests/config/inventory_fee_weight_tests.move
+++ b/packages/predict/tests/config/inventory_fee_weight_tests.move
@@ -1,0 +1,325 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Unit coverage for `strike_exposure_config::inventory_fee_weight` and the
+/// capital-derived depth that normalizes it.
+///
+/// Every expected value is derived from the mechanism's specification rather
+/// than the implementation's expression: the weight is
+/// `1 ± sensitivity · min(1, |post_trade_aggregate| / depth_lots)`, raised when
+/// the trade deepens the pool's existing directional lean and lowered when it
+/// offsets one. Each constant below shows that arithmetic worked out by hand.
+#[test_only]
+module deepbook_predict::inventory_fee_weight_tests;
+
+use deepbook_predict::{config_constants, strike_exposure_config};
+use fixed_math::i64;
+use std::unit_test::{assert_eq, destroy};
+
+/// The unweighted fee: weight 1.0 in FLOAT_SCALING.
+const UNWEIGHTED: u64 = 1_000_000_000;
+/// 30% — the most this sensitivity may move a fee in either direction.
+const SENSITIVITY_THIRTY_PERCENT: u64 = 300_000_000;
+/// Capital that yields a 1,000,000-lot depth at `HALF_OF_CAPITAL`:
+/// 50% of 20_000e6 base units is 10_000e6, over the 10_000-unit lot size.
+const CAPITAL_FOR_DEPTH: u64 = 20_000_000_000;
+/// The depth `CAPITAL_FOR_DEPTH` produces, in lots.
+const DEPTH_LOTS: u64 = 1_000_000;
+const HALF_DEPTH_LOTS: u64 = 500_000;
+/// Ten times the depth, to exercise the saturation clamp on the loading.
+const TEN_TIMES_DEPTH_LOTS: u64 = 10_000_000;
+
+/// 1 + 0.30 · 1.0 = 1.30. Trade deepens a fully-loaded lean.
+const FULL_DEEPENING: u64 = 1_300_000_000;
+/// 1 - 0.30 · 1.0 = 0.70. Trade offsets a fully-loaded lean.
+const FULL_OFFSETTING: u64 = 700_000_000;
+/// 1 + 0.30 · 0.5 = 1.15. Half-loaded book.
+const HALF_DEEPENING: u64 = 1_150_000_000;
+/// 1 - 0.30 · 0.5 = 0.85.
+const HALF_OFFSETTING: u64 = 850_000_000;
+
+/// 50%, in FLOAT_SCALING: the shipped default share of an expiry's capital.
+const HALF_OF_CAPITAL: u64 = 500_000_000;
+/// The test-fixture per-expiry allocation, in DUSDC base units.
+const EXPIRY_ALLOCATION: u64 = 250_000_000_000;
+/// 50% of 250_000e6 = 125_000e6 base units, over the 10_000-unit lot size.
+const HALF_ALLOCATION_DEPTH_LOTS: u64 = 12_500_000;
+/// An allocation whose half is under one lot (10_000 base units).
+const DUST_ALLOCATION: u64 = 10_000;
+/// `1 - 0.5`, the weight at the hard sensitivity ceiling on the offsetting side.
+const HALF_WEIGHT: u64 = 500_000_000;
+
+/// Capital yielding a 3-lot depth: 50% of 60_000 is 30_000, over the 10_000-unit
+/// lot size. Chosen so `|aggregate| / depth` does not divide evenly.
+const CAPITAL_FOR_THREE_LOT_DEPTH: u64 = 60_000;
+/// 1 lot against a 3-lot depth: loading truncates to 0.333_333_333, and
+/// `0.3 · 0.333_333_333` truncates again to 0.099_999_999, so the weight is
+/// 1.099_999_999 — both truncations round toward the trader on a surcharge.
+const WEIGHT_AT_ONE_THIRD_LOADING: u64 = 1_099_999_999;
+
+/// Capital yielding a 1-lot depth: 50% of 20_000 is 10_000, exactly one lot.
+const CAPITAL_FOR_ONE_LOT_DEPTH: u64 = 20_000;
+
+/// A config with the weight enabled at 30%.
+fun weighted_config(): strike_exposure_config::StrikeExposureConfig {
+    let mut config = strike_exposure_config::new();
+    config.set_inventory_fee_sensitivity(SENSITIVITY_THIRTY_PERCENT);
+    config.set_inventory_capital_fraction(HALF_OF_CAPITAL);
+    config
+}
+
+/// The pool is net SHORT UP by `lots` (traders are long UP): aggregate negative.
+fun short_up(lots: u64): i64::I64 {
+    i64::from_parts(lots, true)
+}
+
+/// The pool is net LONG UP by `lots`: aggregate positive.
+fun long_up(lots: u64): i64::I64 {
+    i64::from_u64(lots)
+}
+
+// === Direction ===
+
+/// A trade that leaves the pool deeper in the direction it was already leaning
+/// pays more. Both the trade and the resulting position are short UP.
+#[test]
+fun trade_deepening_the_lean_raises_the_fee() {
+    let config = weighted_config();
+    assert_eq!(
+        config.inventory_fee_weight(
+            &short_up(DEPTH_LOTS),
+            &short_up(DEPTH_LOTS),
+            CAPITAL_FOR_DEPTH,
+        ),
+        FULL_DEEPENING,
+    );
+    destroy(config);
+}
+
+/// The mirror: a trade whose own direction opposes the resulting position is
+/// rebalancing flow and pays less.
+#[test]
+fun trade_offsetting_the_lean_lowers_the_fee() {
+    let config = weighted_config();
+    assert_eq!(
+        config.inventory_fee_weight(&short_up(DEPTH_LOTS), &long_up(DEPTH_LOTS), CAPITAL_FOR_DEPTH),
+        FULL_OFFSETTING,
+    );
+    destroy(config);
+}
+
+/// Sign-symmetric: a pool leaning long UP treats a long-UP trade as deepening.
+#[test]
+fun direction_is_symmetric_in_the_sign_of_the_position() {
+    let config = weighted_config();
+    assert_eq!(
+        config.inventory_fee_weight(&long_up(DEPTH_LOTS), &long_up(DEPTH_LOTS), CAPITAL_FOR_DEPTH),
+        FULL_DEEPENING,
+    );
+    assert_eq!(
+        config.inventory_fee_weight(&long_up(DEPTH_LOTS), &short_up(DEPTH_LOTS), CAPITAL_FOR_DEPTH),
+        FULL_OFFSETTING,
+    );
+    destroy(config);
+}
+
+// === Magnitude ===
+
+/// The swing is linear in how loaded the book is, up to the depth.
+#[test]
+fun half_loaded_book_swings_half_as_far() {
+    let config = weighted_config();
+    assert_eq!(
+        config.inventory_fee_weight(&short_up(HALF_DEPTH_LOTS), &short_up(1), CAPITAL_FOR_DEPTH),
+        HALF_DEEPENING,
+    );
+    assert_eq!(
+        config.inventory_fee_weight(&short_up(HALF_DEPTH_LOTS), &long_up(1), CAPITAL_FOR_DEPTH),
+        HALF_OFFSETTING,
+    );
+    destroy(config);
+}
+
+/// Position past the depth saturates: the weight never exceeds `1 ± sensitivity`,
+/// which is what bounds the fee no matter how lopsided the book gets.
+#[test]
+fun position_beyond_depth_saturates_at_the_configured_sensitivity() {
+    let config = weighted_config();
+    assert_eq!(
+        config.inventory_fee_weight(
+            &short_up(TEN_TIMES_DEPTH_LOTS),
+            &short_up(DEPTH_LOTS),
+            CAPITAL_FOR_DEPTH,
+        ),
+        FULL_DEEPENING,
+    );
+    destroy(config);
+}
+
+// === Weight is exactly 1 ===
+
+/// A trade that leaves the book exactly flat is neutral, whichever way it came.
+#[test]
+fun trade_landing_on_a_flat_book_is_unweighted() {
+    let config = weighted_config();
+    assert_eq!(
+        config.inventory_fee_weight(&i64::zero(), &long_up(DEPTH_LOTS), CAPITAL_FOR_DEPTH),
+        UNWEIGHTED,
+    );
+    destroy(config);
+}
+
+/// A two-sided range is directionally flat — the pool is short one boundary and
+/// long the other — so it never moves the fee, even on a lopsided book.
+#[test]
+fun directionally_neutral_trade_is_unweighted() {
+    let config = weighted_config();
+    assert_eq!(
+        config.inventory_fee_weight(&short_up(DEPTH_LOTS), &i64::zero(), CAPITAL_FOR_DEPTH),
+        UNWEIGHTED,
+    );
+    destroy(config);
+}
+
+/// The shipped default: every trade pays exactly today's fee until an admin
+/// snapshots a sensitivity into a new expiry.
+#[test]
+fun default_config_leaves_every_fee_unweighted() {
+    let config = strike_exposure_config::new();
+    assert_eq!(config.inventory_fee_sensitivity(), 0);
+    assert_eq!(
+        config.inventory_fee_weight(
+            &short_up(DEPTH_LOTS),
+            &short_up(DEPTH_LOTS),
+            CAPITAL_FOR_DEPTH,
+        ),
+        UNWEIGHTED,
+    );
+    destroy(config);
+}
+
+/// At the ceiling of the sensitivity envelope a fully-offsetting trade still
+/// pays a strictly positive fee. This is the property that keeps the weight from
+/// ever owing the trader a rebate, which would make a round trip through the
+/// vault profitable.
+#[test]
+fun ceiling_sensitivity_still_charges_a_positive_fee() {
+    let mut config = strike_exposure_config::new();
+    config.set_inventory_fee_sensitivity(config_constants::max_inventory_fee_sensitivity!());
+    config.set_inventory_capital_fraction(HALF_OF_CAPITAL);
+    let weight = config.inventory_fee_weight(
+        &short_up(DEPTH_LOTS),
+        &long_up(DEPTH_LOTS),
+        CAPITAL_FOR_DEPTH,
+    );
+    // 1 - 0.5 = 0.5 exactly, at the hard ceiling: still strictly positive, so
+    // the vault is never in the position of owing the trader a rebate.
+    assert_eq!(weight, HALF_WEIGHT);
+    destroy(config);
+}
+
+// === Capital-derived depth ===
+
+/// The depth is a fraction of the expiry's own allocated capital, converted to
+/// lots: 50% of 250_000e6 base units is 125_000e6, or 12.5M lots at the
+/// 10_000-unit lot size.
+#[test]
+fun depth_is_a_fraction_of_the_expiry_allocation() {
+    let config = weighted_config();
+    assert_eq!(config.inventory_depth_lots(EXPIRY_ALLOCATION), HALF_ALLOCATION_DEPTH_LOTS);
+    destroy(config);
+}
+
+/// Twice the capital absorbs twice the position before the fee moves by the same
+/// amount — the property that makes the weight self-scaling, and the reason the
+/// depth is derived rather than hand-set per market.
+#[test]
+fun depth_scales_linearly_with_allocated_capital() {
+    let config = weighted_config();
+    assert_eq!(config.inventory_depth_lots(2 * EXPIRY_ALLOCATION), 2 * HALF_ALLOCATION_DEPTH_LOTS);
+    destroy(config);
+}
+
+/// An expiry whose share of the fraction is under one lot yields depth zero. The
+/// weight must saturate rather than divide by zero: a trade on an under-funded
+/// expiry still has to price, and an abort here would brick its trade path.
+#[test]
+fun sub_lot_depth_saturates_instead_of_aborting() {
+    let config = weighted_config();
+    assert_eq!(config.inventory_depth_lots(DUST_ALLOCATION), 0);
+    assert_eq!(config.inventory_fee_weight(&short_up(1), &short_up(1), 0), FULL_DEEPENING);
+    destroy(config);
+}
+
+// === Rounding and overflow ===
+
+/// Both fixed-point truncations are visible only at a ratio that does not divide
+/// evenly. Every other test here uses loadings of 1.0 or 0.5, where they hide.
+#[test]
+fun weight_truncates_at_a_non_round_loading() {
+    let config = weighted_config();
+    assert_eq!(config.inventory_depth_lots(CAPITAL_FOR_THREE_LOT_DEPTH), 3);
+    assert_eq!(
+        config.inventory_fee_weight(&short_up(1), &short_up(1), CAPITAL_FOR_THREE_LOT_DEPTH),
+        WEIGHT_AT_ONE_THIRD_LOADING,
+    );
+    destroy(config);
+}
+
+/// The other half of the checked-arithmetic arm: a position whose ratio to the
+/// depth overflows `u64` saturates at full strength instead of aborting. The
+/// zero-depth half is covered by `sub_lot_depth_saturates_instead_of_aborting`.
+#[test]
+fun ratio_too_large_for_u64_saturates_instead_of_aborting() {
+    let config = weighted_config();
+    assert_eq!(config.inventory_depth_lots(CAPITAL_FOR_ONE_LOT_DEPTH), 1);
+    assert_eq!(
+        config.inventory_fee_weight(
+            &short_up(std::u64::max_value!()),
+            &short_up(1),
+            CAPITAL_FOR_ONE_LOT_DEPTH,
+        ),
+        FULL_DEEPENING,
+    );
+    destroy(config);
+}
+
+/// The smallest legal capital fraction drives the depth to zero against a
+/// realistic allocation, so every trade saturates at full sensitivity. That is
+/// the boundary an operator can actually reach by misconfiguration, and it must
+/// still price rather than abort.
+#[test]
+fun minimum_capital_fraction_saturates_every_trade() {
+    let mut config = strike_exposure_config::new();
+    config.set_inventory_fee_sensitivity(SENSITIVITY_THIRTY_PERCENT);
+    config.set_inventory_capital_fraction(config_constants::min_inventory_capital_fraction!());
+    assert_eq!(config.inventory_depth_lots(EXPIRY_ALLOCATION), 0);
+    assert_eq!(
+        config.inventory_fee_weight(&short_up(1), &short_up(1), EXPIRY_ALLOCATION),
+        FULL_DEEPENING,
+    );
+    destroy(config);
+}
+
+// === Config envelope ===
+
+#[test, expected_failure(abort_code = config_constants::EInvalidInventoryFeeSensitivity)]
+fun sensitivity_above_ceiling_aborts() {
+    let mut config = strike_exposure_config::new();
+    config.set_inventory_fee_sensitivity(config_constants::max_inventory_fee_sensitivity!() + 1);
+    abort 1337
+}
+
+#[test, expected_failure(abort_code = config_constants::EInvalidInventoryCapitalFraction)]
+fun zero_capital_fraction_aborts() {
+    let mut config = strike_exposure_config::new();
+    config.set_inventory_capital_fraction(0);
+    abort 1337
+}
+
+#[test, expected_failure(abort_code = config_constants::EInvalidInventoryCapitalFraction)]
+fun capital_fraction_above_one_aborts() {
+    let mut config = strike_exposure_config::new();
+    config.set_inventory_capital_fraction(config_constants::max_inventory_capital_fraction!() + 1);
+    abort 1337
+}

--- a/packages/predict/tests/config/protocol_config_bounds_tests.move
+++ b/packages/predict/tests/config/protocol_config_bounds_tests.move
@@ -19,6 +19,7 @@ module deepbook_predict::protocol_config_bounds_tests;
 use deepbook_predict::{
     admin::{Self, AdminCap},
     config_constants,
+    constants,
     flow_test_helpers as helpers,
     protocol_config::{Self, ProtocolConfig},
     test_constants
@@ -28,6 +29,10 @@ use sui::test_scenario::{Self as test, Scenario, return_shared};
 
 /// Create a real shared `ProtocolConfig` (all template values at defaults) and
 /// an `AdminCap`, ready for admin setter calls in the next transaction.
+/// A representative per-expiry allocation, for observing the capital fraction
+/// through the depth it derives.
+const TEMPLATE_TEST_ALLOCATION: u64 = 250_000_000_000;
+
 fun new_shared_config(): (Scenario, AdminCap, ID) {
     let mut scenario = test::begin(test_constants::admin());
     let config_id = protocol_config::create_and_share(scenario.ctx());
@@ -264,6 +269,14 @@ fun strike_exposure_template_setters_accept_envelope_boundaries() {
         &admin_cap,
         config_constants::min_backing_buffer_lambda!(),
     );
+    config.set_template_inventory_capital_fraction(
+        &admin_cap,
+        config_constants::min_inventory_capital_fraction!(),
+    );
+    config.set_template_inventory_fee_sensitivity(
+        &admin_cap,
+        config_constants::min_inventory_fee_sensitivity!(),
+    );
 
     let snapshot = config.strike_exposure_config_snapshot();
     assert_eq!(snapshot.base_fee(), config_constants::min_base_fee!());
@@ -281,6 +294,14 @@ fun strike_exposure_template_setters_accept_envelope_boundaries() {
     assert_eq!(snapshot.liquidation_ltv(), config_constants::min_liquidation_ltv!());
     assert_eq!(snapshot.max_admission_leverage(), config_constants::min_max_admission_leverage!());
     assert_eq!(snapshot.backing_buffer_lambda(), config_constants::min_backing_buffer_lambda!());
+    assert_eq!(
+        snapshot.inventory_fee_sensitivity(),
+        config_constants::min_inventory_fee_sensitivity!(),
+    );
+    // The capital fraction has no getter; its snapshot is observable through the
+    // depth it derives. At the minimum fraction a realistic allocation rounds to
+    // a zero-lot depth.
+    assert_eq!(snapshot.inventory_depth_lots(TEMPLATE_TEST_ALLOCATION), 0);
     destroy(snapshot);
 
     // Envelope ceilings. max entry probability goes up first so min entry
@@ -314,6 +335,14 @@ fun strike_exposure_template_setters_accept_envelope_boundaries() {
         &admin_cap,
         config_constants::max_backing_buffer_lambda!(),
     );
+    config.set_template_inventory_capital_fraction(
+        &admin_cap,
+        config_constants::max_inventory_capital_fraction!(),
+    );
+    config.set_template_inventory_fee_sensitivity(
+        &admin_cap,
+        config_constants::max_inventory_fee_sensitivity!(),
+    );
 
     let snapshot = config.strike_exposure_config_snapshot();
     assert_eq!(snapshot.base_fee(), config_constants::max_base_fee!());
@@ -331,6 +360,15 @@ fun strike_exposure_template_setters_accept_envelope_boundaries() {
     assert_eq!(snapshot.liquidation_ltv(), config_constants::max_liquidation_ltv!());
     assert_eq!(snapshot.max_admission_leverage(), config_constants::max_max_admission_leverage!());
     assert_eq!(snapshot.backing_buffer_lambda(), config_constants::max_backing_buffer_lambda!());
+    assert_eq!(
+        snapshot.inventory_fee_sensitivity(),
+        config_constants::max_inventory_fee_sensitivity!(),
+    );
+    // At a 100% capital fraction the depth is the whole allocation in lots.
+    assert_eq!(
+        snapshot.inventory_depth_lots(TEMPLATE_TEST_ALLOCATION),
+        TEMPLATE_TEST_ALLOCATION / constants::position_lot_size!(),
+    );
     destroy(snapshot);
 
     return_shared(config);

--- a/packages/predict/tests/flows/inventory_fee_weight_flow_tests.move
+++ b/packages/predict/tests/flows/inventory_fee_weight_flow_tests.move
@@ -1,0 +1,464 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Flow coverage for the inventory fee weight, driven through the production
+/// mint and redeem entrypoints.
+///
+/// The load-bearing property is the separation: inventory moves the FEE and
+/// never the mid, so `entry_probability` stays the oracle's fair mark through
+/// every trade and a complementary pair of ranges still costs exactly its payout
+/// before fees. The weight arithmetic itself is unit-tested in
+/// `config/inventory_fee_weight_tests`.
+#[test_only]
+module deepbook_predict::inventory_fee_weight_flow_tests;
+
+use deepbook_predict::{
+    constants,
+    expiry_market::MintQuote,
+    flow_test_helpers as helpers,
+    test_constants
+};
+use fixed_math::math::float_scaling as float;
+use std::unit_test::assert_eq;
+
+/// 30% maximum fee swing in either direction.
+const SENSITIVITY_THIRTY_PERCENT: u64 = 300_000_000;
+/// Fraction of the expiry's allocated capital at which the weight saturates.
+/// Against the fixture's 250_000e6 allocation this is 2_000e6 base units, or
+/// 200_000 lots — so one `MINT_QUANTITY` is exactly half the depth and swings
+/// the fee by half its maximum, well clear of integer rounding.
+const CAPITAL_FRACTION: u64 = 8_000_000;
+
+/// 1e9 base units at the 10_000-unit lot size = 100_000 lots.
+const MINT_QUANTITY: u64 = 1_000_000_000;
+const MINT_LOTS: u64 = 100_000;
+const HALF_MINT_QUANTITY: u64 = 500_000_000;
+const HALF_MINT_LOTS: u64 = 50_000;
+
+/// Finite mint boundaries must sit on the coarse admission grid, which is
+/// `default_admission_tick_size / default_tick_size = 10` fine ticks apart.
+const ADMISSION_TICK_MULTIPLE: u64 = 10;
+
+/// The unweighted fee for `MINT_QUANTITY`. The fixture sets `base_fee` to 1, so
+/// the Bernoulli term rounds to zero and the rate is pinned at the `min_fee`
+/// floor of 5_000_000: `5_000_000 · 1e9 / 1e9` per unit over 1e9 units.
+const UNWEIGHTED_FEE: u64 = 5_000_000;
+/// `MINT_QUANTITY` is half the 200_000-lot depth, so a trade that lands the book
+/// there carries loading 0.5 and weight `1 + 0.3·0.5` = 1.15.
+const FEE_AT_HALF_DEPTH_DEEPENING: u64 = 5_750_000;
+/// Loading 1.0 (book at full depth): `1 + 0.3·1.0` = 1.30.
+const FEE_AT_FULL_DEPTH_DEEPENING: u64 = 6_500_000;
+/// Loading 0.5 on the offsetting side: `1 - 0.3·0.5` = 0.85.
+const FEE_AT_HALF_DEPTH_OFFSETTING: u64 = 4_250_000;
+
+fun one_x(): u64 { test_constants::leverage_one_x() }
+
+/// 2x, so the order carries a floor and can be knocked out at all.
+const LEVERAGE_TWO_X: u64 = 2_000_000_000;
+/// Spot far below the strike, so an UP binary is worthless and liquidatable.
+const DROPPED_SPOT: u64 = 50_000_000_000;
+/// Clock at liquidation, past the fixture's `now_ms` so the mint and the
+/// knockout do not share a timestamp.
+const LIQUIDATION_CLOCK_MS: u64 = 121_000;
+/// Source timestamp of the dropped observation: before the clock reads it, and
+/// inside the freshness window.
+const DROP_SOURCE_TS: u64 = 120_500;
+
+fun strike(): u64 { helpers::strike_tick() }
+
+fun setup(): (helpers::Fixture, helpers::MarketBundle, helpers::AccountBundle) {
+    let (mut fx, expiry_id, trader) = helpers::setup_everything_with_fee_weight(
+        SENSITIVITY_THIRTY_PERCENT,
+        CAPITAL_FRACTION,
+    );
+    fx.scenario_mut().next_tx(test_constants::alice());
+    let market = fx.take_market_bundle(expiry_id);
+    let account = fx.take_account_bundle(&trader);
+    (fx, market, account)
+}
+
+fun cleanup(fx: helpers::Fixture, market: helpers::MarketBundle, account: helpers::AccountBundle) {
+    helpers::return_account_bundle(account);
+    helpers::return_market_bundle(market);
+    fx.finish();
+}
+
+/// Quote a `(K, +inf]` UP binary without touching the book.
+fun quote_up(fx: &mut helpers::Fixture, market: &helpers::MarketBundle, quantity: u64): MintQuote {
+    fx.quote_mint_bundle(market, strike(), constants::pos_inf_tick!(), quantity, one_x())
+}
+
+/// Quote the complementary `(-inf, K]` DOWN binary.
+fun quote_down(
+    fx: &mut helpers::Fixture,
+    market: &helpers::MarketBundle,
+    quantity: u64,
+): MintQuote {
+    fx.quote_mint_bundle(market, constants::neg_inf!(), strike(), quantity, one_x())
+}
+
+fun mint_up(
+    fx: &mut helpers::Fixture,
+    market: &mut helpers::MarketBundle,
+    account: &mut helpers::AccountBundle,
+    quantity: u64,
+): u256 {
+    fx.mint_bundle(market, account, strike(), constants::pos_inf_tick!(), quantity, one_x())
+}
+
+// === The mid is untouched ===
+
+/// The headline property. However lopsided the book gets, the quoted
+/// probability stays the oracle's fair mark — so NAV, the LP flush mark, and
+/// mint admission all continue to read exactly what they read before, and only
+/// the fee line moves.
+#[test]
+fun inventory_moves_the_fee_and_never_the_probability() {
+    let (mut fx, mut market, mut account) = setup();
+
+    // Even on an empty book this quote is already weighted: it is priced against
+    // the position it would itself create, which is half the depth.
+    let first = quote_up(&mut fx, &market, MINT_QUANTITY);
+    let probability = first.entry_probability();
+    assert_eq!(first.trading_fee(), FEE_AT_HALF_DEPTH_DEEPENING);
+
+    mint_up(&mut fx, &mut market, &mut account, MINT_QUANTITY);
+
+    // The same order now lands the book at full depth: dearer fee, same mid.
+    let second = quote_up(&mut fx, &market, MINT_QUANTITY);
+    assert_eq!(second.entry_probability(), probability);
+    assert_eq!(second.trading_fee(), FEE_AT_FULL_DEPTH_DEEPENING);
+
+    cleanup(fx, market, account);
+}
+
+/// A complementary pair still costs exactly its payout in premium terms, at any
+/// inventory state. The mid-shift design had to prove this; leaving the mid
+/// alone makes it hold by construction.
+#[test]
+fun complementary_pair_prices_at_exactly_one_regardless_of_inventory() {
+    let (mut fx, mut market, mut account) = setup();
+
+    let up_flat = quote_up(&mut fx, &market, MINT_QUANTITY).entry_probability();
+    let down_flat = quote_down(&mut fx, &market, MINT_QUANTITY).entry_probability();
+    assert_eq!(up_flat + down_flat, float!());
+
+    mint_up(&mut fx, &mut market, &mut account, 2 * MINT_QUANTITY);
+
+    let up_skewed = quote_up(&mut fx, &market, MINT_QUANTITY).entry_probability();
+    let down_skewed = quote_down(&mut fx, &market, MINT_QUANTITY).entry_probability();
+    assert_eq!(up_skewed + down_skewed, float!());
+    assert_eq!(up_skewed, up_flat);
+
+    cleanup(fx, market, account);
+}
+
+// === The fee responds to direction ===
+
+/// Flow that deepens the pool's lean pays a surcharge; flow that offsets it pays
+/// a genuine discount — strictly below the unweighted fee, not merely below the
+/// surcharged one.
+///
+/// The book is leaned by TWICE the quote size on purpose. At a single lean the
+/// offsetting quote would drive the book to exactly flat, hit the zero-aggregate
+/// early return, and come back unweighted — which would still satisfy
+/// `offsetting < deepening` while never exercising the discount branch at all.
+#[test]
+fun offsetting_flow_is_discounted_below_the_unweighted_fee() {
+    let (mut fx, mut market, mut account) = setup();
+
+    mint_up(&mut fx, &mut market, &mut account, 2 * MINT_QUANTITY);
+
+    // Lands the book at full depth in the direction it already leans.
+    let deepening = quote_up(&mut fx, &market, MINT_QUANTITY).trading_fee();
+    assert_eq!(deepening, FEE_AT_FULL_DEPTH_DEEPENING);
+
+    // Pulls the book back to half depth: still leaning, so still weighted.
+    let offsetting = quote_down(&mut fx, &market, MINT_QUANTITY).trading_fee();
+    assert_eq!(offsetting, FEE_AT_HALF_DEPTH_OFFSETTING);
+    assert!(offsetting < UNWEIGHTED_FEE);
+
+    cleanup(fx, market, account);
+}
+
+/// A trade that exactly flattens the book is unweighted — the boundary the test
+/// above deliberately steps around.
+#[test]
+fun trade_that_flattens_the_book_is_unweighted() {
+    let (mut fx, mut market, mut account) = setup();
+
+    mint_up(&mut fx, &mut market, &mut account, MINT_QUANTITY);
+    let flattening = quote_down(&mut fx, &market, MINT_QUANTITY).trading_fee();
+    assert_eq!(flattening, UNWEIGHTED_FEE);
+
+    cleanup(fx, market, account);
+}
+
+/// A trade whose delta exceeds the pool's current lean overshoots into the
+/// opposite exposure, and is surcharged for the position it creates rather than
+/// rewarded for the one it cleared. This is the sharp end of pricing post-trade.
+#[test]
+fun overshooting_trade_pays_for_the_exposure_it_creates() {
+    let (mut fx, mut market, mut account) = setup();
+
+    mint_up(&mut fx, &mut market, &mut account, MINT_QUANTITY);
+
+    // Pool is short 100_000 lots; a 300_000-lot DOWN binary lands it long
+    // 200_000 — past the depth, so the weight saturates at the surcharge.
+    let overshoot = quote_down(&mut fx, &market, 3 * MINT_QUANTITY).trading_fee();
+    assert_eq!(overshoot, 3 * FEE_AT_FULL_DEPTH_DEEPENING);
+
+    cleanup(fx, market, account);
+}
+
+/// A two-sided range takes no directional position, so its fee is the
+/// unweighted one even on a lopsided book.
+#[test]
+fun two_sided_range_pays_the_unweighted_fee() {
+    let (mut fx, mut market, mut account) = setup();
+
+    let lower = strike() - ADMISSION_TICK_MULTIPLE;
+    let flat_book_fee = fx
+        .quote_mint_bundle(&market, lower, strike(), MINT_QUANTITY, one_x())
+        .trading_fee();
+
+    mint_up(&mut fx, &mut market, &mut account, 2 * MINT_QUANTITY);
+
+    let lopsided_book_fee = fx
+        .quote_mint_bundle(&market, lower, strike(), MINT_QUANTITY, one_x())
+        .trading_fee();
+    assert_eq!(lopsided_book_fee, flat_book_fee);
+    assert_eq!(lopsided_book_fee, UNWEIGHTED_FEE);
+
+    cleanup(fx, market, account);
+}
+
+/// The weight reads the position a trade LEAVES BEHIND, so it cannot be dodged
+/// by sequencing: buying 2x at once and buying 1x after another 1x already
+/// landed both end on the same book and pay the same weighted fee.
+#[test]
+fun fee_depends_only_on_the_resulting_position() {
+    let (mut fx, mut market, mut account) = setup();
+
+    let double_on_flat_book = quote_up(&mut fx, &market, 2 * MINT_QUANTITY).trading_fee();
+
+    mint_up(&mut fx, &mut market, &mut account, MINT_QUANTITY);
+    let single_after_the_first = quote_up(&mut fx, &market, MINT_QUANTITY).trading_fee();
+
+    // Twice the quantity carries twice the unweighted fee, so compare per-unit:
+    // the 2x order's fee at 2x quantity against the 1x order's at 1x quantity.
+    assert_eq!(double_on_flat_book / 2, single_after_the_first);
+
+    cleanup(fx, market, account);
+}
+
+/// The close path is weighted too, and its direction depends on the book the
+/// close lands on — not on the fact that it is a close.
+///
+/// Both closes below are the same order, the same size, at the same mid (the
+/// weight never moves the mid) and the same fee ramp, so the unweighted fee is
+/// identical and the ONLY difference is the pool's directional position. The
+/// first lands while the pool is still short UP, so releasing an UP position
+/// offsets the lean and is discounted. Between them the book is flipped long UP,
+/// so the second release now deepens the lean and is surcharged.
+///
+/// Driven through the real redeem entrypoint and measured on fees actually
+/// debited from the account, so this pins the `close_trading_fee` payment path
+/// rather than a quote.
+#[test]
+fun close_is_discounted_offsetting_and_surcharged_when_it_deepens() {
+    let (mut fx, expiry_id, trader) = helpers::setup_everything_with_fee_weight(
+        SENSITIVITY_THIRTY_PERCENT,
+        CAPITAL_FRACTION,
+    );
+    fx.scenario_mut().next_tx(test_constants::alice());
+    let mut market = fx.take_market_bundle(expiry_id);
+    let mut account = fx.take_account_bundle(&trader);
+
+    let order_id = mint_up(&mut fx, &mut market, &mut account, MINT_QUANTITY);
+    let after_mint = helpers::fees_paid_bundle(&account, expiry_id);
+
+    // A position cannot be minted and closed in the same millisecond.
+    fx.set_clock_for_testing(test_constants::now_ms() + 1);
+
+    // Pool is short UP; releasing an UP position offsets that lean.
+    let (_, replacement) = fx.redeem_bundle(
+        &mut market,
+        &mut account,
+        order_id,
+        HALF_MINT_QUANTITY,
+    );
+    let offsetting_close_fee = helpers::fees_paid_bundle(&account, expiry_id) - after_mint;
+    let after_first_close = helpers::market(&market).directional_aggregate();
+    assert!(after_first_close.is_negative());
+    assert_eq!(after_first_close.magnitude(), HALF_MINT_LOTS);
+
+    // Flip the book long UP, so releasing the rest now deepens the lean instead.
+    fx.mint_bundle(
+        &mut market,
+        &mut account,
+        constants::neg_inf!(),
+        strike(),
+        2 * MINT_QUANTITY,
+        one_x(),
+    );
+    let before_second_close = helpers::fees_paid_bundle(&account, expiry_id);
+    let after_flip = helpers::market(&market).directional_aggregate();
+    assert!(!after_flip.is_negative());
+    assert_eq!(after_flip.magnitude(), 3 * HALF_MINT_LOTS);
+
+    fx.redeem_bundle(&mut market, &mut account, replacement.destroy_some(), HALF_MINT_QUANTITY);
+    let deepening_close_fee = helpers::fees_paid_bundle(&account, expiry_id) - before_second_close;
+
+    assert!(deepening_close_fee > offsetting_close_fee);
+
+    cleanup(fx, market, account);
+}
+
+// === Aggregate accounting ===
+
+/// The aggregate moves by exactly the traded lots and returns to exactly zero on
+/// a full round trip — including across two partial closes, which exercise the
+/// survivor reinsertion path rather than one symmetric removal. Exact, not
+/// approximate: the aggregate reads only atoms that round-trip through the
+/// packed order id, so no oracle movement between open and close leaves a
+/// residual.
+#[test]
+fun aggregate_tracks_traded_lots_and_returns_to_zero() {
+    let (mut fx, mut market, mut account) = setup();
+
+    assert!(helpers::market(&market).directional_aggregate().is_zero());
+
+    let order_id = mint_up(&mut fx, &mut market, &mut account, MINT_QUANTITY);
+    let after_mint = helpers::market(&market).directional_aggregate();
+    assert!(after_mint.is_negative());
+    assert_eq!(after_mint.magnitude(), MINT_LOTS);
+
+    // A position cannot be minted and closed in the same millisecond.
+    fx.set_clock_for_testing(test_constants::now_ms() + 1);
+    let (_, replacement) = fx.redeem_bundle(
+        &mut market,
+        &mut account,
+        order_id,
+        HALF_MINT_QUANTITY,
+    );
+    let mid_close = helpers::market(&market).directional_aggregate();
+    assert!(mid_close.is_negative());
+    assert_eq!(mid_close.magnitude(), HALF_MINT_LOTS);
+
+    fx.redeem_bundle(&mut market, &mut account, replacement.destroy_some(), HALF_MINT_QUANTITY);
+    assert!(helpers::market(&market).directional_aggregate().is_zero());
+
+    cleanup(fx, market, account);
+}
+
+/// Buying the DOWN leg moves the aggregate the other way.
+#[test]
+fun down_binary_moves_the_aggregate_the_other_way() {
+    let (mut fx, mut market, mut account) = setup();
+
+    fx.mint_bundle(
+        &mut market,
+        &mut account,
+        constants::neg_inf!(),
+        strike(),
+        MINT_QUANTITY,
+        one_x(),
+    );
+
+    let aggregate = helpers::market(&market).directional_aggregate();
+    assert!(!aggregate.is_negative());
+    assert_eq!(aggregate.magnitude(), MINT_LOTS);
+
+    cleanup(fx, market, account);
+}
+
+// === Every mutation site releases ===
+
+/// Liquidation releases the knocked-out order's directional weight, and the
+/// later redeem of that already-liquidated order must NOT release it a second
+/// time. Nothing else pins that asymmetry: `apply_liquidation` releases, while
+/// the `Liquidated` close arm only clears the holder's position — a future edit
+/// adding a release there would double-subtract and flip the aggregate's sign,
+/// mis-weighting every subsequent fee on the expiry.
+#[test]
+fun liquidation_releases_once_and_the_liquidated_redeem_does_not_release_again() {
+    let (mut fx, expiry_id, trader) = helpers::setup_everything_with_fee_weight(
+        SENSITIVITY_THIRTY_PERCENT,
+        CAPITAL_FRACTION,
+    );
+    fx.scenario_mut().next_tx(test_constants::alice());
+    let mut market = fx.take_market_bundle(expiry_id);
+    let mut account = fx.take_account_bundle(&trader);
+
+    // Leveraged, so the order is liquidatable at all (a 1x order has no floor).
+    let order_id = fx.mint_bundle(
+        &mut market,
+        &mut account,
+        strike(),
+        constants::pos_inf_tick!(),
+        MINT_QUANTITY,
+        LEVERAGE_TWO_X,
+    );
+    assert_eq!(helpers::market(&market).directional_aggregate().magnitude(), MINT_LOTS);
+
+    // Drop the forward far below the strike so the UP binary knocks out.
+    fx.set_clock_for_testing(LIQUIDATION_CLOCK_MS);
+    fx.set_pyth_price_for_testing_bundle(&mut market, DROPPED_SPOT, DROP_SOURCE_TS);
+    assert!(fx.liquidate_order_bundle(&mut market, order_id));
+    assert!(helpers::market(&market).directional_aggregate().is_zero());
+
+    // Redeeming the already-liquidated order pays zero and must leave the
+    // aggregate exactly where liquidation left it.
+    fx.redeem_bundle(&mut market, &mut account, order_id, MINT_QUANTITY);
+    assert!(helpers::market(&market).directional_aggregate().is_zero());
+
+    cleanup(fx, market, account);
+}
+
+/// A settled redeem releases too, so the aggregate reads as the net live
+/// one-sided position in every phase rather than stranding a phantom position
+/// on the public getter after expiry.
+#[test]
+fun settled_redeem_releases_the_aggregate() {
+    let (mut fx, expiry_id, trader) = helpers::setup_everything_with_fee_weight(
+        SENSITIVITY_THIRTY_PERCENT,
+        CAPITAL_FRACTION,
+    );
+    fx.scenario_mut().next_tx(test_constants::alice());
+    let mut market = fx.take_market_bundle(expiry_id);
+    let mut account = fx.take_account_bundle(&trader);
+
+    let order_id = mint_up(&mut fx, &mut market, &mut account, MINT_QUANTITY);
+    assert_eq!(helpers::market(&market).directional_aggregate().magnitude(), MINT_LOTS);
+
+    fx.set_clock_for_testing(test_constants::default_expiry_ms());
+    fx.insert_exact_settlement_spot_bundle(&mut market, test_constants::default_live_price());
+    assert!(fx.try_settle_bundle(&mut market));
+
+    fx.redeem_settled_bundle(&mut market, &mut account, order_id, MINT_QUANTITY);
+    assert!(helpers::market(&market).directional_aggregate().is_zero());
+
+    cleanup(fx, market, account);
+}
+
+// === Disabled by default ===
+
+/// With the weight off — the shipped default — the fee is the unweighted one at
+/// every inventory state, while the aggregate is still maintained. Enabling a
+/// future expiry therefore needs no migration.
+#[test]
+fun disabled_weight_leaves_every_fee_unweighted() {
+    let (mut fx, expiry_id, trader) = helpers::setup_everything();
+    fx.scenario_mut().next_tx(test_constants::alice());
+    let mut market = fx.take_market_bundle(expiry_id);
+    let mut account = fx.take_account_bundle(&trader);
+
+    let flat_fee = quote_up(&mut fx, &market, MINT_QUANTITY).trading_fee();
+
+    mint_up(&mut fx, &mut market, &mut account, MINT_QUANTITY);
+    assert_eq!(helpers::market(&market).directional_aggregate().magnitude(), MINT_LOTS);
+    assert_eq!(quote_up(&mut fx, &market, MINT_QUANTITY).trading_fee(), flat_fee);
+
+    cleanup(fx, market, account);
+}

--- a/packages/predict/tests/helper/flow_test_helpers.move
+++ b/packages/predict/tests/helper/flow_test_helpers.move
@@ -272,8 +272,36 @@ public fun setup_everything(): (Fixture, ID, Trader) {
     )
 }
 
+/// `setup_everything` with the inventory fee weight snapshotted into the expiry.
+/// The weight ships disabled and the snapshot has no live setter, so the
+/// template must be set before the market is created.
+public fun setup_everything_with_fee_weight(
+    sensitivity: u64,
+    capital_fraction: u64,
+): (Fixture, ID, Trader) {
+    let mut fx = setup_market_default();
+    fx.set_template_inventory_fee_weight(sensitivity, capital_fraction);
+    fx.fund_live_market(
+        test_constants::default_expiry_ms(),
+        test_constants::default_live_price(),
+        test_constants::default_manager_deposit(),
+    )
+}
+
 fun setup_funded_live_market(expiry_ms: u64, live_price: u64, deposit: u64): (Fixture, ID, Trader) {
     let mut fx = setup_market_default();
+    fx.fund_live_market(expiry_ms, live_price, deposit)
+}
+
+/// The shared bring-up tail: create the expiry, fund a trader, seed the live
+/// oracle and expiry cash. Takes the fixture by value and hands it back so every
+/// variant composes the same sequence rather than copying it.
+fun fund_live_market(
+    mut fx: Fixture,
+    expiry_ms: u64,
+    live_price: u64,
+    deposit: u64,
+): (Fixture, ID, Trader) {
     let expiry_id = fx.create_expiry(expiry_ms);
     let trader = fx.create_funded_manager(deposit);
     let mut market = fx.take_market_bundle(expiry_id);
@@ -491,6 +519,22 @@ public fun set_template_max_admission_leverage(self: &mut Fixture, value: u64) {
     self.scenario.next_tx(test_constants::admin());
     let mut config = self.scenario.take_shared<ProtocolConfig>();
     config.set_template_max_admission_leverage(&self.admin_cap, value);
+    return_shared(config);
+    self.scenario.next_tx(test_constants::admin());
+}
+
+/// Enable the inventory fee weight for expiries created after this call. The
+/// weight ships disabled and the per-expiry snapshot has no live setter, so this
+/// must run before `create_expiry`.
+public fun set_template_inventory_fee_weight(
+    self: &mut Fixture,
+    sensitivity: u64,
+    capital_fraction: u64,
+) {
+    self.scenario.next_tx(test_constants::admin());
+    let mut config = self.scenario.take_shared<ProtocolConfig>();
+    config.set_template_inventory_fee_sensitivity(&self.admin_cap, sensitivity);
+    config.set_template_inventory_capital_fraction(&self.admin_cap, capital_fraction);
     return_shared(config);
     self.scenario.next_tx(test_constants::admin());
 }

--- a/packages/predict/tests/reference_tick_tests.move
+++ b/packages/predict/tests/reference_tick_tests.move
@@ -277,6 +277,7 @@ fun create_and_share_exposure_harness(fx: &mut OracleFixture): ID {
         test_constants::default_tick_size(),
         test_constants::default_admission_tick_size(),
         fx.expiry() - test_constants::default_cadence_period_ms(),
+        test_constants::default_max_expiry_allocation(),
         strike_exposure_config::new(),
         fx.scenario_mut().ctx(),
     );

--- a/packages/predict/tests/strike_exposure/close_terms_boundary_tests.move
+++ b/packages/predict/tests/strike_exposure/close_terms_boundary_tests.move
@@ -171,6 +171,7 @@ fun create_and_share_exposure_harness(
         test_constants::default_tick_size(),
         test_constants::default_tick_size(),
         expiry_ms - test_constants::default_cadence_period_ms(),
+        test_constants::default_max_expiry_allocation(),
         config,
         fx.scenario_mut().ctx(),
     );

--- a/packages/predict/tests/strike_exposure/liquidated_settled_redeem_tests.move
+++ b/packages/predict/tests/strike_exposure/liquidated_settled_redeem_tests.move
@@ -142,6 +142,7 @@ fun create_and_share_exposure_harness(fx: &mut OracleFixture): ID {
         test_constants::default_tick_size(),
         test_constants::default_tick_size(),
         expiry_ms - test_constants::default_cadence_period_ms(),
+        test_constants::default_max_expiry_allocation(),
         config,
         fx.scenario_mut().ctx(),
     );

--- a/packages/predict/tests/strike_exposure/mint_terms_binding_tests.move
+++ b/packages/predict/tests/strike_exposure/mint_terms_binding_tests.move
@@ -72,6 +72,7 @@ fun create_and_share_exposure_harness(
         test_constants::default_tick_size(),
         test_constants::default_tick_size(),
         expiry_ms - test_constants::default_cadence_period_ms(),
+        test_constants::default_max_expiry_allocation(),
         strike_exposure_config::new(),
         fx.scenario_mut().ctx(),
     );


### PR DESCRIPTION
## Summary

- Weights the trading fee by the directional position a trade leaves the pool holding: dearer when it deepens the pool's lean, cheaper when it offsets one. The mid is untouched.
- `fee = unweighted_fee · (1 ± sensitivity · min(1, |aggregate| / depth))`, exactly the unweighted fee when the mechanism is off, the book ends flat, or the trade is directionally neutral.
- Adds an exact signed-lot directional aggregate on `StrikeExposure`, released at every close path, plus a per-expiry capital snapshot that normalises it.
- Two admin-tunable knobs snapshotted per expiry (`inventory_fee_sensitivity`, `inventory_capital_fraction`). **Ships disabled.**

## Why

Predict's fee is symmetric in the pool's own position — it charges the same whether a trade adds to the vault's directional exposure or offsets it — so the pool accumulates inventory at no price and nothing in the quote rewards flow that brings the book back toward neutral.

This is the inventory weight from Block Scholes' `DeepBook: Confidence Price Adjustment` (appendix, post-MVP direction), which specifies it as a multiplier on the fee with `w = 1` reproducing the unweighted fee exactly. That paper also names the prerequisite as an architectural one: the vault's net position has to be reachable in the pricing path at quote/mint time, and it is cheaper to allow for while the contracts are being finalised than to retrofit. This PR builds that state and uses it.

Predict's existing base fee is already BS's `max(0.02·sqrt(p(1-p)), 0.005)` exactly, so the weight composes with the fee that is there rather than replacing it. The classical inventory models (Avellaneda-Stoikov, Ho-Stoll) skew the *reservation price* rather than the fee, and their adjustment is likewise linear in inventory; the saturation clamp here is the one addition, and it is forced — a fee multiplier has to stay positive.

## Linear / Context

- DBU-627
- Supersedes #1156, which applied the same signal to the **mid** instead. Moving it to the fee removes an entire class of interaction — see below.
- Prior art: #995 (merged, then reverted) and #999 (closed) both skewed the mid against the pre-rework contracts.

## Key Decisions

- **The mid is untouched, and that is the point.** Pricing, NAV, the LP flush mark, mint admission, and liquidation all continue to read the oracle's fair mark. A complementary pair of ranges still costs exactly its payout before fees — by construction, not by proof — and inventory can never move the admitted-leverage curve or push an order across its knockout. `packages/predict/docs/design/decisions.md` records "no inventory-aware mid shift" as a rejected direction; this does not revisit it.
- **The stored aggregate carries no oracle state.** It reads only atoms that round-trip losslessly through the packed order id, through one owned evaluator shared by mint, close, liquidation, and settled close, so a removal subtracts bit-equal what the insert added. Weighting a *stored* aggregate by the live surface is exactly what drifted in the reverted attempts; any price-dependent weighting belongs at read time.
- **Every close path releases**, including settled redeems, so the aggregate means "net live one-sided position" in every phase rather than stranding a phantom position on the public getter after expiry.
- **The depth is derived from the expiry's own capital,** not hand-set: an expiry funded with twice the capital absorbs twice the position before its fee moves as far. The capital snapshot is immutable — a depth that tracked LP flows would reprice open interest with no trade occurring.
- **Post-trade, so sequencing cannot dodge it.** An order that overshoots from one lean into the opposite one pays for the exposure it just created rather than being rewarded for the one it cleared.
- **Bounded so the fee can never invert.** `max_inventory_fee_sensitivity` is strictly below 1.0: at 1.0 a fully-offsetting trade would pay zero fee, and beyond it the vault would owe a rebate — which makes a round trip through the vault profitable and is a drain, not an inducement. A zero depth (an expiry funded below one lot) saturates rather than dividing by zero.
- **The weight multiplies the assembled fee, so a discount can settle below `min_fee · quantity`.** `min_fee` floors the unweighted *rate*; the weight is a policy multiplier on top of it. Deliberate, documented at the function, and pinned by test.

## Scope / Descoped

- **Whether the weight improves LP outcomes is not answered here**, which is why the default is off. BS is explicit that this is calibrated on real fills rather than a proxy.
- The aggregate is one scalar in payout space. A one-sided binary counts its full size regardless of strike, so a deep out-of-the-money position and an at-the-money one move it equally. BS's `loading` is the price-space analogue; reconciling the two is follow-up work and cannot be done by weighting the stored aggregate (see drift above).
- Per-expiry, not pool-wide: correlated exposure across several live expiries of the same underlying is not visible to any one of them.
- BS's MVP `loading` multiplier and 300bps cap are not implemented here; the weight multiplies Predict's existing assembled fee.

## Test Plan

- [x] `sui move build --path packages/predict --warnings-are-errors` — clean
- [x] `sui move test --path packages/predict --gas-limit 100000000000` — **541/541** pass (503 pre-existing unchanged + 38 new/extended)
- [x] Formatted with the repo-pinned `prettier-move`
- [x] **Unit** (`tests/config/inventory_fee_weight_tests.move`, 18): both directions, sign symmetry, linear response, saturation past depth, all three exactly-1 cases, the positive-fee floor at the sensitivity ceiling, capital-derived depth and its linear scaling, **both arms of the checked-arithmetic saturation** (zero depth and a `u64`-overflowing ratio), **fixed-point truncation at a non-round loading**, the minimum-capital-fraction boundary, and every config bound
- [x] **Flow** (`tests/flows/inventory_fee_weight_flow_tests.move`, 13): probability identical while the fee moves, complementary pair at exactly 1 on a lopsided book, a **genuine discount below the unweighted fee**, the exactly-flattening trade that is unweighted, an **overshooting trade surcharged for the exposure it creates**, two-sided range unweighted, path-independence, exact aggregate round trip across two partial closes, a close discounted then surcharged across a book sign flip, **liquidation releasing exactly once with the liquidated redeem not double-releasing**, and **settled redeem releasing**
- [x] **Admin surface**: both new template setters added to the existing `protocol_config_bounds_tests` envelope test, asserting the snapshot round-trips at each bound
- [x] Fee assertions are exact values hand-derived from the fixture, not inequalities
- [ ] Independent review (not yet run)

## Risk / Rollout

Ships inert: `default_inventory_fee_sensitivity = 0`, so every trade pays exactly today's fee and the pre-existing suite passes unchanged. Enabling is per-expiry and forward-only — the snapshot has no live setter, deliberately. The aggregate is maintained while disabled, so enabling a later expiry needs no migration.
