### PR TITLE
predict: harness probe for the trade-path liquidation-budget ceiling (DBU-695)

### DIFF
--- a/packages/predict/harness/README.md
+++ b/packages/predict/harness/README.md
@@ -83,9 +83,25 @@ near-the-money orders that knock out, so the liquidation pass + NAV-under-liquid
 are exercised), `mint-batch` (batched leveraged mint scaling), `nav-stress` / `nav-stress-atm` /
 `nav-stress-multi` (single-market, ATM-cost, and pool-total flush scaling), and
 `batch-max-book` / `batch-max-markets` (fast batched fills toward the per-market leveraged cap and
-the live-market pool total). Stress strategies that submit large mint PTBs should be run with
-`SIM_GAS_BUDGET=50000000000` so the trader has headroom and the keeper flush is measured against
-the protocol computation ceiling.
+the live-market pool total), and `liq-budget-sweep` / `liq-budget-adverse` (per-mint cost of the
+ambient liquidation pass as the budget rises — healthy and liquidating branches). Stress
+strategies that submit large mint PTBs should be run with `SIM_GAS_BUDGET=50000000000` so the
+trader has headroom and the keeper flush is measured against the protocol computation ceiling.
+
+The two `liq-budget-*` strategies measure the trade path's `trade_liquidation_budget` ceiling. The
+keeper walks the on-chain budget through `TRADE_LIQ_BUDGET_STAGES="<elapsedSeconds>:<budget>,…"`
+(unset = leave the contract default of 24), tracing each rung as `{type:"liqBudget", budget}`, so
+one run sweeps the whole range against a book built once — the pass costs
+`min(budget, active_leveraged_orders)`. `KEEPER_LIQ_BUDGET` sizes the keeper's own permissionless
+`liquidate()` lane and takes `0` to disable it, which the adverse arm needs so liquidatable orders
+survive for a mint's ambient pass to meet:
+
+```
+TRADE_LIQ_BUDGET_STAGES=0:24,900:512,1800:1500,2700:3000 SIM_GAS_BUDGET=50000000000 \
+  python3 -m harness campaign liq-budget-sweep --timeout 3600
+KEEPER_LIQ_BUDGET=0 TRADE_LIQ_BUDGET_STAGES=0:24,900:512,1800:1500,2700:3000 \
+  SIM_GAS_BUDGET=50000000000 python3 -m harness campaign liq-budget-adverse --timeout 3600
+```
 
 `campaign S1 S2 …` runs each named strategy on its **own** localnet (all off one shared hub) to
 completion, tears everything down, then prints a **per-strategy** `analyze` report + an aggregate

--- a/packages/predict/harness/README.md
+++ b/packages/predict/harness/README.md
@@ -94,7 +94,11 @@ keeper walks the on-chain budget through `TRADE_LIQ_BUDGET_STAGES="<elapsedSecon
 one run sweeps the whole range against a book built once — the pass costs
 `min(budget, active_leveraged_orders)`. `KEEPER_LIQ_BUDGET` sizes the keeper's own permissionless
 `liquidate()` lane and takes `0` to disable it, which the adverse arm needs so liquidatable orders
-survive for a mint's ambient pass to meet:
+survive for a mint's ambient pass to meet.
+
+Each arm fills to a 2,000-order book with batched mints and then sends every mint alone, because
+only single-mint transactions measure the trade path (an N-mint PTB runs N ambient passes). The run
+must outlast the ladder for the sweep to have data at every rung — size `--timeout` accordingly:
 
 ```
 TRADE_LIQ_BUDGET_STAGES=0:24,900:512,1800:1500,2700:3000 SIM_GAS_BUDGET=50000000000 \

--- a/packages/predict/harness/analyze.py
+++ b/packages/predict/harness/analyze.py
@@ -363,6 +363,70 @@ def _analyze_one(inst: Path) -> list[str]:
             else:
                 print(f"    => (AB-A)/S = {r1:.1f}x  (BB missing — run longer)")
 
+    # liq-budget: the trade-path ambient-pass ceiling (liqBudgetProbe.ts, DBU-695). The pass costs
+    # min(budget, active_leveraged_orders) candidates, each priced with an un-memoized range_price, so
+    # the model is comp ~ base + slope*candidates: `slope` is the per-candidate cost and `base` is the
+    # mint's own. Only n==1 batches are used — a 1-leg batch is byte-identical to an ordinary mint,
+    # while N>1 pays N ambient passes in one PTB and would bias the slope. Budget comes from the
+    # keeper's ladder records; with no ladder configured there is nothing to sweep, so the section is
+    # skipped rather than assuming the contract default.
+    rungs = sorted([r for r in recs if r.get("type") == "liqBudget" and r.get("ts")], key=lambda r: r["ts"])
+    if rungs:
+        def _budget_at(ts: int) -> int:
+            b = 0
+            for r in rungs:
+                if r["ts"] <= ts:
+                    b = int(r["budget"])
+                else:
+                    break
+            return b
+
+        # (budget, book-before-this-mint, comp) for every single-mint probe under a known rung.
+        probes = [
+            (_budget_at(r["ts"]), int(r.get("minted", 0)), int(r["compGas"]))
+            for r in recs
+            if r.get("type") == "mintBatch" and int(r.get("n", 0)) == 1 and not r.get("oog")
+            and r.get("compGas") and r.get("ts") and _budget_at(r["ts"]) > 0
+        ]
+        print(f"\nliq-budget — single-mint computation vs ambient-pass budget ({len(rungs)} rung(s) applied):")
+        by_budget: dict[int, list[tuple[int, int]]] = defaultdict(list)
+        for b, book, c in probes:
+            by_budget[b].append((book, c))
+        for b in sorted(by_budget):
+            pts = by_budget[b]
+            mean_c = sum(c for _, c in pts) // len(pts)
+            books = [bk for bk, _ in pts]
+            cand = min(b, max(books)) if books else 0
+            print(f"  budget {b:>5} (book {min(books):>4}-{max(books):<4}, ~{cand:>4} candidates scanned): "
+                  f"{mean_c:>13,} comp = {mean_c / COMP_CAP * 100:>4.0f}% of cap  [n={len(pts)}]")
+        # Fit on CANDIDATES (= min(budget, book)) rather than budget: below saturation the book, not the
+        # budget, is what the pass actually walks, so regressing on budget alone understates the slope.
+        fit = [(min(b, book), c) for b, book, c in probes]
+        if len({x for x, _ in fit}) >= 2:
+            n = len(fit)
+            sx, sy = sum(x for x, _ in fit), sum(y for _, y in fit)
+            denom = n * sum(x * x for x, _ in fit) - sx * sx
+            if denom:
+                slope = (n * sum(x * y for x, y in fit) - sx * sy) / denom
+                base = (sy - slope * sx) / n
+                print(f"  ~{int(slope):,} comp/candidate (+{int(base):,} base mint)")
+                if slope > 0:
+                    cross = int((COMP_CAP - base) / slope)
+                    print(f"  -> an ordinary mint stops fitting one tx at ~{cross:,} candidates "
+                          f"(the ceiling max_trade_liquidation_budget should be set under, with margin)")
+        # The empirical wall: the smallest candidate count at which a SINGLE mint actually OOG'd.
+        walls = [
+            (min(_budget_at(r["ts"]), int(r.get("minted", 0))), _budget_at(r["ts"]), int(r.get("minted", 0)))
+            for r in recs
+            if r.get("type") == "mintBatch" and r.get("oog") and int(r.get("n", 0)) == 1
+            and r.get("ts") and _budget_at(r["ts"]) > 0
+        ]
+        if walls:
+            cand, b, book = min(walls)
+            print(f"  EMPIRICAL wall: a single mint OOG'd at budget {b} / book {book} (~{cand} candidates)")
+        else:
+            print("  no single-mint OOG — every rung reached was affordable at the book this run built")
+
     # bug oracle (code-aware; tags are module:code). nav-stress breakpoint deferrals excluded (above).
     fails = [r for r in recs if r.get("type") == "fail" and not r.get("_navbreak")]
     expected, transient, flagged = _classify(fails)

--- a/packages/predict/harness/analyze.py
+++ b/packages/predict/harness/analyze.py
@@ -71,6 +71,14 @@ _MOVE_ABORT = re.compile(r"^[a-z_][a-z0-9_]*:\d+$")
 # size is network-independent. Both the nav-stress and mint-batch sections compare compGas against this.
 COMP_CAP = 5_000_000_000
 
+# The liq-budget fit extrapolates a production ceiling from sampled points, so it needs a real
+# lever arm: the largest candidate count sampled must be at least this many times the smallest.
+# Below that the line is fitted to a cluster and the crossing is noise dressed as a measurement.
+MIN_LIQ_BUDGET_FIT_SPAN = 4
+# Beyond this multiple of the largest count actually measured, the crossing is flagged as an
+# extrapolation in the report rather than presented as a measured limit.
+MAX_LIQ_BUDGET_EXTRAPOLATION = 3
+
 # The shortest keeper cadence (1m). A run shorter than this has produced no expected flush, so a
 # "never flushed" keeper is not yet a brick; a keeper that has NOT flushed past ~2x this (bootstrap +
 # one expiry) despite non-transient fails IS bricked. (M1: the old `stuck` heuristic false-FAILed a
@@ -371,6 +379,9 @@ def _analyze_one(inst: Path) -> list[str]:
     # keeper's ladder records; with no ladder configured there is nothing to sweep, so the section is
     # skipped rather than assuming the contract default.
     unexpected_wall: str | None = None  # set when a single mint OOGs on an arm that never declared that wall
+    no_data = False           # the section ran but collected no single-mint samples at all
+    insufficient_fit = False  # samples too clustered (or unphysical) to support a ceiling
+    wall_tags: set[str] = set()  # OOG tags from the probe, used as declared-wall evidence
     rungs = sorted([r for r in recs if r.get("type") == "liqBudget" and r.get("ts")], key=lambda r: r["ts"])
     if rungs:
         def _budget_at(ts: int) -> int:
@@ -418,7 +429,18 @@ def _analyze_one(inst: Path) -> list[str]:
         # Fit on CANDIDATES (= min(budget, book)) rather than budget: below saturation the book, not the
         # budget, is what the pass actually walks, so regressing on budget alone understates the slope.
         fit = [(min(b, book), c) for b, book, c in probes]
-        if len({x for x, _ in fit}) >= 2:
+        xs = {x for x, _ in fit}
+        # A ceiling extrapolated from a narrow, low-x cluster is worse than no number: fitting over
+        # x in {23..29} and projecting to ~4,000 recovers a slope 2.4x off the truth and still prints
+        # to the same decimal places. Demand a real lever arm before reporting, and refuse a negative
+        # base mint outright — a mint cannot cost less than nothing, so it means the line is being
+        # driven by noise rather than by the candidate count.
+        span = (max(xs) / min(xs)) if xs and min(xs) > 0 else 0
+        if len(xs) < 2 or span < MIN_LIQ_BUDGET_FIT_SPAN:
+            print(f"  fit SKIPPED — candidate counts span only {min(xs, default=0)}-{max(xs, default=0)}"
+                  f" ({span:.1f}x, want >={MIN_LIQ_BUDGET_FIT_SPAN}x); widen the ladder or run longer")
+            insufficient_fit = True
+        else:
             n = len(fit)
             sx, sy = sum(x for x, _ in fit), sum(y for _, y in fit)
             denom = n * sum(x * x for x, _ in fit) - sx * sx
@@ -426,10 +448,18 @@ def _analyze_one(inst: Path) -> list[str]:
                 slope = (n * sum(x * y for x, y in fit) - sx * sy) / denom
                 base = (sy - slope * sx) / n
                 print(f"  ~{int(slope):,} comp/candidate (+{int(base):,} base mint)")
-                if slope > 0:
+                if base < 0:
+                    print("  fit REJECTED — negative base mint is unphysical; the samples do not "
+                          "constrain the line (too narrow a range, or cost dominated by something "
+                          "other than the candidate count)")
+                    insufficient_fit = True
+                elif slope > 0:
                     cross = int((COMP_CAP - base) / slope)
                     print(f"  -> an ordinary mint stops fitting one tx at ~{cross:,} candidates "
                           f"(the ceiling max_trade_liquidation_budget should be set under, with margin)")
