### PR TITLE
predict: unbreak localnet bring-up on newer sui, and clear probe leftovers

### DIFF
--- a/packages/predict/harness/analyze.py
+++ b/packages/predict/harness/analyze.py
@@ -455,7 +455,6 @@ def _analyze_one(inst: Path) -> list[str]:
     # the section is skipped rather than assuming the contract default.
     no_data = False           # the section ran but collected no single-mint samples at all
     insufficient_fit = False  # samples too clustered (or unphysical) to support a ceiling
-    wall_tags: set[str] = set()  # OOG tags from the probe, used as declared-wall evidence
     rungs = sorted([r for r in recs if r.get("type") == "liqBudget" and r.get("ts")], key=lambda r: r["ts"])
     if rungs:
         def _budget_at(ts: int) -> int:
@@ -567,8 +566,6 @@ def _analyze_one(inst: Path) -> list[str]:
             # through `signExecThreaded`, which — unlike the keeper's `executeAndWait` — writes no
             # failed-tx artifact, and the OOG is traced as a `mintBatch` rather than a `fail`, so it
             # reaches the bug oracle by neither route. That is deliberate here.
-            wall_tags = {str(r.get("err", "")) for r in recs
-                         if r.get("type") == "mintBatch" and r.get("oog") and r.get("err")}
         elif not probes:
             # No successful single-mint samples AND no wall: the run measured nothing. Claiming
             # "affordable" here would be an affirmative safety claim drawn from zero evidence.
@@ -611,8 +608,7 @@ def _analyze_one(inst: Path) -> list[str]:
 
         reached = {d for d in declared
                    if any(d in m for m in vm_msgs)
-                   or any(_declared_package_abort(t) and d in t for t in flagged + list(expected))
-                   or any(d in t for t in wall_tags)}
+                   or any(_declared_package_abort(t) and d in t for t in flagged + list(expected))}
         kept: list[str] = []
         for t in flagged:
             if _declared_package_abort(t):

