### PR TITLE
Relax Pyth chart history bounds by resolution

### DIFF
--- a/crates/server/README.md
+++ b/crates/server/README.md
@@ -125,8 +125,12 @@ Configure the server with:
   defaults to `60`.
 - `PYTH_PRO_CHART_HISTORY_CACHE_MAX_ENTRIES` — maximum chart-history responses
   cached per process; defaults to `256`.
-- `PYTH_PRO_CHART_HISTORY_MAX_RANGE_SECS` — maximum `to - from` span accepted
-  by the chart-history route; defaults to `86400` (24 hours).
+- `PYTH_PRO_CHART_HISTORY_MAX_RANGE_SECS` — absolute maximum `to - from` span
+  accepted by the chart-history route; defaults to `7776000` (90 days).
+  Requests are also limited to 2161 candles, so the effective default range is
+  36 hours at 1-minute resolution, 3 days at 2-minute resolution, 7.5 days at
+  5-minute resolution, 22.5 days at 15-minute resolution, 45 days at
+  30-minute resolution, and 90 days at hourly or coarser resolutions.
 
 Latest prices are loaded on demand. The first request after the cache TTL
 expires fetches every allowed feed in one Pyth Pro call and stores the snapshot

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -89,7 +89,8 @@ struct Args {
     /// Maximum chart-history responses cached in this process.
     #[clap(env, long, default_value_t = DEFAULT_CHART_HISTORY_CACHE_MAX_ENTRIES)]
     pyth_pro_chart_history_cache_max_entries: u64,
-    /// Maximum chart-history query range, in seconds.
+    /// Absolute maximum chart-history query range, in seconds.
+    /// A resolution-aware candle limit may lower the effective range.
     #[clap(env, long, default_value_t = DEFAULT_CHART_HISTORY_MAX_RANGE_SECS)]
     pyth_pro_chart_history_max_range_secs: u64,
 }

--- a/crates/server/src/pyth/config.rs
+++ b/crates/server/src/pyth/config.rs
@@ -11,7 +11,7 @@ pub const DEFAULT_HISTORY_CACHE_TTL_SECS: u64 = 86_400;
 pub const DEFAULT_HISTORY_CACHE_MAX_ENTRIES: u64 = 10_000;
 pub const DEFAULT_CHART_HISTORY_CACHE_TTL_SECS: u64 = 60;
 pub const DEFAULT_CHART_HISTORY_CACHE_MAX_ENTRIES: u64 = 256;
-pub const DEFAULT_CHART_HISTORY_MAX_RANGE_SECS: u64 = 86_400;
+pub const DEFAULT_CHART_HISTORY_MAX_RANGE_SECS: u64 = 90 * 86_400;
 
 pub const LATEST_PRICE_PATH: &str = "/updates/price/latest";
 pub const PRICE_AT_TIMESTAMP_PATH: &str = "/updates/price/:publish_time";

--- a/crates/server/src/pyth/models.rs
+++ b/crates/server/src/pyth/models.rs
@@ -6,6 +6,8 @@ use std::{collections::HashSet, time::Duration};
 
 pub(super) const MICROS_PER_SECOND: u64 = 1_000_000;
 const SECONDS_PER_MINUTE: u64 = 60;
