### PR TITLE
propbook: carry the Block Scholes base asset on its registry row (DBU-537)

### DIFF
--- a/packages/predict/predeploy/open-items.md
+++ b/packages/predict/predeploy/open-items.md
@@ -1,6 +1,6 @@
 # Predict Predeploy Open Items
 
-Updated 2026-08-03. This is the live work register governed by the [predeploy lifecycle and update rules](./README.md#lifecycle).
+Updated 2026-08-05. This is the live work register governed by the [predeploy lifecycle and update rules](./README.md#lifecycle).
 
 ## Deploy Gates
 
@@ -83,7 +83,7 @@ written down.
 
 ### P-26: An underlying's Block Scholes store pair can never be repointed
 
-**Severity:** Low pre-deploy; one-way door after.
+**Severity:** Medium; one-way door with no recovery, on an unvalidatable input.
 
 `registry::create_and_share_block_scholes_stores` is create-once per underlying
 (`EBlockScholesStoresAlreadyExist`) with no admin replacement path, while the
@@ -91,15 +91,39 @@ Pyth lane carries `replace_pyth_binding_for_underlying` for exactly this
 purpose. The stated reason — that a second pair would leave two stores each able
 to claim the underlying with nothing to choose between them — does not hold: the
 registry binding *is* what chooses, which is why the Pyth replacement is safe.
-If a pair is ever created against the wrong underlying, or becomes unusable
-under a future store shape, that underlying has no on-chain route to a working
-pair and every market on it is stranded behind a package upgrade. Adding the
-setter is free while pre-deploy and impossible to add compatibly later only in
-the sense that the absence has to be lived with.
 
-**Action:** Add an admin-gated replacement for an underlying's store pair
-mirroring `replace_pyth_binding_for_underlying`, or record the decision that the
-pair is deliberately permanent and what the recovery path is if one is wrong.
+Provider-defined series ids widened what a wrong creation costs. The accepted
+series now derive from an admin-supplied `block_scholes_base_asset`, carried
+into the id exactly as spelled, where they previously derived from the `u32`
+underlying id — so the set of unrecoverable mistakes grew from "wrong
+underlying" to "any spelling the provider does not serve." Worse, a spelling
+that is wrong but names a *different real* asset is not a halt: genuinely
+signed observations for that asset land, the basis and SVI pass the pricing
+envelope, and the underlying is priced off the wrong asset with every on-chain
+check passing. Nothing on chain can distinguish that from a correct binding.
+
+There is no recovery by re-registration either. Allocating a fresh
+`propbook_underlying_id` and binding the correct spelling is admissible on the
+Block Scholes side, but the Pyth lane refuses to follow: `source_bindings` is
+append-only, so `assert_source_assignable` permanently rejects binding the same
+Pyth source key to a second underlying (`ESourceAlreadyBound`), and the source
+key is the real Lazer feed id, so no substitute names the same asset. The two
+lanes' recovery mechanisms are mutually exclusive.
+
+Adding the replacement *function* stays possible after deploy (new functions are
+upgrade-legal). What does not is the registry row's shape: a replacement can
+only be made safe by requiring it to carry the identical base asset — the
+analogue of the Pyth lane's sticky-source guard, which is what stops a replace
+from silently changing *which asset* an underlying tracks — and that guard is
+unwritable unless the row carries the spelling. The spelling is now on
+`BlockScholesStorePair` for that reason, and bounded to 32 bytes so a malformed
+input cannot be permanently baked into a value re-hashed on every read.
+
+**Action:** Add the admin-gated replacement mirroring
+`replace_pyth_binding_for_underlying`, gated on base-asset equality against the
+existing row. Independently, and because no on-chain check can substitute for
+it, confirm the bound spelling against the provider's acknowledged subscription
+before the pair is treated as canonical, and record that confirmation.
 
 ### P-5: BS zero/non-normalizable updates can blank live reads
 

--- a/packages/propbook/README.md
+++ b/packages/propbook/README.md
@@ -180,7 +180,7 @@ unbound intermediate state:
 - `replace_pyth_binding_for_underlying` replaces the active Pyth feed for one
   Propbook underlying.
 
-Block Scholes stores sit outside the source catalog: `create_and_share_block_scholes_stores` binds the exact provider base-asset spelling, creates the pair, and records it as canonical for one underlying in a single admin-gated step. The value and SVI stores independently retain the same immutable spelling, and an underlying keeps that pair for its lifetime — there is no store rebinding. Predict market creation requires Pyth bound plus both stores present.
+Block Scholes stores sit outside the source catalog: `create_and_share_block_scholes_stores` binds the exact provider base-asset spelling, creates the pair, and records it as canonical for one underlying in a single admin-gated step. The registry row carries that spelling alongside the two object IDs, so `propbook_block_scholes_store_pair_for_underlying` answers the whole binding — including `block_scholes_base_asset` — in one lookup, and the value and SVI stores independently retain the same spelling. The spelling is bounded to 32 bytes and is otherwise unconstrained: it is carried into every derived series id exactly as given, and no on-chain fact can say whether it names the asset the underlying is meant to track. An underlying keeps that pair for its lifetime — there is no store rebinding — so a spelling the provider does not serve leaves the underlying permanently unfeedable, and one naming a different real asset prices the underlying off that asset with every check passing. Confirm the spelling against the provider's acknowledged subscription before binding; the emitted `BlockScholesStoresRegistered` and the registry reader exist so that confirmation can be made against the chain. Predict market creation requires Pyth bound plus both stores present.
 
 Source assignment remains sticky: once a source key has been assigned to an
 underlying, that source key can only be reused for the same underlying. Replacing
@@ -198,7 +198,7 @@ Typical discovery question:
 
 > What is the Propbook Pyth oracle object for BTC?
 
-Use `propbook_pyth_id_for_underlying(registry, propbook_underlying_id)`. The Block Scholes lookup is `propbook_block_scholes_store_pair_for_underlying(registry, propbook_underlying_id)`. Use `block_scholes_value_store_id(&pair)` and `block_scholes_svi_store_id(&pair)` to read the two shared-object IDs from the returned pair.
+Use `propbook_pyth_id_for_underlying(registry, propbook_underlying_id)`. The Block Scholes lookup is `propbook_block_scholes_store_pair_for_underlying(registry, propbook_underlying_id)`. Use `block_scholes_value_store_id(&pair)` and `block_scholes_svi_store_id(&pair)` to read the two shared-object IDs from the returned pair, and `block_scholes_base_asset(&pair)` to read the provider spelling those stores derive their accepted series ids from.
 
 ## Events
 

--- a/packages/propbook/sources/registry.move
+++ b/packages/propbook/sources/registry.move
@@ -20,6 +20,13 @@ const EBindingNotFound: u64 = 5;
 const EBlockScholesStoresAlreadyExist: u64 = 6;
 const EInvalidBlockScholesBaseAsset: u64 = 7;
 
+/// Longest accepted provider base-asset spelling. Provider tickers are short; the ceiling exists
+/// because the spelling is permanent, is BCS-encoded and hashed on every read to derive a series
+/// id, and so a malformed long input would be an unbounded per-read cost with no way to shrink it.
+macro fun max_block_scholes_base_asset_len(): u64 {
+    32
+}
+
 // Stable discriminators stored in source keys, binding keys, metadata, and events.
 public(package) macro fun kind_pyth(): u8 {
     0
@@ -49,10 +56,18 @@ public struct OracleRegistry has key {
     block_scholes_stores: Table<u32, BlockScholesStorePair>,
 }
 
-/// The two canonical shared Block Scholes objects of one Propbook underlying.
+/// The two canonical shared Block Scholes objects of one Propbook underlying, and the provider
+/// base asset both of them derive their accepted series ids from.
+///
+/// The base asset is duplicated here rather than only living on the stores because it is the one
+/// fact that says which real-world asset this underlying tracks, and a repoint can only be made
+/// safe by comparing a replacement against it — a guard the registry cannot express while the
+/// spelling is reachable only by fetching both store objects. Carrying it also lets a caller read
+/// the whole binding from one row.
 public struct BlockScholesStorePair has copy, drop, store {
     value_store_id: ID,
     svi_store_id: ID,
+    block_scholes_base_asset: String,
 }
 
 /// Unique identity of a provider source within one oracle kind.
@@ -164,6 +179,12 @@ public fun block_scholes_value_store_id(pair: &BlockScholesStorePair): ID {
     pair.value_store_id
 }
 
+/// Returns the bound provider base asset for external composition, discovery, or devInspect
+/// confirmation that the binding names the asset the subscription resolves to.
+public fun block_scholes_base_asset(pair: &BlockScholesStorePair): String {
+    pair.block_scholes_base_asset
+}
+
 /// Returns the canonical SVI-store identity for external composition or discovery.
 public fun block_scholes_svi_store_id(pair: &BlockScholesStorePair): ID {
     pair.svi_store_id
@@ -220,6 +241,14 @@ public fun create_and_share_pyth_feed(
 
 /// Create and share this underlying's Block Scholes store partition and bind its source identity.
 /// Admin-gated and once per underlying so consumers have one immutable descriptor and store pair.
+///
+/// `block_scholes_base_asset` is carried into every derived series id exactly as spelled, and no
+/// on-chain fact can say whether it is the asset this underlying is meant to track: a spelling the
+/// provider does not serve makes the underlying permanently unfeedable, and a spelling naming a
+/// *different* real asset prices this underlying off that asset with every check passing. Confirm
+/// it against the provider's acknowledged subscription before this call — the emitted
+/// `BlockScholesStoresRegistered` and `block_scholes_base_asset` reader exist so that confirmation
+/// can be made against the chain rather than against the intent.
 public fun create_and_share_block_scholes_stores(
     registry: &mut OracleRegistry,
     _admin_cap: &RegistryAdminCap,
@@ -232,6 +261,10 @@ public fun create_and_share_block_scholes_stores(
         EBlockScholesStoresAlreadyExist,
     );
     assert!(!block_scholes_base_asset.is_empty(), EInvalidBlockScholesBaseAsset);
+    assert!(
+        block_scholes_base_asset.as_bytes().length() <= max_block_scholes_base_asset_len!(),
+        EInvalidBlockScholesBaseAsset,
+    );
     let value_store_id = block_scholes_store::create_and_share_value_store(
         copy block_scholes_base_asset,
         ctx,
@@ -243,13 +276,14 @@ public fun create_and_share_block_scholes_stores(
     let pair = BlockScholesStorePair {
         value_store_id,
         svi_store_id,
+        block_scholes_base_asset,
     };
     registry.block_scholes_stores.add(propbook_underlying_id, copy pair);
     event::emit(BlockScholesStoresRegistered {
         propbook_underlying_id,
         value_store_id,
         svi_store_id,
-        block_scholes_base_asset,
+        block_scholes_base_asset: pair.block_scholes_base_asset,
     });
     pair
 }

--- a/packages/propbook/tests/registry_tests.move
+++ b/packages/propbook/tests/registry_tests.move
@@ -229,6 +229,7 @@ fun create_block_scholes_stores_records_the_pair_lookup() {
         .destroy_some();
     assert_eq!(pair.block_scholes_value_store_id(), value_store_id);
     assert_eq!(pair.block_scholes_svi_store_id(), svi_store_id);
+    assert_eq!(pair.block_scholes_base_asset(), btc());
     assert!(value_store_id != svi_store_id);
 
     let events = event::events_by_type<registry::BlockScholesStoresRegistered>();
@@ -362,8 +363,57 @@ fun creating_store_pair_with_empty_base_asset_aborts() {
     abort 999
 }
 
+/// 32 bytes is the longest accepted spelling; the boundary lands on the accepting side.
+#[test]
+fun creating_store_pair_with_a_maximum_length_base_asset_succeeds() {
+    let mut scenario = test::begin(ADMIN);
+    registry::init_for_testing(scenario.ctx());
+    scenario.next_tx(ADMIN);
+
+    let mut registry = scenario.take_shared<OracleRegistry>();
+    let admin_cap = scenario.take_from_sender<RegistryAdminCap>();
+    let pair = registry::create_and_share_block_scholes_stores(
+        &mut registry,
+        &admin_cap,
+        BTC_UNDERLYING_ID,
+        thirty_two_byte_asset(),
+        scenario.ctx(),
+    );
+    assert_eq!(pair.block_scholes_base_asset(), thirty_two_byte_asset());
+
+    return_shared(registry);
+    destroy(admin_cap);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = registry::EInvalidBlockScholesBaseAsset)]
+fun creating_store_pair_with_an_over_length_base_asset_aborts() {
+    let mut scenario = test::begin(ADMIN);
+    registry::init_for_testing(scenario.ctx());
+    scenario.next_tx(ADMIN);
+
+    let mut registry = scenario.take_shared<OracleRegistry>();
+    let admin_cap = scenario.take_from_sender<RegistryAdminCap>();
+    let mut over_length = thirty_two_byte_asset();
+    over_length.append(b"X".to_string());
+    registry::create_and_share_block_scholes_stores(
+        &mut registry,
+        &admin_cap,
+        BTC_UNDERLYING_ID,
+        over_length,
+        scenario.ctx(),
+    );
+
+    abort 999
+}
+
 fun btc(): String {
     b"BTC".to_string()
+}
+
+/// Exactly 32 ASCII bytes, counted by hand: eight groups of four.
+fun thirty_two_byte_asset(): String {
+    b"ABCDEFGHIJKLMNOPQRSTUVWXYZ012345".to_string()
 }
 
 fun eth(): String {


### PR DESCRIPTION
## Summary

- Add `block_scholes_base_asset` to `BlockScholesStorePair`, with a reader, so the registry row answers the whole binding in one lookup.
- Bound the spelling to 32 bytes, with tests at both sides of the boundary.
- State at the call site and in the README what no on-chain check can verify.
- Re-rate P-26 to Medium and record why re-registration is not a recovery path.

## Why

Provider-defined series ids moved the answer to "which real asset does this underlying track" from the `u32` underlying id to an admin-supplied string carried into every derived id verbatim. Two failure modes follow, and neither is recoverable.

A spelling the provider does not serve makes the underlying permanently unfeedable. A spelling naming a *different real* asset is worse, because it is silent: genuinely signed observations for that asset land, the basis passes, the SVI surface passes the pricing envelope, both store-binding checks pass, and the underlying prices off the wrong asset. `use_pyth_spot_for_forward` defaults on, so the forward is re-anchored to the correct Pyth spot and only the vol surface and basis are wrong — which is exactly the shape no guard catches.

Re-registering under a fresh `propbook_underlying_id` is not an escape. It is admissible on the Block Scholes side, but the Pyth lane refuses to follow: `source_bindings` is append-only, so `assert_source_assignable` permanently rejects binding the same source key to a second underlying, and `pyth_source_id` is the real Lazer feed id (`pyth_feed.move` resolves updates via `feeds.find_index!(|f| f.feed_id() == pyth_source_id)`), so no substitute names the same asset. The two lanes' recovery mechanisms are mutually exclusive.

## Key decisions

- **Only the row shape is time-critical.** Adding the replacement *function* stays possible after deploy — new functions are upgrade-legal. What expires is the struct layout. A replace is only safe if it must carry the identical base asset (the analogue of the Pyth sticky-source guard, which is what stops a replace from silently changing which asset an underlying tracks), and that guard is unwritable while the spelling is reachable only by fetching both store objects. So this PR adds the field and leaves the function to a follow-up, where its preconditions are a policy call rather than a deadline.
- **The 32-byte ceiling is about permanence, not correctness.** The spelling is BCS-encoded and keccak-hashed on every read to derive a series id, is immutable, and cannot be shrunk — so a malformed long input would be an unbounded per-read cost forever. Provider tickers are short.
- **No attempt to validate the spelling on chain.** Nothing on chain can distinguish a correct binding from one naming a different real asset. The honest response is to say so at the call site and give the confirmation something to read — hence the reader and the existing `BlockScholesStoresRegistered` event.
- No behavioural change to ingestion, storage, or pricing. Predict consumes the pair through the two id getters and is untouched.

## Scope / Descoped

- `replace_block_scholes_stores_for_underlying` is deliberately not here. It is P-26's action item, it is not time-critical, and its preconditions (may a live-market underlying be repointed?) are the author's call.
- The other items from the audit — the unregistered ingest response policy, the missing wrong-expiry-witness test, the retransmission event/doc contradiction, the unmeasured flush cost — are not in this PR.

## Test plan

- [x] `sui move build --path packages/propbook --warnings-are-errors` — exit 0
- [x] `sui move build --path packages/predict --warnings-are-errors` — exit 0
- [x] `sui move test --path packages/propbook --gas-limit 100000000000` — 75/75 (73 + 2 new), exit 0
- [x] `sui move test --path packages/predict --gas-limit 100000000000` — 543/543, exit 0
- [x] `python3 packages/predict/predeploy/check.py` — 0 warnings
- [x] `checks/format-move.sh` on both changed Move files — unchanged

## Risk / Rollout

Pre-deploy struct-layout change to `BlockScholesStorePair`, which is why it wants to land before the deployment rather than after. No migration concern: nothing is deployed against this shape yet.