+                    if cross > max(xs) * MAX_LIQ_BUDGET_EXTRAPOLATION:
+                        print(f"     CAUTION: that is {cross / max(xs):.0f}x beyond the largest measured "
+                              f"count ({max(xs)}) — extrapolation, not measurement")
         # The empirical wall: the smallest candidate count at which a SINGLE mint actually OOG'd.
         walls = [
             (min(_budget_at(r["ts"]), int(r.get("book", r.get("minted", 0)))),
@@ -441,12 +471,24 @@ def _analyze_one(inst: Path) -> list[str]:
         if walls:
             cand, b, book = min(walls)
             print(f"  EMPIRICAL wall: a single mint OOG'd at budget {b} / book {book} (~{cand} candidates)")
+            # The trader submits through `signExecThreaded`, which — unlike the keeper's
+            # `executeAndWait` — writes no failed-tx artifact, and the strategy traces the OOG as a
+            # mintBatch record rather than a `fail`. So neither source the declared-wall check reads
+            # can see this, and an arm that reached exactly the wall it declared would be failed
+            # VACUOUS for not reaching it. Feed the OOG's own tag forward as the evidence.
+            wall_tags = {str(r.get("err", "")) for r in recs
+                         if r.get("type") == "mintBatch" and r.get("oog") and r.get("err")}
             # A strategy that DECLARED this wall was built to reach it; one that did not has just
             # shown an ordinary mint failing to fit in a tx, which is a finding in its own right and
-            # must fail the run rather than print quietly. The OOG is traced as a mintBatch record,
-            # not a `fail`, so the bug oracle below never sees it — this is what surfaces it.
+            # must fail the run rather than print quietly.
             if not _declared_terminals(recs):
                 unexpected_wall = f"liq-budget-wall-undeclared:budget={b},book={book}"
+        elif not probes:
+            # No successful single-mint samples AND no wall: the run measured nothing at all. Saying
+            # "affordable" here would be an affirmative safety claim drawn from zero evidence.
+            print("  NO single-mint samples collected — this run measured nothing (check the fill "
+                  "reached FILL_TARGET and that the ladder outlasts it)")
+            no_data = True
         else:
             print("  no single-mint OOG — every rung reached was affordable at the book this run built")
 
@@ -462,7 +504,8 @@ def _analyze_one(inst: Path) -> list[str]:
         vm_msgs = list(_vm_errors(inst))  # the run's real VM-error summaries (framework aborts' true cause)
         undeclared_vm = [m for m in vm_msgs if not any(d in m for d in declared)]
         reached = {d for d in declared
-                   if any(d in m for m in vm_msgs) or any(d in t for t in flagged + list(expected))}
+                   if any(d in m for m in vm_msgs) or any(d in t for t in flagged + list(expected))
+                   or any(d in t for t in wall_tags)}
         kept: list[str] = []
         for t in flagged:
             if any(d in t for d in declared):
@@ -505,6 +548,10 @@ def _analyze_one(inst: Path) -> list[str]:
     signals = list(flagged)
     if unexpected_wall:
         signals.append(unexpected_wall)
+    if no_data:
+        signals.append("liq-budget-no-samples")
+    if insufficient_fit:
+        signals.append("liq-budget-fit-unusable")
     signals += [f"adversarial-accepted:{r.get('mode')}" for r in adv_accepted]
     if stuck:
         signals.append("keeper-stuck")  # (1) a bricked settlement/LP lifecycle must fail the run

--- a/packages/predict/harness/analyze.py
+++ b/packages/predict/harness/analyze.py
@@ -370,6 +370,7 @@ def _analyze_one(inst: Path) -> list[str]:
     # while N>1 pays N ambient passes in one PTB and would bias the slope. Budget comes from the
     # keeper's ladder records; with no ladder configured there is nothing to sweep, so the section is
     # skipped rather than assuming the contract default.
+    unexpected_wall: str | None = None  # set when a single mint OOGs on an arm that never declared that wall
     rungs = sorted([r for r in recs if r.get("type") == "liqBudget" and r.get("ts")], key=lambda r: r["ts"])
     if rungs:
         def _budget_at(ts: int) -> int:
@@ -381,12 +382,27 @@ def _analyze_one(inst: Path) -> list[str]:
                     break
             return b
 
-        # (budget, book-before-this-mint, comp) for every single-mint probe under a known rung.
+        # A rung's set-tx is submitted at `requestedAtMs` and traced once it lands, so a probe inside
+        # that window ran under an indeterminate budget. Discard those rather than attribute them to
+        # either side: crediting them to the older, lower rung understates the per-candidate slope
+        # and overstates the ceiling. Records without `requestedAtMs` predate the bracketing and
+        # contribute no window.
+        blackouts = [(int(r["requestedAtMs"]), int(r["ts"])) for r in rungs if r.get("requestedAtMs")]
+
+        def _indeterminate(ts: int) -> bool:
+            return any(lo <= ts < hi for lo, hi in blackouts)
+
+        # (budget, book-before-this-mint, comp) for every single-mint probe under a known rung. The
+        # book is the ACTIVE index size the pass walked (mints issued minus knockouts), not mints
+        # issued: on the adverse arm the ambient pass removes orders continuously, and counting
+        # issued mints would overstate the candidates scanned, understate the per-candidate slope,
+        # and overstate the ceiling. `minted` is the pre-DBU-695 field name, kept as a fallback.
         probes = [
-            (_budget_at(r["ts"]), int(r.get("minted", 0)), int(r["compGas"]))
+            (_budget_at(r["ts"]), int(r.get("book", r.get("minted", 0))), int(r["compGas"]))
             for r in recs
             if r.get("type") == "mintBatch" and int(r.get("n", 0)) == 1 and not r.get("oog")
             and r.get("compGas") and r.get("ts") and _budget_at(r["ts"]) > 0
+            and not _indeterminate(r["ts"])
         ]
         print(f"\nliq-budget — single-mint computation vs ambient-pass budget ({len(rungs)} rung(s) applied):")
         by_budget: dict[int, list[tuple[int, int]]] = defaultdict(list)
@@ -416,14 +432,21 @@ def _analyze_one(inst: Path) -> list[str]:
                           f"(the ceiling max_trade_liquidation_budget should be set under, with margin)")
         # The empirical wall: the smallest candidate count at which a SINGLE mint actually OOG'd.
         walls = [
-            (min(_budget_at(r["ts"]), int(r.get("minted", 0))), _budget_at(r["ts"]), int(r.get("minted", 0)))
+            (min(_budget_at(r["ts"]), int(r.get("book", r.get("minted", 0)))),
+             _budget_at(r["ts"]), int(r.get("book", r.get("minted", 0))))
             for r in recs
             if r.get("type") == "mintBatch" and r.get("oog") and int(r.get("n", 0)) == 1
-            and r.get("ts") and _budget_at(r["ts"]) > 0
+            and r.get("ts") and _budget_at(r["ts"]) > 0 and not _indeterminate(r["ts"])
         ]
         if walls:
             cand, b, book = min(walls)
             print(f"  EMPIRICAL wall: a single mint OOG'd at budget {b} / book {book} (~{cand} candidates)")
+            # A strategy that DECLARED this wall was built to reach it; one that did not has just
+            # shown an ordinary mint failing to fit in a tx, which is a finding in its own right and
+            # must fail the run rather than print quietly. The OOG is traced as a mintBatch record,
+            # not a `fail`, so the bug oracle below never sees it — this is what surfaces it.
+            if not _declared_terminals(recs):
+                unexpected_wall = f"liq-budget-wall-undeclared:budget={b},book={book}"
         else:
             print("  no single-mint OOG — every rung reached was affordable at the book this run built")
 
@@ -480,6 +503,8 @@ def _analyze_one(inst: Path) -> list[str]:
                 print(f"     {n}x  {mode}")
 
     signals = list(flagged)
+    if unexpected_wall:
+        signals.append(unexpected_wall)
     signals += [f"adversarial-accepted:{r.get('mode')}" for r in adv_accepted]
     if stuck:
         signals.append("keeper-stuck")  # (1) a bricked settlement/LP lifecycle must fail the run

--- a/packages/predict/harness/tests/test_analyze_liq_budget.py
+++ b/packages/predict/harness/tests/test_analyze_liq_budget.py
@@ -42,6 +42,9 @@ def _synthesise(root: Path, books: list[int], slope: int) -> Path:
     * The first rung also carries a real multi-mint batch. Every mint in a PTB runs its own
       ambient pass, so an N-mint batch costs ~N times a single one; a fit that forgets to restrict
       to n==1 swallows that point and the slope collapses.
+    * Each rung change plants a probe inside the request-to-landed window, priced at the OLD rung.
+      Counting it drags the slope down and the ceiling up — the unsafe direction — so the analysis
+      has to discard the window rather than attribute it to either side.
 
     A probe whose modelled cost exceeds the cap is emitted as an OOG rather than a successful
     mint, which is what the strategy itself does at the wall.
@@ -51,36 +54,50 @@ def _synthesise(root: Path, books: list[int], slope: int) -> Path:
     keeper, trader = [], []
     ts = 1_000_000
     for i, ((elapsed_s, budget), book) in enumerate(zip(LADDER, books)):
+        # The rung's set-tx is requested a tick before it lands, and a probe inside that window ran
+        # under an indeterminate budget. One such probe is planted per rung, priced at the OLD rung
+        # so that counting it would visibly drag the fit — the analysis must drop it.
+        requested = ts + 50
+        if i > 0:
+            prev_budget, prev_book = LADDER[i - 1][1], books[i - 1]
+            trader.append({"type": "mintBatch", "n": 1, "gas": BASE + slope * min(prev_budget, prev_book),
+                           "compGas": BASE + slope * min(prev_budget, prev_book),
+                           "book": book, "batch": 1, "ts": requested + 10})
         ts += 1_000
-        keeper.append({"type": "liqBudget", "budget": budget, "elapsedMs": elapsed_s * 1000, "ts": ts})
+        keeper.append({"type": "liqBudget", "budget": budget, "elapsedMs": elapsed_s * 1000,
+                       "requestedAtMs": requested, "ts": ts})
         single = BASE + slope * min(budget, book)
         if i == 0:
             # The fill phase's batched mints, at the one rung cheap enough for a batch to fit.
             ts += 100
             trader.append({"type": "mintBatch", "n": 8, "gas": 8 * single, "compGas": 8 * single,
-                           "minted": book, "batch": 8, "ts": ts})
+                           "book": book, "batch": 8, "ts": ts})
         for offset in NOISE:
             ts += 100
             comp = single + offset
             trader.append(
-                {"type": "mintBatch", "n": 1, "minted": book, "batch": 1, "ts": ts,
+                {"type": "mintBatch", "n": 1, "book": book, "batch": 1, "ts": ts,
                  "oog": True, "err": "InsufficientGas"}
                 if comp > CAP
                 else {"type": "mintBatch", "n": 1, "gas": comp, "compGas": comp,
-                      "minted": book, "batch": 1, "ts": ts}
+                      "book": book, "batch": 1, "ts": ts}
             )
     (inst / "trace" / "keeper.jsonl").write_text("\n".join(json.dumps(r) for r in keeper))
     (inst / "trace" / "trader.jsonl").write_text("\n".join(json.dumps(r) for r in trader))
     return inst
 
 
-def _report(books: list[int], slope: int) -> str:
+def _run(books: list[int], slope: int) -> tuple[str, list[str]]:
     with tempfile.TemporaryDirectory() as tmp:
         inst = _synthesise(Path(tmp), books, slope)
         buf = io.StringIO()
         with redirect_stdout(buf):
-            analyze._analyze_one(inst)
-        return buf.getvalue()
+            signals = analyze._analyze_one(inst)
+        return buf.getvalue(), signals
+
+
+def _report(books: list[int], slope: int) -> str:
+    return _run(books, slope)[0]
 
 
 def _int_after(report: str, pattern: str) -> int:
@@ -120,6 +137,101 @@ class LiqBudgetAnalysisTests(unittest.TestCase):
         self.assertEqual(_int_after(report, r"stops fitting one tx at ~([\d,]+) candidates"), 2705)
         self.assertRegex(report, r"EMPIRICAL wall: a single mint OOG'd at budget 3000 / book 4600")
         self.assertNotIn("no single-mint OOG", report)
