### PR TITLE
predict: document safe deployment workflow (DBU-568)

### DIFF
--- a/.claude/rules/move.md
+++ b/.claude/rules/move.md
@@ -1,6 +1,8 @@
 ---
 paths:
   - "packages/**/*.move"
+  - "packages/**/Move.toml"
+  - "packages/**/Published.toml"
 ---
 
 # Sui Move Instructions
@@ -165,6 +167,14 @@ Then call as `self.id.exists_(key)`, `self.id.add(key, value)`, `self.id.borrow(
 - When you have completed making Move changes, run `pnpm install --frozen-lockfile && pnpm format:move` before opening the PR. CI runs the same script (`format:move:check`) over the same file set, so a clean local run means a clean check.
 - **Never format with `bunx`/`npx prettier-move`, a globally-installed prettier, or `sui move format`.** Those resolve whatever plugin version is latest; the lockfile pins the version CI enforces, and the two format differently. A local run with the wrong version silently rewrites files CI then rejects — or worse, passes locally and reddens someone else's PR later.
 - `pnpm format:move` formats every package, not just your files. That is deliberate and safe: the tree is formatted at HEAD, so it is a no-op outside your own edits. If it reports changes to files you did not touch, do not just commit them — that means something upstream drifted, and the drift belongs in its own PR (why: the check once matched only 45 of 182 files, so drift accumulated where it could not be seen, and the next PR to format such a file inherited unrelated churn in its diff — deepbookv3#1126).
+
+## Package manifests and publication identity
+
+- `Move.toml` is the canonical production dependency declaration. Keep dependency sources and identities correct for production publication; localnet, simulation, and harness environments must adapt in isolated staged copies rather than changing the canonical manifest.
+- `Published.toml` is durable target-chain publication history, not a prospective deployment plan. Preserve existing network entries and add or update an entry only after verifying the successful publication transaction and resulting package on that chain.
+- A `Published.toml` `toolchain-version` records the toolchain used for that historical publication; it does not select or constrain the toolchain for the current build or deployment.
+- Before publication, resolve the entire local dependency closure and validate an explicit topological publish order. Never use `--with-unpublished-dependencies`, because implicit republication changes package and type identity.
+- If the current CLI cannot reproduce an immutable dependency's historical bytecode, do not republish it or rewrite its identity to make verification pass. Diagnose the mismatch and verify the intended package and original IDs on the target chain; `.claude/rules/predict-deployment.md` owns the narrow conditions for an explicit dependency-verification bypass during Predict publication.
 
 ## Upstream Move Style (2024 Edition)
 

--- a/.claude/rules/predict-deployment.md
+++ b/.claude/rules/predict-deployment.md
@@ -1,0 +1,70 @@
+---
+paths:
+  - "packages/predict/deployment/**"
+---
+
+# Predict publication and deployment
+
+Read this before creating, changing, running, resuming, or auditing a script that publishes or wires the Predict package suite. Also read `.claude/rules/move.md` whenever the work touches `Move.toml` or `Published.toml`.
+
+## Workflow contract
+
+- Treat deployment as a resumable state machine, not a linear shell recipe. The same workflow owns preflight, package publication, protocol wiring, bootstrap, capability handoff, final audit, and integration-manifest generation.
+- Make the default invocation non-broadcasting. Require an explicit execution flag before any transaction can be submitted, and print the fully resolved target, signer, source commit, package plan, and expected capability recipients at the go/no-go boundary.
+- Bind a run to an exact network, chain identifier, RPC environment, signer, Sui CLI version, source commit, and capability-recipient set. Refuse to start or resume if any binding changes.
+- Point CLI and SDK operations at the same validated Sui client configuration and keystore for the entire run. If the workflow snapshots client configuration, keep the copy mode-restricted, remove it on exit, and never mutate the operator's active environment.
+- Acquire a repository-shared lock keyed by the deployment target before preflight. Two processes must not publish or wire the same deployment concurrently.
+
+## Preflight
+
+- Verify the exact Sui CLI version and binary, SDK-reported chain identifier, CLI environment, active address, expected signer, gas balance, per-step gas budgets, and source commit before broadcasting.
+- Require a committed source tree and enumerate the narrow generated files the workflow may change. Refuse unrelated dirt and refuse a source-commit change during a resumed run.
+- Build every package with warnings treated as errors before publication.
+- Resolve the complete Move dependency closure and validate an explicit topological publication plan from the package manifests. Do not copy a previous deployment's order without rechecking the current graph.
+- Verify every already-published package and external object against the target chain by package or object ID, original ID where applicable, type, and ownership before any new package is published.
+
+## Move publication
+
+- Never use `--with-unpublished-dependencies`; implicit republication changes package and type identity.
+- Use normal dependency verification by default. If an immutable on-chain dependency cannot be byte-for-byte reproduced by the selected historical toolchain, isolate the failing dependency, verify all resolved package and original IDs against the target chain, make any `--skip-dependency-verification` use explicit and local to the affected publish command, and record the justification in the workflow.
+- Do not change production `Move.toml`, `Published.toml`, or contract source to accommodate localnet, simulation, or verifier behavior.
+- After each publish, derive the package ID, transaction digest, created shared objects, owned capabilities, and upgrade capability from the receipt and target chain. Verify the resulting `Published.toml` identity before checkpointing the step.
+- If publication metadata appears without the corresponding operator checkpoint, stop and reconcile the package and sender transaction history; do not assume either the file or journal is authoritative by itself.
+
+## Operator journal and transaction recovery
+
+- Keep the private operator journal separate from the public integration manifest. The journal is gitignored, mode `0600`, contains no secret material, and is written atomically with temp-file-plus-rename.
+- Record the schema version, target bindings, source commit, package identities, completed steps, and current in-flight submission in the journal.
+- Persist transaction intent before submission and checkpoint every irreversible result immediately after target-chain verification.
+- For SDK-built transactions, derive and persist the transaction digest from the built transaction-data bytes before signing or submission, then sign and submit those exact bytes. A transport error with a known digest is an ambiguous submission to reconcile on-chain, not permission to construct replacement bytes.
+- A CLI submission that fails before returning a digest is also ambiguous. Fail closed, inspect the deployer's transaction history and affected `Published.toml`, and resume only after proving whether the transaction landed.
+- Never automatically retry an ambiguous write. Retry only after proving the original transaction did not execute.
+- On resume, verify every completed checkpoint against the target chain and require the original source commit, signer, client environment, toolchain, package identities, and journal. Resume from verified chain state rather than trusting local completion flags.
+
+## Wiring, configuration, and custody
+
+- Implement every wiring operation as an idempotent `ensure` step: read current chain state, skip when it is already correct, submit only when necessary, then read back and assert the intended state.
+- Treat mutable protocol and cadence configuration as chain-owned. Deployment inputs initialize shared objects; keepers and other services must read the live shared-object values rather than treating deployment defaults or the integration manifest as current authority.
+- Use the Sui `Clock` and live cadence state for time-sensitive initialization. If a cadence window is full, wait for a valid slot and resume instead of changing policy or creating duplicate markets.
+- Inventory every publisher, upgrade, admin, metadata, oracle-writer, and lifecycle capability created or consumed by the workflow, including its expected final owner.
+- Perform irreversible capability handoff last, after package publication, authorization, oracle wiring, configuration, bootstrap, funding, and market-readiness checks succeed. Verify the final owner on-chain.
+
+## Completion audit
+
+- Audit package publication provenance, linked dependency identities, expected shared and owned object types, Predict application authorization, Propbook oracle bindings and writers, cadence configuration, and capability ownership from the target chain.
+- Audit bootstrap events and their account attribution, enabled-cadence market coverage, funding, pending lifecycle queues, and the pool accounting invariants exposed by the deployed package.
+- Record the earliest relevant package-publication checkpoint as the indexer's replay start; a later wiring or completion transaction can omit deployment events.
+- Mark the journal `complete` only after the entire audit passes. A partial, failed, ambiguous, or in-flight run must never produce or replace the public integration manifest.
+
+## Public integration manifest
+
+- Generate the integration manifest deterministically from a complete, audited journal. It may contain stable network and chain identity, source and toolchain identity, package and shared-object IDs, coin types, oracle and writer identities, the replay checkpoint, units, and an initial configuration snapshot.
+- Anchor every mutable-object snapshot to its exact object version and digest. If the RPC cannot read the requested historical version, bracket the configuration read with object-reference reads and reject the snapshot unless the version and digest remain unchanged.
+- A transaction checkpoint is a verification fence, not proof that mutable object values were read at that checkpoint.
+- Exclude deployer and bootstrap accounts, transaction receipts and incidental digests, temporary markets, balances, rebalances, private topology, and publisher, upgrade, admin, or metadata capabilities from the public manifest.
+
+## Verification
+
+- Add deterministic tests for non-broadcasting default behavior, wrong chain, wrong signer, wrong CLI version, dirty or changed source, dependency-plan validation, known-digest recovery, unknown-digest fail-closed behavior, and idempotent resume.
+- Inject a failure after every irreversible step and prove the next run reconciles rather than duplicates it.
+- Prove the manifest cannot be written before completion and rejects operator-only fields. Validate deterministic manifest generation against an independent explicit fixture, never an expected value derived from the generator's own output.

--- a/.claude/rules/predict-harness.md
+++ b/.claude/rules/predict-harness.md
@@ -98,6 +98,11 @@ user-facing overview; this file is the editing-critical knowledge.
 ## Don't
 - Don't modify the Predict Move contracts or `dusdc.move` (deployed to testnet) to suit the
   harness — the harness re-signs oracle updates with a local trusted signer instead.
+- Treat production Move source, `Move.toml`, `Published.toml`, and tracked deployment manifests
+  as read-only inputs. If localnet needs different publication identity, dependency mapping, or
+  configuration, materialize those changes only in the disposable staged harness environment.
+- Build staged packages from the selected Git commit, not another worktree or a mutable cache
+  working tree. A cache may store derived artifacts, but it is never source authority.
 
 ## Bug oracle caveat
 - `analyze.py`'s bug oracle is **abort-only**: it flags transaction aborts, NOT a wrong-but-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,10 +25,11 @@ This file is the repo-level entry point for coding agents working in `deepbookv3
 
 ### Path-Scoped Rules — read before editing files under the glob
 
