### PR TITLE
predict: record the Block Scholes SID trust residual (DBU-537)

### DIFF
--- a/packages/predict/predeploy/open-items.md
+++ b/packages/predict/predeploy/open-items.md
@@ -1,8 +1,39 @@
 # Predict Predeploy Open Items
 
-Updated 2026-08-03. This is the live work register governed by the [predeploy lifecycle and update rules](./README.md#lifecycle).
+Updated 2026-08-04. This is the live work register governed by the [predeploy lifecycle and update rules](./README.md#lifecycle).
 
 ## Deploy Gates
+
+### S-6: The `bs_sid` copy the deployment executes is never the one anything tests
+
+**Severity:** Deploy gate.
+
+The series-id derivation is checked on every edge but the deployed one.
+`DirectWsSource` hard-fails a subscription whose acknowledgement does not return
+exactly the locally derived ids, so TypeScript-against-provider is verified at
+every subscribe; the localnet run signs batches carrying TypeScript-derived ids
+and pushes them through `apply_*_batch`, which aborts `ESeriesIdMismatch` unless
+they equal the Move derivation, so Move-against-TypeScript is verified by every
+green harness run.
+
+Both of those exercise a `bs_sid` the harness publishes itself from the pinned
+source. A real deployment links the provider's published package instead, whose
+bytecode nothing compares against that source. If the two ever diverge, every
+subscription acknowledges, every batch verifies, and ingestion aborts against a
+store whose expectations no test has ever read.
+
+Separately unpinned: the `block_scholes_base_asset` bound at
+`registry::create_and_share_block_scholes_stores` is checked only non-empty and
+is permanent per P-26. A spelling that is wrong but *real* routes another
+asset's honestly-signed data into this underlying's markets with every check
+passing, on-chain and off, because the series id is correct for what it names.
+
+**Action:** Before a value-bearing deployment, devInspect the created stores'
+`spot_sid()` / `forward_sid(expiry)` / `svi_sid(expiry)` and assert they equal
+the ids the subscription layer derives. Those getters are `public fun` so an
+external caller can ask the chain what it will accept; nothing asks today.
+Confirm the bound base asset against the subscription config in the same step
+and record the answer, since no code path can.
 
 ## Contract Findings
 
@@ -100,6 +131,34 @@ the sense that the absence has to be lived with.
 **Action:** Add an admin-gated replacement for an underlying's store pair
 mirroring `replace_pyth_binding_for_underlying`, or record the decision that the
 pair is deliberately permanent and what the recovery path is if one is wrong.
+
+### P-28: A provider envelope ahead of the Sui clock silently empties the feed
+
+**Severity:** Medium; liveness, misattributed failure.
+
+`block_scholes_store::apply` returns `false` rather than aborting when
+`published_at_ms > recorded_at_ms` — the batch's envelope time is ahead of the
+Sui `Clock` at execution. The transaction still succeeds, so the relayer sees
+success, and the only signal is `applied` reading below `update_count` in
+`BlockScholesBatchIngested`. Skipping is the right response for one unusable
+entry, but this particular condition is not per-entry: the provider's publish
+clock and the Sui checkpoint clock are independent, so a provider running even
+slightly ahead at relay latency fails *every* observation in *every* batch. The
+feed then looks like it is ingesting while nothing is ever stored, and pricing
+halts a freshness window later on `EBlockScholesPriceStale` — an error naming
+provider staleness for what is actually clock skew on our side of the boundary.
+
+The comparison has a real duty and is not simply removable: accepting a
+future-dated envelope would let that observation win the `(model, published)`
+ordering against every honest later batch at equal model time, pinning the
+series until its model time advances.
+
+**Action:** Measure the observed `published_at_ms - recorded_at_ms` distribution
+against the live provider before a value-bearing deployment, and alert on
+`update_count > 0 && applied == 0` sustained across consecutive batches, which
+is what distinguishes this from a genuinely quiet feed. If the observed margin
+is thin, decide the response deliberately — a bounded tolerance on the
+comparison is a `response-policies.md` decision, not a silent widening.
 
 ### P-5: BS zero/non-normalizable updates can blank live reads
 
@@ -467,6 +526,25 @@ correctness today.
 - `fee_incentive_balance` DUSDC custody sits on `ExpiryMarket` outside the
   `ExpiryCash` solvency invariant — consider folding it into the custody
   component so per-expiry DUSDC has one owner.
+- The store pair could be one object. The verifier's two batch types force two
+  typed entry functions, not two stores; a single store would drop
+  `BlockScholesStorePair`, one registry id, one of the two binding checks in
+  `pricing::assert_current_oracles`, and the duplicated
+  `block_scholes_base_asset` field whose two copies agree only by construction
+  and can never be checked against each other on-chain.
+- Every series id is scoped to the verifier package id
+  (`type_name::original_id<PackageMarker>()`), so repointing Propbook at a new
+  `bs_oracle` publication rotates the entire identity space at once: stored rows
+  go dead and unprunable, and reads fail closed with no error distinguishing it
+  from a stopped feed. The revision bump in this cutover already moved it once.
+  Deployment procedure should treat a verifier repoint as feed re-provisioning
+  rather than a configuration change.
+- The upstream publication metadata records a live `UpgradeCap` for `bs_sid`.
+  Sui pins linkage at publish, so a provider-side upgrade cannot move Propbook's
+  derivation on its own, but a future Propbook upgrade rebuilt against a newer
+  revision would, silently. Upstream's manifest states nothing there depends on
+  retaining the capability, and the burn commitment obtained for the verifier
+  package does not cover this one — worth asking for it.
 
 ### H-6: Maintainability backlog
 

--- a/packages/predict/sources/pricing/pricing.move
+++ b/packages/predict/sources/pricing/pricing.move
@@ -326,6 +326,10 @@ fun assert_current_oracles(
     let block_scholes_binding = propbook_registry.propbook_block_scholes_store_pair_for_underlying(
         propbook_underlying_id,
     );
+    // Unreachable for a live market: creation requires the binding
+    // (`market_manager::next_deployable_market`) and Propbook never removes one.
+    // The unwrap needs a code regardless, so it shares the store-mismatch one
+    // rather than spending a second on a branch nothing reaches.
     assert!(block_scholes_binding.is_some(), EWrongBlockScholesValueStore);
     let block_scholes_binding = block_scholes_binding.destroy_some();
     assert!(


### PR DESCRIPTION
## Summary

- Add deploy gate **S-6** and finding **P-28** to `open-items.md`, plus three `H-3` rows.
- Record at the site why `pricing::assert_current_oracles` can unwrap the registry's store pair unconditionally.

Two files, one of them a four-line comment. No behavioural change and no new public surface.

## Why

Provider-defined SIDs close S-5: a signature now commits to a fully specified instrument rather than to a slot id we chose, so the gate's attack — having the provider sign one asset's data under another's id — needs a keccak256 preimage collision. S-5 was deleted with no successor, and the residual it leaves is worth naming rather than rediscovering at deployment.

The derivation itself is well covered. `DirectWsSource` hard-fails a subscription whose acknowledgement does not return exactly the locally derived ids, so TypeScript-against-provider is verified at every subscribe. The localnet run signs batches carrying TypeScript-derived ids and pushes them through `apply_*_batch`, which aborts `ESeriesIdMismatch` unless they equal the Move derivation — so Move-against-TypeScript is verified by every green harness run.

What neither reaches is the copy a real deployment executes. Both exercise a `bs_sid` the harness publishes itself from the pinned source; a deployment links the provider's published package, whose bytecode nothing compares against that source. One devInspect of the store's own `spot_sid()` / `forward_sid()` / `svi_sid()` closes it — those getters are `public fun` so an external caller can ask the chain what it will accept, and nothing asks today.

## Key decisions

- S-6 is scoped to that one question plus the unvalidated `block_scholes_base_asset` binding, which is not a derivation problem at all: a wrong-but-real spelling passes every check on-chain and off, because the id is correct for what it names. No code path can close it, so it is a record-the-answer item.
- P-28 (an envelope ahead of the Sui clock silently drops every observation in every batch) is filed measure-and-decide, not as a fix. The comparison has a real duty — a future-dated envelope would win the `(model, published)` ordering against every honest later batch — so any tolerance on it is a `response-policies.md` decision. `series_kind` on `BlockScholesBatchIngested` makes the `applied == 0` signal per-lane; nothing reads it yet.
- The store-pair-could-be-one-object observation is filed as `H-3`, not acted on.

## Scope / Descoped

- An earlier revision gave the store-pair unwrap its own error constant. Cut: the branch is dead — `assert_current_oracles` is reached only through `expiry_market::load_live_pricer`, whose market cannot exist without the binding, and Propbook has no removal path — so the constant would be permanent surface on something no one can ever read. Kept the invariant as a comment, which is the half with value.
- An earlier revision also parameterized the `index.px` SID encoder to pin three published vectors. Cut: `spot_matches_the_official_pinned_id` and its TypeScript twin already pin the same literal through the same `digest()` and body layout, and BCS is positional (an absent Option still emits its tag byte), so any encoding change moves the spot id too. The added vectors only reached `index_type`-some and `index_spread`-true, which Propbook never emits.
- Numbered P-28 rather than P-27; main brought in a P-27 (PLP exit fee) while this branch was open.

## Test plan

- [x] `sui move build --path packages/predict --warnings-are-errors` — exit 0
- [x] `sui move test --path packages/predict --gas-limit 100000000000` — 543/543, exit 0
- [x] `sui move test --path packages/propbook --gas-limit 100000000000` — 73/73, exit 0
- [x] `python3 packages/predict/predeploy/check.py` — 0 warnings
- [x] `checks/format-move.sh` on the edited Move file — unchanged

## Risk / Rollout

None on its own — one register file and one comment. S-6 gates the deployment this stack is preparing, so it wants an answer before that deployment carries value, not before this merges.