### PR TITLE
sessions: add time-limited Predict sessions (DBU-707)

### DIFF
--- a/packages/predict/tests/helper/flow_test_helpers.move
+++ b/packages/predict/tests/helper/flow_test_helpers.move
@@ -66,6 +66,9 @@ const PYTH_EXPONENT_NEG_9: u16 = 9;
 /// from `test_constants` so existing call sites keep one source of truth.
 public fun strike_tick(): u64 { test_constants::default_strike_tick() }
 
+/// Positive-infinity tick sentinel for fixtures owned by dependent packages.
+public fun pos_inf_tick(): u64 { constants::pos_inf_tick!() }
+
 /// Assert a quoted at-the-money entry probability against the independently
 /// generated true digital, within its documented budget.
 ///
@@ -542,6 +545,15 @@ public fun set_default_cadence_allocation(
     );
     return_shared(config);
     return_shared(registry);
+    self.scenario.next_tx(test_constants::admin());
+}
+
+/// Authorize an Account app in fixtures owned by another package.
+public fun authorize_account_app<App>(self: &mut Fixture) {
+    self.scenario.next_tx(test_constants::admin());
+    let mut account_registry = self.scenario.take_shared<AccountRegistry>();
+    account_registry.authorize_app<App>(&self.account_admin_cap);
+    return_shared(account_registry);
     self.scenario.next_tx(test_constants::admin());
 }
 

--- a/packages/sessions/Move.toml
+++ b/packages/sessions/Move.toml
@@ -6,3 +6,4 @@ version = "0.0.1"
 [dependencies]
 account = { local = "../account" }
 deepbook_predict = { local = "../predict" }
+propbook = { local = "../propbook" }

--- a/packages/sessions/Move.toml
+++ b/packages/sessions/Move.toml
@@ -1,0 +1,8 @@
+[package]
+name = "deepbook_sessions"
+edition = "2024.beta"
+version = "0.0.1"
+
+[dependencies]
+account = { local = "../account" }
+deepbook_predict = { local = "../predict" }

--- a/packages/sessions/Move.toml
+++ b/packages/sessions/Move.toml
@@ -7,3 +7,13 @@ version = "0.0.1"
 account = { local = "../account" }
 deepbook_predict = { local = "../predict" }
 propbook = { local = "../propbook" }
+fixed_math = { local = "../fixed_math" }
+# This publishable root repeats Predict's direct Pyth source so the testnet
+# replacement identities below apply to the transitive Pyth/Wormhole graph.
+pyth_lazer = { git = "https://github.com/pyth-network/pyth-crosschain.git", subdir = "lazer/contracts/sui", rev = "f80ff8b1aa2aa9ca17530a9b6294d254f938a5bf" }
+# The production-valid oracle fixture mints verifier-authenticated test batches.
+bs_oracle = { git = "https://github.com/blockscholes/sui-signed-oracle.git", subdir = "move/bs_oracle", rev = "83bfec450540068a27277b40babcb6fbb26c7e11" }
+
+[dep-replacements.testnet]
+pyth_lazer = { git = "https://github.com/pyth-network/pyth-crosschain.git", subdir = "lazer/contracts/sui", rev = "f80ff8b1aa2aa9ca17530a9b6294d254f938a5bf", published-at = "0xf5bd2141967507050a91b58de3d95e77c432cd90d1799ee46effc27430a68c21", original-id = "0xf5bd2141967507050a91b58de3d95e77c432cd90d1799ee46effc27430a68c21" }
+wormhole = { git = "https://github.com/pyth-network/wormhole.git", subdir = "sui/wormhole", rev = "a596dc27243e6b6dab95539c98b0af9836af2bc2", published-at = "0xd5afd4e456e5451f1ca1e7b3d734ce7a0a3b397811a6cb72a4bd1dfc387839f2", original-id = "0xd5afd4e456e5451f1ca1e7b3d734ce7a0a3b397811a6cb72a4bd1dfc387839f2" }

--- a/packages/sessions/Move.toml
+++ b/packages/sessions/Move.toml
@@ -8,6 +8,7 @@ account = { local = "../account" }
 deepbook_predict = { local = "../predict" }
 propbook = { local = "../propbook" }
 fixed_math = { local = "../fixed_math" }
+dusdc = { local = "../dusdc" }
 # This publishable root repeats Predict's direct Pyth source so the testnet
 # replacement identities below apply to the transitive Pyth/Wormhole graph.
 pyth_lazer = { git = "https://github.com/pyth-network/pyth-crosschain.git", subdir = "lazer/contracts/sui", rev = "f80ff8b1aa2aa9ca17530a9b6294d254f938a5bf" }

--- a/packages/sessions/README.md
+++ b/packages/sessions/README.md
@@ -10,7 +10,7 @@ The Account registry administrator must authorize `SessionsApp` before any wrapp
 
 An Account owner opts in by calling `authorize_session` on the Account's shared `AccountWrapper`. Owner authorization is derived from the transaction sender, so this flow supports EOA-owned Accounts and does not authorize object-owned Accounts.
 
-A session grant contains only the session address and its expiration timestamp in milliseconds. Each Account may store at most 10 session addresses. The requested duration must be greater than zero and no more than 30 days. Expiration is calculated from the on-chain `Clock` at execution time, and reauthorizing the same address replaces its stored expiration without consuming another slot.
+A session grant contains only the session address and its expiration timestamp in milliseconds. Each Account may store at most 20 session addresses. The requested duration must be greater than zero and no more than 30 days. Expiration is calculated from the on-chain `Clock` at execution time, and reauthorizing the same address replaces its stored expiration without consuming another slot.
 
 Every Predict wrapper requires both of these conditions:
 