+
+    def test_an_undeclared_wall_fails_the_run(self) -> None:
+        # These fixtures carry no `expect` record, i.e. the arm never declared it was probing for a
+        # wall — so a single mint that cannot fit is an unexpected finding and must fail the run.
+        # The OOG is traced as a mintBatch record rather than a `fail`, so the bug oracle cannot see
+        # it; without an explicit signal the run would print the wall and still exit 0.
+        report, signals = _run([100, 300, 2000, 4600], 1_700_000)
+
+        self.assertIn("EMPIRICAL wall", report)
+        self.assertTrue(
+            any(s.startswith("liq-budget-wall-undeclared") for s in signals),
+            f"expected an undeclared-wall signal, got {signals}",
+        )
+
+    def test_a_declared_wall_does_not_fail_the_run(self) -> None:
+        # The adverse arm declares the computation cap, so reaching it is the point, not a surprise.
+        with tempfile.TemporaryDirectory() as tmp:
+            inst = _synthesise(Path(tmp), [100, 300, 2000, 4600], 1_700_000)
+            trace = inst / "trace" / "trader.jsonl"
+            trace.write_text(
+                trace.read_text()
+                + "\n"
+                + json.dumps({"type": "expect", "terminal": ["InsufficientGas"], "ts": 999_999})
+            )
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                signals = analyze._analyze_one(inst)
+
+        self.assertIn("EMPIRICAL wall", buf.getvalue())
+        self.assertFalse([s for s in signals if s.startswith("liq-budget-wall-undeclared")], signals)
+
+    def test_wall_reports_the_smallest_candidate_count_not_the_last_or_largest(self) -> None:
+        # Two rungs OOG a single mint, at different books. The wall worth reporting is the CHEAPEST
+        # state that could not fit — a ceiling set from the largest would be set above a budget
+        # already known to break. Rungs 1500 (book 1600 -> 1500 candidates) and 3000 (book 3400 ->
+        # 3000 candidates) both OOG at slope 3,000,000: 400,000,000 + 3,000,000*1500 = 4.9e9 fits,
+        # so make it 3,200,000 -> 5.2e9 at 1500 candidates and 9.6e9 at 3000. Smallest = 1500.
+        report = _report([100, 300, 1600, 3400], 3_200_000)
+
+        self.assertRegex(report, r"EMPIRICAL wall: a single mint OOG'd at budget 1500 / book 1600")
+        self.assertNotIn("budget 3000 / book 3400", report)
+
+    def test_a_multi_leg_batch_oog_is_not_reported_as_the_wall(self) -> None:
+        # An N-mint PTB pays N ambient passes, so it OOGs long before a single mint does. Treating
+        # that as the wall would report a ceiling several times lower than the truth and, at the
+        # extreme, condemn a budget that ordinary trading handles comfortably.
+        with tempfile.TemporaryDirectory() as tmp:
+            inst = Path(tmp) / "inst"
+            (inst / "trace").mkdir(parents=True)
+            (inst / "trace" / "keeper.jsonl").write_text(
+                json.dumps({"type": "liqBudget", "budget": 512, "requestedAtMs": 900, "ts": 1000})
+            )
+            (inst / "trace" / "trader.jsonl").write_text("\n".join(json.dumps(r) for r in [
+                # A 40-leg batch cannot fit; single mints at the same budget and book still do.
+                {"type": "mintBatch", "n": 40, "book": 900, "batch": 40, "ts": 1100,
+                 "oog": True, "err": "InsufficientGas"},
+                {"type": "mintBatch", "n": 1, "gas": 900_000_000, "compGas": 900_000_000,
+                 "book": 900, "batch": 1, "ts": 1200},
+                {"type": "mintBatch", "n": 1, "gas": 902_000_000, "compGas": 902_000_000,
+                 "book": 1000, "batch": 1, "ts": 1300},
+            ]))
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                analyze._analyze_one(inst)
+            report = buf.getvalue()
+
+        self.assertIn("no single-mint OOG", report)
+        self.assertNotIn("EMPIRICAL wall", report)
+
+    def test_book_is_the_active_index_not_mints_issued(self) -> None:
+        # The adverse arm's ambient pass knocks orders out as it goes, so mints issued runs ahead of
+        # the live index. Reading issued mints as the book overstates the candidates scanned, which
+        # understates the per-candidate slope and overstates the ceiling — the unsafe direction.
+        # Here the true book is a third of mints issued; the fit must recover the true slope.
+        with tempfile.TemporaryDirectory() as tmp:
+            inst = Path(tmp) / "inst"
+            (inst / "trace").mkdir(parents=True)
+            (inst / "trace" / "keeper.jsonl").write_text(
+                json.dumps({"type": "liqBudget", "budget": 3000, "requestedAtMs": 900, "ts": 1000})
+            )
+            rows = []
+            for i, book in enumerate([200, 400, 600, 800]):
+                rows.append({"type": "mintBatch", "n": 1, "book": book, "minted": book * 3,
+                             "gas": BASE + 1_000_000 * book, "compGas": BASE + 1_000_000 * book,
+                             "batch": 1, "ts": 1100 + i * 100})
+            (inst / "trace" / "trader.jsonl").write_text("\n".join(json.dumps(r) for r in rows))
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                analyze._analyze_one(inst)
+            report = buf.getvalue()
+
+        # Against `book` the slope is exactly 1,000,000. Against `minted` (3x the x-values) it
+        # would read 333,333 and the ceiling would be inflated threefold.
+        self.assertEqual(_int_after(report, r"~([\d,]+) comp/candidate"), 1_000_000)
+        self.assertEqual(_int_after(report, r"stops fitting one tx at ~([\d,]+) candidates"), 4600)
 
     def test_section_is_skipped_when_no_budget_ladder_ran(self) -> None:
         # With no rung applied the in-force budget is the contract default, which the harness must

