### PR TITLE
predict: fix three defects found reviewing the campaign hardening

### DIFF
--- a/packages/predict/harness/analyze.py
+++ b/packages/predict/harness/analyze.py
@@ -467,7 +467,9 @@ def _analyze_one(inst: Path) -> list[str]:
         for t in flagged:
             if _declared_package_abort(t):
                 expected[f"declared:{t[:32]}"] += 1            # package abort itself names a declared wall
-            elif framework_allowance[t] > 0 and reached and not undeclared_vm:
+            elif (
+                framework_allowance[t] > 0 or not verdict.MOVE_ABORT.match(t)
+            ) and reached and not undeclared_vm:
                 framework_allowance[t] -= 1
                 expected["declared-wall (framework)"] += 1     # framework tag whose real cause IS a declared VM wall
             else:

--- a/packages/predict/harness/localnet.py
+++ b/packages/predict/harness/localnet.py
@@ -154,7 +154,15 @@ def balance(client_config: Path, address: str) -> int:
             client_config,
             ["balance", address, "--coin-type", "0x2::sui::SUI"],
         )
+        # `sui client balance --json` returns a two-element array: [coin_entries, has_more].
+        # `SuiClientCommandResult::Balance` is `#[serde(untagged)]` over
+        # `(Vec<(Option<GetCoinInfoResponse>, Vec<Coin>)>, bool)`, so the coin list is the FIRST
+        # element rather than the response itself. Without unwrapping it every lookup raises and
+        # returns -1, which `_refill_gas`'s `0 <= balance` gate reads as "nothing to do" — so no
+        # address is ever refilled, silently, and long runs drift into gas exhaustion.
         entries = data if isinstance(data, list) else [data]
+        if entries and isinstance(entries[0], list):
+            entries = entries[0]
         if not entries:
             return 0
         entry = entries[0]

--- a/packages/predict/harness/tests/test_staging_publish.py
+++ b/packages/predict/harness/tests/test_staging_publish.py
@@ -1385,7 +1385,10 @@ class LifecycleTests(unittest.TestCase):
                     self.fail(f"setup process {pid} still exists after cancellation")
                 try:
                     state = stat_path.read_text().split(") ", 1)[1][0]
-                except FileNotFoundError:
+                except (FileNotFoundError, ProcessLookupError):
+                    # The pid passed `kill(pid, 0)` a moment ago but was reaped before the read.
+                    # Linux raises ProcessLookupError (ESRCH) rather than FileNotFoundError for a
+                    # vanished /proc entry, so catching only the latter makes this flake on CI.
                     continue
                 # Linux containers may leave the orphaned grandchild as an
                 # unreaped zombie briefly. A zombie is dead and holds no pipes.

--- a/packages/predict/harness/tests/test_verdict.py
+++ b/packages/predict/harness/tests/test_verdict.py
@@ -234,6 +234,54 @@ class VerdictTests(unittest.TestCase):
                 signals,
             )
 
