### PR TITLE
[schema] Add account history indexes

### DIFF
--- a/crates/schema/migrations/2026-07-30-000000-0000_add_account_history_indexes/down.sql
+++ b/crates/schema/migrations/2026-07-30-000000-0000_add_account_history_indexes/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_order_fills_maker_history;
+DROP INDEX IF EXISTS idx_order_fills_taker_history;

--- a/crates/schema/migrations/2026-07-30-000000-0000_add_account_history_indexes/up.sql
+++ b/crates/schema/migrations/2026-07-30-000000-0000_add_account_history_indexes/up.sql
@@ -1,0 +1,17 @@
+-- Supports newest-first account history lookups for maker fills.
+CREATE INDEX IF NOT EXISTS idx_order_fills_maker_history
+    ON order_fills (
+        maker_balance_manager_id,
+        checkpoint_timestamp_ms DESC,
+        checkpoint DESC,
+        event_digest COLLATE "C" DESC
+    );
+
+-- Supports newest-first account history lookups for taker fills.
+CREATE INDEX IF NOT EXISTS idx_order_fills_taker_history
+    ON order_fills (
+        taker_balance_manager_id,
+        checkpoint_timestamp_ms DESC,
+        checkpoint DESC,
+        event_digest COLLATE "C" DESC
+    );


### PR DESCRIPTION
## Summary
- Add maker- and taker-side composite indexes for newest-first account execution history.
- Add a reversible Diesel migration with `IF NOT EXISTS`/`DROP INDEX IF EXISTS`.

## Why
- [deepbook-services PR 92](https://github.com/MystenLabs/deepbook-services/pull/92) reads Core fills by balance-manager ID and paginates by `(checkpoint_timestamp_ms, checkpoint, event_digest)`.
- On the 31.6-million-row production `order_fills` table, the previous unaligned access path scanned and sorted millions of matches before returning a 501-row page.
- The production indexes were created concurrently and validated manually; this PR records them in the source-of-truth schema for every database.

## Key decisions
- Put the maker/taker balance-manager ID first, followed by the exact descending history cursor order.
- Use `COLLATE "C"` for `event_digest` so PostgreSQL ordering matches the API's bytewise cursor comparison.
- Use `CREATE INDEX IF NOT EXISTS` because Diesel migrations run transactionally and cannot use `CREATE INDEX CONCURRENTLY`; production was pre-provisioned concurrently, so this migration is a no-op there.

## Test plan
- [x] Run `cargo test -p deepbook-indexer --test snapshot_tests order_fill_test -- --nocapture`.
- [x] Confirm the test starts temporary PostgreSQL, applies all embedded migrations, processes the order-fill checkpoint fixture, and matches its snapshot.