--- a/packages/predict/harness/tests/test_analyze_liq_budget.py
+++ b/packages/predict/harness/tests/test_analyze_liq_budget.py
@@ -1,0 +1,140 @@
+"""Analysis checks for the liq-budget section (liqBudgetProbe.ts, DBU-695).
+
+The section turns a run's trace into the number `max_trade_liquidation_budget` gets set from, so
+its arithmetic is worth pinning without an hour of localnet. Each case synthesises a trace from a
+KNOWN cost model — comp = base + slope*min(budget, book) — and asserts the reported slope, base
+and cap crossing recover it, in both the wall-reached and wall-not-reached branches.
+
+Expected values are hand-computed and written as literals (the working is shown at each one), not
+re-derived with the fit's own formula, so a change to that formula fails these tests instead of
+moving the goalposts with them.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import re
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+from harness import analyze
+
+BASE = 400_000_000
+CAP = 5_000_000_000  # the per-tx computation cap, asserted against analyze.COMP_CAP below
+LADDER = [(0, 24), (900, 512), (1800, 1500), (2700, 3000)]
+# Six probes per rung, offsets summing to exactly zero so the fitted base is not pulled off the
+# true one by the fixture's own noise.
+NOISE = [(2 * k - 5) * 100_000 for k in range(6)]
+
+
+def _synthesise(root: Path, books: list[int], slope: int) -> Path:
+    """One instance dir whose single-mint probes follow base + slope*min(budget, book) exactly.
+
+    Two properties of this fixture are load-bearing, each pinning one way the analysis could go
+    wrong and still look right:
+
+    * At the second rung the BOOK is smaller than the budget, so the pass walks the book, not the
+      budget. A fit that regresses on budget rather than min(budget, book) gets a different slope
+      here — where a fixture whose book always exceeds the budget could not tell them apart.
+    * The first rung also carries a real multi-mint batch. Every mint in a PTB runs its own
+      ambient pass, so an N-mint batch costs ~N times a single one; a fit that forgets to restrict
+      to n==1 swallows that point and the slope collapses.
+
+    A probe whose modelled cost exceeds the cap is emitted as an OOG rather than a successful
+    mint, which is what the strategy itself does at the wall.
+    """
+    inst = root / "inst"
+    (inst / "trace").mkdir(parents=True)
+    keeper, trader = [], []
+    ts = 1_000_000
+    for i, ((elapsed_s, budget), book) in enumerate(zip(LADDER, books)):
+        ts += 1_000
+        keeper.append({"type": "liqBudget", "budget": budget, "elapsedMs": elapsed_s * 1000, "ts": ts})
+        single = BASE + slope * min(budget, book)
+        if i == 0:
+            # The fill phase's batched mints, at the one rung cheap enough for a batch to fit.
+            ts += 100
+            trader.append({"type": "mintBatch", "n": 8, "gas": 8 * single, "compGas": 8 * single,
+                           "minted": book, "batch": 8, "ts": ts})
+        for offset in NOISE:
+            ts += 100
+            comp = single + offset
+            trader.append(
+                {"type": "mintBatch", "n": 1, "minted": book, "batch": 1, "ts": ts,
+                 "oog": True, "err": "InsufficientGas"}
+                if comp > CAP
+                else {"type": "mintBatch", "n": 1, "gas": comp, "compGas": comp,
+                      "minted": book, "batch": 1, "ts": ts}
+            )
+    (inst / "trace" / "keeper.jsonl").write_text("\n".join(json.dumps(r) for r in keeper))
+    (inst / "trace" / "trader.jsonl").write_text("\n".join(json.dumps(r) for r in trader))
+    return inst
+
+
+def _report(books: list[int], slope: int) -> str:
+    with tempfile.TemporaryDirectory() as tmp:
+        inst = _synthesise(Path(tmp), books, slope)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            analyze._analyze_one(inst)
+        return buf.getvalue()
+
+
+def _int_after(report: str, pattern: str) -> int:
+    m = re.search(pattern, report)
+    assert m, f"pattern {pattern!r} not found in:\n{report}"
+    return int(m.group(1).replace(",", ""))
+
+
+class LiqBudgetAnalysisTests(unittest.TestCase):
+    def test_computation_cap_is_the_value_the_expectations_below_were_computed_against(self) -> None:
+        # Every crossing literal in this file was worked out against this number; if the protocol
+        # constant moves, those literals are stale and must be recomputed, not silently re-derived.
+        self.assertEqual(analyze.COMP_CAP, CAP)
+
+    def test_fit_recovers_the_cost_model_and_reports_no_wall_when_none_is_reached(self) -> None:
+        # 1,086,000/candidate is the pre-memo correction_value slope — the sweep's closest measured
+        # analogue. Crossing: (5,000,000,000 - 400,000,000) / 1,086,000 = 4,600,000,000 / 1,086,000
+        # = 4235.7 -> 4235, which sits ABOVE the 3,000 budget max. So the top rung costs
+        # 400,000,000 + 1,086,000*3000 = 3,658,000,000 (73% of cap) and no wall is reached.
+        # Books: rung 2 is book-limited (300 < 512), so candidates are 24 / 300 / 1500 / 3000.
+        report = _report([100, 300, 2000, 3400], 1_086_000)
+
+        self.assertEqual(_int_after(report, r"~([\d,]+) comp/candidate"), 1_086_000)
+        self.assertEqual(_int_after(report, r"\+([\d,]+) base mint"), BASE)
+        self.assertEqual(_int_after(report, r"stops fitting one tx at ~([\d,]+) candidates"), 4235)
+        self.assertIn("no single-mint OOG", report)
+        self.assertNotIn("EMPIRICAL wall", report)
+
+    def test_steeper_cost_reports_the_empirical_wall(self) -> None:
+        # The adverse branch also pays index + payout-tree removal per liquidated candidate, so the
+        # slope is steeper. Crossing: 4,600,000,000 / 1,700,000 = 2705.9 -> 2705, INSIDE the allowed
+        # budget range, so the 3,000 rung costs 400,000,000 + 5,100,000,000 = 5.5e9 and every probe
+        # there OOGs. The fit then runs on the three rungs below it and must still recover the model.
+        report = _report([100, 300, 2000, 4600], 1_700_000)
+
+        self.assertEqual(_int_after(report, r"~([\d,]+) comp/candidate"), 1_700_000)
+        self.assertEqual(_int_after(report, r"stops fitting one tx at ~([\d,]+) candidates"), 2705)
+        self.assertRegex(report, r"EMPIRICAL wall: a single mint OOG'd at budget 3000 / book 4600")
+        self.assertNotIn("no single-mint OOG", report)
+
+    def test_section_is_skipped_when_no_budget_ladder_ran(self) -> None:
+        # With no rung applied the in-force budget is the contract default, which the harness must
+        # not assume — an ordinary run has nothing to sweep and prints no liq-budget section.
+        with tempfile.TemporaryDirectory() as tmp:
+            inst = Path(tmp) / "inst"
+            (inst / "trace").mkdir(parents=True)
+            (inst / "trace" / "trader.jsonl").write_text(
+                json.dumps({"type": "mintBatch", "n": 1, "gas": 5, "compGas": 5, "minted": 10, "ts": 1})
+            )
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                analyze._analyze_one(inst)
+            self.assertNotIn("liq-budget —", buf.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/predict/harness/tests/test_analyze_liq_budget.py
+++ b/packages/predict/harness/tests/test_analyze_liq_budget.py
@@ -165,8 +165,12 @@ class LiqBudgetAnalysisTests(unittest.TestCase):
             with redirect_stdout(buf):
                 signals = analyze._analyze_one(inst)
 
+        # The whole run must come back clean, not merely free of the undeclared-wall signal: the
+        # trader submits via a path that writes no failed-tx artifact and traces its OOG as a
+        # mintBatch rather than a `fail`, so neither source the declared-wall check normally reads
+        # can see it — an arm that reached exactly the wall it declared would be failed VACUOUS.
         self.assertIn("EMPIRICAL wall", buf.getvalue())
-        self.assertFalse([s for s in signals if s.startswith("liq-budget-wall-undeclared")], signals)
+        self.assertEqual(signals, [], f"a declared, reached wall must not fail the run: {signals}")
 
     def test_wall_reports_the_smallest_candidate_count_not_the_last_or_largest(self) -> None:
         # Two rungs OOG a single mint, at different books. The wall worth reporting is the CHEAPEST
@@ -232,6 +236,110 @@ class LiqBudgetAnalysisTests(unittest.TestCase):
         # would read 333,333 and the ceiling would be inflated threefold.
         self.assertEqual(_int_after(report, r"~([\d,]+) comp/candidate"), 1_000_000)
         self.assertEqual(_int_after(report, r"stops fitting one tx at ~([\d,]+) candidates"), 4600)
+
+    def _one_rung_trace(self, tmp: Path, rows: list[dict], budget: int = 3000) -> tuple[str, list[str]]:
+        inst = tmp / "inst"
+        (inst / "trace").mkdir(parents=True)
+        (inst / "trace" / "keeper.jsonl").write_text(
+            json.dumps({"type": "liqBudget", "budget": budget, "requestedAtMs": 900, "ts": 1000})
+        )
+        (inst / "trace" / "trader.jsonl").write_text("\n".join(json.dumps(r) for r in rows))
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            signals = analyze._analyze_one(inst)
+        return buf.getvalue(), signals
+
+    def test_wall_is_keyed_on_candidates_not_on_the_budget_alone(self) -> None:
+        # The pass walks min(budget, book), so the cheapest state that failed to fit is the one with
+        # the fewest CANDIDATES — which need not be the one with the lowest budget. Here budget 3000
+        # at book 500 scans 500 candidates while budget 1500 at book 2000 scans 1500, so the wall is
+        # the 3000/500 row. Keying on budget would report 1500 and set a ceiling three times too high.
+        with tempfile.TemporaryDirectory() as tmp:
+            inst = Path(tmp) / "inst"
+            (inst / "trace").mkdir(parents=True)
+            (inst / "trace" / "keeper.jsonl").write_text("\n".join(json.dumps(r) for r in [
+                {"type": "liqBudget", "budget": 1500, "requestedAtMs": 900, "ts": 1000},
+                {"type": "liqBudget", "budget": 3000, "requestedAtMs": 2900, "ts": 3000},
+            ]))
+            (inst / "trace" / "trader.jsonl").write_text("\n".join(json.dumps(r) for r in [
+                {"type": "mintBatch", "n": 1, "book": 2000, "batch": 1, "ts": 2000,
+                 "oog": True, "err": "InsufficientGas"},
+                {"type": "mintBatch", "n": 1, "book": 500, "batch": 1, "ts": 4000,
+                 "oog": True, "err": "InsufficientGas"},
+            ]))
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                analyze._analyze_one(inst)
+
+        self.assertRegex(buf.getvalue(), r"EMPIRICAL wall: a single mint OOG'd at budget 3000 / book 500 \(~500 candidates\)")
+
+    def test_probes_before_the_first_rung_are_ignored(self) -> None:
+        # Before any rung lands the in-force budget is the contract default, which the harness does
+        # not assume. A probe from that window has no known budget and must not enter the fit.
+        with tempfile.TemporaryDirectory() as tmp:
+            report, _ = self._one_rung_trace(Path(tmp), [
+                # ts 500 is before the rung's ts 1000 — unknown budget, must be dropped.
+                {"type": "mintBatch", "n": 1, "gas": 99, "compGas": 99, "book": 40, "batch": 1, "ts": 500},
+                {"type": "mintBatch", "n": 1, "gas": 900_000_000, "compGas": 900_000_000,
+                 "book": 500, "batch": 1, "ts": 1100},
+                {"type": "mintBatch", "n": 1, "gas": 2_400_000_000, "compGas": 2_400_000_000,
+                 "book": 2000, "batch": 1, "ts": 1200},
+            ])
+
+        self.assertNotIn("book   40", report)
+        # Two kept samples: (500, 9e8) and (2000, 2.4e9) -> slope exactly 1,000,000. Including the
+        # pre-rung sample at (40, 99) would drag it to ~1,180,000 and the ceiling with it.
+        self.assertEqual(_int_after(report, r"~([\d,]+) comp/candidate"), 1_000_000)
+
+    def test_a_run_that_collected_no_samples_says_so_and_fails(self) -> None:
+        # The failure this guards is a run that measured nothing yet printed an affirmative
+        # "affordable" line and exited 0 — an affirmative safety claim from zero evidence.
+        with tempfile.TemporaryDirectory() as tmp:
+            report, signals = self._one_rung_trace(Path(tmp), [
+                {"type": "mintBatch", "n": 40, "gas": 3_000_000_000, "compGas": 3_000_000_000,
+                 "book": 900, "batch": 40, "ts": 1100},
+            ])
+
+        self.assertIn("measured nothing", report)
+        self.assertNotIn("affordable", report)
+        self.assertIn("liq-budget-no-samples", signals)
+
+    def test_a_fit_over_a_narrow_cluster_is_refused_not_extrapolated(self) -> None:
+        # Samples spanning 23-29 candidates cannot support a ceiling near 4,000: the recovered slope
+        # is dominated by noise and the crossing came out 2.4x off truth in simulation, printed to
+        # the same decimal places as a real measurement. Refuse rather than report.
+        with tempfile.TemporaryDirectory() as tmp:
+            rows = [
+                {"type": "mintBatch", "n": 1, "gas": 400_000_000 + 1_086_000 * bk,
+                 "compGas": 400_000_000 + 1_086_000 * bk, "book": bk, "batch": 1, "ts": 1100 + i}
+                for i, bk in enumerate([23, 25, 27, 29])
+            ]
+            report, signals = self._one_rung_trace(Path(tmp), rows)
+
+        self.assertIn("fit SKIPPED", report)
+        self.assertNotIn("stops fitting one tx", report)
+        self.assertIn("liq-budget-fit-unusable", signals)
+
+    def test_an_unphysical_negative_base_mint_is_refused_even_on_a_wide_span(self) -> None:
+        # A wide span is necessary but not sufficient. If cost grows super-linearly in the book
+        # (page splits, tree depth), a straight line through the samples cuts the axis below zero:
+        # here (100, 1.0e9) and (2000, 4.8e9) give slope 2,000,000 and base 1.0e9 - 2.0e8 = ... in
+        # fact 8.0e8; use a steeper pair so the intercept is genuinely negative —
+        # (100, 1.0e8) and (2000, 4.0e9): slope = 3.9e9/1900 = 2,052,631, base = 1e8 - 2.053e8 < 0.
+        # A mint cannot cost less than nothing, so the line is not describing the candidate count and
+        # its crossing must not be reported however wide the span (20x here).
+        with tempfile.TemporaryDirectory() as tmp:
+            report, signals = self._one_rung_trace(Path(tmp), [
+                {"type": "mintBatch", "n": 1, "gas": 100_000_000, "compGas": 100_000_000,
+                 "book": 100, "batch": 1, "ts": 1100},
+                {"type": "mintBatch", "n": 1, "gas": 4_000_000_000, "compGas": 4_000_000_000,
+                 "book": 2000, "batch": 1, "ts": 1200},
+            ])
+
+        self.assertNotIn("fit SKIPPED", report)  # the span guard is NOT what catches this
+        self.assertIn("fit REJECTED", report)
+        self.assertNotIn("stops fitting one tx", report)
+        self.assertIn("liq-budget-fit-unusable", signals)
 
     def test_section_is_skipped_when_no_budget_ladder_ran(self) -> None:
         # With no rung applied the in-force budget is the contract default, which the harness must

--- a/packages/predict/harness/ts/keeperService.ts
+++ b/packages/predict/harness/ts/keeperService.ts
@@ -291,10 +291,21 @@ async function applyBudgetStages(startedAt: number) {
       appendTrace("keeper", { type: "fail", lane: "liqBudget", tag: errorTag(e) });
       budgetStageFailures++;
       if (budgetStageFailures >= MAX_BUDGET_STAGE_FAILURES) {
-        throw new Error(
-          `TRADE_LIQ_BUDGET_STAGES: rung ${budget} failed ${budgetStageFailures}x — the sweep cannot proceed ` +
-            `(last: ${e instanceof Error ? e.message.slice(0, 160) : e})`,
+        // ABANDON the ladder — never throw. This runs before tick() inside the same try, so a throw
+        // here would skip settlement, flush, rebalance and roll on every subsequent iteration, and
+        // since the counter never clears it would do so for the rest of the run: one bad rung would
+        // brick every other keeper lane, against the harness's own per-step isolation invariant.
+        // The `fatal` trace fails the run in `analyze` instead, which is the loud part.
+        nextBudgetStage = TRADE_LIQ_BUDGET_STAGES.length;
+        appendTrace("keeper", {
+          type: "fail", lane: "liqBudget", fatal: true,
+          tag: `budget-ladder-abandoned:rung=${budget}:${errorTag(e)}`,
+        });
+        console.error(
+          `[keeper] TRADE_LIQ_BUDGET_STAGES: rung ${budget} failed ${budgetStageFailures}x — abandoning the ` +
+            `ladder; the sweep will collect nothing further (last: ${e instanceof Error ? e.message.slice(0, 160) : e})`,
         );
+        return;
       }
       console.warn(`[keeper] trade_liquidation_budget deferred: ${e instanceof Error ? e.message.slice(0, 100) : e}`);
       return; // retry this rung next tick; do not run ahead to a later one

--- a/packages/predict/harness/ts/keeperService.ts
+++ b/packages/predict/harness/ts/keeperService.ts
@@ -42,14 +42,16 @@ const TRADER_DUSDC = BigInt(process.env.TRADER_DUSDC ?? "1000000000000"); // $1M
 // on-chain `trade_liquidation_budget` below, which the TRADE path spends. Set 0 to disable the
 // lane entirely — the DBU-695 adverse probe needs liquidatable orders to survive long enough
 // for a mint's ambient pass to meet them, and a keeper sweeping them first hides that branch.
-const LIQ_BUDGET = BigInt(process.env.KEEPER_LIQ_BUDGET ?? "24");
+// `||` not `??`: an empty string is BigInt-coercible to 0n, so `KEEPER_LIQ_BUDGET=` would silently
+// disable the lane rather than fall back to the default.
+const LIQ_BUDGET = BigInt(process.env.KEEPER_LIQ_BUDGET || "24");
 // Ladder for the on-chain ambient-pass budget (`ProtocolConfig::trade_liquidation_budget`), as
 // "<elapsedSeconds>:<budget>,…" measured from keeper start — e.g. "0:24,900:512,1800:3000".
 // Each stage is applied once, on the first tick at or after its mark, and traced. Unset (the
 // default) never touches the config, so every existing run keeps the contract default of 24.
 // This exists so ONE run can sweep the budget: the trade path's cost is min(budget, book), so
 // a book built cheaply at 24 can then be re-probed at each higher rung without republishing.
-const TRADE_LIQ_BUDGET_STAGES = (process.env.TRADE_LIQ_BUDGET_STAGES ?? "")
+const TRADE_LIQ_BUDGET_STAGES = (process.env.TRADE_LIQ_BUDGET_STAGES || "")
   .split(",")
   .filter(Boolean)
   .map((s) => {
@@ -62,6 +64,13 @@ const TRADE_LIQ_BUDGET_STAGES = (process.env.TRADE_LIQ_BUDGET_STAGES ?? "")
   })
   .sort((a, b) => a.atMs - b.atMs);
 let nextBudgetStage = 0;
+let budgetStageFailures = 0;
+// A rung that cannot be applied is retried, but not forever. An out-of-range value aborts
+// `EInvalidTradeLiquidationBudget` every single tick, and `protocol_config` is a GUARD module, so
+// the repeated fail records classify as expected preconditions and the run exits 0 having swept
+// nothing. Rather than mirror the contract's bounds here (they are the contract's to own), give up
+// loudly after a few attempts — that covers a bad value, a lost cap, and anything else alike.
+const MAX_BUDGET_STAGE_FAILURES = 3;
 // Flush gas budget. The SINGLE dense market (nav-stress) OOGs at the per-tx COMPUTATION cap
 // (5e9 MIST), not the budget; the pool total binds earlier on the object-runtime cached-objects
 // limit (C-1) at ~16-50% of that cap. Either way the budget only needs headroom above the 5e9 cap.
@@ -267,13 +276,26 @@ async function applyBudgetStages(startedAt: number) {
   const elapsed = Date.now() - startedAt;
   while (nextBudgetStage < TRADE_LIQ_BUDGET_STAGES.length && TRADE_LIQ_BUDGET_STAGES[nextBudgetStage].atMs <= elapsed) {
     const { budget } = TRADE_LIQ_BUDGET_STAGES[nextBudgetStage];
+    // Stamped BEFORE the tx. A probe between the request and the trace record ran under an unknown
+    // budget — the set may already have landed — so the analysis must discard that window rather
+    // than attribute it to either rung. Attributing it to the old rung understates the slope and
+    // overstates the ceiling, which is the unsafe direction.
+    const requestedAtMs = Date.now();
     try {
       await executeAndWait(setTradeLiquidationBudgetTx(PROTOCOL_CONFIG_ID, budget), "trade-liq-budget");
-      appendTrace("keeper", { type: "liqBudget", budget: Number(budget), elapsedMs: elapsed });
+      appendTrace("keeper", { type: "liqBudget", budget: Number(budget), elapsedMs: elapsed, requestedAtMs });
       console.log(`[keeper] trade_liquidation_budget -> ${budget} (t+${Math.round(elapsed / 1000)}s)`);
       nextBudgetStage++;
+      budgetStageFailures = 0;
     } catch (e) {
       appendTrace("keeper", { type: "fail", lane: "liqBudget", tag: errorTag(e) });
+      budgetStageFailures++;
+      if (budgetStageFailures >= MAX_BUDGET_STAGE_FAILURES) {
+        throw new Error(
+          `TRADE_LIQ_BUDGET_STAGES: rung ${budget} failed ${budgetStageFailures}x — the sweep cannot proceed ` +
+            `(last: ${e instanceof Error ? e.message.slice(0, 160) : e})`,
+        );
+      }
       console.warn(`[keeper] trade_liquidation_budget deferred: ${e instanceof Error ? e.message.slice(0, 100) : e}`);
       return; // retry this rung next tick; do not run ahead to a later one
     }

--- a/packages/predict/harness/ts/keeperService.ts
+++ b/packages/predict/harness/ts/keeperService.ts
@@ -27,6 +27,7 @@ import {
   readActiveMarketIds,
   readMarketExpiry,
   rebalanceExpiryCashTx,
+  setTradeLiquidationBudgetTx,
 } from "./runtime.js";
 
 // Prod testnet cadence set: 1m / 5m / 1h (deployment.testnet.json @ predict-testnet-6-24). The
@@ -37,7 +38,30 @@ const DURATION_MS = Number(process.env.DURATION_MS ?? 0); // 0 = until killed
 const MARKETS_PATH = `${process.env.INSTANCE_DIR}/markets.json`;
 const TRADER_ADDRESSES = (process.env.TRADER_ADDRESSES ?? "").split(",").filter(Boolean);
 const TRADER_DUSDC = BigInt(process.env.TRADER_DUSDC ?? "1000000000000"); // $1M default; campaign overrides per strategy
-const LIQ_BUDGET = 24n; // trade_liquidation_budget
+// Budget the KEEPER spends on its own permissionless `liquidate()` lane. Distinct from the
+// on-chain `trade_liquidation_budget` below, which the TRADE path spends. Set 0 to disable the
+// lane entirely — the DBU-695 adverse probe needs liquidatable orders to survive long enough
+// for a mint's ambient pass to meet them, and a keeper sweeping them first hides that branch.
+const LIQ_BUDGET = BigInt(process.env.KEEPER_LIQ_BUDGET ?? "24");
+// Ladder for the on-chain ambient-pass budget (`ProtocolConfig::trade_liquidation_budget`), as
+// "<elapsedSeconds>:<budget>,…" measured from keeper start — e.g. "0:24,900:512,1800:3000".
+// Each stage is applied once, on the first tick at or after its mark, and traced. Unset (the
+// default) never touches the config, so every existing run keeps the contract default of 24.
+// This exists so ONE run can sweep the budget: the trade path's cost is min(budget, book), so
+// a book built cheaply at 24 can then be re-probed at each higher rung without republishing.
+const TRADE_LIQ_BUDGET_STAGES = (process.env.TRADE_LIQ_BUDGET_STAGES ?? "")
+  .split(",")
+  .filter(Boolean)
+  .map((s) => {
+    // Fail loudly at load rather than with a BigInt TypeError mid-run: a typo here would
+    // otherwise cost the whole campaign it was meant to configure. The VALUE range is the
+    // contract's to enforce (EInvalidTradeLiquidationBudget) — only the shape is checked here.
+    const m = s.trim().match(/^(\d+):(\d+)$/);
+    if (!m) throw new Error(`TRADE_LIQ_BUDGET_STAGES: bad stage '${s}' (want "<elapsedSeconds>:<budget>")`);
+    return { atMs: Number(m[1]) * 1000, budget: BigInt(m[2]) };
+  })
+  .sort((a, b) => a.atMs - b.atMs);
+let nextBudgetStage = 0;
 // Flush gas budget. The SINGLE dense market (nav-stress) OOGs at the per-tx COMPUTATION cap
 // (5e9 MIST), not the budget; the pool total binds earlier on the object-runtime cached-objects
 // limit (C-1) at ~16-50% of that cap. Either way the budget only needs headroom above the 5e9 cap.
@@ -172,7 +196,7 @@ async function tick(feeds: Feeds, lifecycleCapId: string) {
   //    during step 1 isn't passed to load_live_pricer (pricing:9). Isolated.
   const liveClock = Number(await clockTimestampMs());
   const live = active.filter((m) => m.expiryMs > liveClock);
-  if (live.length) {
+  if (live.length && LIQ_BUDGET > 0n) {
     try {
       const lr = await executeAndWait(
         keeperLiquidateTx({ feeds, markets: live.map((m) => m.id), protocolConfigId: PROTOCOL_CONFIG_ID, budget: LIQ_BUDGET }),
@@ -231,6 +255,26 @@ async function tick(feeds: Feeds, lifecycleCapId: string) {
   atomicWriteFile(MARKETS_PATH, JSON.stringify(live.filter((m) => funded.has(m.id)).map((m) => ({ id: m.id, expiryMs: m.expiryMs }))));
 }
 
+// Apply every due rung of the trade-liquidation-budget ladder. Isolated like the other lanes:
+// a failed set defers to the next tick rather than killing the run, and the stage is only
+// consumed on success so the sweep cannot silently skip a rung it never actually applied.
+async function applyBudgetStages(startedAt: number) {
+  const elapsed = Date.now() - startedAt;
+  while (nextBudgetStage < TRADE_LIQ_BUDGET_STAGES.length && TRADE_LIQ_BUDGET_STAGES[nextBudgetStage].atMs <= elapsed) {
+    const { budget } = TRADE_LIQ_BUDGET_STAGES[nextBudgetStage];
+    try {
+      await executeAndWait(setTradeLiquidationBudgetTx(PROTOCOL_CONFIG_ID, budget), "trade-liq-budget");
+      appendTrace("keeper", { type: "liqBudget", budget: Number(budget), elapsedMs: elapsed });
+      console.log(`[keeper] trade_liquidation_budget -> ${budget} (t+${Math.round(elapsed / 1000)}s)`);
+      nextBudgetStage++;
+    } catch (e) {
+      appendTrace("keeper", { type: "fail", lane: "liqBudget", tag: errorTag(e) });
+      console.warn(`[keeper] trade_liquidation_budget deferred: ${e instanceof Error ? e.message.slice(0, 100) : e}`);
+      return; // retry this rung next tick; do not run ahead to a later one
+    }
+  }
+}
+
 async function main() {
   console.log(`[keeper] cadences=${CADENCE_IDS.join(",")} windows=${CADENCE_IDS.map((c) => CADENCES[c].windowSize).join(",")} tick=${TICK_MS}ms duration=${DURATION_MS || "∞"}ms`);
   const { feeds, lifecycleCapId } = await setupFeedsAndConfig(CADENCE_IDS);
@@ -240,9 +284,11 @@ async function main() {
   }
   console.log(`[keeper] bootstrapped (PLP minted, feeds.json published); funded ${TRADER_ADDRESSES.length} trader(s); rolling markets...`);
 
-  const deadline = DURATION_MS > 0 ? Date.now() + DURATION_MS : 0;
+  const startedAt = Date.now();
+  const deadline = DURATION_MS > 0 ? startedAt + DURATION_MS : 0;
   for (;;) {
     try {
+      await applyBudgetStages(startedAt);
       await tick(feeds, lifecycleCapId);
     } catch (e) {
       appendTrace("keeper", { type: "fail", tag: errorTag(e) });

--- a/packages/predict/harness/ts/keeperService.ts
+++ b/packages/predict/harness/ts/keeperService.ts
@@ -258,6 +258,11 @@ async function tick(feeds: Feeds, lifecycleCapId: string) {
 // Apply every due rung of the trade-liquidation-budget ladder. Isolated like the other lanes:
 // a failed set defers to the next tick rather than killing the run, and the stage is only
 // consumed on success so the sweep cannot silently skip a rung it never actually applied.
+//
+// The ladder is in-memory, so a keeper restart replays it from the first rung and walks the budget
+// back DOWN before climbing again. That costs run time, not correctness: every rung is traced, and
+// the analysis joins each probe to the rung in force at its own timestamp, so a replayed sweep
+// reads correctly. Persisting the cursor would buy only the wasted minutes.
 async function applyBudgetStages(startedAt: number) {
   const elapsed = Date.now() - startedAt;
   while (nextBudgetStage < TRADE_LIQ_BUDGET_STAGES.length && TRADE_LIQ_BUDGET_STAGES[nextBudgetStage].atMs <= elapsed) {

--- a/packages/predict/harness/ts/runtime.ts
+++ b/packages/predict/harness/ts/runtime.ts
@@ -1303,6 +1303,23 @@ export function setTemplateMaxAdmissionLeverageTx(
     return tx;
 }
 
+// Set the ambient liquidation-pass budget spent before every mint and every live redeem
+// (`ProtocolConfig::trade_liquidation_budget`). Contract bounds are [24, 3000]; outside them
+// the call aborts `EInvalidTradeLiquidationBudget`. The keeper drives this from a ladder
+// (TRADE_LIQ_BUDGET_STAGES) so one run can sweep the budget without republishing.
+export function setTradeLiquidationBudgetTx(protocolConfigId: string, budget: bigint): Transaction {
+    const tx = new Transaction();
+    tx.moveCall({
+        target: target("protocol_config", "set_trade_liquidation_budget"),
+        arguments: [
+            tx.object(protocolConfigId),
+            tx.object(ADMIN_CAP_ID),
+            tx.pure.u64(budget),
+        ],
+    });
+    return tx;
+}
+
 // Pin oracle read freshness to the testnet values. Testnet loosened pyth/bs price
 // freshness from the contract defaults (2s/3s) to 10s so realistic push cadence does
 // not stale-reject reads; the localnet must match or live pricing aborts under load.

--- a/packages/predict/harness/ts/strategies/index.ts
+++ b/packages/predict/harness/ts/strategies/index.ts
@@ -7,6 +7,8 @@ import cleanoutGas from "./cleanoutGas.js";
 import claimMarginal from "./claimMarginal.js";
 import cleanoutGasLiq from "./cleanoutGasLiq.js";
 import fuzz from "./fuzz.js";
+import liqBudgetAdverse from "./liqBudgetAdverse.js";
+import liqBudgetSweep from "./liqBudgetSweep.js";
 import liqChurn from "./liqChurn.js";
 import mintBatch from "./mintBatch.js";
 import mintOnly from "./mintOnly.js";
@@ -23,6 +25,8 @@ export const STRATEGIES: Record<string, Strategy> = {
   [mintOnly.name]: mintOnly,
   [mixedChurn.name]: mixedChurn,
   [liqChurn.name]: liqChurn,
+  [liqBudgetSweep.name]: liqBudgetSweep,
+  [liqBudgetAdverse.name]: liqBudgetAdverse,
   [navStress.name]: navStress,
   [navStressAtm.name]: navStressAtm,
   [navStressMulti.name]: navStressMulti,

--- a/packages/predict/harness/ts/strategies/liqBudgetAdverse.ts
+++ b/packages/predict/harness/ts/strategies/liqBudgetAdverse.ts
@@ -1,10 +1,10 @@
 // Strategy: liq-budget-adverse — the ADVERSE arm of the trade-path liquidation-budget ceiling
-// (DBU-695, Three Sigma #48). Same probe as liq-budget-sweep, but mints high-leverage near-ATM
-// orders (just under the admission cap, p~0.5 -> thin floor buffer, same profile as liq-churn),
+// (DBU-695). Same probe as liq-budget-sweep, but mints high-leverage near-ATM orders (just under
+// the admission cap, p~0.5 -> thin floor buffer, same profile as liq-churn),
 // so real BTC drift pushes them under their knock-out threshold and a mint's ambient pass MEETS
 // liquidatable candidates instead of only healthy ones.
 //
-// This is the branch the filed issue is actually about: a liquidatable candidate does not just
+// This is the branch the ceiling question is actually about: a liquidatable candidate does not just
 // get priced, it gets removed from the paged liquidation index AND has its boundaries removed
 // from the payout treap. Whether the per-tx wall is the computation cap or the object-runtime
 // cached-objects limit (1,000 dynamic-field children) is the open question — see the header of

--- a/packages/predict/harness/ts/strategies/liqBudgetAdverse.ts
+++ b/packages/predict/harness/ts/strategies/liqBudgetAdverse.ts
@@ -21,6 +21,11 @@ import { makeLiqBudgetStrategy } from "./liqBudgetProbe.js";
 export default makeLiqBudgetStrategy({
   name: "liq-budget-adverse",
   fund: 20_000_000_000_000n,
+  // Reaching the computation cap IS this arm's purpose, so it is declared. A VACUOUS verdict here
+  // is still a result — it says the removal branch stays affordable to the top of the allowed
+  // budget range — but it is worth failing the run for, because the more likely cause is that
+  // drift never knocked enough orders under their floor to build the branch under test.
+  expect: { terminal: ["InsufficientGas"], note: "per-tx computation cap on a liquidating ambient pass" },
   instruction: (ctx): Instruction => {
     const p = ctx.rand(0.45, 0.55); // near the money -> high static floor -> tight knock-out level
     return {

--- a/packages/predict/harness/ts/strategies/liqBudgetAdverse.ts
+++ b/packages/predict/harness/ts/strategies/liqBudgetAdverse.ts
@@ -1,0 +1,33 @@
+// Strategy: liq-budget-adverse — the ADVERSE arm of the trade-path liquidation-budget ceiling
+// (DBU-695, Three Sigma #48). Same probe as liq-budget-sweep, but mints high-leverage near-ATM
+// orders (just under the admission cap, p~0.5 -> thin floor buffer, same profile as liq-churn),
+// so real BTC drift pushes them under their knock-out threshold and a mint's ambient pass MEETS
+// liquidatable candidates instead of only healthy ones.
+//
+// This is the branch the filed issue is actually about: a liquidatable candidate does not just
+// get priced, it gets removed from the paged liquidation index AND has its boundaries removed
+// from the payout treap. Whether the per-tx wall is the computation cap or the object-runtime
+// cached-objects limit (1,000 dynamic-field children) is the open question — see the header of
+// liqBudgetProbe.ts for why neither is pre-declared as expected.
+//
+// Pair with KEEPER_LIQ_BUDGET=0: the keeper's own permissionless liquidate() lane would
+// otherwise sweep these orders before a mint's ambient pass could reach them, hiding the branch.
+//
+// Run: KEEPER_LIQ_BUDGET=0 TRADE_LIQ_BUDGET_STAGES=0:24,900:512,1800:1500,2700:3000 \
+//      SIM_GAS_BUDGET=50000000000 python3 -m harness campaign liq-budget-adverse --timeout 3600
+import { type Instruction } from "../resolver.js";
+import { makeLiqBudgetStrategy } from "./liqBudgetProbe.js";
+
+export default makeLiqBudgetStrategy({
+  name: "liq-budget-adverse",
+  fund: 20_000_000_000_000n,
+  instruction: (ctx): Instruction => {
+    const p = ctx.rand(0.45, 0.55); // near the money -> high static floor -> tight knock-out level
+    return {
+      direction: ctx.pick(["UP", "DN"]) as "UP" | "DN",
+      leverage: ctx.leverageCap(p) * ctx.rand(0.9, 0.99), // just under the admission cap
+      targetProbability: p,
+      spendUsd: ctx.rand(5, 10),
+    };
+  },
+});

--- a/packages/predict/harness/ts/strategies/liqBudgetProbe.ts
+++ b/packages/predict/harness/ts/strategies/liqBudgetProbe.ts
@@ -80,24 +80,31 @@ export function makeLiqBudgetStrategy(arm: LiqBudgetArm): Strategy {
   const book = () => minted - liquidated;
 
   function targetMarket(ctx: StrategyCtx): Mkt | null {
+    const live = ctx.markets();
     if (lockedId) {
-      const m = ctx.markets().find((mk) => mk.id === lockedId);
+      const m = live.find((mk) => mk.id === lockedId);
       if (m) return m;
-      // Locked market settled (shouldn't happen for a >2h market) — re-lock onto a fresh one and
-      // reset EVERY piece of book-derived state with it. Carrying `batch`/`wallHits` across the
-      // re-lock would strand the strategy: a run that reached the wall on the old book holds at
-      // batch==1 with wallHits past its limit, so it would never mint into the new empty book.
-      lockedId = null;
+      // The locked market is missing from this tick's view. That is NOT proof it settled:
+      // `markets()` reads markets.json, which comes back empty on a torn read and drops markets
+      // whose keeper-side `funded` set was cleared by a restart. Resetting the book counter on that
+      // alone would leave `book` under-reporting the real index for the rest of the run — silently,
+      // and in the direction that corrupts the measurement. So hold state and wait; only a genuine
+      // re-lock onto a DIFFERENT market resets, below.
+      if (!live.length) return null;
+    }
+    if (!live.length) return null;
+    const farthest = live.reduce((a, b) => (b.expiryMs > a.expiryMs ? b : a));
+    if (farthest.expiryMs <= Date.now() + TWO_HOURS_MS) return null;
+    if (farthest.id !== lockedId) {
+      // A different market: the old book is gone with it, so every piece of book-derived state
+      // resets together. Carrying `batch`/`wallHits` over would strand the strategy — a run that
+      // reached the wall holds at batch==1 with wallHits past its limit and never mints again.
+      lockedId = farthest.id;
       minted = 0;
       liquidated = 0;
       batch = START_BATCH;
       wallHits = 0;
     }
-    const live = ctx.markets();
-    if (!live.length) return null;
-    const farthest = live.reduce((a, b) => (b.expiryMs > a.expiryMs ? b : a));
-    if (farthest.expiryMs <= Date.now() + TWO_HOURS_MS) return null;
-    lockedId = farthest.id;
     return farthest;
   }
 
@@ -143,12 +150,15 @@ export function makeLiqBudgetStrategy(arm: LiqBudgetArm): Strategy {
         // ordinary mint's cost, which is the number the ceiling is set from. `book` is the index
         // size the ambient pass saw — BEFORE this tx's own mints and knockouts.
         const res = await ctx.submitMintBatch(market, legs, { book: book(), minted, batch });
-        // The ambient pass in this very tx may have knocked orders out of the index.
+        // The ambient pass in this very tx may have knocked orders out of the index. `knocked` also
+        // goes onto the record (via the follow-up trace) because a liquidating candidate costs more
+        // than a scanned one — index removal plus payout-tree boundary removal — so without it the
+        // fitted comp/candidate is a blend of the two whose mix is invisible after the fact.
         const knocked = ((res?.events ?? []) as any[]).filter((e) => e.type?.includes("OrderLiquidated")).length;
         minted += legs.length;
         liquidated += knocked;
         wallHits = 0;
-        ctx.trace({ type: "book", size: book(), minted, liquidated, market: market.id });
+        ctx.trace({ type: "book", size: book(), minted, liquidated, knocked, n: legs.length, market: market.id });
         return "mint";
       } catch (e) {
         if (isOog(e)) {

--- a/packages/predict/harness/ts/strategies/liqBudgetProbe.ts
+++ b/packages/predict/harness/ts/strategies/liqBudgetProbe.ts
@@ -34,11 +34,22 @@ const TWO_HOURS_MS = 2 * 3_600_000;
 const MAX_BOOK = 5000; // EMaxActiveLeveragedOrders — the per-market index cap
 const START_BATCH = 40; // safely under the ~110-mint atomic-batch OOG ceiling at budget 24
 
+// After this many consecutive single-mint OOGs the wall is measured and the strategy holds. Without
+// it the probe submits a failing ~cap-sized tx every tick forever: the trader's gas coin drains (an
+// OOG still executes and charges), and the trace fills with duplicate wall records. Higher rungs
+// only cost more, so there is nothing left to learn once a 1-leg mint cannot fit.
+const WALL_CONFIRMATIONS = 3;
+
 export interface LiqBudgetArm {
   name: string;
   fund: bigint;
   // The arm's leverage profile — the ONLY difference between the healthy and adverse probes.
   instruction(ctx: StrategyCtx): Instruction;
+  // Declared terminal wall, when reaching it is this arm's PURPOSE. Omit when it is not: `analyze`
+  // fails a run VACUOUS if a declared wall goes unreached, and whitelists it when it is hit — so
+  // declaring a wall an arm is not expected to reach turns every clean run red AND suppresses the
+  // surprise if it ever does happen.
+  expect?: { terminal: string[]; note?: string };
 }
 
 export function makeLiqBudgetStrategy(arm: LiqBudgetArm): Strategy {
@@ -49,6 +60,7 @@ export function makeLiqBudgetStrategy(arm: LiqBudgetArm): Strategy {
   let lockedId: string | null = null;
   let minted = 0;
   let batch = START_BATCH;
+  let wallHits = 0; // consecutive single-mint OOGs; reset by any success
 
   function targetMarket(ctx: StrategyCtx): Mkt | null {
     if (lockedId) {
@@ -84,10 +96,11 @@ export function makeLiqBudgetStrategy(arm: LiqBudgetArm): Strategy {
     tickMs: 1500,
     maxOps: 0, // duration-only: fill, then hold and keep probing as the budget ladder steps up
     fund: arm.fund,
-    expect: { terminal: ["InsufficientGas"], note: "per-tx computation cap on the ambient liquidation pass" },
+    ...(arm.expect ? { expect: arm.expect } : {}),
     async tick(ctx) {
       const market = targetMarket(ctx);
       if (!market || !ctx.snapshot()) return null;
+      if (batch === 1 && wallHits >= WALL_CONFIRMATIONS) return null; // wall measured — hold
       const want = Math.min(batch, MAX_BOOK - minted);
       if (want <= 0) return null; // at the index cap — hold; the ladder keeps re-probing
       const legs: MintLeg[] = [];
@@ -101,13 +114,15 @@ export function makeLiqBudgetStrategy(arm: LiqBudgetArm): Strategy {
         // ordinary mint's cost, which is the number the ceiling is set from.
         await ctx.submitMintBatch(market, legs, { minted, batch });
         minted += legs.length;
+        wallHits = 0;
         ctx.trace({ type: "book", size: minted, market: market.id });
         return "mint";
       } catch (e) {
         if (isOog(e)) {
-          // The cap: halve and retry smaller. At batch==1 this IS the wall — keep probing so
-          // every later rung of the ladder gets a data point at the same book.
+          // The cap: halve and retry smaller. At batch==1 there is nothing left to halve — that
+          // IS the wall, so confirm it a few times and then hold.
           ctx.trace({ type: "mintBatch", n: legs.length, minted, batch, oog: true, err: errorTag(e) });
+          if (batch === 1) wallHits += 1;
           batch = Math.max(1, Math.floor(batch / 2));
         } else {
           ctx.trace({ type: "fail", tag: errorTag(e), n: legs.length, minted, batch });

--- a/packages/predict/harness/ts/strategies/liqBudgetProbe.ts
+++ b/packages/predict/harness/ts/strategies/liqBudgetProbe.ts
@@ -1,4 +1,4 @@
-// Shared core for the two trade-path liquidation-budget probes (DBU-695, Three Sigma #48).
+// Shared core for the two trade-path liquidation-budget probes (DBU-695).
 //
 // WHAT IS BEING MEASURED. `trade_liquidation_budget` bounds the ambient liquidation pass that
 // runs before every mint and every live redeem. It ships at 24 and is admin-raisable to a
@@ -10,21 +10,25 @@
 // HOW ONE RUN SWEEPS IT. The cost is min(budget, book), so a book built cheaply at budget 24 can
 // be re-probed at every higher rung without rebuilding it. The keeper walks
 // TRADE_LIQ_BUDGET_STAGES ("<elapsedSeconds>:<budget>,…") and traces each rung as
-// {type:"liqBudget", budget, elapsedMs}; analysis joins probes to rungs on time. Run with e.g.
+// {type:"liqBudget", budget, requestedAtMs, elapsedMs}; analysis joins probes to rungs on time and
+// discards the request-to-landed window, where the in-force budget is indeterminate. Run e.g.
 //   TRADE_LIQ_BUDGET_STAGES=0:24,900:512,1800:1500,2700:3000 SIM_GAS_BUDGET=50000000000
 //
-// BATCHING IS ADAPTIVE, AND THAT IS THE POINT. Every `mint_exact_quantity` in a PTB runs its own
-// ambient pass, so an N-mint batch pays N sweeps: at budget 3,000 even a 2-mint batch is over the
-// cap. The batch therefore starts at 40 (fast fill while the budget is low) and halves on each
-// OOG until it reaches 1. A 1-leg batch is byte-identical to an ordinary mint, so every
-// submission at batch==1 IS the measurement — no separate probe path to keep honest.
+// FILL, THEN PROBE ONE AT A TIME. Every `mint_exact_quantity` in a PTB runs its own ambient pass,
+// so an N-mint batch pays N sweeps and only n==1 transactions measure the trade path. Batching
+// exists solely to reach a deep book fast: up to FILL_TARGET the probe batches (halving on any
+// OOG), and past it every mint goes out alone for the rest of the run. A 1-leg batch is
+// byte-identical to an ordinary mint, so each of those submissions IS the measurement — there is
+// no separate probe path that could drift from what a real trader pays.
 //
-// READING THE RESULT. The declared wall is the per-tx computation cap (`InsufficientGas`).
-// `analyze` fails a run VACUOUS when a declared wall is never reached — here that is a real
-// result, not a harness failure: it means the ladder's top rung was affordable at the book the
-// run built. If the object-runtime cached-objects limit (1,000 children/tx) binds first on the
-// adverse arm instead, it surfaces as an UNdeclared VM error and gets flagged; that is
-// deliberate — which wall binds is the open question, so neither is pre-declared as expected.
+// READING THE RESULT. Only the adverse arm declares the per-tx computation cap
+// (`InsufficientGas`) as its terminal wall, because only it is expected to reach one; `analyze`
+// fails a run VACUOUS when a DECLARED wall goes unreached, so declaring it on the healthy arm
+// would turn every clean run red. An undeclared arm that OOGs a single mint raises
+// `liq-budget-wall-undeclared` instead — that is a finding, not the measurement. If the
+// object-runtime cached-objects limit (1,000 children/tx) binds before the computation cap on the
+// adverse arm, it surfaces as an UNdeclared VM error and gets flagged; which wall binds first is
+// the open question, so neither is pre-declared as the expected one.
 import { type Instruction } from "../resolver.js";
 import { type MintLeg, type Mkt, type Strategy, type StrategyCtx } from "../strategy.js";
 import { errorTag, isOog } from "../trace.js";

--- a/packages/predict/harness/ts/strategies/liqBudgetProbe.ts
+++ b/packages/predict/harness/ts/strategies/liqBudgetProbe.ts
@@ -1,0 +1,119 @@
+// Shared core for the two trade-path liquidation-budget probes (DBU-695, Three Sigma #48).
+//
+// WHAT IS BEING MEASURED. `trade_liquidation_budget` bounds the ambient liquidation pass that
+// runs before every mint and every live redeem. It ships at 24 and is admin-raisable to a
+// compile-time max of 3,000 that no measurement stands behind. The pass costs
+// min(budget, active_leveraged_orders) candidates, each priced with an un-memoized
+// `range_price`, so the deliverable is per-mint `compGas` as a joint function of the configured
+// budget and the book — and the budget at which an ordinary mint stops fitting in one tx.
+//
+// HOW ONE RUN SWEEPS IT. The cost is min(budget, book), so a book built cheaply at budget 24 can
+// be re-probed at every higher rung without rebuilding it. The keeper walks
+// TRADE_LIQ_BUDGET_STAGES ("<elapsedSeconds>:<budget>,…") and traces each rung as
+// {type:"liqBudget", budget, elapsedMs}; analysis joins probes to rungs on time. Run with e.g.
+//   TRADE_LIQ_BUDGET_STAGES=0:24,900:512,1800:1500,2700:3000 SIM_GAS_BUDGET=50000000000
+//
+// BATCHING IS ADAPTIVE, AND THAT IS THE POINT. Every `mint_exact_quantity` in a PTB runs its own
+// ambient pass, so an N-mint batch pays N sweeps: at budget 3,000 even a 2-mint batch is over the
+// cap. The batch therefore starts at 40 (fast fill while the budget is low) and halves on each
+// OOG until it reaches 1. A 1-leg batch is byte-identical to an ordinary mint, so every
+// submission at batch==1 IS the measurement — no separate probe path to keep honest.
+//
+// READING THE RESULT. The declared wall is the per-tx computation cap (`InsufficientGas`).
+// `analyze` fails a run VACUOUS when a declared wall is never reached — here that is a real
+// result, not a harness failure: it means the ladder's top rung was affordable at the book the
+// run built. If the object-runtime cached-objects limit (1,000 children/tx) binds first on the
+// adverse arm instead, it surfaces as an UNdeclared VM error and gets flagged; that is
+// deliberate — which wall binds is the open question, so neither is pre-declared as expected.
+import { type Instruction } from "../resolver.js";
+import { type MintLeg, type Mkt, type Strategy, type StrategyCtx } from "../strategy.js";
+import { errorTag, isOog } from "../trace.js";
+
+const SCALE = 1_000_000_000n;
+const TWO_HOURS_MS = 2 * 3_600_000;
+const MAX_BOOK = 5000; // EMaxActiveLeveragedOrders — the per-market index cap
+const START_BATCH = 40; // safely under the ~110-mint atomic-batch OOG ceiling at budget 24
+
+export interface LiqBudgetArm {
+  name: string;
+  fund: bigint;
+  // The arm's leverage profile — the ONLY difference between the healthy and adverse probes.
+  instruction(ctx: StrategyCtx): Instruction;
+}
+
+export function makeLiqBudgetStrategy(arm: LiqBudgetArm): Strategy {
+  // Batch mints never enter ctx.held, so lock the market and count our own mints. `minted` is
+  // mints ISSUED, which equals the active book only on the healthy arm (leverage low enough that
+  // nothing is ever knocked out). On the adverse arm liquidations leave the index, so
+  // minted >= book and the active count must come from the liquidation events, not from here.
+  let lockedId: string | null = null;
+  let minted = 0;
+  let batch = START_BATCH;
+
+  function targetMarket(ctx: StrategyCtx): Mkt | null {
+    if (lockedId) {
+      const m = ctx.markets().find((mk) => mk.id === lockedId);
+      if (m) return m;
+      lockedId = null; // locked market settled (shouldn't happen for a >2h market) — re-lock
+      minted = 0;
+    }
+    const live = ctx.markets();
+    if (!live.length) return null;
+    const farthest = live.reduce((a, b) => (b.expiryMs > a.expiryMs ? b : a));
+    if (farthest.expiryMs <= Date.now() + TWO_HOURS_MS) return null;
+    lockedId = farthest.id;
+    return farthest;
+  }
+
+  function legFrom(ctx: StrategyCtx, market: Mkt): MintLeg | null {
+    const inst = arm.instruction(ctx);
+    const r = ctx.resolve(inst, market); // null when infeasible (e.g. too near expiry) — skip the leg
+    if (!r) return null;
+    return {
+      strike1e9: BigInt(Math.round(r.strikeUsd)) * SCALE,
+      isUp: inst.direction === "UP",
+      quantity: r.quantity,
+      leverage1e9: r.leverage1e9,
+      maxCost: r.maxCost,
+      maxProbability: r.maxProbability1e9,
+    };
+  }
+
+  return {
+    name: arm.name,
+    tickMs: 1500,
+    maxOps: 0, // duration-only: fill, then hold and keep probing as the budget ladder steps up
+    fund: arm.fund,
+    expect: { terminal: ["InsufficientGas"], note: "per-tx computation cap on the ambient liquidation pass" },
+    async tick(ctx) {
+      const market = targetMarket(ctx);
+      if (!market || !ctx.snapshot()) return null;
+      const want = Math.min(batch, MAX_BOOK - minted);
+      if (want <= 0) return null; // at the index cap — hold; the ladder keeps re-probing
+      const legs: MintLeg[] = [];
+      for (let i = 0; i < want; i++) {
+        const l = legFrom(ctx, market);
+        if (l) legs.push(l);
+      }
+      if (legs.length === 0) return null;
+      try {
+        // submitMintBatch traces {type:"mintBatch", n, gas, compGas, …meta}; at n==1 that IS an
+        // ordinary mint's cost, which is the number the ceiling is set from.
+        await ctx.submitMintBatch(market, legs, { minted, batch });
+        minted += legs.length;
+        ctx.trace({ type: "book", size: minted, market: market.id });
+        return "mint";
+      } catch (e) {
+        if (isOog(e)) {
+          // The cap: halve and retry smaller. At batch==1 this IS the wall — keep probing so
+          // every later rung of the ladder gets a data point at the same book.
+          ctx.trace({ type: "mintBatch", n: legs.length, minted, batch, oog: true, err: errorTag(e) });
+          batch = Math.max(1, Math.floor(batch / 2));
+        } else {
+          ctx.trace({ type: "fail", tag: errorTag(e), n: legs.length, minted, batch });
+        }
+        return null;
+      }
+    },
+  };
+}

--- a/packages/predict/harness/ts/strategies/liqBudgetProbe.ts
+++ b/packages/predict/harness/ts/strategies/liqBudgetProbe.ts
@@ -66,8 +66,14 @@ export function makeLiqBudgetStrategy(arm: LiqBudgetArm): Strategy {
     if (lockedId) {
       const m = ctx.markets().find((mk) => mk.id === lockedId);
       if (m) return m;
-      lockedId = null; // locked market settled (shouldn't happen for a >2h market) — re-lock
+      // Locked market settled (shouldn't happen for a >2h market) — re-lock onto a fresh one and
+      // reset EVERY piece of book-derived state with it. Carrying `batch`/`wallHits` across the
+      // re-lock would strand the strategy: a run that reached the wall on the old book holds at
+      // batch==1 with wallHits past its limit, so it would never mint into the new empty book.
+      lockedId = null;
       minted = 0;
+      batch = START_BATCH;
+      wallHits = 0;
     }
     const live = ctx.markets();
     if (!live.length) return null;

--- a/packages/predict/harness/ts/strategies/liqBudgetProbe.ts
+++ b/packages/predict/harness/ts/strategies/liqBudgetProbe.ts
@@ -33,6 +33,15 @@ const SCALE = 1_000_000_000n;
 const TWO_HOURS_MS = 2 * 3_600_000;
 const MAX_BOOK = 5000; // EMaxActiveLeveragedOrders — the per-market index cap
 const START_BATCH = 40; // safely under the ~110-mint atomic-batch OOG ceiling at budget 24
+// Book size at which the fill stops batching and every mint becomes a single-mint probe. Batching
+// exists only to reach a deep book quickly; past this the run's job is to emit n==1 samples, and it
+// must keep emitting them for the WHOLE ladder. MAX_BOOK - FILL_TARGET = 3,000 single mints, ~75
+// minutes at tickMs 1500, which outlasts the documented ladder — so every rung gets probed.
+//
+// Getting this wrong is silent: batching to the index cap saturates the book in ~3 minutes, long
+// before the first rung steps, after which there is nothing left to mint and the run collects
+// nothing while still reporting a clean verdict.
+const FILL_TARGET = 2000;
 
 // After this many consecutive single-mint OOGs the wall is measured and the strategy holds. Without
 // it the probe submits a failing ~cap-sized tx every tick forever: the trader's gas coin drains (an
@@ -53,14 +62,18 @@ export interface LiqBudgetArm {
 }
 
 export function makeLiqBudgetStrategy(arm: LiqBudgetArm): Strategy {
-  // Batch mints never enter ctx.held, so lock the market and count our own mints. `minted` is
-  // mints ISSUED, which equals the active book only on the healthy arm (leverage low enough that
-  // nothing is ever knocked out). On the adverse arm liquidations leave the index, so
-  // minted >= book and the active count must come from the liquidation events, not from here.
+  // Batch mints never enter ctx.held, so lock the market and track the index ourselves. The book is
+  // mints issued MINUS orders the ambient pass knocked out, counted from each tx's OrderLiquidated
+  // events — on the adverse arm those removals are continuous, so issued-mints alone overstates the
+  // index, and overstating it understates the per-candidate slope and overstates the ceiling the
+  // whole run exists to set. On the healthy arm nothing knocks out and `liquidated` stays 0.
   let lockedId: string | null = null;
   let minted = 0;
+  let liquidated = 0;
   let batch = START_BATCH;
   let wallHits = 0; // consecutive single-mint OOGs; reset by any success
+
+  const book = () => minted - liquidated;
 
   function targetMarket(ctx: StrategyCtx): Mkt | null {
     if (lockedId) {
@@ -72,6 +85,7 @@ export function makeLiqBudgetStrategy(arm: LiqBudgetArm): Strategy {
       // batch==1 with wallHits past its limit, so it would never mint into the new empty book.
       lockedId = null;
       minted = 0;
+      liquidated = 0;
       batch = START_BATCH;
       wallHits = 0;
     }
@@ -100,15 +114,20 @@ export function makeLiqBudgetStrategy(arm: LiqBudgetArm): Strategy {
   return {
     name: arm.name,
     tickMs: 1500,
-    maxOps: 0, // duration-only: fill, then hold and keep probing as the budget ladder steps up
+    maxOps: 0, // duration-only: fill to FILL_TARGET, then probe one mint at a time for the rest
     fund: arm.fund,
     ...(arm.expect ? { expect: arm.expect } : {}),
     async tick(ctx) {
       const market = targetMarket(ctx);
       if (!market || !ctx.snapshot()) return null;
       if (batch === 1 && wallHits >= WALL_CONFIRMATIONS) return null; // wall measured — hold
-      const want = Math.min(batch, MAX_BOOK - minted);
-      if (want <= 0) return null; // at the index cap — hold; the ladder keeps re-probing
+      // Past FILL_TARGET every mint goes out alone, whether or not anything has OOG'd. Halving on
+      // OOG alone is not enough: batching only shrinks when it stops fitting, so a run would sit at
+      // n=5 or n=2 for most of the ladder and emit n==1 samples — the only ones the fit uses — at
+      // the very top rung, if ever.
+      if (book() >= FILL_TARGET) batch = 1;
+      const want = Math.min(batch, MAX_BOOK - book());
+      if (want <= 0) return null; // index cap with nothing knocked out — no room left to probe
       const legs: MintLeg[] = [];
       for (let i = 0; i < want; i++) {
         const l = legFrom(ctx, market);
@@ -117,21 +136,25 @@ export function makeLiqBudgetStrategy(arm: LiqBudgetArm): Strategy {
       if (legs.length === 0) return null;
       try {
         // submitMintBatch traces {type:"mintBatch", n, gas, compGas, …meta}; at n==1 that IS an
-        // ordinary mint's cost, which is the number the ceiling is set from.
-        await ctx.submitMintBatch(market, legs, { minted, batch });
+        // ordinary mint's cost, which is the number the ceiling is set from. `book` is the index
+        // size the ambient pass saw — BEFORE this tx's own mints and knockouts.
+        const res = await ctx.submitMintBatch(market, legs, { book: book(), minted, batch });
+        // The ambient pass in this very tx may have knocked orders out of the index.
+        const knocked = ((res?.events ?? []) as any[]).filter((e) => e.type?.includes("OrderLiquidated")).length;
         minted += legs.length;
+        liquidated += knocked;
         wallHits = 0;
-        ctx.trace({ type: "book", size: minted, market: market.id });
+        ctx.trace({ type: "book", size: book(), minted, liquidated, market: market.id });
         return "mint";
       } catch (e) {
         if (isOog(e)) {
           // The cap: halve and retry smaller. At batch==1 there is nothing left to halve — that
           // IS the wall, so confirm it a few times and then hold.
-          ctx.trace({ type: "mintBatch", n: legs.length, minted, batch, oog: true, err: errorTag(e) });
+          ctx.trace({ type: "mintBatch", n: legs.length, book: book(), minted, batch, oog: true, err: errorTag(e) });
           if (batch === 1) wallHits += 1;
           batch = Math.max(1, Math.floor(batch / 2));
         } else {
-          ctx.trace({ type: "fail", tag: errorTag(e), n: legs.length, minted, batch });
+          ctx.trace({ type: "fail", tag: errorTag(e), n: legs.length, book: book(), minted, batch });
         }
         return null;
       }

--- a/packages/predict/harness/ts/strategies/liqBudgetSweep.ts
+++ b/packages/predict/harness/ts/strategies/liqBudgetSweep.ts
@@ -13,7 +13,9 @@
 // ~73% of the computation cap — expensive, but it fits. So the wall is not expected here, and a
 // declared-but-unreached wall would fail every clean run VACUOUS. It also means an OOG on this arm
 // is genuine news — a scan-only mint that cannot fit is a bigger finding than the one being
-// measured — and leaving it undeclared is what lets the bug oracle flag it instead of whitelisting it.
+// measured. `analyze` raises `liq-budget-wall-undeclared` for exactly that case, which is what
+// fails the run: an OOG is traced as a mintBatch record, not a `fail`, so the bug oracle never
+// sees it and leaving it undeclared alone would print the wall and still exit 0.
 //
 // Run: TRADE_LIQ_BUDGET_STAGES=0:24,900:512,1800:1500,2700:3000 SIM_GAS_BUDGET=50000000000
 //      python3 -m harness campaign liq-budget-sweep --timeout 3600

--- a/packages/predict/harness/ts/strategies/liqBudgetSweep.ts
+++ b/packages/predict/harness/ts/strategies/liqBudgetSweep.ts
@@ -1,6 +1,6 @@
 // Strategy: liq-budget-sweep — the HEALTHY arm of the trade-path liquidation-budget ceiling
-// (DBU-695, Three Sigma #48). Fills one far-1h market with LOW-leverage orders (1.1x, far above
-// their floor, so nothing is ever knocked out) and measures per-mint computation as the keeper's
+// (DBU-695). Fills one far-1h market with LOW-leverage orders (1.1x, far above their floor, so
+// nothing is ever knocked out) and measures per-mint computation as the keeper's
 // budget ladder steps up. Every candidate the ambient pass selects is priced and found healthy,
 // so this isolates the scan+price cost — the floor under any budget setting, paid on every mint
 // and live redeem whether or not anything is liquidatable.

--- a/packages/predict/harness/ts/strategies/liqBudgetSweep.ts
+++ b/packages/predict/harness/ts/strategies/liqBudgetSweep.ts
@@ -10,7 +10,7 @@
 //
 // This arm declares NO terminal wall, deliberately. At the pre-memo `correction_value` slope
 // (~1.09M/order, the closest measured analogue) a scan-only pass at the 3,000 budget max costs
-// ~73% of the computation cap — expensive, but it fits. So the wall is not expected here, and a
+// ~3.26e9 of the 5e9 computation cap — about 65%, expensive but it fits. So the wall is not expected here, and a
 // declared-but-unreached wall would fail every clean run VACUOUS. It also means an OOG on this arm
 // is genuine news — a scan-only mint that cannot fit is a bigger finding than the one being
 // measured. `analyze` raises `liq-budget-wall-undeclared` for exactly that case, which is what

--- a/packages/predict/harness/ts/strategies/liqBudgetSweep.ts
+++ b/packages/predict/harness/ts/strategies/liqBudgetSweep.ts
@@ -1,0 +1,25 @@
+// Strategy: liq-budget-sweep — the HEALTHY arm of the trade-path liquidation-budget ceiling
+// (DBU-695, Three Sigma #48). Fills one far-1h market with LOW-leverage orders (1.1x, far above
+// their floor, so nothing is ever knocked out) and measures per-mint computation as the keeper's
+// budget ladder steps up. Every candidate the ambient pass selects is priced and found healthy,
+// so this isolates the scan+price cost — the floor under any budget setting, paid on every mint
+// and live redeem whether or not anything is liquidatable.
+//
+// Because nothing liquidates, `minted` here IS the active leveraged book, which makes this the
+// arm that yields the clean cost(budget, book) surface. The adverse branch is liq-budget-adverse.
+//
+// Run: TRADE_LIQ_BUDGET_STAGES=0:24,900:512,1800:1500,2700:3000 SIM_GAS_BUDGET=50000000000
+//      python3 -m harness campaign liq-budget-sweep --timeout 3600
+import { type Instruction } from "../resolver.js";
+import { makeLiqBudgetStrategy } from "./liqBudgetProbe.js";
+
+export default makeLiqBudgetStrategy({
+  name: "liq-budget-sweep",
+  fund: 20_000_000_000_000n,
+  instruction: (ctx): Instruction => ({
+    direction: "UP",
+    leverage: 1.1, // low -> far above floor -> never liquidated -> minted == active book
+    targetProbability: ctx.rand(0.45, 0.6),
+    spendUsd: ctx.rand(5, 10),
+  }),
+});

--- a/packages/predict/harness/ts/strategies/liqBudgetSweep.ts
+++ b/packages/predict/harness/ts/strategies/liqBudgetSweep.ts
@@ -8,6 +8,13 @@
 // Because nothing liquidates, `minted` here IS the active leveraged book, which makes this the
 // arm that yields the clean cost(budget, book) surface. The adverse branch is liq-budget-adverse.
 //
+// This arm declares NO terminal wall, deliberately. At the pre-memo `correction_value` slope
+// (~1.09M/order, the closest measured analogue) a scan-only pass at the 3,000 budget max costs
+// ~73% of the computation cap — expensive, but it fits. So the wall is not expected here, and a
+// declared-but-unreached wall would fail every clean run VACUOUS. It also means an OOG on this arm
+// is genuine news — a scan-only mint that cannot fit is a bigger finding than the one being
+// measured — and leaving it undeclared is what lets the bug oracle flag it instead of whitelisting it.
+//
 // Run: TRADE_LIQ_BUDGET_STAGES=0:24,900:512,1800:1500,2700:3000 SIM_GAS_BUDGET=50000000000
 //      python3 -m harness campaign liq-budget-sweep --timeout 3600
 import { type Instruction } from "../resolver.js";


### PR DESCRIPTION
## Summary

- `setTradeLiquidationBudgetTx` in `runtime.ts` — the AdminCap-gated `protocol_config::set_trade_liquidation_budget` setter the harness was missing.
- Keeper ladder `TRADE_LIQ_BUDGET_STAGES="<elapsedSeconds>:<budget>,…"`, applied one rung at a time and traced as `{type:"liqBudget", budget, requestedAtMs, elapsedMs}`. Unset — the default — never touches the config, so every existing run keeps the contract default of 24.
- `KEEPER_LIQ_BUDGET` sizes the keeper's own permissionless `liquidate()` lane and accepts `0` to disable it.
- Two probe strategies over a shared core: `liq-budget-sweep` (healthy) and `liq-budget-adverse` (liquidating). Each fills to a 2,000-order book with batched mints, then sends every mint alone for the rest of the run.
- `analyze` grows a liq-budget section that joins budget rungs to single-mint probes and fits `comp ~ base + slope*candidates`, reporting per-candidate cost, the mint's own base, and the candidate count at which an ordinary mint stops fitting one tx — plus the empirical wall if one was hit.
- README: strategy list, run recipes, pacing constraint.

No contract change. **The measurement itself has not been run** — see Test plan.

## Why

`ProtocolConfig::trade_liquidation_budget` bounds the ambient liquidation pass that runs before every mint and every live redeem. It ships at 24 and is admin-raisable to a compile-time maximum of 3,000. Every other capacity ceiling in Predict traces to a harness run with an evidence file behind it; this one does not, and an external review asked us to justify it.

Extrapolating from the closest measured analogue — the pre-memo `correction_value` slope of ~1.09M MIST/order (`predeploy/evidence/c1-price-memo-2026-07-01.md`), which has the same shape as the ambient sweep (paged liquidation-book walk plus one un-memoized `range_price`) — 3,000 candidates costs ~3.26e9 against the 5e9 per-tx computation cap, about 65%, before the mint's own work. Expensive but survivable, and entirely an extrapolation: nothing has measured the trade path as a function of budget.

The same number also answers whether the ambient sweep alone is a viable liquidation mechanism at launch, or whether the Predict liquidation keeper has to exist first.

## Key decisions

- **One run sweeps the range.** The pass costs `min(budget, active_leveraged_orders)`, so a book built cheaply at budget 24 can be re-probed at every higher rung without rebuilding it. Hence a keeper-driven ladder rather than a per-run constant — otherwise this is N localnet runs instead of one.
- **Fill with batches, then measure one mint at a time.** Every mint in a PTB runs its own ambient pass, so only `n==1` transactions measure the trade path — and a 1-leg batch is byte-identical to an ordinary mint, so no separate probe path can drift from the real one. Past `FILL_TARGET` every mint goes out alone, leaving ~3,000 single mints (~75 min) so the sweep outlasts the ladder.
- **The book is the active index, not mints issued.** The strategy counts `OrderLiquidated` events per transaction and traces `book = minted - liquidated`, plus the per-tx `knocked` count so removal cost stays separable from scan cost. On the adverse arm the ambient pass removes orders continuously, so issued-mints overstates candidates scanned, understates the slope and overstates the ceiling — the unsafe direction, on the arm that matters most.
- **The fit regresses on `min(budget, book)`, not budget,** using only `n==1` records, and discards probes inside a rung's request-to-landed window where the in-force budget is indeterminate.
- **The fit refuses to answer when the samples cannot support one.** A ceiling extrapolated from a narrow cluster is worse than no number: in simulation a fit over candidate counts 23–29 projected to ~1,900 against a truth of 4,236, printed to the same decimal places. It now requires a 4x lever arm, rejects an unphysical negative base outright, labels a crossing far past the measured range as extrapolation, and raises a signal when a run collected no single-mint samples at all.
- **Only the adverse arm declares the computation cap.** At the extrapolated slope a scan-only pass at budget 3,000 fits, so declaring the wall on the healthy arm would fail every clean run VACUOUS *and* whitelist the OOG if it happened. An undeclared arm that OOGs raises `liq-budget-wall-undeclared` instead. Because the trader's submit path writes no failed-tx artifact and traces its OOG as a `mintBatch` record, the declared-wall check is fed the OOG's own tag — without that, an arm reaching exactly the wall it declared was failed for not reaching it.
- **A failing rung abandons the ladder; it never throws.** `applyBudgetStages` runs before `tick()` in the same `try`, so throwing would skip settlement, flush, rebalance and roll for the rest of the run. It marks the trace fatal instead, which fails the run in `analyze` while leaving every other keeper lane isolated.
- **Adverse arm needs `KEEPER_LIQ_BUDGET=0`.** Otherwise the keeper's own `liquidate()` lane sweeps the liquidatable orders before a mint's ambient pass can meet them, and the branch under test never executes.

## Scope / descoped

- The head/tail scan split is untouched. At budget 3,000 the split is head 2,000 / tail 1,000 and the head is re-scanned every pass, so two-thirds of the cost re-prices the same largest-by-size orders — known, and separate from the ceiling question.
- No change to `max_trade_liquidation_budget`. That is the follow-up PR, and its value comes from this instrument's output.
- Does not close the H-6 `liquidate()` self-DoS probe, which needs a raw `ctx.submitLiquidate` builder.

## Known risks in the measurement

- **The adverse arm may not build its branch.** Its orders only become liquidatable after real BTC drift. If drift is mild, few orders go under floor and the run reads VACUOUS with an ambiguous cause — either the removal branch is affordable, or it never executed. Check the `knocked` totals before trusting a VACUOUS adverse verdict.
- **The adverse arm depends on the operator remembering `KEEPER_LIQ_BUDGET=0`.** `liquidated` counts only the trader's own transactions, so orders swept by the keeper's lane are invisible and `book` over-counts — again overstating the ceiling. Nothing enforces the pairing; the README's two separate invocations are the only correct usage.
- **`TRADE_LIQ_BUDGET_STAGES` is process-wide**, so naming several strategies in one `campaign` invocation would sweep the budget on every instance, including ones whose analysis assumes the 24-candidate default.
- **In the regime the run reaches, `candidates == book`**, so the fitted slope cannot fully separate the ambient pass's per-candidate cost from the mint's own book-dependent cost. That term is positive, so it biases the ceiling down — the safe direction — but the number is an upper bound on per-candidate cost, not a clean isolate.

## Test plan

- [x] `npx tsc --noEmit` in `packages/predict/harness/ts` — exit 0.
- [x] `python3 -m unittest harness.tests.test_staging_publish harness.tests.test_analyze_liq_budget` — 37 tests, OK (23 existing + 14 new).
- [x] **Real strategy module driven against a modelled contract for a full 3,600s ladder, trace fed to the real `analyze`:** 2,350 single-mint probes across the ladder; reported slope 1,086,000, base 2,000,000, crossing 4,602 — all exact against the model; 65% of cap at budget 3,000; zero signals.
- [x] Same simulation with a `markets.json` blip mid-run: zero book drift (the earlier revision under-reported the index by ~2,100 for the rest of the run).
- [x] Mutation battery over `analyze.py` — 12 targeted mutants (wall picks max not min; wall keyed on budget alone; wall counts multi-leg OOGs; book↔minted; no rung blackout; fit on budget; no `n==1` filter; no span guard; negative base allowed; no no-samples signal; declared-wall evidence ignored; pre-ladder probes admitted). All 12 killed.
- [x] Ladder parser: unset yields no stages, out-of-order rungs sort by time, `900:` / `abc` throw a named error at load.
- [ ] **Localnet campaign — NOT RUN.** Needs `harness/.env` (`PYTH_PRO_API_KEY`, `BLOCK_SCHOLES_API_KEY`), absent from this checkout. **This is the deliverable; the PR must not merge without it.** Everything above validates that the instrument is wired correctly, not that its number is right.

Formatting note: `prettier -c` flags these files, but it flags the untouched harness files on `main` identically and no CI workflow runs `prettier:check`, so the new code matches the surrounding harness style rather than reformatting shared files.

## Risk / rollout

None. Harness-only, no contract or deployment surface. Every new knob is opt-in via an unset-by-default env var; with none set, keeper, strategy, and `analyze` output are what they are on `main`.