-- `.claude/rules/move.md` for `packages/**/*.move`
+- `.claude/rules/move.md` for `packages/**/*.move`, `packages/**/Move.toml`, and `packages/**/Published.toml`
 - `.claude/rules/predict-contracts.md` for the Predict-cluster packages `packages/{predict,propbook,block_scholes_oracle,account}/**/*.move` (also read `move.md`)
 - `.claude/rules/unit-tests.md` for `packages/**/tests/**`
 - `.claude/rules/predict-harness.md` for `packages/predict/harness/**`
+- `.claude/rules/predict-deployment.md` for `packages/predict/deployment/**`
 - `.claude/rules/indexer.md` for the CORE crates `crates/{server,indexer,schema}/**` (thin stub)
 - `.claude/rules/scripts.md` for `scripts/**`
 
@@ -37,6 +38,7 @@ This file is the repo-level entry point for coding agents working in `deepbookv3
 - `.claude/rules/code-review.md` when the user asks for a code review or review of uncommitted changes (for a deep Predict smart-contract audit, invoke the `predict-audit` skill at `.claude/skills/predict-audit/` — `rule-sweep.workflow.js` is the per-rule mechanical sweep, `ownership-walk.workflow.js` the per-module ownership conformance).
 - Before proposing/changing any **Predict economics** (NAV/backing, rounding, oracle trust, liquidation, tick/order-id encoding, floor/leverage, supply/withdraw): read `packages/predict/predeploy/README.md` (the system map + authority order), then `open-items.md`, `response-policies.md` (incl. its Rounding policy R1–R3 section), and the settled + rejected lists below. `.claude/predict-design/` and `.redesign/` are personal scratch only — nothing load-bearing lives there; verify any old claim against current HEAD before relying on it.
 - `.claude/rules/harness-strategy.md` when the user wants to add or build a Predict harness trading strategy or test a scenario in the harness (also read `.claude/rules/predict-harness.md`).
+- `.claude/rules/predict-deployment.md` when the user asks to create, change, run, publish, deploy, migrate, resume, audit, or verify a Predict deployment or publication script (also read `.claude/rules/move.md` for package manifests).
 - `.claude/rules/wrap-up.md` when the user says "wrap up".
 
 ## Common Commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,10 +25,11 @@ DeepBook is a decentralized order book on the Sui blockchain.
 
 ### Path-Scoped Rules — read before editing files under the glob
 
-- **Move files** (`packages/**/*.move`) → `.claude/rules/move.md`
+- **Move package sources and manifests** (`packages/**/*.move`, `packages/**/Move.toml`, `packages/**/Published.toml`) → `.claude/rules/move.md`
 - **Predict-cluster contracts** (`packages/{predict,propbook,block_scholes_oracle,account}/**/*.move`) → `.claude/rules/predict-contracts.md` *(also read `move.md`)*
 - **Unit tests** (`packages/**/tests/**`) → `.claude/rules/unit-tests.md`
 - **Predict harness** (`packages/predict/harness/**`) → `.claude/rules/predict-harness.md`
+- **Predict deployment** (`packages/predict/deployment/**`) → `.claude/rules/predict-deployment.md`
 - **Core indexer** (`crates/{server,schema,indexer}/**`) → `.claude/rules/indexer.md` *(thin stub — retires when the core crates migrate)*
 - **Scripts** (`scripts/**`) → `.claude/rules/scripts.md`
 
@@ -37,6 +38,7 @@ DeepBook is a decentralized order book on the Sui blockchain.
 - **Code review / review uncommitted changes** → `.claude/rules/code-review.md` (for a deep Predict smart-contract audit, invoke the `predict-audit` skill — `.claude/skills/predict-audit/` — which fans the lenses out via `orchestrator.workflow.js`, with `ownership-walk.workflow.js` + `rule-sweep.workflow.js` for per-module + per-rule conformance audits)
 - **Wrap-up requests** → `.claude/rules/wrap-up.md`
 - **Add / build a harness strategy** → `.claude/rules/harness-strategy.md` (engage when the user wants to add a Predict harness strategy or test a scenario in the harness)
+- **Create, change, run, publish, deploy, migrate, resume, audit, or verify a Predict deployment or publication script** → `.claude/rules/predict-deployment.md` *(also read `move.md` for package manifests)*
 
 When reviewing code in this repo, always read `.claude/rules/code-review.md` and check against its patterns. When I say "wrap up", follow `.claude/rules/wrap-up.md`. When the user wants to add or build a harness strategy (e.g. "I want to add a harness strategy"), follow `.claude/rules/harness-strategy.md`.
 


### PR DESCRIPTION
## Summary
- Add a Predict publication and deployment rule covering target preflight, package identity, resumability, idempotent wiring, capability custody, final chain audit, and integration-manifest boundaries.
- Route Move manifests and Predict deployment work to the applicable agent guidance before edits begin.
- Require local harness publication and configuration overrides to remain isolated from canonical production package files.

## Why
- Predict deployment scripts coordinate package publication, on-chain configuration, capability handoff, bootstrap state, and the integration data consumed by indexers and transaction writers.
- Constructing the Testnet deployment exposed missing guidance around immutable dependency verification, ambiguous transaction recovery, chain-owned configuration, time-sensitive initialization, and separation of operator state from public integration data.
- Capturing those constraints as routed repository rules prevents future deployments from having to rediscover them during execution.

## Linear / Context
- DBU-568
- Related dependency cleanup: #1178

## Key Decisions
- Canonical Move manifests remain production package truth; localnet and harness environments adapt in disposable staged copies.
- Dependency-verification bypasses are exceptional and require explicit target-chain package-identity checks.
- Deployment execution state remains private and resumable, while the public integration manifest is generated only from a completed chain audit.

## Scope / Descoped
- This PR contains agent guidance only. It does not add a deployment script, publication records, package or object IDs, deployment JSON, or runtime configuration.

## Test Plan
- [x] git diff --check
- [x] Verified path-scoped routing for Move.toml, Published.toml, and Predict deployment files.
- [x] Compared the guidance with the final predict-testnet-7-29 deployment workflow and commit history.

## Risk / Rollout
- Documentation and agent-routing changes only; no protocol or deployment behavior changes.