+const SECONDS_PER_DAY: u64 = 86_400;
+const MAX_CHART_HISTORY_BARS: u64 = 2_161;
 
 #[derive(Clone, Debug)]
 pub(super) struct PriceQuery {
@@ -132,6 +134,13 @@ impl ChartHistoryQuery {
         } else {
             (from, to)
         };
+        let resolution_secs = history_resolution_secs(&resolution);
+        let requested_bars = (to - from) / resolution_secs + 1;
+        if requested_bars > MAX_CHART_HISTORY_BARS {
+            return Err(format!(
+                "requested chart history exceeds the maximum of {MAX_CHART_HISTORY_BARS} bars for resolution `{resolution}`"
+            ));
+        }
 
         Ok(Self {
             symbol,
@@ -162,6 +171,22 @@ pub(super) fn normalize_history_resolution(resolution: &str) -> Result<String, S
         }
     };
     Ok(canonical)
+}
+
+fn history_resolution_secs(resolution: &str) -> u64 {
+    match resolution {
+        "D" => SECONDS_PER_DAY,
+        "W" => 7 * SECONDS_PER_DAY,
+        // Calendar months vary in length. Using the shortest possible month
+        // conservatively estimates the most bars Pyth could return.
+        "M" => 28 * SECONDS_PER_DAY,
+        minutes => {
+            minutes
+                .parse::<u64>()
+                .expect("normalized intraday resolution must be numeric")
+                * SECONDS_PER_MINUTE
+        }
+    }
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/crates/server/src/pyth/tests.rs
+++ b/crates/server/src/pyth/tests.rs
@@ -507,16 +507,34 @@ fn chart_history_canonicalizes_tradingview_resolution_aliases() {
 
 #[test]
 fn chart_history_requires_pyth_parameters_and_enforces_range() {
-    let max_range = Duration::from_secs(86_400);
+    let max_range = Duration::from_secs(90 * 86_400);
 
-    // The configured boundary is inclusive.
+    // Intraday queries are bounded to 2161 inclusive candles. Coarser
+    // resolutions therefore receive progressively larger windows.
+    for (resolution, max_span) in [
+        ("1", 129_600),
+        ("2", 259_200),
+        ("5", 648_000),
+        ("15", 1_944_000),
+        ("30", 3_888_000),
+    ] {
+        let boundary =
+            format!("symbol=Crypto.BTC%2FUSD&resolution={resolution}&from=0&to={max_span}");
+        assert!(ChartHistoryQuery::parse(Some(&boundary), max_range).is_ok());
+
+        let one_more_bar = max_span + resolution.parse::<u64>().unwrap() * 60;
+        let oversized =
+            format!("symbol=Crypto.BTC%2FUSD&resolution={resolution}&from=0&to={one_more_bar}");
+        assert!(ChartHistoryQuery::parse(Some(&oversized), max_range).is_err());
+    }
+
+    // Hourly and coarser queries can use the full configured 90-day range.
+    for resolution in ["60", "D", "W", "M"] {
+        let query = format!("symbol=Crypto.BTC%2FUSD&resolution={resolution}&from=0&to=7776000");
+        assert!(ChartHistoryQuery::parse(Some(&query), max_range).is_ok());
+    }
     assert!(ChartHistoryQuery::parse(
-        Some("symbol=Crypto.BTC%2FUSD&resolution=1&from=0&to=86400"),
-        max_range
-    )
-    .is_ok());
-    assert!(ChartHistoryQuery::parse(
-        Some("symbol=Crypto.BTC%2FUSD&resolution=1&from=0&to=86401"),
+        Some("symbol=Crypto.BTC%2FUSD&resolution=60&from=0&to=7776001"),
         max_range,
     )
     .is_err());
@@ -572,7 +590,7 @@ async fn chart_history_rejects_unsupported_queries_without_loading() {
         "symbol=Crypto.ETH%2FUSD&resolution=1&from=1700000000&to=1700003600",
         "symbol=Crypto.BTC%2FUSD&resolution=3&from=1700000000&to=1700003600",
         "symbol=Crypto.BTC%2FUSD&resolution=1&from=1700003600&to=1700000000",
-        "symbol=Crypto.BTC%2FUSD&resolution=1&from=1700000000&to=1700100000",
+        "symbol=Crypto.BTC%2FUSD&resolution=1&from=1700000000&to=1700200000",
     ] {
         let response = reqwest::get(
             server_url


### PR DESCRIPTION
## Summary
- Raise the default absolute TradingView history window from 24 hours to 90 days.
- Add a resolution-aware limit of 2,161 inclusive candles per request.
- Document and test the resulting default windows: 36 hours at 1-minute resolution, 3 days at 2-minute, 7.5 days at 5-minute, 22.5 days at 15-minute, 45 days at 30-minute, and 90 days at hourly or coarser resolutions.

## Why
- A universal 24-hour limit makes hourly and daily charts unnecessarily shallow even though those responses contain relatively few candles.
- Pyth Pro does not document a maximum History API range, so the DeepBook server still needs a local bound to protect authenticated upstream usage and keep each cached response bounded.

## Key decisions
- Keep `PYTH_PRO_CHART_HISTORY_MAX_RANGE_SECS` as the configurable absolute ceiling and change only its default to 90 days; no deployment configuration migration is required.
- Cap requests at 2,161 candles because that permits an inclusive 90-day hourly window while naturally giving finer resolutions smaller windows.
- Apply the candle limit after minute-aligning the query, so validation reflects the range actually sent upstream and used as the cache key.
- Continue allowing old historical windows; this change bounds request size, not lookback age.

## Test plan
- [x] `cargo fmt -p deepbook-server -- --check`
- [x] `cargo test -p deepbook-server pyth::tests::chart_history`
- [x] `cargo test -p deepbook-server`
- [x] `cargo build -p deepbook-server`