--- a/packages/predict/harness/localnet.py
+++ b/packages/predict/harness/localnet.py
@@ -87,7 +87,17 @@ def wait_for_rpc(
         try:
             if chain_id(client_config, cancel_event):
                 return
-        except (subprocess.SubprocessError, suicli.SuiError, OSError, json.JSONDecodeError):
+        except (
+            subprocess.SubprocessError,
+            suicli.SuiError,
+            OSError,
+            json.JSONDecodeError,
+            # An unrecognised chain-identifier shape must degrade to a bring-up TIMEOUT, not an
+            # unhandled crash out of the poll loop on the first successful RPC. `chain_id` raises
+            # ValueError for a payload it cannot read, and a future CLI format change would
+            # otherwise take the whole harness down with no diagnosis.
+            ValueError,
+        ):
             pass
         if cancel_event is not None:
             cancel_event.wait(timeout=1)
@@ -203,7 +213,16 @@ def chain_id(
     if isinstance(data, str):
         return data
     if isinstance(data, dict):
-        value = data.get("chainIdentifier") or data.get("chain_identifier")
+        # The pinned CLI emits a bare string; newer ones emit an object. sui 1.76 prints
+        # {"base58": "69WiPg…", "hex": "4c78adac"} — `hex` is the identifier every caller wants
+        # (it is what the retired `sui_getChainIdentifier` JSON-RPC returned), so prefer it and keep
+        # the older key names for the pinned build.
+        value = (
+            data.get("chainIdentifier")
+            or data.get("chain_identifier")
+            or data.get("hex")
+            or data.get("base58")
+        )
         if isinstance(value, str):
             return value
     raise ValueError(f"unexpected chain identifier response: {data!r}")

--- a/packages/predict/harness/tests/test_analyze_liq_budget.py
+++ b/packages/predict/harness/tests/test_analyze_liq_budget.py
@@ -182,27 +182,6 @@ class LiqBudgetAnalysisTests(unittest.TestCase):
         self.assertIn("REJECTED", report)
         self.assertIn("liq-budget-fit-unusable", signals)
 
-    def test_a_declared_wall_does_not_fail_the_run(self) -> None:
-        # The adverse arm declares the computation cap, so reaching it is the point, not a surprise.
-        with tempfile.TemporaryDirectory() as tmp:
-            inst = _synthesise(Path(tmp), [100, 300, 2000, 4600], 1_700_000)
-            trace = inst / "trace" / "trader.jsonl"
-            trace.write_text(
-                trace.read_text()
-                + "\n"
-                + json.dumps({"type": "expect", "strategy": "liq-budget-adverse", "terminal": ["InsufficientGas"], "ts": 999_999, "schema": 1})
-            )
-            buf = io.StringIO()
-            with redirect_stdout(buf):
-                signals = analyze._analyze_one(inst)
-
-        # The whole run must come back clean, not merely free of the undeclared-wall signal: the
-        # trader submits via a path that writes no failed-tx artifact and traces its OOG as a
-        # mintBatch rather than a `fail`, so neither source the declared-wall check normally reads
-        # can see it — an arm that reached exactly the wall it declared would be failed VACUOUS.
-        self.assertIn("EMPIRICAL wall", buf.getvalue())
-        self.assertEqual(signals, [], f"a declared, reached wall must not fail the run: {signals}")
-
     def test_wall_reports_the_smallest_candidate_count_not_the_last_or_largest(self) -> None:
         # Two rungs OOG a single mint, at different books. The wall worth reporting is the CHEAPEST
         # state that could not fit — a ceiling set from the largest would be set above a budget

--- a/packages/predict/harness/tests/test_staging_publish.py
+++ b/packages/predict/harness/tests/test_staging_publish.py
@@ -19,6 +19,7 @@ from harness import (
     cli,
     config,
     live,
+    localnet,
     oracle_setup,
     publish,
     run_manifest,
@@ -318,6 +319,53 @@ class PublicationPlanTests(unittest.TestCase):
             self.assertNotIn("--skip-dependency-verification", args)
             self.assertNotIn("--with-unpublished-dependencies", args)
             self.assertNotIn("--publish-unpublished-deps", args)
+
+class LocalnetQueryTests(unittest.TestCase):
+    def test_balance_unwraps_the_cli_coin_list(self) -> None:
+        # `sui client balance --json` returns [coin_entries, has_more] — the coin list is the FIRST
+        # element, not the response. Reading the response as the entry list makes every lookup raise
+        # and return -1, which `_refill_gas`'s `0 <= balance` gate reads as "nothing to do", so no
+        # address is ever refilled and nothing is logged. Payload recorded from sui 1.76.0.
+        payload = [
+            [
+                {
+                    "metadata": {"decimals": 9, "symbol": "SUI"},
+                    "balance": {"balance": "2557200000", "addressBalance": "2557200000"},
+                    "coins": [],
+                }
+            ],
+            False,
+        ]
+        with mock.patch.object(localnet, "_client_json", return_value=payload):
+            self.assertEqual(localnet.balance(Path("/tmp/cfg"), "0xabc"), 2557200000)
+
+    def test_balance_reports_failure_rather_than_zero(self) -> None:
+        # -1 and 0 mean different things to `_refill_gas`: 0 is a genuinely empty address that must
+        # be topped up, -1 is "the query failed". An unreadable response must not look empty.
+        with mock.patch.object(localnet, "_client_json", return_value={"unexpected": "shape"}):
+            self.assertEqual(localnet.balance(Path("/tmp/cfg"), "0xabc"), -1)
+        with mock.patch.object(localnet, "_client_json", return_value=[[], False]):
+            self.assertEqual(localnet.balance(Path("/tmp/cfg"), "0xabc"), 0)
+
+    def test_chain_id_reads_every_shape_the_cli_emits(self) -> None:
+        # The pinned CLI emits a bare string; sui 1.76 emits {"base58", "hex"}. Reading only the
+        # older key names raises ValueError, and `wait_for_rpc` did not catch it — so localnet
+        # bring-up died on the first successful poll for anyone on a newer CLI.
+        for payload, expected in [
+            ("4c78adac", "4c78adac"),
+            ({"chainIdentifier": "4c78adac"}, "4c78adac"),
+            ({"base58": "69WiPg3DAQiwdxfncX6wYQ2siKwAe6L9BZthQea3JNMD", "hex": "4c78adac"}, "4c78adac"),
+        ]:
+            with mock.patch.object(localnet, "_client_json", return_value=payload):
+                self.assertEqual(localnet.chain_id(Path("/tmp/cfg")), expected)
+
+    def test_wait_for_rpc_treats_an_unreadable_identifier_as_not_ready(self) -> None:
+        # A shape nobody anticipated must degrade to a bring-up timeout, not an unhandled crash out
+        # of the poll loop.
+        with mock.patch.object(localnet, "_client_json", return_value={"nothing": "recognisable"}):
+            with self.assertRaises(TimeoutError):
+                localnet.wait_for_rpc(Path("/tmp/cfg"), 9000, timeout=0.2)
+
 
 class LifecycleTests(unittest.TestCase):
     @staticmethod

--- a/packages/predict/harness/tests/test_verdict.py
+++ b/packages/predict/harness/tests/test_verdict.py
@@ -234,6 +234,34 @@ class VerdictTests(unittest.TestCase):
                 signals,
             )
 
+    def test_declared_wall_amnesty_requires_corroborating_vm_evidence(self) -> None:
+        # The raw-tag branch exists because the producer's tag names only the framework call. It is
+        # gated on the failed-tx artifact corroborating the declared wall — evidence, not a name
+        # match. Without an artifact, a raw failure is an ordinary unexplained failure and must
+        # still reach the oracle; otherwise declaring any terminal silently excuses everything.
+        with tempfile.TemporaryDirectory() as directory:
+            instance = Path(directory)
+            trace = instance / "trace"
+            trace.mkdir(parents=True)
+            (trace / "keeper.jsonl").write_text(
+                '{"schema":1,"type":"liquidate","markets":1,"gas":10,"ts":1}\n'
+            )
+            (trace / "trader.jsonl").write_text(
+                '{"schema":1,"type":"expect","strategy":"capacity-tree",'
+                '"terminal":["cached objects limit"],"ts":2}\n'
+                + json.dumps({
+                    "schema": 1, "type": "fail", "strategy": "capacity-tree",
+                    "tag": "TypeError: Cannot read properties of undefined", "ts": 3,
+                }) + "\n"
+            )
+            # No artifacts/ directory at all: nothing corroborates the declared wall.
+            signals = analyze._analyze_one(instance)
+
+        self.assertTrue(
+            any("TypeError" in s for s in signals),
+            f"an uncorroborated raw failure must still be flagged, got {signals}",
+        )
+
     def test_declared_wall_accepts_the_raw_tag_the_producer_actually_emits(self) -> None:
         # `capacity-tree` declares "cached objects limit". Under the gRPC executor that wall
         # surfaces as a bare MovePrimitiveRuntimeError with no module in the message, so the trace

--- a/packages/predict/harness/ts/strategies/liqBudget.ts
+++ b/packages/predict/harness/ts/strategies/liqBudget.ts
@@ -31,12 +31,12 @@
 // liquidatable candidates — which are not merely priced but removed from the paged index and from
 // the payout treap. That is the branch the ceiling question is really about.
 //
-// Only `adverse` declares a terminal wall. At the pre-memo `correction_value` slope (~1.09M/order,
-// the closest measured analogue) a scan-only pass at the 3,000 max costs ~3.26e9 of the 5e9
-// computation cap — expensive, but it fits — so declaring the wall on `healthy` would fail every
-// clean run VACUOUS, and would whitelist the OOG if it ever did happen. An undeclared arm that
-// OOGs a single mint raises `liq-budget-wall-undeclared` in the analysis instead: a scan-only mint
-// that cannot fit is a bigger finding than the one being measured.
+// NEITHER arm declares a terminal wall, and neither declares `done`. "The budget max fits" and "it
+// does not" are equally valid answers to the question this asks, so the outcome must not be encoded
+// as pass/fail: a declared wall that goes unreached fails the run VACUOUS, and `done` opts the
+// strategy out of the runner's bounded-stop branch so a `--timeout` stop reports `incomplete`. What
+// fails a run is measuring NOTHING — see `failure()` — or an analysis that cannot fit a usable
+// line, which `analyze` signals separately. Reaching the cap is reported as a bracket, not a fault.
 //
 // Run `adverse` with KEEPER_LIQ_BUDGET=0. The keeper's own permissionless liquidate() lane would
 // otherwise sweep the liquidatable orders before a mint's ambient pass could reach them, and
@@ -76,7 +76,6 @@ interface LiqBudgetConfig {
   leverage: (ctx: StrategyCtx, probability: number) => number;
   probability: [number, number];
   directions: ("UP" | "DN")[];
-  expect?: { terminal: string[]; note?: string };
 }
 
 const CONFIG: Record<LiqBudgetProfile, LiqBudgetConfig> = {
@@ -89,10 +88,6 @@ const CONFIG: Record<LiqBudgetProfile, LiqBudgetConfig> = {
     leverage: (ctx, probability) => ctx.leverageCap(probability) * ctx.rand(0.9, 0.99),
     probability: [0.45, 0.55], // near the money -> high static floor -> tight knock-out level
     directions: ["UP", "DN"],
-    expect: {
-      terminal: ["InsufficientGas"],
-      note: "per-tx computation cap on a liquidating ambient pass",
-    },
   },
 };
 


### PR DESCRIPTION
> Targets #1181. Opened as its own PR rather than pushed to that branch. Merge this into #1181, then #1181 into `main`.

From the final review of #1181 after #1198 and #1199 merged into it.

## 1. `chain_id()` breaks localnet bring-up — blocking

`sui client chain-identifier --json` on **sui 1.76** prints:

```json
{ "base58": "69WiPg3DAQiwdxfncX6wYQ2siKwAe6L9BZthQea3JNMD", "hex": "4c78adac" }
```

The parser accepted only `chainIdentifier` / `chain_identifier`, so it raised `ValueError` — and `wait_for_rpc`'s except tuple is `(SubprocessError, SuiError, OSError, JSONDecodeError)`, which does not include it. The exception escaped the poll loop on the *first successful RPC*. Every `harness live` and `harness campaign` died during bring-up.

**This was a regression.** `main` had:

```python
def chain_id(rpc_port): return _rpc(rpc_port, "sui_getChainIdentifier")["result"]
```

which worked. Nothing caught it because no unit test or CI job starts a localnet, and `config.sui_binary()` takes whatever is on `PATH` with no documented version floor.

`hex` is now preferred — it is exactly what the retired JSON-RPC returned — the older key names still resolve for the pinned build, and `ValueError` joins the except tuple so a future CLI format change degrades to a bring-up timeout rather than an unhandled crash.

## 2. Leftovers from removing `expect` from the liq-budget probe

- `LiqBudgetConfig.expect` and `CONFIG.adverse.expect` were still set and never read.
- The file header still described the design they belonged to, including a `liq-budget-wall-undeclared` signal that no longer exists anywhere in the repo — contradicting the code 140 lines below it in the same file, and the `.claude/rules/predict-harness.md` text added alongside it.
- `wall_tags` in `analyze.py` was unreachable in production: no liq-budget arm declares a terminal, and `isOog` only matches `/InsufficientGas|OUT_OF_GAS|computation/i`, so it cannot match the one terminal `capacity-tree` does declare. Its only test hand-wrote an `expect` record that `harnessTest.ts` separately asserts the producer cannot emit — two tests in one PR asserting contradictory premises.

Removing it also closes a composition hazard: #1198 widened `reached` while #1199 widened what `reached` unlocks, so if `expect` were ever rewired, a `mintBatch` OOG whose `err` merely contained the declared string would mark the wall reached with **no VM artifact at all**, amnestying every raw failure in the instance.

## 3. Coverage for the two #1199 fixes that mutation showed were unpinned

- **`localnet.balance()` had zero parse coverage** — its only existing test mocks the function wholesale, which is how the bug it fixes survived in the first place. Now covers the payload recorded from sui 1.76, and pins that an unreadable response returns `-1` while a genuinely empty address returns `0`, since `_refill_gas` treats those differently (`0 <= balance` means "top up", `-1` means "query failed").
- **The declared-wall amnesty's stated property was unasserted.** Its comment says the allowance rests on "evidence, not a name match", but dropping `and reached and not undeclared_vm` survived mutation. Now pinned by a case with no `artifacts/` directory, where an uncorroborated raw failure must still reach the oracle.

## Test plan

- [x] `npm run build` — clean.
- [x] `npm test` — 17 TS tests.
- [x] `python3 -m unittest discover -s harness/tests -p 'test_*.py'` — 93 tests.
- [x] `python3 predeploy/check.py` — 0 warnings.
- [x] Mutation-checked: reverting the `[coin_entries, has_more]` unwrap, the `hex`/`base58` keys, the `ValueError` catch, or the amnesty's evidence gate each fails a test.
- [x] `chain_id` verified against all three real payload shapes (bare string, `chainIdentifier`, `{base58, hex}`).

## Not addressed here

Four items from the review are left for Aslan, since they are design calls in his scope rather than defects:

- `cleanup-survivor` / `cleanup-claim` mint at exactly 1x, where no liquidation-book entry is created — so they may no longer match the committed `predeploy/evidence/p9-cleanout-gas-*.md` that RP-11 rests on.
- The hub re-reads provider trust per signed batch, uncached and unretried, inside a branch that sets a sticky `#fatal`; one transient RPC hiccup kills the stream for the rest of the run.
- `capacity-tree` lost `treeNodeSweep`'s DN-band strike fallback, roughly halving its distinct-strike headroom against the 1,000-node target.
- `predeploy/response-policies.md:345` still names the deleted `mint-batch` strategy as RP-10's pinning instrument.

## Risk / rollout

None beyond #1181's own surface. No contract or deployment change.