@@ -46,7 +46,7 @@ public fun revoke_session(
 
 The shared `AccountWrapper` can be supplied as an object input in a programmable transaction block and borrowed immutably for `session_expiration_ms`. SDKs may also use the function through dev-inspect reads.
 
-Revoking a known session removes it from the session map immediately, whether it is active or already expired, and frees its slot for another address. When the final grant is revoked, the package detaches its app-data slot from the Account. Revoking an unknown session is a no-op. Expired entries are not removed automatically because time passing does not execute Move code; they continue to count toward the 10-session limit until the owner revokes them, while reauthorization replaces the expiration in place.
+Revoking a known session removes it from the session map immediately, whether it is active or already expired, and frees its slot for another address. Once the Sessions app-data slot has been attached to an Account, it remains attached even when the session map becomes empty. Revoking an unknown session is a no-op. Expired entries are not removed automatically because time passing does not execute Move code; they continue to count toward the 20-session limit until the owner revokes them, while reauthorization replaces the expiration in place.
 
 ## Predict wrappers
 

--- a/packages/sessions/README.md
+++ b/packages/sessions/README.md
@@ -10,7 +10,7 @@ The Account registry administrator must authorize `SessionsApp` before any wrapp
 
 An Account owner opts in by calling `authorize_session` on the Account's shared `AccountWrapper`. Owner authorization is derived from the transaction sender, so this flow supports EOA-owned Accounts and does not authorize object-owned Accounts.
 
-A session grant contains only the session address and its expiration timestamp in milliseconds. The requested duration must be greater than zero and no more than 30 days. Expiration is calculated from the on-chain `Clock` at execution time, and reauthorizing the same address replaces its stored expiration.
+A session grant contains only the session address and its expiration timestamp in milliseconds. Each Account may store at most 10 session addresses. The requested duration must be greater than zero and no more than 30 days. Expiration is calculated from the on-chain `Clock` at execution time, and reauthorizing the same address replaces its stored expiration without consuming another slot.
 
 Every Predict wrapper requires both of these conditions:
 
@@ -46,7 +46,7 @@ public fun revoke_session(
 
 The shared `AccountWrapper` can be supplied as an object input in a programmable transaction block and borrowed immutably for `session_expiration_ms`. SDKs may also use the function through dev-inspect reads.
 
-Revoking a known session removes it immediately, whether it is active or already expired. When the final grant is revoked, the package destroys the empty session table and detaches its app-data slot from the Account. Revoking an unknown session is a no-op. Expired entries are not removed automatically because time passing does not execute Move code; an owner may revoke them or replace them through reauthorization.
+Revoking a known session removes it from the session map immediately, whether it is active or already expired, and frees its slot for another address. When the final grant is revoked, the package detaches its app-data slot from the Account. Revoking an unknown session is a no-op. Expired entries are not removed automatically because time passing does not execute Move code; they continue to count toward the 10-session limit until the owner revokes them, while reauthorization replaces the expiration in place.
 
 ## Predict wrappers
 

--- a/packages/sessions/README.md
+++ b/packages/sessions/README.md
@@ -46,7 +46,7 @@ public fun revoke_session(
 
 The shared `AccountWrapper` can be supplied as an object input in a programmable transaction block and borrowed immutably for `session_expiration_ms`. SDKs may also use the function through dev-inspect reads.
 
-Revoking a known session removes it immediately, whether it is active or already expired. Revoking an unknown session is a no-op. Expired entries are not removed automatically because time passing does not execute Move code; an owner may revoke them or replace them through reauthorization.
+Revoking a known session removes it immediately, whether it is active or already expired. When the final grant is revoked, the package destroys the empty session table and detaches its app-data slot from the Account. Revoking an unknown session is a no-op. Expired entries are not removed automatically because time passing does not execute Move code; an owner may revoke them or replace them through reauthorization.
 
 ## Predict wrappers
 

--- a/packages/sessions/README.md
+++ b/packages/sessions/README.md
@@ -1,0 +1,101 @@
+# Sessions
+
+`deepbook_sessions` lets the owner of a canonical DeepBook Account authorize an ephemeral address to submit a limited set of Predict transactions for that Account until a fixed expiration time.
+
+The package is an Account app. It stores session grants in the Account's app-local data and generates Account app authorization only inside its Predict wrapper functions. Session callers never receive a reusable `account::Auth`, and the package exposes no withdrawal or arbitrary Account mutation entrypoint.
+
+## Authority model
+
+The Account registry administrator must authorize `SessionsApp` before any wrapper can generate app authorization. This registry-level authorization makes the package trusted Account infrastructure; it does not itself grant a session for any user.
+
+An Account owner opts in by calling `authorize_session` on the Account's shared `AccountWrapper`. Owner authorization is derived from the transaction sender, so this flow supports EOA-owned Accounts and does not authorize object-owned Accounts.
+
+A session grant contains only the session address and its expiration timestamp in milliseconds. The requested duration must be greater than zero and no more than 30 days. Expiration is calculated from the on-chain `Clock` at execution time, and reauthorizing the same address replaces its stored expiration.
+
+Every Predict wrapper requires both of these conditions:
+
+- The transaction sender has a stored session grant for the supplied Account.
+- The current clock timestamp is strictly less than the stored expiration.
+
+At the exact expiration timestamp, the session is no longer authorized.
+
+## Session lifecycle
+
+```move
+public fun session_expiration_ms(
+    wrapper: &AccountWrapper,
+    session: address,
+): Option<u64>
+
+public fun authorize_session(
+    wrapper: &mut AccountWrapper,
+    session: address,
+    duration_ms: u64,
+    clock: &Clock,
+    ctx: &mut TxContext,
+)
+
+public fun revoke_session(
+    wrapper: &mut AccountWrapper,
+    session: address,
+    ctx: &mut TxContext,
+)
+```
+
+`session_expiration_ms` returns the stored expiration for a known session and `none` for a session that was never authorized or has been revoked. It does not classify the timestamp as active or expired; callers that need that distinction must compare it with the current on-chain time.
+
+The shared `AccountWrapper` can be supplied as an object input in a programmable transaction block and borrowed immutably for `session_expiration_ms`. SDKs may also use the function through dev-inspect reads.
+
+Revoking a known session removes it immediately, whether it is active or already expired. Revoking an unknown session is a no-op. Expired entries are not removed automatically because time passing does not execute Move code; an owner may revoke them or replace them through reauthorization.
+
+## Predict wrappers
+
+An active session may call these wrappers:
+
+- `mint_exact_quantity`
+- `mint_exact_amount`
+- `redeem_live`
+- `redeem_settled`
+
+Each wrapper validates the session against the supplied Account, generates app authorization internally, and immediately passes that authorization into the corresponding Predict function. All market parameters remain caller-selected and are validated by Predict.
+
+The session can therefore submit adverse trades for the Account until it expires or is revoked. A grant should be treated as trading authority, not read-only access. Revocation and expiration stop future wrapper calls but do not unwind positions or transactions that already executed.
+
+## Events
+
+`SessionAuthorized` is emitted for both a new grant and a reauthorization:
+
+```move
+public struct SessionAuthorized has copy, drop {
+    account_id: ID,
+    session: address,
+    expires_at_ms: u64,
+}
+```
+
+`SessionRevoked` is emitted only when an existing grant is removed:
+
+```move
+public struct SessionRevoked has copy, drop {
+    account_id: ID,
+    session: address,
+    expires_at_ms: u64,
+}
+```
+
+Expiration emits no event, and a no-op revocation emits no event. Predict continues to emit the underlying mint and redeem events; the wrappers do not duplicate them.
+
+## Integration requirements
+
+Before Sessions can be used, the package must be published against the intended Account, Predict, and Propbook package lineage, and `SessionsApp` must be authorized in the corresponding Account registry. Publication, registry configuration, SDK transaction construction, ephemeral-key storage, indexing, and deployment are outside this package.
+
+If the package is published with an upgrade capability, custody of that capability is part of the trust boundary because an upgrade can change the behavior of an authorized Account app.
+
+## Build and test
+
+From the repository root:
+
+```sh
+sui move build --path packages/sessions --warnings-are-errors
+sui move test --path packages/sessions --gas-limit 100000000000
+```

--- a/packages/sessions/sources/sessions.move
+++ b/packages/sessions/sources/sessions.move
@@ -238,3 +238,15 @@ fun generate_auth_as_session(
     assert!(clock.timestamp_ms() < *expiration.borrow(), ESessionNotAuthorized);
     account_registry.generate_auth_as_app<SessionsApp>(permit<SessionsApp>())
 }
+
+// === Test-Only Functions ===
+
+#[test_only]
+public fun session_authorized_fields(event: &SessionAuthorized): (ID, address, u64) {
+    (event.account_id, event.session, event.expires_at_ms)
+}
+
+#[test_only]
+public fun session_revoked_fields(event: &SessionRevoked): (ID, address, u64) {
+    (event.account_id, event.session, event.expires_at_ms)
+}

--- a/packages/sessions/sources/sessions.move
+++ b/packages/sessions/sources/sessions.move
@@ -6,7 +6,7 @@
 /// app auth inside the four Predict wrappers exposed here.
 module deepbook_sessions::sessions;
 
-use account::{account::{Self, Account, AccountWrapper, Auth}, account_registry::AccountRegistry};
+use account::{account::{Self, AccountWrapper, Auth}, account_registry::AccountRegistry};
 use deepbook_predict::{
     expiry_market::{Self as expiry_market, ExpiryMarket},
     pricing::Pricer,
@@ -37,7 +37,8 @@ public struct SessionsData has store {
 // === Public Functions ===
 
 /// Return a known session's expiration timestamp for SDK and devInspect reads.
-public fun session_expiration_ms(account: &Account, session: address): Option<u64> {
+public fun session_expiration_ms(wrapper: &AccountWrapper, session: address): Option<u64> {
+    let account = wrapper.load_account();
     if (!account.has_data<SessionsApp>()) return option::none();
     let data = account.borrow_data<SessionsApp, SessionsData>();
     if (!data.sessions.contains(session)) {
@@ -218,7 +219,7 @@ fun generate_auth_as_session(
     clock: &Clock,
     ctx: &TxContext,
 ): Auth {
-    let expiration = session_expiration_ms(wrapper.load_account(), ctx.sender());
+    let expiration = session_expiration_ms(wrapper, ctx.sender());
     assert!(expiration.is_some(), ESessionNotAuthorized);
     assert!(clock.timestamp_ms() < *expiration.borrow(), ESessionNotAuthorized);
     account_registry.generate_auth_as_app<SessionsApp>(permit<SessionsApp>())

--- a/packages/sessions/sources/sessions.move
+++ b/packages/sessions/sources/sessions.move
@@ -237,15 +237,3 @@ fun generate_auth_as_session(
     assert!(clock.timestamp_ms() < *expiration.borrow(), ESessionNotAuthorized);
     account_registry.generate_auth_as_app<SessionsApp>(permit<SessionsApp>())
 }
-
-// === Test-Only Functions ===
-
-#[test_only]
-public fun session_authorized_fields(event: &SessionAuthorized): (ID, address, u64) {
-    (event.account_id, event.session, event.expires_at_ms)
-}
-
-#[test_only]
-public fun session_revoked_fields(event: &SessionRevoked): (ID, address, u64) {
-    (event.account_id, event.session, event.expires_at_ms)
-}

--- a/packages/sessions/sources/sessions.move
+++ b/packages/sessions/sources/sessions.move
@@ -1,0 +1,225 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Owns time-limited Predict session grants attached to canonical Accounts.
+/// Account owners grant and revoke sessions; an active session can only generate
+/// app auth inside the four Predict wrappers exposed here.
+module deepbook_sessions::sessions;
+
+use account::{account::{Self, Account, AccountWrapper, Auth}, account_registry::AccountRegistry};
+use deepbook_predict::{
+    expiry_market::{Self as expiry_market, ExpiryMarket},
+    pricing::Pricer,
+    protocol_config::ProtocolConfig
+};
+use std::internal::permit;
+use sui::{accumulator::AccumulatorRoot, clock::Clock, table::{Self, Table}};
+
+// === Errors ===
+
+const EInvalidSessionDuration: u64 = 0;
+const ESessionNotAuthorized: u64 = 1;
+
+// === Constants ===
+
+macro fun max_session_duration_ms(): u64 { 30 * 24 * 60 * 60 * 1000 }
+
+// === Structs ===
+
+/// App witness for Account registry authorization and per-account data namespacing.
+public struct SessionsApp has drop {}
+
+/// Session expiration timestamps keyed by transaction signer address.
+public struct SessionsData has store {
+    sessions: Table<address, u64>,
+}
+
+// === Public Functions ===
+
+/// Return a known session's expiration timestamp for SDK and devInspect reads.
+public fun session_expiration_ms(account: &Account, session: address): Option<u64> {
+    if (!account.has_data<SessionsApp>()) return option::none();
+    let data = account.borrow_data<SessionsApp, SessionsData>();
+    if (!data.sessions.contains(session)) {
+        option::none()
+    } else {
+        option::some(*data.sessions.borrow(session))
+    }
+}
+
+/// Authorize `session` from execution time for at most 30 days.
+/// Reauthorizing an existing address replaces its expiration timestamp.
+public fun authorize_session(
+    wrapper: &mut AccountWrapper,
+    session: address,
+    duration_ms: u64,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    assert!(duration_ms > 0 && duration_ms <= max_session_duration_ms!(), EInvalidSessionDuration);
+    let expires_at_ms = clock.timestamp_ms() + duration_ms;
+    let account = wrapper.load_account_mut(account::generate_auth(ctx));
+    if (!account.has_data<SessionsApp>()) {
+        account.attach(permit<SessionsApp>(), SessionsData { sessions: table::new(ctx) });
+    };
+    let data = account.borrow_data_mut<SessionsApp, SessionsData>(permit<SessionsApp>());
+    if (data.sessions.contains(session)) {
+        *data.sessions.borrow_mut(session) = expires_at_ms;
+    } else {
+        data.sessions.add(session, expires_at_ms);
+    };
+}
+
+/// Revoke `session` if it is present. Only the Account owner may call this function.
+public fun revoke_session(wrapper: &mut AccountWrapper, session: address, ctx: &mut TxContext) {
+    let account = wrapper.load_account_mut(account::generate_auth(ctx));
+    if (!account.has_data<SessionsApp>()) return;
+    let data = account.borrow_data_mut<SessionsApp, SessionsData>(permit<SessionsApp>());
+    if (data.sessions.contains(session)) {
+        data.sessions.remove(session);
+    };
+}
+
+/// Mint an exact Predict position quantity for an Account with an active session.
+public fun mint_exact_quantity(
+    market: &mut ExpiryMarket,
+    account_registry: &AccountRegistry,
+    wrapper: &mut AccountWrapper,
+    config: &ProtocolConfig,
+    pricer: &Pricer,
+    lower_tick: u64,
+    higher_tick: u64,
+    quantity: u64,
+    leverage: u64,
+    max_cost: u64,
+    max_probability: u64,
+    root: &AccumulatorRoot,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): u256 {
+    let auth = generate_auth_as_session(account_registry, wrapper, clock, ctx);
+    expiry_market::mint_exact_quantity(
+        market,
+        wrapper,
+        auth,
+        config,
+        pricer,
+        lower_tick,
+        higher_tick,
+        quantity,
+        leverage,
+        max_cost,
+        max_probability,
+        root,
+        clock,
+        ctx,
+    )
+}
+
+/// Mint a budget-sized Predict position for an Account with an active session.
+public fun mint_exact_amount(
+    market: &mut ExpiryMarket,
+    account_registry: &AccountRegistry,
+    wrapper: &mut AccountWrapper,
+    config: &ProtocolConfig,
+    pricer: &Pricer,
+    lower_tick: u64,
+    higher_tick: u64,
+    max_premium: u64,
+    min_quantity: u64,
+    leverage: u64,
+    max_cost: u64,
+    root: &AccumulatorRoot,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): u256 {
+    let auth = generate_auth_as_session(account_registry, wrapper, clock, ctx);
+    expiry_market::mint_exact_amount(
+        market,
+        wrapper,
+        auth,
+        config,
+        pricer,
+        lower_tick,
+        higher_tick,
+        max_premium,
+        min_quantity,
+        leverage,
+        max_cost,
+        root,
+        clock,
+        ctx,
+    )
+}
+
+/// Redeem a live Predict order for an Account with an active session.
+public fun redeem_live(
+    market: &mut ExpiryMarket,
+    account_registry: &AccountRegistry,
+    wrapper: &mut AccountWrapper,
+    config: &ProtocolConfig,
+    pricer: &Pricer,
+    order_id: u256,
+    close_quantity: u64,
+    min_probability: u64,
+    min_proceeds: u64,
+    root: &AccumulatorRoot,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): (u256, Option<u256>) {
+    let auth = generate_auth_as_session(account_registry, wrapper, clock, ctx);
+    expiry_market::redeem_live(
+        market,
+        wrapper,
+        auth,
+        config,
+        pricer,
+        order_id,
+        close_quantity,
+        min_probability,
+        min_proceeds,
+        root,
+        clock,
+        ctx,
+    )
+}
+
+/// Redeem a settled Predict order for an Account with an active session.
+public fun redeem_settled(
+    market: &mut ExpiryMarket,
+    account_registry: &AccountRegistry,
+    wrapper: &mut AccountWrapper,
+    config: &ProtocolConfig,
+    order_id: u256,
+    close_quantity: u64,
+    root: &AccumulatorRoot,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): (u256, Option<u256>) {
+    let auth = generate_auth_as_session(account_registry, wrapper, clock, ctx);
+    expiry_market::redeem_settled(
+        market,
+        wrapper,
+        auth,
+        config,
+        order_id,
+        close_quantity,
+        root,
+        clock,
+        ctx,
+    )
+}
+
+// === Private Functions ===
+
+fun generate_auth_as_session(
+    account_registry: &AccountRegistry,
+    wrapper: &AccountWrapper,
+    clock: &Clock,
+    ctx: &TxContext,
+): Auth {
+    let expiration = session_expiration_ms(wrapper.load_account(), ctx.sender());
+    assert!(expiration.is_some(), ESessionNotAuthorized);
+    assert!(clock.timestamp_ms() < *expiration.borrow(), ESessionNotAuthorized);
+    account_registry.generate_auth_as_app<SessionsApp>(permit<SessionsApp>())
+}

--- a/packages/sessions/sources/sessions.move
+++ b/packages/sessions/sources/sessions.move
@@ -92,10 +92,18 @@ public fun revoke_session(wrapper: &mut AccountWrapper, session: address, ctx: &
     let account = wrapper.load_account_mut(account::generate_auth(ctx));
     if (!account.has_data<SessionsApp>()) return;
     let account_id = account.account_id();
-    let data = account.borrow_data_mut<SessionsApp, SessionsData>(permit<SessionsApp>());
-    if (data.sessions.contains(session)) {
+    let remove_data = {
+        let data = account.borrow_data_mut<SessionsApp, SessionsData>(permit<SessionsApp>());
+        if (!data.sessions.contains(session)) return;
         let expires_at_ms = data.sessions.remove(session);
         event::emit(SessionRevoked { account_id, session, expires_at_ms });
+        data.sessions.is_empty()
+    };
+    if (remove_data) {
+        let SessionsData { sessions } = account.detach<SessionsApp, SessionsData>(
+            permit<SessionsApp>(),
+        );
+        sessions.destroy_empty();
     };
 }
 

--- a/packages/sessions/sources/sessions.move
+++ b/packages/sessions/sources/sessions.move
@@ -8,7 +8,7 @@ module deepbook_sessions::sessions;
 
 use account::{account::{Self, AccountWrapper, Auth}, account_registry::AccountRegistry};
 use deepbook_predict::{
-    expiry_market::{Self as expiry_market, ExpiryMarket},
+    expiry_market::ExpiryMarket,
     pricing::Pricer,
     protocol_config::ProtocolConfig
 };
@@ -99,8 +99,7 @@ public fun mint_exact_quantity(
     ctx: &mut TxContext,
 ): u256 {
     let auth = generate_auth_as_session(account_registry, wrapper, clock, ctx);
-    expiry_market::mint_exact_quantity(
-        market,
+    market.mint_exact_quantity(
         wrapper,
         auth,
         config,
@@ -135,8 +134,7 @@ public fun mint_exact_amount(
     ctx: &mut TxContext,
 ): u256 {
     let auth = generate_auth_as_session(account_registry, wrapper, clock, ctx);
-    expiry_market::mint_exact_amount(
-        market,
+    market.mint_exact_amount(
         wrapper,
         auth,
         config,
@@ -169,8 +167,7 @@ public fun redeem_live(
     ctx: &mut TxContext,
 ): (u256, Option<u256>) {
     let auth = generate_auth_as_session(account_registry, wrapper, clock, ctx);
-    expiry_market::redeem_live(
-        market,
+    market.redeem_live(
         wrapper,
         auth,
         config,
@@ -198,8 +195,7 @@ public fun redeem_settled(
     ctx: &mut TxContext,
 ): (u256, Option<u256>) {
     let auth = generate_auth_as_session(account_registry, wrapper, clock, ctx);
-    expiry_market::redeem_settled(
-        market,
+    market.redeem_settled(
         wrapper,
         auth,
         config,

--- a/packages/sessions/sources/sessions.move
+++ b/packages/sessions/sources/sessions.move
@@ -13,16 +13,19 @@ use deepbook_predict::{
     protocol_config::ProtocolConfig
 };
 use std::internal::permit;
-use sui::{accumulator::AccumulatorRoot, clock::Clock, event, table::{Self, Table}};
+use sui::{accumulator::AccumulatorRoot, clock::Clock, event, vec_map::{Self, VecMap}};
 
 // === Errors ===
 
 const EInvalidSessionDuration: u64 = 0;
 const ESessionNotAuthorized: u64 = 1;
+const ESessionLimitExceeded: u64 = 2;
 
 // === Constants ===
 
 macro fun max_session_duration_ms(): u64 { 30 * 24 * 60 * 60 * 1000 }
+
+macro fun max_sessions(): u64 { 10 }
 
 // === Structs ===
 
@@ -31,7 +34,7 @@ public struct SessionsApp has drop {}
 
 /// Session expiration timestamps keyed by transaction signer address.
 public struct SessionsData has store {
-    sessions: Table<address, u64>,
+    sessions: VecMap<address, u64>,
 }
 
 /// A session was authorized or reauthorized through `expires_at_ms`.
@@ -55,15 +58,11 @@ public fun session_expiration_ms(wrapper: &AccountWrapper, session: address): Op
     let account = wrapper.load_account();
     if (!account.has_data<SessionsApp>()) return option::none();
     let data = account.borrow_data<SessionsApp, SessionsData>();
-    if (!data.sessions.contains(session)) {
-        option::none()
-    } else {
-        option::some(*data.sessions.borrow(session))
-    }
+    data.sessions.try_get(&session)
 }
 
 /// Authorize `session` from execution time for at most 30 days.
-/// Reauthorizing an existing address replaces its expiration timestamp.
+/// Accounts may store at most 10 addresses; reauthorization replaces in place.
 public fun authorize_session(
     wrapper: &mut AccountWrapper,
     session: address,
@@ -76,13 +75,14 @@ public fun authorize_session(
     let account = wrapper.load_account_mut(account::generate_auth(ctx));
     let account_id = account.account_id();
     if (!account.has_data<SessionsApp>()) {
-        account.attach(permit<SessionsApp>(), SessionsData { sessions: table::new(ctx) });
+        account.attach(permit<SessionsApp>(), SessionsData { sessions: vec_map::empty() });
     };
     let data = account.borrow_data_mut<SessionsApp, SessionsData>(permit<SessionsApp>());
-    if (data.sessions.contains(session)) {
-        *data.sessions.borrow_mut(session) = expires_at_ms;
+    if (data.sessions.contains(&session)) {
+        *data.sessions.get_mut(&session) = expires_at_ms;
     } else {
-        data.sessions.add(session, expires_at_ms);
+        assert!(data.sessions.length() < max_sessions!(), ESessionLimitExceeded);
+        data.sessions.insert(session, expires_at_ms);
     };
     event::emit(SessionAuthorized { account_id, session, expires_at_ms });
 }
@@ -94,8 +94,8 @@ public fun revoke_session(wrapper: &mut AccountWrapper, session: address, ctx: &
     let account_id = account.account_id();
     let remove_data = {
         let data = account.borrow_data_mut<SessionsApp, SessionsData>(permit<SessionsApp>());
-        if (!data.sessions.contains(session)) return;
-        let expires_at_ms = data.sessions.remove(session);
+        if (!data.sessions.contains(&session)) return;
+        let (_, expires_at_ms) = data.sessions.remove(&session);
         event::emit(SessionRevoked { account_id, session, expires_at_ms });
         data.sessions.is_empty()
     };

--- a/packages/sessions/sources/sessions.move
+++ b/packages/sessions/sources/sessions.move
@@ -13,7 +13,7 @@ use deepbook_predict::{
     protocol_config::ProtocolConfig
 };
 use std::internal::permit;
-use sui::{accumulator::AccumulatorRoot, clock::Clock, table::{Self, Table}};
+use sui::{accumulator::AccumulatorRoot, clock::Clock, event, table::{Self, Table}};
 
 // === Errors ===
 
@@ -32,6 +32,20 @@ public struct SessionsApp has drop {}
 /// Session expiration timestamps keyed by transaction signer address.
 public struct SessionsData has store {
     sessions: Table<address, u64>,
+}
+
+/// A session was authorized or reauthorized through `expires_at_ms`.
+public struct SessionAuthorized has copy, drop {
+    account_id: ID,
+    session: address,
+    expires_at_ms: u64,
+}
+
+/// An existing session grant was removed before or after its expiration.
+public struct SessionRevoked has copy, drop {
+    account_id: ID,
+    session: address,
+    expires_at_ms: u64,
 }
 
 // === Public Functions ===
@@ -60,6 +74,7 @@ public fun authorize_session(
     assert!(duration_ms > 0 && duration_ms <= max_session_duration_ms!(), EInvalidSessionDuration);
     let expires_at_ms = clock.timestamp_ms() + duration_ms;
     let account = wrapper.load_account_mut(account::generate_auth(ctx));
+    let account_id = account.account_id();
     if (!account.has_data<SessionsApp>()) {
         account.attach(permit<SessionsApp>(), SessionsData { sessions: table::new(ctx) });
     };
@@ -69,15 +84,18 @@ public fun authorize_session(
     } else {
         data.sessions.add(session, expires_at_ms);
     };
+    event::emit(SessionAuthorized { account_id, session, expires_at_ms });
 }
 
 /// Revoke `session` if it is present. Only the Account owner may call this function.
 public fun revoke_session(wrapper: &mut AccountWrapper, session: address, ctx: &mut TxContext) {
     let account = wrapper.load_account_mut(account::generate_auth(ctx));
     if (!account.has_data<SessionsApp>()) return;
+    let account_id = account.account_id();
     let data = account.borrow_data_mut<SessionsApp, SessionsData>(permit<SessionsApp>());
     if (data.sessions.contains(session)) {
-        data.sessions.remove(session);
+        let expires_at_ms = data.sessions.remove(session);
+        event::emit(SessionRevoked { account_id, session, expires_at_ms });
     };
 }
 

--- a/packages/sessions/sources/sessions.move
+++ b/packages/sessions/sources/sessions.move
@@ -25,7 +25,7 @@ const ESessionLimitExceeded: u64 = 2;
 
 macro fun max_session_duration_ms(): u64 { 30 * 24 * 60 * 60 * 1000 }
 
-macro fun max_sessions(): u64 { 10 }
+macro fun max_sessions(): u64 { 20 }
 
 // === Structs ===
 
@@ -62,7 +62,7 @@ public fun session_expiration_ms(wrapper: &AccountWrapper, session: address): Op
 }
 
 /// Authorize `session` from execution time for at most 30 days.
-/// Accounts may store at most 10 addresses; reauthorization replaces in place.
+/// Accounts may store at most 20 addresses; reauthorization replaces in place.
 public fun authorize_session(
     wrapper: &mut AccountWrapper,
     session: address,
@@ -92,19 +92,10 @@ public fun revoke_session(wrapper: &mut AccountWrapper, session: address, ctx: &
     let account = wrapper.load_account_mut(account::generate_auth(ctx));
     if (!account.has_data<SessionsApp>()) return;
     let account_id = account.account_id();
-    let remove_data = {
-        let data = account.borrow_data_mut<SessionsApp, SessionsData>(permit<SessionsApp>());
-        if (!data.sessions.contains(&session)) return;
-        let (_, expires_at_ms) = data.sessions.remove(&session);
-        event::emit(SessionRevoked { account_id, session, expires_at_ms });
-        data.sessions.is_empty()
-    };
-    if (remove_data) {
-        let SessionsData { sessions } = account.detach<SessionsApp, SessionsData>(
-            permit<SessionsApp>(),
-        );
-        sessions.destroy_empty();
-    };
+    let data = account.borrow_data_mut<SessionsApp, SessionsData>(permit<SessionsApp>());
+    if (!data.sessions.contains(&session)) return;
+    let (_, expires_at_ms) = data.sessions.remove(&session);
+    event::emit(SessionRevoked { account_id, session, expires_at_ms });
 }
 
 /// Mint an exact Predict position quantity for an Account with an active session.

--- a/packages/sessions/tests/sessions_tests.move
+++ b/packages/sessions/tests/sessions_tests.move
@@ -39,6 +39,17 @@ const ADMIN: address = @0xAD;
 const ALICE: address = @0xA11CE;
 const BOB: address = @0xB0B;
 const SESSION: address = @0x5E5510;
+const SESSION_ONE: address = @0x51;
+const SESSION_TWO: address = @0x52;
+const SESSION_THREE: address = @0x53;
+const SESSION_FOUR: address = @0x54;
+const SESSION_FIVE: address = @0x55;
+const SESSION_SIX: address = @0x56;
+const SESSION_SEVEN: address = @0x57;
+const SESSION_EIGHT: address = @0x58;
+const SESSION_NINE: address = @0x59;
+const SESSION_TEN: address = @0x510;
+const SESSION_ELEVEN: address = @0x511;
 
 const NOW_MS: u64 = 1_000;
 const SESSION_DURATION_MS: u64 = 60_000;
@@ -50,6 +61,11 @@ const MAX_SESSION_DURATION_MS: u64 = 2_592_000_000; // 30 days.
 const MAX_SESSION_EXPIRES_AT_MS: u64 = 2_592_001_000; // 1_000 + 30 days.
 const ABOVE_MAX_SESSION_DURATION_MS: u64 = 2_592_000_001;
 const ZERO_DURATION_MS: u64 = 0;
+const MAX_SESSIONS: u64 = 10;
+const FIRST_SESSION_INDEX: u64 = 0;
+const LAST_SESSION_INDEX: u64 = 9;
+const EXCESS_SESSION_INDEX: u64 = 10;
+const POST_REVOKE_EXPIRES_AT_MS: u64 = 62_000; // 2_000 + 60_000.
 const ONE_EVENT: u64 = 1;
 const EUnexpectedSuccess: u64 = 999;
 
@@ -203,6 +219,107 @@ fun maximum_session_duration_is_accepted() {
     return_shared(wrapper);
     clock.destroy_for_testing();
     scenario.end();
+}
+
+#[test]
+fun session_limit_allows_reauthorization_and_reuse_after_revocation() {
+    let (mut scenario, mut clock, wrapper_id) = setup_account();
+    scenario.next_tx(ALICE);
+    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let session_addresses = session_addresses();
+    let mut index = FIRST_SESSION_INDEX;
+    while (index < MAX_SESSIONS) {
+        sessions::authorize_session(
+            &mut wrapper,
+            session_addresses[index],
+            SESSION_DURATION_MS,
+            &clock,
+            scenario.ctx(),
+        );
+        index = index + 1;
+    };
+    assert_eq!(
+        sessions::session_expiration_ms(&wrapper, session_addresses[FIRST_SESSION_INDEX]),
+        option::some(SESSION_EXPIRES_AT_MS),
+    );
+    assert_eq!(
+        sessions::session_expiration_ms(&wrapper, session_addresses[LAST_SESSION_INDEX]),
+        option::some(SESSION_EXPIRES_AT_MS),
+    );
+
+    clock.set_for_testing(REAUTH_NOW_MS);
+    sessions::authorize_session(
+        &mut wrapper,
+        session_addresses[LAST_SESSION_INDEX],
+        REAUTH_DURATION_MS,
+        &clock,
+        scenario.ctx(),
+    );
+    assert_eq!(
+        sessions::session_expiration_ms(&wrapper, session_addresses[LAST_SESSION_INDEX]),
+        option::some(REAUTH_EXPIRES_AT_MS),
+    );
+
+    sessions::revoke_session(
+        &mut wrapper,
+        session_addresses[FIRST_SESSION_INDEX],
+        scenario.ctx(),
+    );
+    assert!(
+        sessions::session_expiration_ms(&wrapper, session_addresses[FIRST_SESSION_INDEX]).is_none(),
+    );
+    sessions::authorize_session(
+        &mut wrapper,
+        session_addresses[EXCESS_SESSION_INDEX],
+        SESSION_DURATION_MS,
+        &clock,
+        scenario.ctx(),
+    );
+    assert_eq!(
+        sessions::session_expiration_ms(&wrapper, session_addresses[EXCESS_SESSION_INDEX]),
+        option::some(POST_REVOKE_EXPIRES_AT_MS),
+    );
+    assert_eq!(
+        sessions::session_expiration_ms(&wrapper, session_addresses[LAST_SESSION_INDEX]),
+        option::some(REAUTH_EXPIRES_AT_MS),
+    );
+
+    return_shared(wrapper);
+    clock.destroy_for_testing();
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = sessions::ESessionLimitExceeded)]
+fun eleventh_distinct_session_aborts() {
+    let (mut scenario, clock, wrapper_id) = setup_account();
+    scenario.next_tx(ALICE);
+    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let session_addresses = session_addresses();
+    let mut index = FIRST_SESSION_INDEX;
+    while (index < MAX_SESSIONS) {
+        sessions::authorize_session(
+            &mut wrapper,
+            session_addresses[index],
+            SESSION_DURATION_MS,
+            &clock,
+            scenario.ctx(),
+        );
+        index = index + 1;
+    };
+    assert_eq!(
+        sessions::session_expiration_ms(&wrapper, session_addresses[LAST_SESSION_INDEX]),
+        option::some(SESSION_EXPIRES_AT_MS),
+    );
+
+    sessions::authorize_session(
+        &mut wrapper,
+        session_addresses[EXCESS_SESSION_INDEX],
+        SESSION_DURATION_MS,
+        &clock,
+        scenario.ctx(),
+    );
+
+    abort EUnexpectedSuccess
 }
 
 #[test, expected_failure(abort_code = sessions::EInvalidSessionDuration)]
@@ -703,6 +820,22 @@ fun active_session_reaches_predict_redeem_live() {
     destroy(replacement_order_id);
 
     abort EUnexpectedSuccess
+}
+
+fun session_addresses(): vector<address> {
+    vector[
+        SESSION_ONE,
+        SESSION_TWO,
+        SESSION_THREE,
+        SESSION_FOUR,
+        SESSION_FIVE,
+        SESSION_SIX,
+        SESSION_SEVEN,
+        SESSION_EIGHT,
+        SESSION_NINE,
+        SESSION_TEN,
+        SESSION_ELEVEN,
+    ]
 }
 
 fun setup_account(): (Scenario, Clock, ID) {

--- a/packages/sessions/tests/sessions_tests.move
+++ b/packages/sessions/tests/sessions_tests.move
@@ -50,6 +50,16 @@ const SESSION_EIGHT: address = @0x58;
 const SESSION_NINE: address = @0x59;
 const SESSION_TEN: address = @0x510;
 const SESSION_ELEVEN: address = @0x511;
+const SESSION_TWELVE: address = @0x512;
+const SESSION_THIRTEEN: address = @0x513;
+const SESSION_FOURTEEN: address = @0x514;
+const SESSION_FIFTEEN: address = @0x515;
+const SESSION_SIXTEEN: address = @0x516;
+const SESSION_SEVENTEEN: address = @0x517;
+const SESSION_EIGHTEEN: address = @0x518;
+const SESSION_NINETEEN: address = @0x519;
+const SESSION_TWENTY: address = @0x520;
+const SESSION_TWENTY_ONE: address = @0x521;
 
 const NOW_MS: u64 = 1_000;
 const SESSION_DURATION_MS: u64 = 60_000;
@@ -61,10 +71,10 @@ const MAX_SESSION_DURATION_MS: u64 = 2_592_000_000; // 30 days.
 const MAX_SESSION_EXPIRES_AT_MS: u64 = 2_592_001_000; // 1_000 + 30 days.
 const ABOVE_MAX_SESSION_DURATION_MS: u64 = 2_592_000_001;
 const ZERO_DURATION_MS: u64 = 0;
-const MAX_SESSIONS: u64 = 10;
+const MAX_SESSIONS: u64 = 20;
 const FIRST_SESSION_INDEX: u64 = 0;
-const LAST_SESSION_INDEX: u64 = 9;
-const EXCESS_SESSION_INDEX: u64 = 10;
+const LAST_SESSION_INDEX: u64 = 19;
+const EXCESS_SESSION_INDEX: u64 = 20;
 const POST_REVOKE_EXPIRES_AT_MS: u64 = 62_000; // 2_000 + 60_000.
 const ONE_EVENT: u64 = 1;
 const EUnexpectedSuccess: u64 = 999;
@@ -176,7 +186,7 @@ fun owner_authorizes_reauthorizes_and_revokes_session() {
     let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
     sessions::revoke_session(&mut wrapper, SESSION, scenario.ctx());
     assert!(sessions::session_expiration_ms(&wrapper, SESSION).is_none());
-    assert!(!wrapper.load_account().has_data<SessionsApp>());
+    assert!(wrapper.load_account().has_data<SessionsApp>());
     let revoked = event::events_by_type<SessionRevoked>();
     assert_eq!(revoked.length(), ONE_EVENT);
     let (event_account_id, event_session, event_expiration) = sessions::session_revoked_fields(
@@ -290,7 +300,7 @@ fun session_limit_allows_reauthorization_and_reuse_after_revocation() {
 }
 
 #[test, expected_failure(abort_code = sessions::ESessionLimitExceeded)]
-fun eleventh_distinct_session_aborts() {
+fun twenty_first_distinct_session_aborts() {
     let (mut scenario, clock, wrapper_id) = setup_account();
     scenario.next_tx(ALICE);
     let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
@@ -835,6 +845,16 @@ fun session_addresses(): vector<address> {
         SESSION_NINE,
         SESSION_TEN,
         SESSION_ELEVEN,
+        SESSION_TWELVE,
+        SESSION_THIRTEEN,
+        SESSION_FOURTEEN,
+        SESSION_FIFTEEN,
+        SESSION_SIXTEEN,
+        SESSION_SEVENTEEN,
+        SESSION_EIGHTEEN,
+        SESSION_NINETEEN,
+        SESSION_TWENTY,
+        SESSION_TWENTY_ONE,
     ]
 }
 

--- a/packages/sessions/tests/sessions_tests.move
+++ b/packages/sessions/tests/sessions_tests.move
@@ -6,30 +6,27 @@ module deepbook_sessions::sessions_tests;
 
 use account::{
     account::{Self as account, AccountWrapper},
-    account_registry::{Self as account_registry, AccountAdminCap, AccountRegistry}
+    account_registry::{Self as account_registry, AccountRegistry}
 };
-use bs_oracle::verify;
 use deepbook_predict::{
-    admin::AdminCap,
     expiry_market::{Self as expiry_market, ExpiryMarket},
-    market_lifecycle_cap::MarketLifecycleCap,
-    market_manager,
-    order,
-    plp::{Self as plp, PoolVault},
+    flow_test_helpers as predict_helpers,
+    order_events,
+    predict_account,
     pricing::Pricer,
     protocol_config::ProtocolConfig,
-    registry::{Self as predict_registry, Registry as PredictRegistry}
+    test_constants
 };
 use deepbook_sessions::sessions::{Self as sessions, SessionAuthorized, SessionRevoked, SessionsApp};
-use fixed_math::math;
+use dusdc::dusdc::DUSDC;
 use propbook::{
     block_scholes_store::{BlockScholesSVIStore, BlockScholesValueStore},
-    pyth_feed::{Self as pyth_feed, PythFeed},
-    registry::{Self as propbook_registry, OracleRegistry, RegistryAdminCap}
+    pyth_feed::PythFeed,
+    registry::{Self as propbook_registry, OracleRegistry}
 };
-use std::unit_test::{assert_eq, destroy};
+use std::{bcs, unit_test::{assert_eq, destroy}};
 use sui::{
-    accumulator::{Self as accumulator, AccumulatorRoot},
+    accumulator::AccumulatorRoot,
     clock::{Self as clock, Clock},
     event,
     test_scenario::{Self as test, Scenario, return_shared}
@@ -79,54 +76,62 @@ const POST_REVOKE_EXPIRES_AT_MS: u64 = 62_000; // 2_000 + 60_000.
 const ONE_EVENT: u64 = 1;
 const EUnexpectedSuccess: u64 = 999;
 
-const PROPBOOK_UNDERLYING_ID: u32 = 42;
-const PYTH_SOURCE_ID: u32 = 1;
-const MARKET_TICK_SIZE: u64 = 1_000_000_000;
-const MARKET_ADMISSION_TICK_SIZE: u64 = 10_000_000_000;
-const MARKET_MAX_EXPIRY_ALLOCATION: u64 = 250_000_000_000;
-const MARKET_INITIAL_EXPIRY_CASH: u64 = 20_000_000_000;
-const MARKET_CADENCE_WINDOW_SIZE: u64 = 1;
-const GATE_NOW_MS: u64 = 120_000;
-const GATE_SESSION_EXPIRES_AT_MS: u64 = 180_000; // 120_000 + 60_000.
-const MARKET_EXPIRY_MS: u64 = 180_000;
-const LIVE_SOURCE_TIMESTAMP_MS: u64 = 119_000;
-const LIVE_PRICE: u64 = 100_000_000_000;
-const PYTH_EXPONENT_NEG_9: u16 = 9;
-const SVI_A_MAGNITUDE: u128 = 1;
-const SVI_B: u128 = 10_000;
-const SVI_SIGMA: u128 = 1_000_000;
-const SVI_RHO_MAGNITUDE: u128 = 1_000_000_000;
-const SVI_M_MAGNITUDE: u128 = 10_000_000_000;
-const MINT_LOWER_TICK: u64 = 0;
-const MINT_HIGHER_TICK: u64 = 100;
-// Ten contracts at an approximately 50% range price stays above Predict's one-DUSDC minimum net premium and is an exact position-lot multiple.
-const MINT_QUANTITY: u64 = 10_000_000;
-const MINT_MAX_PREMIUM: u64 = 1_000;
+const FLOW_SESSION_EXPIRES_AT_MS: u64 = 180_000; // 120_000 + 60_000.
+const SETTLEMENT_SESSION_DURATION_MS: u64 = 180_000;
+const SETTLEMENT_SESSION_EXPIRES_AT_MS: u64 = 300_000; // 120_000 + 180_000.
+const LIVE_REDEEM_MS: u64 = 120_001;
+const DEFAULT_TRADE_FEE: u64 = 5_000_000;
+const TEN_THOUSAND_LOTS: u64 = 100_000_000;
+const NEXT_LOT_QUANTITY: u64 = 100_010_000;
+const SETTLEMENT_HIGHER_TICK_OFFSET: u64 = 10;
+const SETTLEMENT_PRICE_TICK_OFFSET: u64 = 1;
+const ONE_RAW_UNIT: u64 = 1;
+const ONE_POSITION: u64 = 1;
+const ZERO_POSITIONS: u64 = 0;
 const ZERO_COST: u64 = 0;
+const ZERO_PREMIUM: u64 = 0;
 const ZERO_PROBABILITY: u64 = 0;
 const MISSING_ORDER_ID: u256 = 1;
 const CLOSE_QUANTITY: u64 = 1;
 
-macro fun mint_leverage(): u64 { math::float_scaling!() }
+public struct ExpectedSessionAuthorized has copy, drop {
+    account_id: ID,
+    session: address,
+    expires_at_ms: u64,
+}
 
-public struct GateFixture {
-    scenario: Scenario,
+public struct ExpectedSessionRevoked has copy, drop {
+    account_id: ID,
+    session: address,
+    expires_at_ms: u64,
+}
+
+public struct SessionFlowFixture {
+    predict: predict_helpers::Fixture,
     clock: Clock,
     market_id: ID,
+    owner: address,
     wrapper_id: ID,
     config_id: ID,
-    oracle_registry_id: ID,
     pyth_id: ID,
     bs_values_id: ID,
     bs_svi_id: ID,
 }
 
-public struct LiveGateInputs {
+public struct LiveInputs {
     market: ExpiryMarket,
     account_registry: AccountRegistry,
     wrapper: AccountWrapper,
     config: ProtocolConfig,
     pricer: Pricer,
+    root: AccumulatorRoot,
+}
+
+public struct SettledInputs {
+    market: ExpiryMarket,
+    account_registry: AccountRegistry,
+    wrapper: AccountWrapper,
+    config: ProtocolConfig,
     root: AccumulatorRoot,
 }
 
@@ -151,12 +156,12 @@ fun owner_authorizes_reauthorizes_and_revokes_session() {
     );
     let authorized = event::events_by_type<SessionAuthorized>();
     assert_eq!(authorized.length(), ONE_EVENT);
-    let (event_account_id, event_session, event_expiration) = sessions::session_authorized_fields(
+    assert_session_authorized_event(
         &authorized[0],
+        account_id,
+        SESSION,
+        SESSION_EXPIRES_AT_MS,
     );
-    assert_eq!(event_account_id, account_id);
-    assert_eq!(event_session, SESSION);
-    assert_eq!(event_expiration, SESSION_EXPIRES_AT_MS);
     return_shared(wrapper);
 
     scenario.next_tx(ALICE);
@@ -175,11 +180,12 @@ fun owner_authorizes_reauthorizes_and_revokes_session() {
     );
     let reauthorized = event::events_by_type<SessionAuthorized>();
     assert_eq!(reauthorized.length(), ONE_EVENT);
-    let (_, event_session, event_expiration) = sessions::session_authorized_fields(
+    assert_session_authorized_event(
         &reauthorized[0],
+        account_id,
+        SESSION,
+        REAUTH_EXPIRES_AT_MS,
     );
-    assert_eq!(event_session, SESSION);
-    assert_eq!(event_expiration, REAUTH_EXPIRES_AT_MS);
     return_shared(wrapper);
 
     scenario.next_tx(ALICE);
@@ -189,12 +195,12 @@ fun owner_authorizes_reauthorizes_and_revokes_session() {
     assert!(wrapper.load_account().has_data<SessionsApp>());
     let revoked = event::events_by_type<SessionRevoked>();
     assert_eq!(revoked.length(), ONE_EVENT);
-    let (event_account_id, event_session, event_expiration) = sessions::session_revoked_fields(
+    assert_session_revoked_event(
         &revoked[0],
+        account_id,
+        SESSION,
+        REAUTH_EXPIRES_AT_MS,
     );
-    assert_eq!(event_account_id, account_id);
-    assert_eq!(event_session, SESSION);
-    assert_eq!(event_expiration, REAUTH_EXPIRES_AT_MS);
     return_shared(wrapper);
 
     scenario.next_tx(ALICE);
@@ -406,20 +412,16 @@ fun non_owner_cannot_revoke_session() {
 
 #[test, expected_failure(abort_code = sessions::ESessionNotAuthorized)]
 fun unapproved_session_cannot_use_predict_wrapper() {
-    let GateFixture {
-        mut scenario,
-        clock,
-        market_id,
-        wrapper_id,
-        config_id,
-        ..,
-    } = setup_gate_fixture();
-    scenario.next_tx(SESSION);
-    let mut market = scenario.take_shared_by_id<ExpiryMarket>(market_id);
-    let account_registry = scenario.take_shared<AccountRegistry>();
-    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
-    let config = scenario.take_shared_by_id<ProtocolConfig>(config_id);
-    let root = scenario.take_shared<AccumulatorRoot>();
+    let mut fixture = setup_flow_fixture(test_constants::default_expiry_ms());
+    let SettledInputs {
+        mut market,
+        account_registry,
+        mut wrapper,
+        config,
+        root,
+    } = begin_settled_tx(&mut fixture, SESSION);
+    let clock = &fixture.clock;
+    let scenario = fixture.predict.scenario_mut();
 
     let (closed_order_id, replacement_order_id) = sessions::redeem_settled(
         &mut market,
@@ -429,7 +431,7 @@ fun unapproved_session_cannot_use_predict_wrapper() {
         MISSING_ORDER_ID,
         CLOSE_QUANTITY,
         &root,
-        &clock,
+        clock,
         scenario.ctx(),
     );
     destroy(closed_order_id);
@@ -440,15 +442,17 @@ fun unapproved_session_cannot_use_predict_wrapper() {
 
 #[test, expected_failure(abort_code = sessions::ESessionNotAuthorized)]
 fun unapproved_session_cannot_mint_exact_quantity() {
-    let (mut scenario, clock, inputs) = setup_unapproved_live_gate();
-    let LiveGateInputs {
+    let mut fixture = setup_flow_fixture(test_constants::default_expiry_ms());
+    let LiveInputs {
         mut market,
         account_registry,
         mut wrapper,
         config,
         pricer,
         root,
-    } = inputs;
+    } = begin_live_tx(&mut fixture, SESSION);
+    let clock = &fixture.clock;
+    let scenario = fixture.predict.scenario_mut();
 
     let order_id = sessions::mint_exact_quantity(
         &mut market,
@@ -456,14 +460,14 @@ fun unapproved_session_cannot_mint_exact_quantity() {
         &mut wrapper,
         &config,
         &pricer,
-        MINT_LOWER_TICK,
-        MINT_HIGHER_TICK,
-        MINT_QUANTITY,
-        mint_leverage!(),
+        predict_helpers::strike_tick(),
+        predict_helpers::pos_inf_tick(),
+        test_constants::mint_quantity(),
+        test_constants::leverage_one_x(),
         std::u64::max_value!(),
         ZERO_PROBABILITY,
         &root,
-        &clock,
+        clock,
         scenario.ctx(),
     );
     destroy(order_id);
@@ -473,15 +477,17 @@ fun unapproved_session_cannot_mint_exact_quantity() {
 
 #[test, expected_failure(abort_code = sessions::ESessionNotAuthorized)]
 fun unapproved_session_cannot_mint_exact_amount() {
-    let (mut scenario, clock, inputs) = setup_unapproved_live_gate();
-    let LiveGateInputs {
+    let mut fixture = setup_flow_fixture(test_constants::default_expiry_ms());
+    let LiveInputs {
         mut market,
         account_registry,
         mut wrapper,
         config,
         pricer,
         root,
-    } = inputs;
+    } = begin_live_tx(&mut fixture, SESSION);
+    let clock = &fixture.clock;
+    let scenario = fixture.predict.scenario_mut();
 
     let order_id = sessions::mint_exact_amount(
         &mut market,
@@ -489,14 +495,14 @@ fun unapproved_session_cannot_mint_exact_amount() {
         &mut wrapper,
         &config,
         &pricer,
-        MINT_LOWER_TICK,
-        MINT_HIGHER_TICK,
-        MINT_MAX_PREMIUM,
-        MINT_QUANTITY,
-        mint_leverage!(),
+        predict_helpers::strike_tick(),
+        predict_helpers::pos_inf_tick(),
+        test_constants::mint_deposit(),
+        test_constants::mint_quantity(),
+        test_constants::leverage_one_x(),
         ZERO_COST,
         &root,
-        &clock,
+        clock,
         scenario.ctx(),
     );
     destroy(order_id);
@@ -506,15 +512,17 @@ fun unapproved_session_cannot_mint_exact_amount() {
 
 #[test, expected_failure(abort_code = sessions::ESessionNotAuthorized)]
 fun unapproved_session_cannot_redeem_live() {
-    let (mut scenario, clock, inputs) = setup_unapproved_live_gate();
-    let LiveGateInputs {
+    let mut fixture = setup_flow_fixture(test_constants::default_expiry_ms());
+    let LiveInputs {
         mut market,
         account_registry,
         mut wrapper,
         config,
         pricer,
         root,
-    } = inputs;
+    } = begin_live_tx(&mut fixture, SESSION);
+    let clock = &fixture.clock;
+    let scenario = fixture.predict.scenario_mut();
 
     let (closed_order_id, replacement_order_id) = sessions::redeem_live(
         &mut market,
@@ -527,7 +535,7 @@ fun unapproved_session_cannot_redeem_live() {
         ZERO_PROBABILITY,
         ZERO_COST,
         &root,
-        &clock,
+        clock,
         scenario.ctx(),
     );
     destroy(closed_order_id);
@@ -538,32 +546,18 @@ fun unapproved_session_cannot_redeem_live() {
 
 #[test, expected_failure(abort_code = sessions::ESessionNotAuthorized)]
 fun session_at_exact_expiration_cannot_use_predict_wrapper() {
-    let GateFixture {
-        mut scenario,
-        mut clock,
-        market_id,
-        wrapper_id,
-        config_id,
-        ..,
-    } = setup_gate_fixture();
-    scenario.next_tx(ALICE);
-    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
-    sessions::authorize_session(
-        &mut wrapper,
-        SESSION,
-        SESSION_DURATION_MS,
-        &clock,
-        scenario.ctx(),
-    );
-    return_shared(wrapper);
-
-    clock.set_for_testing(GATE_SESSION_EXPIRES_AT_MS);
-    scenario.next_tx(SESSION);
-    let mut market = scenario.take_shared_by_id<ExpiryMarket>(market_id);
-    let account_registry = scenario.take_shared<AccountRegistry>();
-    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
-    let config = scenario.take_shared_by_id<ProtocolConfig>(config_id);
-    let root = scenario.take_shared<AccumulatorRoot>();
+    let mut fixture = setup_flow_fixture(test_constants::default_expiry_ms());
+    authorize_flow_session(&mut fixture, SESSION_DURATION_MS);
+    fixture.clock.set_for_testing(FLOW_SESSION_EXPIRES_AT_MS);
+    let SettledInputs {
+        mut market,
+        account_registry,
+        mut wrapper,
+        config,
+        root,
+    } = begin_settled_tx(&mut fixture, SESSION);
+    let clock = &fixture.clock;
+    let scenario = fixture.predict.scenario_mut();
 
     let (closed_order_id, replacement_order_id) = sessions::redeem_settled(
         &mut market,
@@ -573,52 +567,7 @@ fun session_at_exact_expiration_cannot_use_predict_wrapper() {
         MISSING_ORDER_ID,
         CLOSE_QUANTITY,
         &root,
-        &clock,
-        scenario.ctx(),
-    );
-    destroy(closed_order_id);
-    destroy(replacement_order_id);
-
-    abort EUnexpectedSuccess
-}
-
-#[test, expected_failure(abort_code = expiry_market::EMarketNotSettled)]
-fun active_session_passes_session_gate_and_reaches_predict() {
-    let GateFixture {
-        mut scenario,
         clock,
-        market_id,
-        wrapper_id,
-        config_id,
-        ..,
-    } = setup_gate_fixture();
-    scenario.next_tx(ALICE);
-    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
-    sessions::authorize_session(
-        &mut wrapper,
-        SESSION,
-        SESSION_DURATION_MS,
-        &clock,
-        scenario.ctx(),
-    );
-    return_shared(wrapper);
-
-    scenario.next_tx(SESSION);
-    let mut market = scenario.take_shared_by_id<ExpiryMarket>(market_id);
-    let account_registry = scenario.take_shared<AccountRegistry>();
-    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
-    let config = scenario.take_shared_by_id<ProtocolConfig>(config_id);
-    let root = scenario.take_shared<AccumulatorRoot>();
-
-    let (closed_order_id, replacement_order_id) = sessions::redeem_settled(
-        &mut market,
-        &account_registry,
-        &mut wrapper,
-        &config,
-        MISSING_ORDER_ID,
-        CLOSE_QUANTITY,
-        &root,
-        &clock,
         scenario.ctx(),
     );
     destroy(closed_order_id);
@@ -629,27 +578,18 @@ fun active_session_passes_session_gate_and_reaches_predict() {
 
 #[test, expected_failure(abort_code = sessions::ESessionNotAuthorized)]
 fun revoked_session_cannot_use_predict_wrapper() {
-    let GateFixture {
-        mut scenario,
-        clock,
-        market_id,
-        wrapper_id,
-        config_id,
-        ..,
-    } = setup_gate_fixture();
-    authorize_gate_session(&mut scenario, &clock, wrapper_id);
-
-    scenario.next_tx(ALICE);
-    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
-    sessions::revoke_session(&mut wrapper, SESSION, scenario.ctx());
-    return_shared(wrapper);
-
-    scenario.next_tx(SESSION);
-    let mut market = scenario.take_shared_by_id<ExpiryMarket>(market_id);
-    let account_registry = scenario.take_shared<AccountRegistry>();
-    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
-    let config = scenario.take_shared_by_id<ProtocolConfig>(config_id);
-    let root = scenario.take_shared<AccumulatorRoot>();
+    let mut fixture = setup_flow_fixture(test_constants::default_expiry_ms());
+    authorize_flow_session(&mut fixture, SESSION_DURATION_MS);
+    revoke_flow_session(&mut fixture);
+    let SettledInputs {
+        mut market,
+        account_registry,
+        mut wrapper,
+        config,
+        root,
+    } = begin_settled_tx(&mut fixture, SESSION);
+    let clock = &fixture.clock;
+    let scenario = fixture.predict.scenario_mut();
 
     let (closed_order_id, replacement_order_id) = sessions::redeem_settled(
         &mut market,
@@ -659,7 +599,7 @@ fun revoked_session_cannot_use_predict_wrapper() {
         MISSING_ORDER_ID,
         CLOSE_QUANTITY,
         &root,
-        &clock,
+        clock,
         scenario.ctx(),
     );
     destroy(closed_order_id);
@@ -668,168 +608,327 @@ fun revoked_session_cannot_use_predict_wrapper() {
     abort EUnexpectedSuccess
 }
 
-#[test, expected_failure(abort_code = expiry_market::EMintProbabilityAboveMax)]
-fun active_session_reaches_predict_mint_exact_quantity() {
-    let GateFixture {
-        mut scenario,
+#[test, expected_failure(abort_code = sessions::ESessionNotAuthorized)]
+fun another_signer_cannot_use_an_approved_session() {
+    let mut fixture = setup_flow_fixture(test_constants::default_expiry_ms());
+    authorize_flow_session(&mut fixture, SESSION_DURATION_MS);
+    let SettledInputs {
+        mut market,
+        account_registry,
+        mut wrapper,
+        config,
+        root,
+    } = begin_settled_tx(&mut fixture, BOB);
+    let clock = &fixture.clock;
+    let scenario = fixture.predict.scenario_mut();
+
+    let (closed_order_id, replacement_order_id) = sessions::redeem_settled(
+        &mut market,
+        &account_registry,
+        &mut wrapper,
+        &config,
+        MISSING_ORDER_ID,
+        CLOSE_QUANTITY,
+        &root,
         clock,
-        market_id,
-        wrapper_id,
-        config_id,
-        oracle_registry_id,
-        pyth_id,
-        bs_values_id,
-        bs_svi_id,
-    } = setup_gate_fixture();
-    authorize_gate_session(&mut scenario, &clock, wrapper_id);
-    scenario.next_tx(SESSION);
-    let LiveGateInputs {
+        scenario.ctx(),
+    );
+    destroy(closed_order_id);
+    destroy(replacement_order_id);
+
+    abort EUnexpectedSuccess
+}
+
+#[test]
+fun session_mints_exact_quantity_and_redeems_live() {
+    let mut fixture = setup_flow_fixture(test_constants::default_expiry_ms());
+    authorize_flow_session(&mut fixture, SESSION_DURATION_MS);
+    let market_id = fixture.market_id;
+    let LiveInputs {
         mut market,
         account_registry,
         mut wrapper,
         config,
         pricer,
         root,
-    } = take_live_gate_inputs(
-        &mut scenario,
-        market_id,
-        wrapper_id,
-        config_id,
-        oracle_registry_id,
-        pyth_id,
-        bs_values_id,
-        bs_svi_id,
-        &clock,
+    } = begin_live_tx(&mut fixture, SESSION);
+    let clock = &fixture.clock;
+    let scenario = fixture.predict.scenario_mut();
+    // Predict's independent ATM reference anchors the quote; this test owns
+    // forwarding its exact cost and probability through Sessions.
+    let quote = market.quote_mint_for_account(
+        &wrapper,
+        &config,
+        &pricer,
+        predict_helpers::strike_tick(),
+        predict_helpers::pos_inf_tick(),
+        ZERO_PREMIUM,
+        test_constants::mint_quantity(),
+        true,
+        test_constants::leverage_one_x(),
+        &root,
+        clock,
+        scenario.ctx(),
     );
-
+    predict_helpers::assert_atm_entry_probability(quote.entry_probability());
     let order_id = sessions::mint_exact_quantity(
         &mut market,
         &account_registry,
         &mut wrapper,
         &config,
         &pricer,
-        MINT_LOWER_TICK,
-        MINT_HIGHER_TICK,
-        MINT_QUANTITY,
-        mint_leverage!(),
-        std::u64::max_value!(),
-        ZERO_PROBABILITY,
+        predict_helpers::strike_tick(),
+        predict_helpers::pos_inf_tick(),
+        test_constants::mint_quantity(),
+        test_constants::leverage_one_x(),
+        quote.all_in_cost(),
+        quote.entry_probability(),
         &root,
-        &clock,
+        clock,
         scenario.ctx(),
     );
-    destroy(order_id);
+    let post_mint_balance = test_constants::mint_deposit() - quote.all_in_cost();
+    assert_eq!(wrapper.load_account().balance<DUSDC>(&root, clock), post_mint_balance);
+    assert!(predict_account::has_position(wrapper.load_account(), market_id, order_id));
+    assert_eq!(
+        predict_account::expiry_position_count(wrapper.load_account(), market_id),
+        ONE_POSITION,
+    );
+    assert_eq!(event::events_by_type<order_events::OrderMinted>().length(), ONE_EVENT);
+    assert_eq!(
+        sessions::session_expiration_ms(&wrapper, SESSION),
+        option::some(FLOW_SESSION_EXPIRES_AT_MS),
+    );
+    return_live_inputs(LiveInputs { market, account_registry, wrapper, config, pricer, root });
 
-    abort EUnexpectedSuccess
-}
-
-#[test, expected_failure(abort_code = expiry_market::EMintCostCapRequired)]
-fun active_session_reaches_predict_mint_exact_amount() {
-    let GateFixture {
-        mut scenario,
-        clock,
-        market_id,
-        wrapper_id,
-        config_id,
-        oracle_registry_id,
-        pyth_id,
-        bs_values_id,
-        bs_svi_id,
-    } = setup_gate_fixture();
-    authorize_gate_session(&mut scenario, &clock, wrapper_id);
-    scenario.next_tx(SESSION);
-    let LiveGateInputs {
+    fixture.clock.set_for_testing(LIVE_REDEEM_MS);
+    let LiveInputs {
         mut market,
         account_registry,
         mut wrapper,
         config,
         pricer,
         root,
-    } = take_live_gate_inputs(
-        &mut scenario,
-        market_id,
-        wrapper_id,
-        config_id,
-        oracle_registry_id,
-        pyth_id,
-        bs_values_id,
-        bs_svi_id,
-        &clock,
-    );
-
-    let order_id = sessions::mint_exact_amount(
-        &mut market,
-        &account_registry,
-        &mut wrapper,
-        &config,
-        &pricer,
-        MINT_LOWER_TICK,
-        MINT_HIGHER_TICK,
-        MINT_MAX_PREMIUM,
-        MINT_QUANTITY,
-        mint_leverage!(),
-        ZERO_COST,
-        &root,
-        &clock,
-        scenario.ctx(),
-    );
-    destroy(order_id);
-
-    abort EUnexpectedSuccess
-}
-
-#[test, expected_failure(abort_code = order::EInvalidFloorShares)]
-fun active_session_reaches_predict_redeem_live() {
-    let GateFixture {
-        mut scenario,
-        clock,
-        market_id,
-        wrapper_id,
-        config_id,
-        oracle_registry_id,
-        pyth_id,
-        bs_values_id,
-        bs_svi_id,
-    } = setup_gate_fixture();
-    authorize_gate_session(&mut scenario, &clock, wrapper_id);
-    scenario.next_tx(SESSION);
-    let LiveGateInputs {
-        mut market,
-        account_registry,
-        mut wrapper,
-        config,
-        pricer,
-        root,
-    } = take_live_gate_inputs(
-        &mut scenario,
-        market_id,
-        wrapper_id,
-        config_id,
-        oracle_registry_id,
-        pyth_id,
-        bs_values_id,
-        bs_svi_id,
-        &clock,
-    );
-
+    } = begin_live_tx(&mut fixture, SESSION);
+    let clock = &fixture.clock;
+    let scenario = fixture.predict.scenario_mut();
+    let gross_value = market.order_value(option::some(copy pricer), order_id);
     let (closed_order_id, replacement_order_id) = sessions::redeem_live(
         &mut market,
         &account_registry,
         &mut wrapper,
         &config,
         &pricer,
-        MISSING_ORDER_ID,
-        CLOSE_QUANTITY,
+        order_id,
+        test_constants::mint_quantity(),
         ZERO_PROBABILITY,
         ZERO_COST,
         &root,
-        &clock,
+        clock,
         scenario.ctx(),
     );
-    destroy(closed_order_id);
-    destroy(replacement_order_id);
+    assert_eq!(closed_order_id, order_id);
+    assert!(replacement_order_id.is_none());
+    // The public order value is gross of the fixture's one minimum close fee.
+    assert_eq!(
+        wrapper.load_account().balance<DUSDC>(&root, clock),
+        post_mint_balance + gross_value - DEFAULT_TRADE_FEE,
+    );
+    assert!(!predict_account::has_position(wrapper.load_account(), market_id, order_id));
+    assert_eq!(
+        predict_account::expiry_position_count(wrapper.load_account(), market_id),
+        ZERO_POSITIONS,
+    );
+    assert_eq!(event::events_by_type<order_events::LiveOrderRedeemed>().length(), ONE_EVENT);
+    assert_eq!(
+        sessions::session_expiration_ms(&wrapper, SESSION),
+        option::some(FLOW_SESSION_EXPIRES_AT_MS),
+    );
+    return_live_inputs(LiveInputs { market, account_registry, wrapper, config, pricer, root });
+    finish_flow_fixture(fixture);
+}
 
-    abort EUnexpectedSuccess
+#[test]
+fun session_mints_exact_amount() {
+    let mut fixture = setup_flow_fixture(test_constants::default_expiry_ms());
+    authorize_flow_session(&mut fixture, SESSION_DURATION_MS);
+    let market_id = fixture.market_id;
+    let LiveInputs {
+        mut market,
+        account_registry,
+        mut wrapper,
+        config,
+        pricer,
+        root,
+    } = begin_live_tx(&mut fixture, SESSION);
+    let clock = &fixture.clock;
+    let scenario = fixture.predict.scenario_mut();
+    let next_lot_quote = market.quote_mint_for_account(
+        &wrapper,
+        &config,
+        &pricer,
+        predict_helpers::strike_tick(),
+        predict_helpers::pos_inf_tick(),
+        ZERO_PREMIUM,
+        NEXT_LOT_QUANTITY,
+        true,
+        test_constants::leverage_one_x(),
+        &root,
+        clock,
+        scenario.ctx(),
+    );
+    predict_helpers::assert_atm_entry_probability(next_lot_quote.entry_probability());
+    let expected_quote = market.quote_mint_for_account(
+        &wrapper,
+        &config,
+        &pricer,
+        predict_helpers::strike_tick(),
+        predict_helpers::pos_inf_tick(),
+        ZERO_PREMIUM,
+        TEN_THOUSAND_LOTS,
+        true,
+        test_constants::leverage_one_x(),
+        &root,
+        clock,
+        scenario.ctx(),
+    );
+    predict_helpers::assert_atm_entry_probability(expected_quote.entry_probability());
+    // One raw unit below the next lot's premium must size exactly ten thousand lots.
+    let budget = next_lot_quote.net_premium() - ONE_RAW_UNIT;
+    let order_id = sessions::mint_exact_amount(
+        &mut market,
+        &account_registry,
+        &mut wrapper,
+        &config,
+        &pricer,
+        predict_helpers::strike_tick(),
+        predict_helpers::pos_inf_tick(),
+        budget,
+        TEN_THOUSAND_LOTS,
+        test_constants::leverage_one_x(),
+        expected_quote.all_in_cost(),
+        &root,
+        clock,
+        scenario.ctx(),
+    );
+    assert_eq!(expected_quote.quantity(), TEN_THOUSAND_LOTS);
+    assert_eq!(
+        wrapper.load_account().balance<DUSDC>(&root, clock),
+        test_constants::mint_deposit() - expected_quote.all_in_cost(),
+    );
+    assert!(predict_account::has_position(wrapper.load_account(), market_id, order_id));
+    assert_eq!(
+        predict_account::expiry_position_count(wrapper.load_account(), market_id),
+        ONE_POSITION,
+    );
+    assert_eq!(event::events_by_type<order_events::OrderMinted>().length(), ONE_EVENT);
+    assert_eq!(
+        sessions::session_expiration_ms(&wrapper, SESSION),
+        option::some(FLOW_SESSION_EXPIRES_AT_MS),
+    );
+    return_live_inputs(LiveInputs { market, account_registry, wrapper, config, pricer, root });
+    finish_flow_fixture(fixture);
+}
+
+#[test]
+fun session_redeems_settled_order() {
+    let expiry_ms = test_constants::short_expiry_ms();
+    let mut fixture = setup_flow_fixture(expiry_ms);
+    authorize_flow_session(&mut fixture, SETTLEMENT_SESSION_DURATION_MS);
+    let market_id = fixture.market_id;
+    let lower_tick = predict_helpers::strike_tick();
+    let higher_tick = lower_tick + SETTLEMENT_HIGHER_TICK_OFFSET;
+    let LiveInputs {
+        mut market,
+        account_registry,
+        mut wrapper,
+        config,
+        pricer,
+        root,
+    } = begin_live_tx(&mut fixture, SESSION);
+    let clock = &fixture.clock;
+    let scenario = fixture.predict.scenario_mut();
+    // Predict's quote tests own the mint cost; this flow owns session auth and
+    // the independently exact in-range 1x terminal payout.
+    let quote = market.quote_mint_for_account(
+        &wrapper,
+        &config,
+        &pricer,
+        lower_tick,
+        higher_tick,
+        ZERO_PREMIUM,
+        test_constants::mint_quantity(),
+        true,
+        test_constants::leverage_one_x(),
+        &root,
+        clock,
+        scenario.ctx(),
+    );
+    let order_id = sessions::mint_exact_quantity(
+        &mut market,
+        &account_registry,
+        &mut wrapper,
+        &config,
+        &pricer,
+        lower_tick,
+        higher_tick,
+        test_constants::mint_quantity(),
+        test_constants::leverage_one_x(),
+        quote.all_in_cost(),
+        quote.entry_probability(),
+        &root,
+        clock,
+        scenario.ctx(),
+    );
+    let post_mint_balance = test_constants::mint_deposit() - quote.all_in_cost();
+    assert_eq!(wrapper.load_account().balance<DUSDC>(&root, clock), post_mint_balance);
+    assert!(predict_account::has_position(wrapper.load_account(), market_id, order_id));
+    return_live_inputs(LiveInputs { market, account_registry, wrapper, config, pricer, root });
+
+    fixture.clock.set_for_testing(expiry_ms);
+    fixture.predict.set_clock_for_testing(expiry_ms);
+    let settlement_price =
+        (lower_tick + SETTLEMENT_PRICE_TICK_OFFSET) * test_constants::default_tick_size();
+    settle_flow_market(&mut fixture, settlement_price);
+    let SettledInputs {
+        mut market,
+        account_registry,
+        mut wrapper,
+        config,
+        root,
+    } = begin_settled_tx(&mut fixture, SESSION);
+    let clock = &fixture.clock;
+    let scenario = fixture.predict.scenario_mut();
+    assert_eq!(market.order_value(option::none(), order_id), test_constants::mint_quantity());
+    let (closed_order_id, replacement_order_id) = sessions::redeem_settled(
+        &mut market,
+        &account_registry,
+        &mut wrapper,
+        &config,
+        order_id,
+        test_constants::mint_quantity(),
+        &root,
+        clock,
+        scenario.ctx(),
+    );
+    assert_eq!(closed_order_id, order_id);
+    assert!(replacement_order_id.is_none());
+    assert_eq!(
+        wrapper.load_account().balance<DUSDC>(&root, clock),
+        post_mint_balance + test_constants::mint_quantity(),
+    );
+    assert!(!predict_account::has_position(wrapper.load_account(), market_id, order_id));
+    assert_eq!(
+        predict_account::expiry_position_count(wrapper.load_account(), market_id),
+        ZERO_POSITIONS,
+    );
+    assert_eq!(event::events_by_type<order_events::SettledOrderRedeemed>().length(), ONE_EVENT);
+    assert_eq!(
+        sessions::session_expiration_ms(&wrapper, SESSION),
+        option::some(SETTLEMENT_SESSION_EXPIRES_AT_MS),
+    );
+    return_settled_inputs(SettledInputs { market, account_registry, wrapper, config, root });
+    finish_flow_fixture(fixture);
 }
 
 fun session_addresses(): vector<address> {
@@ -875,63 +974,95 @@ fun setup_account(): (Scenario, Clock, ID) {
     (scenario, clock, wrapper_id)
 }
 
-fun authorize_gate_session(scenario: &mut Scenario, clock: &Clock, wrapper_id: ID) {
-    scenario.next_tx(ALICE);
-    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
-    sessions::authorize_session(
-        &mut wrapper,
-        SESSION,
-        SESSION_DURATION_MS,
-        clock,
-        scenario.ctx(),
+fun assert_session_authorized_event(
+    actual: &SessionAuthorized,
+    account_id: ID,
+    session: address,
+    expires_at_ms: u64,
+) {
+    let expected = ExpectedSessionAuthorized { account_id, session, expires_at_ms };
+    assert_eq!(bcs::to_bytes(actual), bcs::to_bytes(&expected));
+}
+
+fun assert_session_revoked_event(
+    actual: &SessionRevoked,
+    account_id: ID,
+    session: address,
+    expires_at_ms: u64,
+) {
+    let expected = ExpectedSessionRevoked { account_id, session, expires_at_ms };
+    assert_eq!(bcs::to_bytes(actual), bcs::to_bytes(&expected));
+}
+
+fun setup_flow_fixture(expiry_ms: u64): SessionFlowFixture {
+    let (mut predict, market_id, trader) = predict_helpers::setup_live_market(
+        expiry_ms,
+        test_constants::default_live_price(),
     );
+    predict.authorize_account_app<SessionsApp>();
+    let owner = predict_helpers::owner(&trader);
+    let config_id = predict.config_id();
+    let pyth_id = predict.pyth_id();
+    let now_ms = predict.clock().timestamp_ms();
+    let mut clock = clock::create_for_testing(predict.scenario_mut().ctx());
+    clock.set_for_testing(now_ms);
+
+    let account_registry = predict.scenario_mut().take_shared<AccountRegistry>();
+    let wrapper_id = account_registry.derived_wrapper_address(owner).to_id();
+    let oracle_registry = predict.scenario_mut().take_shared<OracleRegistry>();
+    let bs_pair = oracle_registry
+        .propbook_block_scholes_store_pair_for_underlying(
+            test_constants::propbook_underlying_id(),
+        )
+        .destroy_some();
+    let bs_values_id = bs_pair.block_scholes_value_store_id();
+    let bs_svi_id = bs_pair.block_scholes_svi_store_id();
+    return_shared(account_registry);
+    return_shared(oracle_registry);
+    predict.scenario_mut().next_tx(test_constants::admin());
+
+    SessionFlowFixture {
+        predict,
+        clock,
+        market_id,
+        owner,
+        wrapper_id,
+        config_id,
+        pyth_id,
+        bs_values_id,
+        bs_svi_id,
+    }
+}
+
+fun authorize_flow_session(fixture: &mut SessionFlowFixture, duration_ms: u64) {
+    let clock = &fixture.clock;
+    let scenario = fixture.predict.scenario_mut();
+    scenario.next_tx(fixture.owner);
+    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(fixture.wrapper_id);
+    sessions::authorize_session(&mut wrapper, SESSION, duration_ms, clock, scenario.ctx());
     return_shared(wrapper);
+    scenario.next_tx(test_constants::admin());
 }
 
-fun setup_unapproved_live_gate(): (Scenario, Clock, LiveGateInputs) {
-    let GateFixture {
-        mut scenario,
-        clock,
-        market_id,
-        wrapper_id,
-        config_id,
-        oracle_registry_id,
-        pyth_id,
-        bs_values_id,
-        bs_svi_id,
-    } = setup_gate_fixture();
-    scenario.next_tx(SESSION);
-    let inputs = take_live_gate_inputs(
-        &mut scenario,
-        market_id,
-        wrapper_id,
-        config_id,
-        oracle_registry_id,
-        pyth_id,
-        bs_values_id,
-        bs_svi_id,
-        &clock,
-    );
-    (scenario, clock, inputs)
+fun revoke_flow_session(fixture: &mut SessionFlowFixture) {
+    let scenario = fixture.predict.scenario_mut();
+    scenario.next_tx(fixture.owner);
+    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(fixture.wrapper_id);
+    sessions::revoke_session(&mut wrapper, SESSION, scenario.ctx());
+    return_shared(wrapper);
+    scenario.next_tx(test_constants::admin());
 }
 
-fun take_live_gate_inputs(
-    scenario: &mut Scenario,
-    market_id: ID,
-    wrapper_id: ID,
-    config_id: ID,
-    oracle_registry_id: ID,
-    pyth_id: ID,
-    bs_values_id: ID,
-    bs_svi_id: ID,
-    clock: &Clock,
-): LiveGateInputs {
-    let market = scenario.take_shared_by_id<ExpiryMarket>(market_id);
-    let config = scenario.take_shared_by_id<ProtocolConfig>(config_id);
-    let oracle_registry = scenario.take_shared_by_id<OracleRegistry>(oracle_registry_id);
-    let pyth = scenario.take_shared_by_id<PythFeed>(pyth_id);
-    let bs_values = scenario.take_shared_by_id<BlockScholesValueStore>(bs_values_id);
-    let bs_svi = scenario.take_shared_by_id<BlockScholesSVIStore>(bs_svi_id);
+fun begin_live_tx(fixture: &mut SessionFlowFixture, sender: address): LiveInputs {
+    let clock = &fixture.clock;
+    let scenario = fixture.predict.scenario_mut();
+    scenario.next_tx(sender);
+    let market = scenario.take_shared_by_id<ExpiryMarket>(fixture.market_id);
+    let config = scenario.take_shared_by_id<ProtocolConfig>(fixture.config_id);
+    let oracle_registry = scenario.take_shared<OracleRegistry>();
+    let pyth = scenario.take_shared_by_id<PythFeed>(fixture.pyth_id);
+    let bs_values = scenario.take_shared_by_id<BlockScholesValueStore>(fixture.bs_values_id);
+    let bs_svi = scenario.take_shared_by_id<BlockScholesSVIStore>(fixture.bs_svi_id);
     let pricer = market.load_live_pricer(
         &config,
         &oracle_registry,
@@ -946,192 +1077,85 @@ fun take_live_gate_inputs(
     return_shared(bs_values);
     return_shared(bs_svi);
 
-    LiveGateInputs {
+    LiveInputs {
         market,
         account_registry: scenario.take_shared<AccountRegistry>(),
-        wrapper: scenario.take_shared_by_id<AccountWrapper>(wrapper_id),
+        wrapper: scenario.take_shared_by_id<AccountWrapper>(fixture.wrapper_id),
         config,
         pricer,
         root: scenario.take_shared<AccumulatorRoot>(),
     }
 }
 
-fun setup_gate_fixture(): GateFixture {
-    let mut scenario = test::begin(ADMIN);
-    scenario.next_tx(@0x0);
-    accumulator::create_for_testing(scenario.ctx());
-    scenario.next_tx(ADMIN);
-    account_registry::init_for_testing(scenario.ctx());
-    let vault_id = plp::init_for_testing(scenario.ctx());
-    let predict_registry_id = predict_registry::init_for_testing(scenario.ctx());
-    propbook_registry::init_for_testing(scenario.ctx());
-    scenario.next_tx(ADMIN);
-
-    let account_admin_cap = scenario.take_from_sender<AccountAdminCap>();
-    let mut account_registry = scenario.take_shared<AccountRegistry>();
-    account_registry.authorize_app<SessionsApp>(&account_admin_cap);
+fun return_live_inputs(inputs: LiveInputs) {
+    let LiveInputs { market, account_registry, wrapper, config, pricer: _, root } = inputs;
+    return_shared(market);
     return_shared(account_registry);
-
-    let admin_cap = scenario.take_from_sender<AdminCap>();
-    let config = scenario.take_shared<ProtocolConfig>();
-    let config_id = config.id();
-    let mut registry = scenario.take_shared_by_id<PredictRegistry>(predict_registry_id);
-    registry.register_underlying(&config, &admin_cap, PROPBOOK_UNDERLYING_ID);
-    registry.set_template_cadence_config(
-        &config,
-        &admin_cap,
-        PROPBOOK_UNDERLYING_ID,
-        market_manager::cadence_one_minute!(),
-        MARKET_TICK_SIZE,
-        MARKET_ADMISSION_TICK_SIZE,
-        MARKET_MAX_EXPIRY_ALLOCATION,
-        MARKET_INITIAL_EXPIRY_CASH,
-        MARKET_CADENCE_WINDOW_SIZE,
-    );
-    let lifecycle_cap = registry.mint_lifecycle_cap(&config, &admin_cap, scenario.ctx());
+    return_shared(wrapper);
     return_shared(config);
-    return_shared(registry);
+    return_shared(root);
+}
 
-    let propbook_admin_cap = scenario.take_from_sender<RegistryAdminCap>();
-    let mut oracle_registry = scenario.take_shared<OracleRegistry>();
-    let oracle_registry_id = oracle_registry.id();
-    let pyth_id = propbook_registry::create_and_share_pyth_feed(
-        &mut oracle_registry,
-        PYTH_SOURCE_ID,
-        scenario.ctx(),
-    );
-    let bs_pair = propbook_registry::create_and_share_block_scholes_stores(
-        &mut oracle_registry,
-        &propbook_admin_cap,
-        PROPBOOK_UNDERLYING_ID,
-        b"BTC".to_string(),
-        scenario.ctx(),
-    );
-    let bs_values_id = bs_pair.block_scholes_value_store_id();
-    let bs_svi_id = bs_pair.block_scholes_svi_store_id();
-    return_shared(oracle_registry);
-
-    scenario.next_tx(ADMIN);
-    let mut oracle_registry = scenario.take_shared_by_id<OracleRegistry>(oracle_registry_id);
-    let mut pyth = scenario.take_shared_by_id<PythFeed>(pyth_id);
-    propbook_registry::bind_pyth_to_underlying(
-        &mut oracle_registry,
-        &propbook_admin_cap,
-        &pyth,
-        PROPBOOK_UNDERLYING_ID,
-    );
-    let mut registry = scenario.take_shared_by_id<PredictRegistry>(predict_registry_id);
-    let mut vault = scenario.take_shared_by_id<PoolVault>(vault_id);
-    let config = scenario.take_shared_by_id<ProtocolConfig>(config_id);
-    let mut clock = clock::create_for_testing(scenario.ctx());
-    clock.set_for_testing(GATE_NOW_MS);
-    let market_id = registry.create_and_share_expiry_market(
-        &mut vault,
-        &config,
-        &oracle_registry,
-        &lifecycle_cap,
-        PROPBOOK_UNDERLYING_ID,
-        market_manager::cadence_one_minute!(),
-        &clock,
-        scenario.ctx(),
-    );
-    pyth_feed::record_raw_for_testing(
-        &mut pyth,
-        LIVE_PRICE,
-        false,
-        PYTH_EXPONENT_NEG_9,
-        true,
-        LIVE_SOURCE_TIMESTAMP_MS * 1000,
-        LIVE_SOURCE_TIMESTAMP_MS * 1000,
-        GATE_NOW_MS,
-        false,
-        scenario.ctx(),
-    );
-    let mut bs_values = scenario.take_shared_by_id<BlockScholesValueStore>(bs_values_id);
-    let spot_sid = bs_values.spot_sid();
-    bs_values.apply_spot_batch(
-        verify::new_value_batch_for_testing(
-            LIVE_SOURCE_TIMESTAMP_MS,
-            vector[
-                verify::new_value_update_for_testing(
-                    spot_sid,
-                    LIVE_SOURCE_TIMESTAMP_MS,
-                    LIVE_PRICE as u128,
-                ),
-            ],
-        ),
-        &clock,
-        scenario.ctx(),
-    );
-    let forward_sid = bs_values.forward_sid(MARKET_EXPIRY_MS);
-    bs_values.apply_forward_batch(
-        verify::new_value_batch_for_testing(
-            LIVE_SOURCE_TIMESTAMP_MS,
-            vector[
-                verify::new_value_update_for_testing(
-                    forward_sid,
-                    LIVE_SOURCE_TIMESTAMP_MS,
-                    LIVE_PRICE as u128,
-                ),
-            ],
-        ),
-        vector[MARKET_EXPIRY_MS],
-        &clock,
-        scenario.ctx(),
-    );
-    let mut bs_svi = scenario.take_shared_by_id<BlockScholesSVIStore>(bs_svi_id);
-    let svi_sid = bs_svi.svi_sid(MARKET_EXPIRY_MS);
-    bs_svi.apply_svi_batch(
-        verify::new_svi_batch_for_testing(
-            GATE_NOW_MS,
-            vector[
-                verify::new_svi_for_testing(
-                    svi_sid,
-                    GATE_NOW_MS,
-                    SVI_A_MAGNITUDE,
-                    false,
-                    SVI_B,
-                    SVI_SIGMA,
-                    SVI_RHO_MAGNITUDE,
-                    false,
-                    SVI_M_MAGNITUDE,
-                    false,
-                ),
-            ],
-        ),
-        vector[MARKET_EXPIRY_MS],
-        &clock,
-        scenario.ctx(),
-    );
-    return_shared(pyth);
-    return_shared(bs_values);
-    return_shared(bs_svi);
-    return_shared(oracle_registry);
-    return_shared(registry);
-    return_shared(vault);
-    return_shared(config);
-    destroy(account_admin_cap);
-    destroy(admin_cap);
-    destroy(propbook_admin_cap);
-    destroy(lifecycle_cap);
-
-    scenario.next_tx(ALICE);
-    let mut account_registry = scenario.take_shared<AccountRegistry>();
-    let wrapper = account_registry.new(scenario.ctx());
-    let wrapper_id = wrapper.id();
-    wrapper.share();
-    return_shared(account_registry);
-    scenario.next_tx(ADMIN);
-
-    GateFixture {
-        scenario,
-        clock,
-        market_id,
-        wrapper_id,
-        config_id,
-        oracle_registry_id,
-        pyth_id,
-        bs_values_id,
-        bs_svi_id,
+fun begin_settled_tx(fixture: &mut SessionFlowFixture, sender: address): SettledInputs {
+    let scenario = fixture.predict.scenario_mut();
+    scenario.next_tx(sender);
+    SettledInputs {
+        market: scenario.take_shared_by_id<ExpiryMarket>(fixture.market_id),
+        account_registry: scenario.take_shared<AccountRegistry>(),
+        wrapper: scenario.take_shared_by_id<AccountWrapper>(fixture.wrapper_id),
+        config: scenario.take_shared_by_id<ProtocolConfig>(fixture.config_id),
+        root: scenario.take_shared<AccumulatorRoot>(),
     }
+}
+
+fun return_settled_inputs(inputs: SettledInputs) {
+    let SettledInputs { market, account_registry, wrapper, config, root } = inputs;
+    return_shared(market);
+    return_shared(account_registry);
+    return_shared(wrapper);
+    return_shared(config);
+    return_shared(root);
+}
+
+fun settle_flow_market(fixture: &mut SessionFlowFixture, settlement_price: u64) {
+    let expiry_ms = fixture.clock.timestamp_ms();
+    fixture.predict.scenario_mut().next_tx(test_constants::admin());
+    let mut pyth = fixture.predict.scenario_mut().take_shared_by_id<PythFeed>(fixture.pyth_id);
+    fixture.predict.insert_exact_settlement_spot(&mut pyth, expiry_ms, settlement_price);
+    return_shared(pyth);
+
+    fixture.predict.scenario_mut().next_tx(test_constants::admin());
+    let mut market = fixture
+        .predict
+        .scenario_mut()
+        .take_shared_by_id<ExpiryMarket>(fixture.market_id);
+    let config = fixture
+        .predict
+        .scenario_mut()
+        .take_shared_by_id<ProtocolConfig>(fixture.config_id);
+    let oracle_registry = fixture.predict.scenario_mut().take_shared<OracleRegistry>();
+    let pyth = fixture.predict.scenario_mut().take_shared_by_id<PythFeed>(fixture.pyth_id);
+    assert_eq!(market.try_settle(&config, &oracle_registry, &pyth, &fixture.clock), true);
+    assert_eq!(market.try_settlement_price(), option::some(settlement_price));
+    return_shared(market);
+    return_shared(config);
+    return_shared(oracle_registry);
+    return_shared(pyth);
+    fixture.predict.scenario_mut().next_tx(test_constants::admin());
+}
+
+fun finish_flow_fixture(fixture: SessionFlowFixture) {
+    let SessionFlowFixture {
+        predict,
+        clock,
+        market_id: _,
+        owner: _,
+        wrapper_id: _,
+        config_id: _,
+        pyth_id: _,
+        bs_values_id: _,
+        bs_svi_id: _,
+    } = fixture;
+    clock.destroy_for_testing();
+    predict.finish();
 }

--- a/packages/sessions/tests/sessions_tests.move
+++ b/packages/sessions/tests/sessions_tests.move
@@ -8,18 +8,23 @@ use account::{
     account::{Self as account, AccountWrapper},
     account_registry::{Self as account_registry, AccountAdminCap, AccountRegistry}
 };
+use bs_oracle::verify;
 use deepbook_predict::{
     admin::AdminCap,
     expiry_market::{Self as expiry_market, ExpiryMarket},
     market_lifecycle_cap::MarketLifecycleCap,
     market_manager,
+    order,
     plp::{Self as plp, PoolVault},
+    pricing::Pricer,
     protocol_config::ProtocolConfig,
     registry::{Self as predict_registry, Registry as PredictRegistry}
 };
 use deepbook_sessions::sessions::{Self as sessions, SessionAuthorized, SessionRevoked, SessionsApp};
+use fixed_math::math;
 use propbook::{
-    pyth_feed::PythFeed,
+    block_scholes_store::{BlockScholesSVIStore, BlockScholesValueStore},
+    pyth_feed::{Self as pyth_feed, PythFeed},
     registry::{Self as propbook_registry, OracleRegistry, RegistryAdminCap}
 };
 use std::unit_test::{assert_eq, destroy};
@@ -57,8 +62,26 @@ const MARKET_INITIAL_EXPIRY_CASH: u64 = 20_000_000_000;
 const MARKET_CADENCE_WINDOW_SIZE: u64 = 1;
 const GATE_NOW_MS: u64 = 120_000;
 const GATE_SESSION_EXPIRES_AT_MS: u64 = 180_000; // 120_000 + 60_000.
+const MARKET_EXPIRY_MS: u64 = 180_000;
+const LIVE_SOURCE_TIMESTAMP_MS: u64 = 119_000;
+const LIVE_PRICE: u64 = 100_000_000_000;
+const PYTH_EXPONENT_NEG_9: u16 = 9;
+const SVI_A_MAGNITUDE: u128 = 1;
+const SVI_B: u128 = 10_000;
+const SVI_SIGMA: u128 = 1_000_000;
+const SVI_RHO_MAGNITUDE: u128 = 1_000_000_000;
+const SVI_M_MAGNITUDE: u128 = 10_000_000_000;
+const MINT_LOWER_TICK: u64 = 0;
+const MINT_HIGHER_TICK: u64 = 100;
+// Ten contracts at an approximately 50% range price stays above Predict's one-DUSDC minimum net premium and is an exact position-lot multiple.
+const MINT_QUANTITY: u64 = 10_000_000;
+const MINT_MAX_PREMIUM: u64 = 1_000;
+const ZERO_COST: u64 = 0;
+const ZERO_PROBABILITY: u64 = 0;
 const MISSING_ORDER_ID: u256 = 1;
 const CLOSE_QUANTITY: u64 = 1;
+
+macro fun mint_leverage(): u64 { math::float_scaling!() }
 
 public struct GateFixture {
     scenario: Scenario,
@@ -66,6 +89,19 @@ public struct GateFixture {
     market_id: ID,
     wrapper_id: ID,
     config_id: ID,
+    oracle_registry_id: ID,
+    pyth_id: ID,
+    bs_values_id: ID,
+    bs_svi_id: ID,
+}
+
+public struct LiveGateInputs {
+    market: ExpiryMarket,
+    account_registry: AccountRegistry,
+    wrapper: AccountWrapper,
+    config: ProtocolConfig,
+    pricer: Pricer,
+    root: AccumulatorRoot,
 }
 
 #[test]
@@ -248,6 +284,7 @@ fun unapproved_session_cannot_use_predict_wrapper() {
         market_id,
         wrapper_id,
         config_id,
+        ..,
     } = setup_gate_fixture();
     scenario.next_tx(SESSION);
     let mut market = scenario.take_shared_by_id<ExpiryMarket>(market_id);
@@ -281,6 +318,7 @@ fun session_at_exact_expiration_cannot_use_predict_wrapper() {
         market_id,
         wrapper_id,
         config_id,
+        ..,
     } = setup_gate_fixture();
     scenario.next_tx(ALICE);
     let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
@@ -326,6 +364,7 @@ fun active_session_passes_session_gate_and_reaches_predict() {
         market_id,
         wrapper_id,
         config_id,
+        ..,
     } = setup_gate_fixture();
     scenario.next_tx(ALICE);
     let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
@@ -362,6 +401,211 @@ fun active_session_passes_session_gate_and_reaches_predict() {
     abort EUnexpectedSuccess
 }
 
+#[test, expected_failure(abort_code = sessions::ESessionNotAuthorized)]
+fun revoked_session_cannot_use_predict_wrapper() {
+    let GateFixture {
+        mut scenario,
+        clock,
+        market_id,
+        wrapper_id,
+        config_id,
+        ..,
+    } = setup_gate_fixture();
+    authorize_gate_session(&mut scenario, &clock, wrapper_id);
+
+    scenario.next_tx(ALICE);
+    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    sessions::revoke_session(&mut wrapper, SESSION, scenario.ctx());
+    return_shared(wrapper);
+
+    scenario.next_tx(SESSION);
+    let mut market = scenario.take_shared_by_id<ExpiryMarket>(market_id);
+    let account_registry = scenario.take_shared<AccountRegistry>();
+    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let config = scenario.take_shared_by_id<ProtocolConfig>(config_id);
+    let root = scenario.take_shared<AccumulatorRoot>();
+
+    let (closed_order_id, replacement_order_id) = sessions::redeem_settled(
+        &mut market,
+        &account_registry,
+        &mut wrapper,
+        &config,
+        MISSING_ORDER_ID,
+        CLOSE_QUANTITY,
+        &root,
+        &clock,
+        scenario.ctx(),
+    );
+    destroy(closed_order_id);
+    destroy(replacement_order_id);
+
+    abort EUnexpectedSuccess
+}
+
+#[test, expected_failure(abort_code = expiry_market::EMintProbabilityAboveMax)]
+fun active_session_reaches_predict_mint_exact_quantity() {
+    let GateFixture {
+        mut scenario,
+        clock,
+        market_id,
+        wrapper_id,
+        config_id,
+        oracle_registry_id,
+        pyth_id,
+        bs_values_id,
+        bs_svi_id,
+    } = setup_gate_fixture();
+    authorize_gate_session(&mut scenario, &clock, wrapper_id);
+    scenario.next_tx(SESSION);
+    let LiveGateInputs {
+        mut market,
+        account_registry,
+        mut wrapper,
+        config,
+        pricer,
+        root,
+    } = take_live_gate_inputs(
+        &mut scenario,
+        market_id,
+        wrapper_id,
+        config_id,
+        oracle_registry_id,
+        pyth_id,
+        bs_values_id,
+        bs_svi_id,
+        &clock,
+    );
+
+    let order_id = sessions::mint_exact_quantity(
+        &mut market,
+        &account_registry,
+        &mut wrapper,
+        &config,
+        &pricer,
+        MINT_LOWER_TICK,
+        MINT_HIGHER_TICK,
+        MINT_QUANTITY,
+        mint_leverage!(),
+        std::u64::max_value!(),
+        ZERO_PROBABILITY,
+        &root,
+        &clock,
+        scenario.ctx(),
+    );
+    destroy(order_id);
+
+    abort EUnexpectedSuccess
+}
+
+#[test, expected_failure(abort_code = expiry_market::EMintCostCapRequired)]
+fun active_session_reaches_predict_mint_exact_amount() {
+    let GateFixture {
+        mut scenario,
+        clock,
+        market_id,
+        wrapper_id,
+        config_id,
+        oracle_registry_id,
+        pyth_id,
+        bs_values_id,
+        bs_svi_id,
+    } = setup_gate_fixture();
+    authorize_gate_session(&mut scenario, &clock, wrapper_id);
+    scenario.next_tx(SESSION);
+    let LiveGateInputs {
+        mut market,
+        account_registry,
+        mut wrapper,
+        config,
+        pricer,
+        root,
+    } = take_live_gate_inputs(
+        &mut scenario,
+        market_id,
+        wrapper_id,
+        config_id,
+        oracle_registry_id,
+        pyth_id,
+        bs_values_id,
+        bs_svi_id,
+        &clock,
+    );
+
+    let order_id = sessions::mint_exact_amount(
+        &mut market,
+        &account_registry,
+        &mut wrapper,
+        &config,
+        &pricer,
+        MINT_LOWER_TICK,
+        MINT_HIGHER_TICK,
+        MINT_MAX_PREMIUM,
+        MINT_QUANTITY,
+        mint_leverage!(),
+        ZERO_COST,
+        &root,
+        &clock,
+        scenario.ctx(),
+    );
+    destroy(order_id);
+
+    abort EUnexpectedSuccess
+}
+
+#[test, expected_failure(abort_code = order::EInvalidFloorShares)]
+fun active_session_reaches_predict_redeem_live() {
+    let GateFixture {
+        mut scenario,
+        clock,
+        market_id,
+        wrapper_id,
+        config_id,
+        oracle_registry_id,
+        pyth_id,
+        bs_values_id,
+        bs_svi_id,
+    } = setup_gate_fixture();
+    authorize_gate_session(&mut scenario, &clock, wrapper_id);
+    scenario.next_tx(SESSION);
+    let LiveGateInputs {
+        mut market,
+        account_registry,
+        mut wrapper,
+        config,
+        pricer,
+        root,
+    } = take_live_gate_inputs(
+        &mut scenario,
+        market_id,
+        wrapper_id,
+        config_id,
+        oracle_registry_id,
+        pyth_id,
+        bs_values_id,
+        bs_svi_id,
+        &clock,
+    );
+
+    let (closed_order_id, replacement_order_id) = sessions::redeem_live(
+        &mut market,
+        &account_registry,
+        &mut wrapper,
+        &config,
+        &pricer,
+        MISSING_ORDER_ID,
+        CLOSE_QUANTITY,
+        ZERO_PROBABILITY,
+        ZERO_COST,
+        &root,
+        &clock,
+        scenario.ctx(),
+    );
+    destroy(closed_order_id);
+    destroy(replacement_order_id);
+
+    abort EUnexpectedSuccess
+}
+
 fun setup_account(): (Scenario, Clock, ID) {
     let mut scenario = test::begin(ADMIN);
     account_registry::init_for_testing(scenario.ctx());
@@ -377,6 +621,60 @@ fun setup_account(): (Scenario, Clock, ID) {
     scenario.next_tx(ADMIN);
 
     (scenario, clock, wrapper_id)
+}
+
+fun authorize_gate_session(scenario: &mut Scenario, clock: &Clock, wrapper_id: ID) {
+    scenario.next_tx(ALICE);
+    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    sessions::authorize_session(
+        &mut wrapper,
+        SESSION,
+        SESSION_DURATION_MS,
+        clock,
+        scenario.ctx(),
+    );
+    return_shared(wrapper);
+}
+
+fun take_live_gate_inputs(
+    scenario: &mut Scenario,
+    market_id: ID,
+    wrapper_id: ID,
+    config_id: ID,
+    oracle_registry_id: ID,
+    pyth_id: ID,
+    bs_values_id: ID,
+    bs_svi_id: ID,
+    clock: &Clock,
+): LiveGateInputs {
+    let market = scenario.take_shared_by_id<ExpiryMarket>(market_id);
+    let config = scenario.take_shared_by_id<ProtocolConfig>(config_id);
+    let oracle_registry = scenario.take_shared_by_id<OracleRegistry>(oracle_registry_id);
+    let pyth = scenario.take_shared_by_id<PythFeed>(pyth_id);
+    let bs_values = scenario.take_shared_by_id<BlockScholesValueStore>(bs_values_id);
+    let bs_svi = scenario.take_shared_by_id<BlockScholesSVIStore>(bs_svi_id);
+    let pricer = market.load_live_pricer(
+        &config,
+        &oracle_registry,
+        &pyth,
+        &bs_values,
+        &bs_svi,
+        clock,
+        scenario.ctx(),
+    );
+    return_shared(oracle_registry);
+    return_shared(pyth);
+    return_shared(bs_values);
+    return_shared(bs_svi);
+
+    LiveGateInputs {
+        market,
+        account_registry: scenario.take_shared<AccountRegistry>(),
+        wrapper: scenario.take_shared_by_id<AccountWrapper>(wrapper_id),
+        config,
+        pricer,
+        root: scenario.take_shared<AccumulatorRoot>(),
+    }
 }
 
 fun setup_gate_fixture(): GateFixture {
@@ -423,18 +721,20 @@ fun setup_gate_fixture(): GateFixture {
         PYTH_SOURCE_ID,
         scenario.ctx(),
     );
-    propbook_registry::create_and_share_block_scholes_stores(
+    let bs_pair = propbook_registry::create_and_share_block_scholes_stores(
         &mut oracle_registry,
         &propbook_admin_cap,
         PROPBOOK_UNDERLYING_ID,
         b"BTC".to_string(),
         scenario.ctx(),
     );
+    let bs_values_id = bs_pair.block_scholes_value_store_id();
+    let bs_svi_id = bs_pair.block_scholes_svi_store_id();
     return_shared(oracle_registry);
 
     scenario.next_tx(ADMIN);
     let mut oracle_registry = scenario.take_shared_by_id<OracleRegistry>(oracle_registry_id);
-    let pyth = scenario.take_shared_by_id<PythFeed>(pyth_id);
+    let mut pyth = scenario.take_shared_by_id<PythFeed>(pyth_id);
     propbook_registry::bind_pyth_to_underlying(
         &mut oracle_registry,
         &propbook_admin_cap,
@@ -456,7 +756,77 @@ fun setup_gate_fixture(): GateFixture {
         &clock,
         scenario.ctx(),
     );
+    pyth_feed::record_raw_for_testing(
+        &mut pyth,
+        LIVE_PRICE,
+        false,
+        PYTH_EXPONENT_NEG_9,
+        true,
+        LIVE_SOURCE_TIMESTAMP_MS * 1000,
+        LIVE_SOURCE_TIMESTAMP_MS * 1000,
+        GATE_NOW_MS,
+        false,
+        scenario.ctx(),
+    );
+    let mut bs_values = scenario.take_shared_by_id<BlockScholesValueStore>(bs_values_id);
+    let spot_sid = bs_values.spot_sid();
+    bs_values.apply_spot_batch(
+        verify::new_value_batch_for_testing(
+            LIVE_SOURCE_TIMESTAMP_MS,
+            vector[
+                verify::new_value_update_for_testing(
+                    spot_sid,
+                    LIVE_SOURCE_TIMESTAMP_MS,
+                    LIVE_PRICE as u128,
+                ),
+            ],
+        ),
+        &clock,
+        scenario.ctx(),
+    );
+    let forward_sid = bs_values.forward_sid(MARKET_EXPIRY_MS);
+    bs_values.apply_forward_batch(
+        verify::new_value_batch_for_testing(
+            LIVE_SOURCE_TIMESTAMP_MS,
+            vector[
+                verify::new_value_update_for_testing(
+                    forward_sid,
+                    LIVE_SOURCE_TIMESTAMP_MS,
+                    LIVE_PRICE as u128,
+                ),
+            ],
+        ),
+        vector[MARKET_EXPIRY_MS],
+        &clock,
+        scenario.ctx(),
+    );
+    let mut bs_svi = scenario.take_shared_by_id<BlockScholesSVIStore>(bs_svi_id);
+    let svi_sid = bs_svi.svi_sid(MARKET_EXPIRY_MS);
+    bs_svi.apply_svi_batch(
+        verify::new_svi_batch_for_testing(
+            GATE_NOW_MS,
+            vector[
+                verify::new_svi_for_testing(
+                    svi_sid,
+                    GATE_NOW_MS,
+                    SVI_A_MAGNITUDE,
+                    false,
+                    SVI_B,
+                    SVI_SIGMA,
+                    SVI_RHO_MAGNITUDE,
+                    false,
+                    SVI_M_MAGNITUDE,
+                    false,
+                ),
+            ],
+        ),
+        vector[MARKET_EXPIRY_MS],
+        &clock,
+        scenario.ctx(),
+    );
     return_shared(pyth);
+    return_shared(bs_values);
+    return_shared(bs_svi);
     return_shared(oracle_registry);
     return_shared(registry);
     return_shared(vault);
@@ -474,5 +844,15 @@ fun setup_gate_fixture(): GateFixture {
     return_shared(account_registry);
     scenario.next_tx(ADMIN);
 
-    GateFixture { scenario, clock, market_id, wrapper_id, config_id }
+    GateFixture {
+        scenario,
+        clock,
+        market_id,
+        wrapper_id,
+        config_id,
+        oracle_registry_id,
+        pyth_id,
+        bs_values_id,
+        bs_svi_id,
+    }
 }

--- a/packages/sessions/tests/sessions_tests.move
+++ b/packages/sessions/tests/sessions_tests.move
@@ -1,0 +1,478 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module deepbook_sessions::sessions_tests;
+
+use account::{
+    account::{Self as account, AccountWrapper},
+    account_registry::{Self as account_registry, AccountAdminCap, AccountRegistry}
+};
+use deepbook_predict::{
+    admin::AdminCap,
+    expiry_market::{Self as expiry_market, ExpiryMarket},
+    market_lifecycle_cap::MarketLifecycleCap,
+    market_manager,
+    plp::{Self as plp, PoolVault},
+    protocol_config::ProtocolConfig,
+    registry::{Self as predict_registry, Registry as PredictRegistry}
+};
+use deepbook_sessions::sessions::{Self as sessions, SessionAuthorized, SessionRevoked, SessionsApp};
+use propbook::{
+    pyth_feed::PythFeed,
+    registry::{Self as propbook_registry, OracleRegistry, RegistryAdminCap}
+};
+use std::unit_test::{assert_eq, destroy};
+use sui::{
+    accumulator::{Self as accumulator, AccumulatorRoot},
+    clock::{Self as clock, Clock},
+    event,
+    test_scenario::{Self as test, Scenario, return_shared}
+};
+
+const ADMIN: address = @0xAD;
+const ALICE: address = @0xA11CE;
+const BOB: address = @0xB0B;
+const SESSION: address = @0x5E5510;
+
+const NOW_MS: u64 = 1_000;
+const SESSION_DURATION_MS: u64 = 60_000;
+const SESSION_EXPIRES_AT_MS: u64 = 61_000; // 1_000 + 60_000.
+const REAUTH_NOW_MS: u64 = 2_000;
+const REAUTH_DURATION_MS: u64 = 120_000;
+const REAUTH_EXPIRES_AT_MS: u64 = 122_000; // 2_000 + 120_000.
+const MAX_SESSION_DURATION_MS: u64 = 2_592_000_000; // 30 days.
+const MAX_SESSION_EXPIRES_AT_MS: u64 = 2_592_001_000; // 1_000 + 30 days.
+const ABOVE_MAX_SESSION_DURATION_MS: u64 = 2_592_000_001;
+const ZERO_DURATION_MS: u64 = 0;
+const ONE_EVENT: u64 = 1;
+const EUnexpectedSuccess: u64 = 999;
+
+const PROPBOOK_UNDERLYING_ID: u32 = 42;
+const PYTH_SOURCE_ID: u32 = 1;
+const MARKET_TICK_SIZE: u64 = 1_000_000_000;
+const MARKET_ADMISSION_TICK_SIZE: u64 = 10_000_000_000;
+const MARKET_MAX_EXPIRY_ALLOCATION: u64 = 250_000_000_000;
+const MARKET_INITIAL_EXPIRY_CASH: u64 = 20_000_000_000;
+const MARKET_CADENCE_WINDOW_SIZE: u64 = 1;
+const GATE_NOW_MS: u64 = 120_000;
+const GATE_SESSION_EXPIRES_AT_MS: u64 = 180_000; // 120_000 + 60_000.
+const MISSING_ORDER_ID: u256 = 1;
+const CLOSE_QUANTITY: u64 = 1;
+
+public struct GateFixture {
+    scenario: Scenario,
+    clock: Clock,
+    market_id: ID,
+    wrapper_id: ID,
+    config_id: ID,
+}
+
+#[test]
+fun owner_authorizes_reauthorizes_and_revokes_session() {
+    let (mut scenario, mut clock, wrapper_id) = setup_account();
+
+    scenario.next_tx(ALICE);
+    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let account_id = wrapper.load_account().account_id();
+    assert!(sessions::session_expiration_ms(&wrapper, SESSION).is_none());
+    sessions::authorize_session(
+        &mut wrapper,
+        SESSION,
+        SESSION_DURATION_MS,
+        &clock,
+        scenario.ctx(),
+    );
+    assert_eq!(
+        sessions::session_expiration_ms(&wrapper, SESSION),
+        option::some(SESSION_EXPIRES_AT_MS),
+    );
+    let authorized = event::events_by_type<SessionAuthorized>();
+    assert_eq!(authorized.length(), ONE_EVENT);
+    let (event_account_id, event_session, event_expiration) = sessions::session_authorized_fields(
+        &authorized[0],
+    );
+    assert_eq!(event_account_id, account_id);
+    assert_eq!(event_session, SESSION);
+    assert_eq!(event_expiration, SESSION_EXPIRES_AT_MS);
+    return_shared(wrapper);
+
+    scenario.next_tx(ALICE);
+    clock.set_for_testing(REAUTH_NOW_MS);
+    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    sessions::authorize_session(
+        &mut wrapper,
+        SESSION,
+        REAUTH_DURATION_MS,
+        &clock,
+        scenario.ctx(),
+    );
+    assert_eq!(
+        sessions::session_expiration_ms(&wrapper, SESSION),
+        option::some(REAUTH_EXPIRES_AT_MS),
+    );
+    let reauthorized = event::events_by_type<SessionAuthorized>();
+    assert_eq!(reauthorized.length(), ONE_EVENT);
+    let (_, event_session, event_expiration) = sessions::session_authorized_fields(
+        &reauthorized[0],
+    );
+    assert_eq!(event_session, SESSION);
+    assert_eq!(event_expiration, REAUTH_EXPIRES_AT_MS);
+    return_shared(wrapper);
+
+    scenario.next_tx(ALICE);
+    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    sessions::revoke_session(&mut wrapper, SESSION, scenario.ctx());
+    assert!(sessions::session_expiration_ms(&wrapper, SESSION).is_none());
+    let revoked = event::events_by_type<SessionRevoked>();
+    assert_eq!(revoked.length(), ONE_EVENT);
+    let (event_account_id, event_session, event_expiration) = sessions::session_revoked_fields(
+        &revoked[0],
+    );
+    assert_eq!(event_account_id, account_id);
+    assert_eq!(event_session, SESSION);
+    assert_eq!(event_expiration, REAUTH_EXPIRES_AT_MS);
+    return_shared(wrapper);
+
+    scenario.next_tx(ALICE);
+    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    sessions::revoke_session(&mut wrapper, SESSION, scenario.ctx());
+    assert!(sessions::session_expiration_ms(&wrapper, SESSION).is_none());
+    assert!(event::events_by_type<SessionRevoked>().is_empty());
+    return_shared(wrapper);
+
+    clock.destroy_for_testing();
+    scenario.end();
+}
+
+#[test]
+fun maximum_session_duration_is_accepted() {
+    let (mut scenario, clock, wrapper_id) = setup_account();
+    scenario.next_tx(ALICE);
+    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+
+    sessions::authorize_session(
+        &mut wrapper,
+        SESSION,
+        MAX_SESSION_DURATION_MS,
+        &clock,
+        scenario.ctx(),
+    );
+
+    assert_eq!(
+        sessions::session_expiration_ms(&wrapper, SESSION),
+        option::some(MAX_SESSION_EXPIRES_AT_MS),
+    );
+    return_shared(wrapper);
+    clock.destroy_for_testing();
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = sessions::EInvalidSessionDuration)]
+fun zero_session_duration_aborts() {
+    let (mut scenario, clock, wrapper_id) = setup_account();
+    scenario.next_tx(ALICE);
+    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+
+    sessions::authorize_session(
+        &mut wrapper,
+        SESSION,
+        ZERO_DURATION_MS,
+        &clock,
+        scenario.ctx(),
+    );
+
+    abort EUnexpectedSuccess
+}
+
+#[test, expected_failure(abort_code = sessions::EInvalidSessionDuration)]
+fun session_duration_above_maximum_aborts() {
+    let (mut scenario, clock, wrapper_id) = setup_account();
+    scenario.next_tx(ALICE);
+    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+
+    sessions::authorize_session(
+        &mut wrapper,
+        SESSION,
+        ABOVE_MAX_SESSION_DURATION_MS,
+        &clock,
+        scenario.ctx(),
+    );
+
+    abort EUnexpectedSuccess
+}
+
+#[test, expected_failure(abort_code = account::EInvalidOwner)]
+fun non_owner_cannot_authorize_session() {
+    let (mut scenario, clock, wrapper_id) = setup_account();
+    scenario.next_tx(BOB);
+    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+
+    sessions::authorize_session(
+        &mut wrapper,
+        SESSION,
+        SESSION_DURATION_MS,
+        &clock,
+        scenario.ctx(),
+    );
+
+    abort EUnexpectedSuccess
+}
+
+#[test, expected_failure(abort_code = account::EInvalidOwner)]
+fun non_owner_cannot_revoke_session() {
+    let (mut scenario, clock, wrapper_id) = setup_account();
+    scenario.next_tx(ALICE);
+    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    sessions::authorize_session(
+        &mut wrapper,
+        SESSION,
+        SESSION_DURATION_MS,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(wrapper);
+
+    scenario.next_tx(BOB);
+    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    sessions::revoke_session(&mut wrapper, SESSION, scenario.ctx());
+
+    abort EUnexpectedSuccess
+}
+
+#[test, expected_failure(abort_code = sessions::ESessionNotAuthorized)]
+fun unapproved_session_cannot_use_predict_wrapper() {
+    let GateFixture {
+        mut scenario,
+        clock,
+        market_id,
+        wrapper_id,
+        config_id,
+    } = setup_gate_fixture();
+    scenario.next_tx(SESSION);
+    let mut market = scenario.take_shared_by_id<ExpiryMarket>(market_id);
+    let account_registry = scenario.take_shared<AccountRegistry>();
+    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let config = scenario.take_shared_by_id<ProtocolConfig>(config_id);
+    let root = scenario.take_shared<AccumulatorRoot>();
+
+    let (closed_order_id, replacement_order_id) = sessions::redeem_settled(
+        &mut market,
+        &account_registry,
+        &mut wrapper,
+        &config,
+        MISSING_ORDER_ID,
+        CLOSE_QUANTITY,
+        &root,
+        &clock,
+        scenario.ctx(),
+    );
+    destroy(closed_order_id);
+    destroy(replacement_order_id);
+
+    abort EUnexpectedSuccess
+}
+
+#[test, expected_failure(abort_code = sessions::ESessionNotAuthorized)]
+fun session_at_exact_expiration_cannot_use_predict_wrapper() {
+    let GateFixture {
+        mut scenario,
+        mut clock,
+        market_id,
+        wrapper_id,
+        config_id,
+    } = setup_gate_fixture();
+    scenario.next_tx(ALICE);
+    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    sessions::authorize_session(
+        &mut wrapper,
+        SESSION,
+        SESSION_DURATION_MS,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(wrapper);
+
+    clock.set_for_testing(GATE_SESSION_EXPIRES_AT_MS);
+    scenario.next_tx(SESSION);
+    let mut market = scenario.take_shared_by_id<ExpiryMarket>(market_id);
+    let account_registry = scenario.take_shared<AccountRegistry>();
+    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let config = scenario.take_shared_by_id<ProtocolConfig>(config_id);
+    let root = scenario.take_shared<AccumulatorRoot>();
+
+    let (closed_order_id, replacement_order_id) = sessions::redeem_settled(
+        &mut market,
+        &account_registry,
+        &mut wrapper,
+        &config,
+        MISSING_ORDER_ID,
+        CLOSE_QUANTITY,
+        &root,
+        &clock,
+        scenario.ctx(),
+    );
+    destroy(closed_order_id);
+    destroy(replacement_order_id);
+
+    abort EUnexpectedSuccess
+}
+
+#[test, expected_failure(abort_code = expiry_market::EMarketNotSettled)]
+fun active_session_passes_session_gate_and_reaches_predict() {
+    let GateFixture {
+        mut scenario,
+        clock,
+        market_id,
+        wrapper_id,
+        config_id,
+    } = setup_gate_fixture();
+    scenario.next_tx(ALICE);
+    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    sessions::authorize_session(
+        &mut wrapper,
+        SESSION,
+        SESSION_DURATION_MS,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(wrapper);
+
+    scenario.next_tx(SESSION);
+    let mut market = scenario.take_shared_by_id<ExpiryMarket>(market_id);
+    let account_registry = scenario.take_shared<AccountRegistry>();
+    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let config = scenario.take_shared_by_id<ProtocolConfig>(config_id);
+    let root = scenario.take_shared<AccumulatorRoot>();
+
+    let (closed_order_id, replacement_order_id) = sessions::redeem_settled(
+        &mut market,
+        &account_registry,
+        &mut wrapper,
+        &config,
+        MISSING_ORDER_ID,
+        CLOSE_QUANTITY,
+        &root,
+        &clock,
+        scenario.ctx(),
+    );
+    destroy(closed_order_id);
+    destroy(replacement_order_id);
+
+    abort EUnexpectedSuccess
+}
+
+fun setup_account(): (Scenario, Clock, ID) {
+    let mut scenario = test::begin(ADMIN);
+    account_registry::init_for_testing(scenario.ctx());
+    let mut clock = clock::create_for_testing(scenario.ctx());
+    clock.set_for_testing(NOW_MS);
+
+    scenario.next_tx(ALICE);
+    let mut registry = scenario.take_shared<AccountRegistry>();
+    let wrapper = registry.new(scenario.ctx());
+    let wrapper_id = wrapper.id();
+    wrapper.share();
+    return_shared(registry);
+    scenario.next_tx(ADMIN);
+
+    (scenario, clock, wrapper_id)
+}
+
+fun setup_gate_fixture(): GateFixture {
+    let mut scenario = test::begin(ADMIN);
+    scenario.next_tx(@0x0);
+    accumulator::create_for_testing(scenario.ctx());
+    scenario.next_tx(ADMIN);
+    account_registry::init_for_testing(scenario.ctx());
+    let vault_id = plp::init_for_testing(scenario.ctx());
+    let predict_registry_id = predict_registry::init_for_testing(scenario.ctx());
+    propbook_registry::init_for_testing(scenario.ctx());
+    scenario.next_tx(ADMIN);
+
+    let account_admin_cap = scenario.take_from_sender<AccountAdminCap>();
+    let mut account_registry = scenario.take_shared<AccountRegistry>();
+    account_registry.authorize_app<SessionsApp>(&account_admin_cap);
+    return_shared(account_registry);
+
+    let admin_cap = scenario.take_from_sender<AdminCap>();
+    let config = scenario.take_shared<ProtocolConfig>();
+    let config_id = config.id();
+    let mut registry = scenario.take_shared_by_id<PredictRegistry>(predict_registry_id);
+    registry.register_underlying(&config, &admin_cap, PROPBOOK_UNDERLYING_ID);
+    registry.set_template_cadence_config(
+        &config,
+        &admin_cap,
+        PROPBOOK_UNDERLYING_ID,
+        market_manager::cadence_one_minute!(),
+        MARKET_TICK_SIZE,
+        MARKET_ADMISSION_TICK_SIZE,
+        MARKET_MAX_EXPIRY_ALLOCATION,
+        MARKET_INITIAL_EXPIRY_CASH,
+        MARKET_CADENCE_WINDOW_SIZE,
+    );
+    let lifecycle_cap = registry.mint_lifecycle_cap(&config, &admin_cap, scenario.ctx());
+    return_shared(config);
+    return_shared(registry);
+
+    let propbook_admin_cap = scenario.take_from_sender<RegistryAdminCap>();
+    let mut oracle_registry = scenario.take_shared<OracleRegistry>();
+    let oracle_registry_id = oracle_registry.id();
+    let pyth_id = propbook_registry::create_and_share_pyth_feed(
+        &mut oracle_registry,
+        PYTH_SOURCE_ID,
+        scenario.ctx(),
+    );
+    propbook_registry::create_and_share_block_scholes_stores(
+        &mut oracle_registry,
+        &propbook_admin_cap,
+        PROPBOOK_UNDERLYING_ID,
+        b"BTC".to_string(),
+        scenario.ctx(),
+    );
+    return_shared(oracle_registry);
+
+    scenario.next_tx(ADMIN);
+    let mut oracle_registry = scenario.take_shared_by_id<OracleRegistry>(oracle_registry_id);
+    let pyth = scenario.take_shared_by_id<PythFeed>(pyth_id);
+    propbook_registry::bind_pyth_to_underlying(
+        &mut oracle_registry,
+        &propbook_admin_cap,
+        &pyth,
+        PROPBOOK_UNDERLYING_ID,
+    );
+    let mut registry = scenario.take_shared_by_id<PredictRegistry>(predict_registry_id);
+    let mut vault = scenario.take_shared_by_id<PoolVault>(vault_id);
+    let config = scenario.take_shared_by_id<ProtocolConfig>(config_id);
+    let mut clock = clock::create_for_testing(scenario.ctx());
+    clock.set_for_testing(GATE_NOW_MS);
+    let market_id = registry.create_and_share_expiry_market(
+        &mut vault,
+        &config,
+        &oracle_registry,
+        &lifecycle_cap,
+        PROPBOOK_UNDERLYING_ID,
+        market_manager::cadence_one_minute!(),
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(pyth);
+    return_shared(oracle_registry);
+    return_shared(registry);
+    return_shared(vault);
+    return_shared(config);
+    destroy(account_admin_cap);
+    destroy(admin_cap);
+    destroy(propbook_admin_cap);
+    destroy(lifecycle_cap);
+
+    scenario.next_tx(ALICE);
+    let mut account_registry = scenario.take_shared<AccountRegistry>();
+    let wrapper = account_registry.new(scenario.ctx());
+    let wrapper_id = wrapper.id();
+    wrapper.share();
+    return_shared(account_registry);
+    scenario.next_tx(ADMIN);
+
+    GateFixture { scenario, clock, market_id, wrapper_id, config_id }
+}

--- a/packages/sessions/tests/sessions_tests.move
+++ b/packages/sessions/tests/sessions_tests.move
@@ -160,6 +160,7 @@ fun owner_authorizes_reauthorizes_and_revokes_session() {
     let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
     sessions::revoke_session(&mut wrapper, SESSION, scenario.ctx());
     assert!(sessions::session_expiration_ms(&wrapper, SESSION).is_none());
+    assert!(!wrapper.load_account().has_data<SessionsApp>());
     let revoked = event::events_by_type<SessionRevoked>();
     assert_eq!(revoked.length(), ONE_EVENT);
     let (event_account_id, event_session, event_expiration) = sessions::session_revoked_fields(
@@ -300,6 +301,104 @@ fun unapproved_session_cannot_use_predict_wrapper() {
         &config,
         MISSING_ORDER_ID,
         CLOSE_QUANTITY,
+        &root,
+        &clock,
+        scenario.ctx(),
+    );
+    destroy(closed_order_id);
+    destroy(replacement_order_id);
+
+    abort EUnexpectedSuccess
+}
+
+#[test, expected_failure(abort_code = sessions::ESessionNotAuthorized)]
+fun unapproved_session_cannot_mint_exact_quantity() {
+    let (mut scenario, clock, inputs) = setup_unapproved_live_gate();
+    let LiveGateInputs {
+        mut market,
+        account_registry,
+        mut wrapper,
+        config,
+        pricer,
+        root,
+    } = inputs;
+
+    let order_id = sessions::mint_exact_quantity(
+        &mut market,
+        &account_registry,
+        &mut wrapper,
+        &config,
+        &pricer,
+        MINT_LOWER_TICK,
+        MINT_HIGHER_TICK,
+        MINT_QUANTITY,
+        mint_leverage!(),
+        std::u64::max_value!(),
+        ZERO_PROBABILITY,
+        &root,
+        &clock,
+        scenario.ctx(),
+    );
+    destroy(order_id);
+
+    abort EUnexpectedSuccess
+}
+
+#[test, expected_failure(abort_code = sessions::ESessionNotAuthorized)]
+fun unapproved_session_cannot_mint_exact_amount() {
+    let (mut scenario, clock, inputs) = setup_unapproved_live_gate();
+    let LiveGateInputs {
+        mut market,
+        account_registry,
+        mut wrapper,
+        config,
+        pricer,
+        root,
+    } = inputs;
+
+    let order_id = sessions::mint_exact_amount(
+        &mut market,
+        &account_registry,
+        &mut wrapper,
+        &config,
+        &pricer,
+        MINT_LOWER_TICK,
+        MINT_HIGHER_TICK,
+        MINT_MAX_PREMIUM,
+        MINT_QUANTITY,
+        mint_leverage!(),
+        ZERO_COST,
+        &root,
+        &clock,
+        scenario.ctx(),
+    );
+    destroy(order_id);
+
+    abort EUnexpectedSuccess
+}
+
+#[test, expected_failure(abort_code = sessions::ESessionNotAuthorized)]
+fun unapproved_session_cannot_redeem_live() {
+    let (mut scenario, clock, inputs) = setup_unapproved_live_gate();
+    let LiveGateInputs {
+        mut market,
+        account_registry,
+        mut wrapper,
+        config,
+        pricer,
+        root,
+    } = inputs;
+
+    let (closed_order_id, replacement_order_id) = sessions::redeem_live(
+        &mut market,
+        &account_registry,
+        &mut wrapper,
+        &config,
+        &pricer,
+        MISSING_ORDER_ID,
+        CLOSE_QUANTITY,
+        ZERO_PROBABILITY,
+        ZERO_COST,
         &root,
         &clock,
         scenario.ctx(),
@@ -634,6 +733,33 @@ fun authorize_gate_session(scenario: &mut Scenario, clock: &Clock, wrapper_id: I
         scenario.ctx(),
     );
     return_shared(wrapper);
+}
+
+fun setup_unapproved_live_gate(): (Scenario, Clock, LiveGateInputs) {
+    let GateFixture {
+        mut scenario,
+        clock,
+        market_id,
+        wrapper_id,
+        config_id,
+        oracle_registry_id,
+        pyth_id,
+        bs_values_id,
+        bs_svi_id,
+    } = setup_gate_fixture();
+    scenario.next_tx(SESSION);
+    let inputs = take_live_gate_inputs(
+        &mut scenario,
+        market_id,
+        wrapper_id,
+        config_id,
+        oracle_registry_id,
+        pyth_id,
+        bs_values_id,
+        bs_svi_id,
+        &clock,
+    );
+    (scenario, clock, inputs)
 }
 
 fun take_live_gate_inputs(


### PR DESCRIPTION
## Summary

- Add a `deepbook_sessions` Move package with owner-managed, account-local session expirations stored in a bounded `VecMap`.
- Allow an active session signer to call Predict exact-quantity mint, exact-amount mint, live redeem, and settled redeem through narrowly scoped wrappers.
- Cover session lifecycle and real successful Predict mint/redeem state transitions with direct Move integration tests.

## Why

DeepBook app users trade Predict positions through their canonical Account, whose owner normally signs each account-authorized transaction. The app needs a short-lived signer stored on the user's device to submit routine Predict transactions without exposing a withdrawal path or reusable Account authorization.

## Linear / Context

- [DBU-707](https://linear.app/mysten-labs/issue/DBU-707/enable-time-limited-predict-sessions-for-account-users)

## Key decisions

- Session grants are available only to EOA-owned Accounts and accept a duration measured from on-chain execution time, capped at 30 days.
- Each Account stores at most 20 session addresses in a `VecMap<address, u64>`. Reauthorization replaces an existing address's expiration in place, while revocation removes the address and frees its slot. Expired entries continue to consume a slot until revoked.
- Once the Sessions app-data slot is attached to an Account, it remains attached even when all session addresses have been revoked.
- A session stores only its signer address and expiration. While active, it may use all four wrappers with caller-selected Predict arguments; it cannot grant sessions, withdraw funds, or receive the generated Account auth.
- `SessionAuthorized` records both initial grants and reauthorizations. `SessionRevoked` is emitted only when an existing entry is removed, and both events carry the stored expiration.
- Expiration emits no event because time passing does not execute Move code. The wrappers emit no duplicate trade events because Predict already records the underlying mint and redeem transitions.
- The wrappers follow the Predict testnet 7-29 public interface at source anchor `a92ceb01`; the Sessions root mirrors Predict's Pyth and Wormhole replacement identities for that lineage.

## Scope / Descoped

- This PR includes the Sessions package source, direct Move tests, package README, and dependency linkage needed for the intended testnet lineage.
- Predict gains two generic test-only fixture helpers so a dependent package can authorize its Account app and use the fixture's positive-infinity tick. Predict production source and behavior are unchanged.
- SDK and frontend work, indexer/API consumption, `Published.toml` publication records, Account app authorization, and deployment are deliberately deferred.

## Test plan

- [x] Move formatting checked with the repository-pinned `prettier-move` version.
- [x] `sui move test --path packages/sessions --gas-limit 100000000000` — all 18 tests pass, including successful exact-quantity mint/live redeem, exact-amount mint, settled redeem, session isolation, lifecycle, and guard coverage.
- [x] `sui move build --path packages/sessions --warnings-are-errors` — builds the package and dependency graph without warnings.
- [x] `sui move test --path packages/predict --gas-limit 100000000000` — all 554 Predict tests pass.
- [x] `sui move build --path packages/predict --warnings-are-errors` — builds with only the package's existing suppressed linter warning.
- [x] `python3 packages/predict/predeploy/check.py` — Predict register and cross-reference checks pass with zero warnings.
- [x] Compare the four forwarded signatures with `git show a92ceb01:packages/predict/sources/expiry_market.move` — confirms the wrappers match the Predict testnet 7-29 interface.

## Risk / Rollout

This PR has no runtime effect until the package is published and `SessionsApp` is authorized in the Account registry. Once authorized, the package is trusted Account infrastructure: a compromised active session can submit adverse Predict trades until the owner revokes it or it expires, and registry-level deauthorization is the global break-glass control. If the package is published upgradeably, upgrade-cap custody is also part of this trust boundary.