+    def test_declared_wall_accepts_the_raw_tag_the_producer_actually_emits(self) -> None:
+        # `capacity-tree` declares "cached objects limit". Under the gRPC executor that wall
+        # surfaces as a bare MovePrimitiveRuntimeError with no module in the message, so the trace
+        # tag is a raw string — NOT `dynamic_field:0`, which no producer emits. Keying the
+        # allowance on an exact tag therefore flags the strategy's own success as a bug and fails
+        # the campaign whenever `capacity-tree` works. The allowance has to rest on the failed-tx
+        # artifact corroborating the declared wall.
+        raw_tag = (
+            "flush failed: MovePrimitiveRuntimeError "
+            "failed_tx=/tmp/inst/artifacts/failed_transactions/flush-0.json"
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            instance = Path(directory)
+            trace = instance / "trace"
+            trace.mkdir(parents=True)
+            (trace / "keeper.jsonl").write_text(
+                '{"schema":1,"type":"liquidate","markets":1,"gas":10,"ts":1}\n'
+            )
+            (trace / "trader.jsonl").write_text(
+                '{"schema":1,"type":"expect","strategy":"capacity-tree",'
+                '"terminal":["cached objects limit"],"ts":2}\n'
+                + json.dumps({
+                    "schema": 1, "type": "fail", "strategy": "capacity-tree",
+                    "tag": raw_tag, "ts": 3,
+                })
+                + "\n"
+            )
+            artifacts = instance / "artifacts" / "failed_transactions"
+            artifacts.mkdir(parents=True)
+            (artifacts / "flush-0.json").write_text(
+                json.dumps({
+                    "dry_run": {
+                        "executionErrorSource": (
+                            "ExecutionError status MEMORY_LIMIT_EXCEEDED at module 0xabc "
+                            "and message Object runtime cached objects limit (1000 entries) "
+                            "reached at code offset 42"
+                        ),
+                        "effects": {"status": {"status": "failure", "error": (
+                            "MovePrimitiveRuntimeError in dynamic_field::borrow_child_object"
+                        )}},
+                    }
+                })
+            )
+
+            signals = analyze._analyze_one(instance)
+
+        self.assertEqual(signals, [], f"capacity-tree reaching its declared wall must pass: {signals}")
+
     def test_semantic_declared_terminal_accepts_matching_framework_failure(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             instance = Path(directory)

--- a/packages/predict/harness/verdict.py
+++ b/packages/predict/harness/verdict.py
@@ -64,7 +64,14 @@ TRANSIENT_MARKERS = (
 MOVE_ABORT = re.compile(r"^[a-z_][a-z0-9_]*:\d+$")
 # Semantic VM walls whose trace tag names only the framework call that surfaced
 # them. Keep this mapping exact: a declared message must never whitelist every
-# abort from an unknown/framework module.
+# abort from an unknown/framework MODULE, i.e. a `module:code` tag.
+#
+# It does not cover the common case on its own. Under the gRPC executor the wall
+# surfaces as a bare `MovePrimitiveRuntimeError` with no module in the message,
+# so `errorTag` yields a raw string rather than `module:code`. Those are allowed
+# by the raw-tag branch in `analyze`, gated on the declared wall being
+# corroborated by the failed-tx artifact and no undeclared VM error being
+# present — evidence, not a name match.
 SEMANTIC_FRAMEWORK_TAGS = {
     "cached objects limit": {"dynamic_field:0"},
 }


### PR DESCRIPTION
> **Merge order: #1181 → #1199 → #1198.** This PR is the middle of the stack.
>
> Opened as a separate PR rather than pushed to #1181's branch, so that branch is not rewritten while under review.
>
> **Worth landing with #1181 rather than after it.** Defects 1 and 2 below are already present on that branch: merging #1181 to `main` on its own puts a false bug-oracle failure and a dead gas-refill path into `main`, and both are silent — green suite, clean build. Merging this into `at/predict-harness-campaign-fixes` first (or merging the stack bottom-up in one sitting) avoids that window.
>
> Verified at `9db5e201`: build clean, 13 TS tests, 71 Python tests, CI green.

Found while reviewing #1181. All three are silent: the suite is green and the code builds.

## 1. `capacity-tree` fails the campaign at exactly the wall it declares — blocking

`verdict.SEMANTIC_FRAMEWORK_TAGS` whitelists the literal tag `dynamic_field:0`. The producer cannot emit that tag: under the gRPC executor the object-runtime cached-objects wall is a `MovePrimitiveRuntimeError`, which the SDK maps to `{$kind:'Unknown', message:'MovePrimitiveRuntimeError'}` with no module name in the message, so `errorTag()` returns a raw string like:

```
flush failed: MovePrimitiveRuntimeError failed_tx=/tmp/inst/artifacts/failed_transactions/flush-0.json
```

That matches neither the exact-tag allowance nor `_declared_package_abort`, so it lands in `flagged` — the strategy *succeeding* produces `*** BUG ORACLE ***` and a non-zero exit. `reached` still resolves via the VM artifact, so it fails as a false bug rather than as vacuous, which is the worse of the two.

Before this PR:

```
new  SIGNALS: ['flush failed: MovePrimitiveRuntimeError failed_tx=...']  EXIT 1
old  SIGNALS: []   expected guards: {'declared-wall (framework)': 1}     EXIT 0
```

The fix restores the raw-tag branch — still gated on the declared wall being corroborated by the failed-tx artifact and no undeclared VM error present — while keeping the tightening's intent that an unknown `module:code` tag stays flagged.

Test-quality note: all four existing declared-terminal tests in `test_verdict.py` assert against `"tag":"dynamic_field:0"`, a value no producer emits, which is why they were green over this. The test added here uses the real tag shape and fails without the fix.

## 2. `localnet.balance()` cannot parse `sui client balance --json`; gas refill is dead — blocking

The CLI returns a two-element array whose **first** element is the coin list — `SuiClientCommandResult::Balance` is `#[serde(untagged)]` over `(Vec<(Option<GetCoinInfoResponse>, Vec<Coin>)>, bool)`. The parser treats the response itself as the entry list, so `entries[0]` is a list, `raise ValueError` fires, and `balance()` returns `-1`.

`_refill_gas` gates on `0 <= balance < GAS_REFILL_FLOOR`, so `-1` means **no address is ever refilled, and nothing is logged**. Confirmed against both sui 1.76.0 and the repo-pinned `testnet-v1.74.1`:

```
              sui 1.76.0: localnet.balance -> -1 ; faucet called: False
  pinned testnet-v1.74.1: localnet.balance -> -1 ; faucet called: False
```

Every long `live --seconds N` hold and every campaign then drifts toward gas exhaustion for keeper, updater and traders. The resulting failures tag as `Balance of gas object ... lower than the needed amount`, which `verdict.TRANSIENT_MARKERS` classifies as transient — so a gas-starved campaign reports "bug oracle clean".

The two `_refill_gas` tests mock `localnet.balance` wholesale, so the parser that changed is untested.

## 3. `test_cancellable_setup_command_kills_group_after_leader_exits` flakes on CI — this is what is currently red

```
File ".../test_staging_publish.py", line 1387
    state = stat_path.read_text().split(") ", 1)[1][0]
ProcessLookupError: [Errno 3] No such process
```

The test probes `os.kill(pid, 0)`, then reads `/proc/<pid>/stat`. Linux raises `ProcessLookupError` (ESRCH), not `FileNotFoundError`, when the pid is reaped in between — and only `FileNotFoundError` is caught. macOS has no `/proc`, so the branch never runs locally, which is why this is green on dev machines and intermittent on CI.

## Test plan

- [x] `npm run build` — clean.
- [x] `npm test` — 13 TS tests.
- [x] `python3 -m unittest discover -s harness/tests -p 'test_*.py'` — 71 tests.
- [x] Reverting fix 1 fails the new `test_declared_wall_accepts_the_raw_tag_the_producer_actually_emits`.

## Risk / rollout

None beyond #1181's own surface. No contract or deployment change.