### PR TITLE
margin_liquidation: add upgraded-Pyth liquidation entrypoints (DBU-668)

### DIFF
--- a/packages/margin_liquidation/Move.lock
+++ b/packages/margin_liquidation/Move.lock
@@ -67,8 +67,8 @@ deps = { deepbook = "deepbook", pyth = "Pyth", pyth_upgraded = "PythProCompatibl
 [pinned.mainnet.margin_liquidation]
 source = { root = true }
 use_environment = "mainnet"
-manifest_digest = "7721CC3A1C8F05A632ACD9BCC88A257DEB2909BBD46126F9270D7CD67E401731"
-deps = { deepbook = "deepbook", deepbook_margin = "deepbook_margin", pyth = "Pyth", std = "MoveStdlib", sui = "Sui", token = "token" }
+manifest_digest = "B97E117E653C85DCC2E5A19DA6CFCC8C177F0D6E05A75617035A434A5997DFF2"
+deps = { deepbook = "deepbook", deepbook_margin = "deepbook_margin", pyth = "Pyth", pyth_upgraded = "PythProCompatible", std = "MoveStdlib", sui = "Sui", token = "token" }
 
 [pinned.mainnet.token]
 source = { git = "https://github.com/MystenLabs/deepbookv3.git", subdir = "packages/token", rev = "2e0a88f860f1ae64f709b3978f1e206a91771169" }
@@ -139,8 +139,8 @@ deps = { deepbook = "deepbook", pyth = "Pyth", pyth_upgraded = "PythProCompatibl
 [pinned.testnet.margin_liquidation]
 source = { root = true }
 use_environment = "testnet"
-manifest_digest = "56AC82023B117F89A629BF2EB76AAF63841990AE835AC41AB35CC5AF466AC876"
-deps = { deepbook = "deepbook", deepbook_margin = "deepbook_margin", pyth = "Pyth", std = "MoveStdlib", sui = "Sui", token = "token" }
+manifest_digest = "A7720ED34155DD32B82A81E6DFE2F7B66A81AAB7F96BFBF7226DEA35A19B7BF6"
+deps = { deepbook = "deepbook", deepbook_margin = "deepbook_margin", pyth = "Pyth", pyth_upgraded = "PythProCompatible", std = "MoveStdlib", sui = "Sui", token = "token" }
 
 [pinned.testnet.token]
 source = { git = "https://github.com/MystenLabs/deepbookv3.git", subdir = "packages/token", rev = "2e0a88f860f1ae64f709b3978f1e206a91771169" }

--- a/packages/margin_liquidation/Move.toml
+++ b/packages/margin_liquidation/Move.toml
@@ -10,6 +10,10 @@ deepbook_margin = { local = "../deepbook_margin" }
 
 # Pyth dependency
 pyth = { git = "https://github.com/pyth-network/pyth-crosschain.git", subdir = "target_chains/sui/contracts", rev = "sui-contract-mainnet" }
+# Pyth's upgraded Core: a separate on-chain package, not an upgrade of the above. Both are
+# linked at once so the legacy entrypoints keep their frozen signatures.
+pyth_upgraded = { git = "https://github.com/pyth-network/pyth-crosschain.git", subdir = "target_chains/sui/contracts", rev = "sui-pro-compatible-contract-mainnet", rename-from = "pyth" }
 
 [dep-replacements.testnet]
 pyth = { git = "https://github.com/pyth-network/pyth-crosschain.git", subdir = "target_chains/sui/contracts", rev = "sui-contract-testnet" }
+pyth_upgraded = { git = "https://github.com/pyth-network/pyth-crosschain.git", subdir = "target_chains/sui/contracts", rev = "sui-pro-compatible-contract-testnet", rename-from = "pyth" }

--- a/packages/margin_liquidation/sources/liquidation_vault.move
+++ b/packages/margin_liquidation/sources/liquidation_vault.move
@@ -289,8 +289,10 @@ public fun balance<T>(self: &LiquidationVault): u64 {
 /// Pyth is replacing Core with a separately published package, so its `PriceInfoObject`
 /// is a distinct Move type and `liquidate_base`'s frozen signature can never accept it.
 /// Once Pyth stops publishing legacy Core the legacy entry aborts on staleness by
-/// itself, and this becomes the only way the vault can liquidate. Everything but the
-/// two oracle reads is shared with the legacy entry.
+/// itself, and this becomes the only way the vault can liquidate. The gate
+/// (`should_liquidate`) and the settlement (`settle_base_liquidation`) are shared with
+/// the legacy entry; the body between them is duplicated, because the two
+/// `PriceInfoObject` types cannot be unified.
 public fun liquidate_base_upgraded<BaseAsset, QuoteAsset>(
     self: &mut LiquidationVault,
     margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
@@ -502,10 +504,12 @@ fun id(self: &LiquidationVault): ID {
 /// liquidation engine accounts from, and its fields are module-private, so without
 /// this a flipped `base_liquidation` discriminator or a transposed `base_in`/`quote_in`
 /// is unobservable from a test.
+#[test_only]
 public fun liquidation_event_margin_pool_id(e: &LiquidationByVault): ID {
     e.margin_pool_id
 }
 
+#[test_only]
 public fun liquidation_event_fields(e: &LiquidationByVault): (u64, u64, u64, u64, u64, bool) {
     (e.base_in, e.quote_in, e.base_out, e.quote_out, e.repay_balance_remaining, e.base_liquidation)
 }

--- a/packages/margin_liquidation/sources/liquidation_vault.move
+++ b/packages/margin_liquidation/sources/liquidation_vault.move
@@ -498,6 +498,14 @@ fun id(self: &LiquidationVault): ID {
 }
 
 // === Test Only ===
+/// Reads back a `LiquidationByVault` for assertions. The event is what the off-chain
+/// liquidation engine accounts from, and its fields are module-private, so without
+/// this a flipped `base_liquidation` discriminator or a transposed `base_in`/`quote_in`
+/// is unobservable from a test.
+public fun liquidation_event_fields(e: &LiquidationByVault): (u64, u64, u64, u64, u64, bool) {
+    (e.base_in, e.quote_in, e.base_out, e.quote_out, e.repay_balance_remaining, e.base_liquidation)
+}
+
 #[test_only]
 public fun create_liquidation_vault_for_testing(ctx: &mut TxContext): LiquidationVault {
     LiquidationVault {

--- a/packages/margin_liquidation/sources/liquidation_vault.move
+++ b/packages/margin_liquidation/sources/liquidation_vault.move
@@ -6,10 +6,12 @@ module margin_liquidation::liquidation_vault;
 use deepbook::pool::Pool;
 use deepbook_margin::{
     margin_manager::{MarginManager, liquidate},
+    margin_manager_upgraded,
     margin_pool::MarginPool,
     margin_registry::MarginRegistry
 };
 use pyth::price_info::PriceInfoObject;
+use pyth_upgraded::price_info::PriceInfoObject as PriceInfoObjectUpgraded;
 use sui::{
     bag::{Self, Bag},
     balance::{Self, Balance},
@@ -194,13 +196,10 @@ public fun liquidate_base<BaseAsset, QuoteAsset>(
         quote_margin_pool,
         clock,
     );
-    let base_balance = self.balance<BaseAsset>();
-    if (!registry.can_liquidate(pool.id(), risk_ratio) || base_balance < 1000) {
-        return
-    };
-    let amount = repay_amount.destroy_with_default(base_balance);
+    if (!self.should_liquidate<BaseAsset>(registry, pool.id(), risk_ratio)) return;
+    let amount = repay_amount.destroy_with_default(self.balance<BaseAsset>());
     let balance = self.withdraw_int<BaseAsset>(amount);
-    let (mut base_coin, quote_coin, base_repay_coin) = margin_manager.liquidate<
+    let (base_coin, quote_coin, base_repay_coin) = margin_manager.liquidate<
         BaseAsset,
         QuoteAsset,
         BaseAsset,
@@ -214,24 +213,14 @@ public fun liquidate_base<BaseAsset, QuoteAsset>(
         clock,
         ctx,
     );
-    let repay_balance_remaining = base_repay_coin.value();
-    let base_out = base_coin.value();
-    let quote_out = quote_coin.value();
-    event::emit(LiquidationByVault {
-        vault_id: self.id(),
-        margin_manager_id: margin_manager.id(),
-        margin_pool_id: base_margin_pool.id(),
-        base_in: amount,
-        quote_in: 0,
-        base_out,
-        quote_out,
-        repay_balance_remaining,
-        base_liquidation: true,
-    });
-
-    base_coin.join(base_repay_coin);
-    self.deposit_int(base_coin.into_balance());
-    self.deposit_int(quote_coin.into_balance());
+    self.settle_base_liquidation(
+        margin_manager.id(),
+        base_margin_pool.id(),
+        amount,
+        base_coin,
+        quote_coin,
+        base_repay_coin,
+    );
 }
 
 public fun liquidate_quote<BaseAsset, QuoteAsset>(
@@ -256,13 +245,10 @@ public fun liquidate_quote<BaseAsset, QuoteAsset>(
         quote_margin_pool,
         clock,
     );
-    let quote_balance = self.balance<QuoteAsset>();
-    if (!registry.can_liquidate(pool.id(), risk_ratio) || quote_balance < 1000) {
-        return
-    };
-    let amount = repay_amount.destroy_with_default(quote_balance);
+    if (!self.should_liquidate<QuoteAsset>(registry, pool.id(), risk_ratio)) return;
+    let amount = repay_amount.destroy_with_default(self.balance<QuoteAsset>());
     let balance = self.withdraw_int<QuoteAsset>(amount);
-    let (base_coin, mut quote_coin, quote_repay_coin) = margin_manager.liquidate<
+    let (base_coin, quote_coin, quote_repay_coin) = margin_manager.liquidate<
         BaseAsset,
         QuoteAsset,
         QuoteAsset,
@@ -276,24 +262,14 @@ public fun liquidate_quote<BaseAsset, QuoteAsset>(
         clock,
         ctx,
     );
-    let repay_balance_remaining = quote_repay_coin.value();
-    let base_out = base_coin.value();
-    let quote_out = quote_coin.value();
-    event::emit(LiquidationByVault {
-        vault_id: self.id(),
-        margin_manager_id: margin_manager.id(),
-        margin_pool_id: quote_margin_pool.id(),
-        base_in: 0,
-        quote_in: amount,
-        base_out,
-        quote_out,
-        repay_balance_remaining,
-        base_liquidation: false,
-    });
-
-    quote_coin.join(quote_repay_coin);
-    self.deposit_int(base_coin.into_balance());
-    self.deposit_int(quote_coin.into_balance());
+    self.settle_quote_liquidation(
+        margin_manager.id(),
+        quote_margin_pool.id(),
+        amount,
+        base_coin,
+        quote_coin,
+        quote_repay_coin,
+    );
 }
 
 public fun balance<T>(self: &LiquidationVault): u64 {
@@ -308,7 +284,187 @@ public fun balance<T>(self: &LiquidationVault): u64 {
     }
 }
 
+/// `liquidate_base` against Pyth's upgraded Core.
+///
+/// Pyth is replacing Core with a separately published package, so its `PriceInfoObject`
+/// is a distinct Move type and `liquidate_base`'s frozen signature can never accept it.
+/// Once Pyth stops publishing legacy Core the legacy entry aborts on staleness by
+/// itself, and this becomes the only way the vault can liquidate. Everything but the
+/// two oracle reads is shared with the legacy entry.
+public fun liquidate_base_upgraded<BaseAsset, QuoteAsset>(
+    self: &mut LiquidationVault,
+    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    registry: &MarginRegistry,
+    base_oracle: &PriceInfoObjectUpgraded,
+    quote_oracle: &PriceInfoObjectUpgraded,
+    base_margin_pool: &mut MarginPool<BaseAsset>,
+    quote_margin_pool: &mut MarginPool<QuoteAsset>,
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    repay_amount: Option<u64>,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    let risk_ratio = margin_manager_upgraded::risk_ratio(
+        margin_manager,
+        registry,
+        base_oracle,
+        quote_oracle,
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        clock,
+    );
+    if (!self.should_liquidate<BaseAsset>(registry, pool.id(), risk_ratio)) return;
+    let amount = repay_amount.destroy_with_default(self.balance<BaseAsset>());
+    let balance = self.withdraw_int<BaseAsset>(amount);
+    let (base_coin, quote_coin, base_repay_coin) = margin_manager_upgraded::liquidate<
+        BaseAsset,
+        QuoteAsset,
+        BaseAsset,
+    >(
+        margin_manager,
+        registry,
+        base_oracle,
+        quote_oracle,
+        base_margin_pool,
+        pool,
+        balance.into_coin(ctx),
+        clock,
+        ctx,
+    );
+
+    self.settle_base_liquidation(
+        margin_manager.id(),
+        base_margin_pool.id(),
+        amount,
+        base_coin,
+        quote_coin,
+        base_repay_coin,
+    );
+}
+
+/// `liquidate_quote` against Pyth's upgraded Core. See `liquidate_base_upgraded`.
+public fun liquidate_quote_upgraded<BaseAsset, QuoteAsset>(
+    self: &mut LiquidationVault,
+    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    registry: &MarginRegistry,
+    base_oracle: &PriceInfoObjectUpgraded,
+    quote_oracle: &PriceInfoObjectUpgraded,
+    base_margin_pool: &mut MarginPool<BaseAsset>,
+    quote_margin_pool: &mut MarginPool<QuoteAsset>,
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    repay_amount: Option<u64>,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    let risk_ratio = margin_manager_upgraded::risk_ratio(
+        margin_manager,
+        registry,
+        base_oracle,
+        quote_oracle,
+        pool,
+        base_margin_pool,
+        quote_margin_pool,
+        clock,
+    );
+    if (!self.should_liquidate<QuoteAsset>(registry, pool.id(), risk_ratio)) return;
+    let amount = repay_amount.destroy_with_default(self.balance<QuoteAsset>());
+    let balance = self.withdraw_int<QuoteAsset>(amount);
+    let (base_coin, quote_coin, quote_repay_coin) = margin_manager_upgraded::liquidate<
+        BaseAsset,
+        QuoteAsset,
+        QuoteAsset,
+    >(
+        margin_manager,
+        registry,
+        base_oracle,
+        quote_oracle,
+        quote_margin_pool,
+        pool,
+        balance.into_coin(ctx),
+        clock,
+        ctx,
+    );
+
+    self.settle_quote_liquidation(
+        margin_manager.id(),
+        quote_margin_pool.id(),
+        amount,
+        base_coin,
+        quote_coin,
+        quote_repay_coin,
+    );
+}
+
 // === Private Functions ===
+
+/// Whether this vault should act on `risk_ratio`, and has enough of `Asset` to be
+/// worth acting with. Shared so the legacy and upgraded entries cannot drift apart on
+/// the gate; the only thing that differs between them is which feed produced the ratio.
+fun should_liquidate<Asset>(
+    self: &LiquidationVault,
+    registry: &MarginRegistry,
+    deepbook_pool_id: ID,
+    risk_ratio: u64,
+): bool {
+    registry.can_liquidate(deepbook_pool_id, risk_ratio) && self.balance<Asset>() >= 1000
+}
+
+/// Emits the vault's liquidation event and returns every coin to the vault. Shared by
+/// the legacy and upgraded base entries.
+fun settle_base_liquidation<BaseAsset, QuoteAsset>(
+    self: &mut LiquidationVault,
+    margin_manager_id: ID,
+    margin_pool_id: ID,
+    base_in: u64,
+    mut base_coin: Coin<BaseAsset>,
+    quote_coin: Coin<QuoteAsset>,
+    base_repay_coin: Coin<BaseAsset>,
+) {
+    event::emit(LiquidationByVault {
+        vault_id: self.id(),
+        margin_manager_id,
+        margin_pool_id,
+        base_in,
+        quote_in: 0,
+        base_out: base_coin.value(),
+        quote_out: quote_coin.value(),
+        repay_balance_remaining: base_repay_coin.value(),
+        base_liquidation: true,
+    });
+
+    base_coin.join(base_repay_coin);
+    self.deposit_int(base_coin.into_balance());
+    self.deposit_int(quote_coin.into_balance());
+}
+
+/// Quote-side twin of `settle_base_liquidation`.
+fun settle_quote_liquidation<BaseAsset, QuoteAsset>(
+    self: &mut LiquidationVault,
+    margin_manager_id: ID,
+    margin_pool_id: ID,
+    quote_in: u64,
+    base_coin: Coin<BaseAsset>,
+    mut quote_coin: Coin<QuoteAsset>,
+    quote_repay_coin: Coin<QuoteAsset>,
+) {
+    event::emit(LiquidationByVault {
+        vault_id: self.id(),
+        margin_manager_id,
+        margin_pool_id,
+        base_in: 0,
+        quote_in,
+        base_out: base_coin.value(),
+        quote_out: quote_coin.value(),
+        repay_balance_remaining: quote_repay_coin.value(),
+        base_liquidation: false,
+    });
+
+    quote_coin.join(quote_repay_coin);
+    self.deposit_int(base_coin.into_balance());
+    self.deposit_int(quote_coin.into_balance());
+}
+
 fun deposit_int<T>(self: &mut LiquidationVault, balance: Balance<T>) {
     let key = BalanceKey<T> {};
 

--- a/packages/margin_liquidation/sources/liquidation_vault.move
+++ b/packages/margin_liquidation/sources/liquidation_vault.move
@@ -174,6 +174,7 @@ public fun swap_quote_to_base<BaseAsset, QuoteAsset>(
 }
 
 // === Public Functions * LIQUIDATION * ===
+/// Twin: `liquidate_base_upgraded`. Edit both.
 public fun liquidate_base<BaseAsset, QuoteAsset>(
     self: &mut LiquidationVault,
     margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
@@ -223,6 +224,7 @@ public fun liquidate_base<BaseAsset, QuoteAsset>(
     );
 }
 
+/// Twin: `liquidate_quote_upgraded`. Edit both.
 public fun liquidate_quote<BaseAsset, QuoteAsset>(
     self: &mut LiquidationVault,
     margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
@@ -293,6 +295,7 @@ public fun balance<T>(self: &LiquidationVault): u64 {
 /// (`should_liquidate`) and the settlement (`settle_base_liquidation`) are shared with
 /// the legacy entry; the body between them is duplicated, because the two
 /// `PriceInfoObject` types cannot be unified.
+/// Twin: `liquidate_base`. Edit both.
 public fun liquidate_base_upgraded<BaseAsset, QuoteAsset>(
     self: &mut LiquidationVault,
     margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
@@ -334,7 +337,6 @@ public fun liquidate_base_upgraded<BaseAsset, QuoteAsset>(
         clock,
         ctx,
     );
-
     self.settle_base_liquidation(
         margin_manager.id(),
         base_margin_pool.id(),
@@ -346,6 +348,7 @@ public fun liquidate_base_upgraded<BaseAsset, QuoteAsset>(
 }
 
 /// `liquidate_quote` against Pyth's upgraded Core. See `liquidate_base_upgraded`.
+/// Twin: `liquidate_quote`. Edit both.
 public fun liquidate_quote_upgraded<BaseAsset, QuoteAsset>(
     self: &mut LiquidationVault,
     margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
@@ -387,7 +390,6 @@ public fun liquidate_quote_upgraded<BaseAsset, QuoteAsset>(
         clock,
         ctx,
     );
-
     self.settle_quote_liquidation(
         margin_manager.id(),
         quote_margin_pool.id(),

--- a/packages/margin_liquidation/sources/liquidation_vault.move
+++ b/packages/margin_liquidation/sources/liquidation_vault.move
@@ -502,6 +502,10 @@ fun id(self: &LiquidationVault): ID {
 /// liquidation engine accounts from, and its fields are module-private, so without
 /// this a flipped `base_liquidation` discriminator or a transposed `base_in`/`quote_in`
 /// is unobservable from a test.
+public fun liquidation_event_margin_pool_id(e: &LiquidationByVault): ID {
+    e.margin_pool_id
+}
+
 public fun liquidation_event_fields(e: &LiquidationByVault): (u64, u64, u64, u64, u64, bool) {
     (e.base_in, e.quote_in, e.base_out, e.quote_out, e.repay_balance_remaining, e.base_liquidation)
 }

--- a/packages/margin_liquidation/tests/liquidation_vault_oracle_tests.move
+++ b/packages/margin_liquidation/tests/liquidation_vault_oracle_tests.move
@@ -1,0 +1,260 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Oracle behaviour of the vault's liquidation entrypoints.
+///
+/// The existing `liquidation_vault_tests` cover deposits, withdrawals, trader
+/// authorisation and swaps, but never call `liquidate_base`/`liquidate_quote` — so
+/// neither the legacy pair nor the upgraded pair added for the Pyth cutover had any
+/// coverage of the two things that can silently go wrong: which oracle generation an
+/// entry reads, and whether the `can_liquidate` gate actually holds.
+#[test_only]
+module margin_liquidation::liquidation_vault_oracle_tests;
+
+use deepbook::pool::Pool;
+use deepbook_margin::{
+    margin_manager::{Self, MarginManager},
+    margin_pool::MarginPool,
+    margin_registry::MarginRegistry,
+    test_constants::{Self, USDC, BTC, btc_multiplier},
+    test_helpers::{
+        setup_btc_usd_deepbook_margin,
+        build_btc_price_info_object,
+        build_demo_usdc_price_info_object,
+        build_btc_price_info_object_upgraded,
+        build_demo_usdc_price_info_object_upgraded,
+        build_stale_btc_price_info_object,
+        build_stale_btc_price_info_object_upgraded,
+        mint_coin,
+    }
+};
+use margin_liquidation::liquidation_vault;
+use std::unit_test::destroy;
+use sui::{clock::Clock, test_scenario::{Self as test, return_shared}};
+
+/// A healthy BTC/USDC manager: 1 BTC of collateral against a 40k USDC loan at $50k.
+/// Every test here starts from it, then varies only the feed handed to the vault.
+fun healthy_manager(): (test::Scenario, Clock, ID, ID, ID) {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        btc_pool_id,
+        usdc_pool_id,
+        _pool_id,
+        registry_id,
+    ) = setup_btc_usd_deepbook_margin();
+
+    scenario.next_tx(test_constants::user1());
+    let pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<deepbook::registry::Registry>(registry_id);
+    margin_manager::new<BTC, USDC>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+    return_shared(pool);
+    return_shared(registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let registry = scenario.take_shared<MarginRegistry>();
+    let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+    let btc = build_btc_price_info_object(&mut scenario, 50000, &clock);
+    let usdc = build_demo_usdc_price_info_object(&mut scenario, &clock);
+
+    margin_manager::deposit<BTC, USDC, BTC>(
+        &mut mm,
+        &registry,
+        &btc,
+        &usdc,
+        mint_coin<BTC>(btc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    margin_manager::borrow_quote<BTC, USDC>(
+        &mut mm,
+        &registry,
+        &mut usdc_pool,
+        &btc,
+        &usdc,
+        &pool,
+        40_000 * test_constants::usdc_multiplier(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    destroy(btc);
+    destroy(usdc);
+    destroy(admin_cap);
+    destroy(maintainer_cap);
+    return_shared(usdc_pool);
+    return_shared(registry);
+    return_shared(pool);
+    return_shared(mm);
+    (scenario, clock, btc_pool_id, usdc_pool_id, registry_id)
+}
+
+/// The gate holds on the upgraded path: a healthy manager is not liquidated, and the
+/// vault's funds are untouched. Without this, a broken `can_liquidate` check would
+/// drain solvent users through the new entrypoint with nothing to catch it.
+#[test]
+fun liquidate_quote_upgraded_leaves_a_healthy_manager_alone() {
+    let (mut scenario, clock, btc_pool_id, usdc_pool_id, _r) = healthy_manager();
+
+    scenario.next_tx(test_constants::admin());
+    let mut vault = liquidation_vault::create_liquidation_vault_for_testing(scenario.ctx());
+    let cap = liquidation_vault::create_admin_cap_for_testing(scenario.ctx());
+    vault.deposit(
+        &cap,
+        mint_coin<USDC>(50_000 * test_constants::usdc_multiplier(), scenario.ctx()),
+    );
+    let funded = vault.balance<USDC>();
+
+    scenario.next_tx(test_constants::admin());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let registry = scenario.take_shared<MarginRegistry>();
+    let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
+    let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+
+    // BTC still at $50k, so the manager is nowhere near the liquidation floor.
+    let btc = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+
+    vault.liquidate_quote_upgraded<BTC, USDC>(
+        &mut mm,
+        &registry,
+        &btc,
+        &usdc,
+        &mut btc_pool,
+        &mut usdc_pool,
+        &mut pool,
+        option::none(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    assert!(vault.balance<USDC>() == funded);
+    assert!(vault.balance<BTC>() == 0);
+    assert!(mm.borrowed_quote_shares() > 0);
+
+    destroy(btc);
+    destroy(usdc);
+    destroy(vault);
+    destroy(cap);
+    return_shared(btc_pool);
+    return_shared(usdc_pool);
+    return_shared(registry);
+    return_shared(pool);
+    return_shared(mm);
+    destroy(clock);
+    scenario.end();
+}
+
+/// The upgraded entry must read through the *validated* upgraded reader. A stale feed
+/// has to abort rather than be tolerated — otherwise the entry would price a
+/// liquidation off an arbitrarily old price after the Pyth cutover.
+#[test, expected_failure(abort_code = pyth_upgraded::pyth::E_STALE_PRICE_UPDATE)]
+fun liquidate_quote_upgraded_rejects_a_stale_feed() {
+    let (mut scenario, clock, btc_pool_id, usdc_pool_id, _r) = healthy_manager();
+
+    scenario.next_tx(test_constants::admin());
+    let mut vault = liquidation_vault::create_liquidation_vault_for_testing(scenario.ctx());
+    let cap = liquidation_vault::create_admin_cap_for_testing(scenario.ctx());
+    vault.deposit(
+        &cap,
+        mint_coin<USDC>(50_000 * test_constants::usdc_multiplier(), scenario.ctx()),
+    );
+
+    scenario.next_tx(test_constants::admin());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let registry = scenario.take_shared<MarginRegistry>();
+    let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
+    let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+
+    let stale_btc = build_stale_btc_price_info_object_upgraded(&mut scenario, 50000, 600, &clock);
+    let usdc = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+
+    vault.liquidate_quote_upgraded<BTC, USDC>(
+        &mut mm,
+        &registry,
+        &stale_btc,
+        &usdc,
+        &mut btc_pool,
+        &mut usdc_pool,
+        &mut pool,
+        option::none(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    destroy(stale_btc);
+    destroy(usdc);
+    destroy(vault);
+    destroy(cap);
+    return_shared(btc_pool);
+    return_shared(usdc_pool);
+    return_shared(registry);
+    return_shared(pool);
+    return_shared(mm);
+    destroy(clock);
+    scenario.end();
+}
+
+/// The legacy entry keeps the same two properties, so the pair cannot drift. This is
+/// the coverage `liquidate_quote` never had.
+#[test, expected_failure(abort_code = pyth::pyth::E_STALE_PRICE_UPDATE)]
+fun liquidate_quote_rejects_a_stale_feed() {
+    let (mut scenario, clock, btc_pool_id, usdc_pool_id, _r) = healthy_manager();
+
+    scenario.next_tx(test_constants::admin());
+    let mut vault = liquidation_vault::create_liquidation_vault_for_testing(scenario.ctx());
+    let cap = liquidation_vault::create_admin_cap_for_testing(scenario.ctx());
+    vault.deposit(
+        &cap,
+        mint_coin<USDC>(50_000 * test_constants::usdc_multiplier(), scenario.ctx()),
+    );
+
+    scenario.next_tx(test_constants::admin());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let registry = scenario.take_shared<MarginRegistry>();
+    let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
+    let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+
+    let stale_btc = build_stale_btc_price_info_object(&mut scenario, 50000, &clock, 600);
+    let usdc = build_demo_usdc_price_info_object(&mut scenario, &clock);
+
+    vault.liquidate_quote<BTC, USDC>(
+        &mut mm,
+        &registry,
+        &stale_btc,
+        &usdc,
+        &mut btc_pool,
+        &mut usdc_pool,
+        &mut pool,
+        option::none(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    destroy(stale_btc);
+    destroy(usdc);
+    destroy(vault);
+    destroy(cap);
+    return_shared(btc_pool);
+    return_shared(usdc_pool);
+    return_shared(registry);
+    return_shared(pool);
+    return_shared(mm);
+    destroy(clock);
+    scenario.end();
+}

--- a/packages/margin_liquidation/tests/liquidation_vault_oracle_tests.move
+++ b/packages/margin_liquidation/tests/liquidation_vault_oracle_tests.move
@@ -327,9 +327,9 @@ fun liquidate_quote_upgraded_seizes_collateral_and_settles() {
     let (
         base_in,
         quote_in,
-        _base_out,
-        _quote_out,
-        _remaining,
+        base_out,
+        quote_out,
+        remaining,
         base_liquidation,
     ) = liquidation_vault::liquidation_event_fields(&events[0]);
     assert!(!base_liquidation);
@@ -337,6 +337,13 @@ fun liquidate_quote_upgraded_seizes_collateral_and_settles() {
     // `quote_in` is what left the vault: the whole funded balance, since `repay_amount`
     // was `none`. An exact value here is what distinguishes it from `quote_out`.
     assert!(quote_in == 50_000_000_000);
+    // The `*_out` pair and the leftover repay were destructured and never asserted, so
+    // transposing them inside `settle_quote_liquidation` was invisible.
+    // The seized quote plus the unspent repay is the whole 50.7e9 the vault ends with;
+    // asserting only the balance could not tell the two apart.
+    assert!(base_out == 0);
+    assert!(quote_out == 36_750_000_000);
+    assert!(remaining == 13_950_000_000);
     assert!(liquidation_vault::liquidation_event_margin_pool_id(&events[0]) == usdc_pool_id);
 
     destroy(btc);
@@ -527,14 +534,17 @@ fun liquidate_base_upgraded_pays_out_and_returns_every_coin() {
     let (
         base_in,
         quote_in,
-        _base_out,
-        _quote_out,
-        _remaining,
+        base_out,
+        quote_out,
+        remaining,
         base_liquidation,
     ) = liquidation_vault::liquidation_event_fields(&events[0]);
     assert!(base_liquidation);
     assert!(quote_in == 0);
     assert!(base_in == 100_000_000);
+    assert!(base_out == 67_499_994);
+    assert!(quote_out == 0);
+    assert!(remaining == 33_785_720);
     assert!(liquidation_vault::liquidation_event_margin_pool_id(&events[0]) == btc_pool_id);
 
     destroy(btc);
@@ -598,14 +608,17 @@ fun liquidate_base_settles_the_same_numbers_on_the_legacy_generation() {
     let (
         base_in,
         quote_in,
-        _base_out,
-        _quote_out,
-        _remaining,
+        base_out,
+        quote_out,
+        remaining,
         base_liquidation,
     ) = liquidation_vault::liquidation_event_fields(&events[0]);
     assert!(base_liquidation);
     assert!(quote_in == 0);
     assert!(base_in == 100_000_000);
+    assert!(base_out == 67_499_994);
+    assert!(quote_out == 0);
+    assert!(remaining == 33_785_720);
     assert!(liquidation_vault::liquidation_event_margin_pool_id(&events[0]) == btc_pool_id);
 
     destroy(btc);

--- a/packages/margin_liquidation/tests/liquidation_vault_oracle_tests.move
+++ b/packages/margin_liquidation/tests/liquidation_vault_oracle_tests.move
@@ -633,3 +633,72 @@ fun liquidate_base_settles_the_same_numbers_on_the_legacy_generation() {
     destroy(clock);
     scenario.end();
 }
+
+/// The vault's swap entrypoints are gated by `assert_trader`, and nothing exercised
+/// that gate through them: the three tests named for it in `liquidation_vault_tests`
+/// call `assert_trader_for_testing` directly, so deleting the check from
+/// `swap_base_to_quote` left the whole suite green. That check is the only thing
+/// between an arbitrary caller and swapping the vault's entire inventory with
+/// `min_quote_out` of zero.
+#[test, expected_failure(abort_code = liquidation_vault::ETraderNotAuthorized)]
+fun swap_base_to_quote_rejects_an_unauthorised_caller() {
+    let (mut scenario, clock, _btc_pool_id, _usdc_pool_id) = manager_with_base_debt();
+
+    scenario.next_tx(test_constants::admin());
+    let mut vault = liquidation_vault::create_liquidation_vault_for_testing(scenario.ctx());
+    let cap = liquidation_vault::create_admin_cap_for_testing(scenario.ctx());
+    vault.deposit(&cap, mint_coin<BTC>(btc_multiplier(), scenario.ctx()));
+    // Authorise someone else, so the traders set exists and the call reaches the
+    // membership check rather than aborting on a missing dynamic field.
+    vault.authorize_trader(&cap, test_constants::user1());
+
+    // user2 was never authorised.
+    scenario.next_tx(test_constants::user2());
+    let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
+    vault.swap_base_to_quote<BTC, USDC>(
+        &mut pool,
+        btc_multiplier(),
+        0,
+        0,
+        &clock,
+        scenario.ctx(),
+    );
+
+    destroy(vault);
+    destroy(cap);
+    return_shared(pool);
+    destroy(clock);
+    scenario.end();
+}
+
+/// Quote-side twin, so neither swap entry can lose its gate unnoticed.
+#[test, expected_failure(abort_code = liquidation_vault::ETraderNotAuthorized)]
+fun swap_quote_to_base_rejects_an_unauthorised_caller() {
+    let (mut scenario, clock, _btc_pool_id, _usdc_pool_id) = manager_with_base_debt();
+
+    scenario.next_tx(test_constants::admin());
+    let mut vault = liquidation_vault::create_liquidation_vault_for_testing(scenario.ctx());
+    let cap = liquidation_vault::create_admin_cap_for_testing(scenario.ctx());
+    vault.deposit(
+        &cap,
+        mint_coin<USDC>(1_000 * test_constants::usdc_multiplier(), scenario.ctx()),
+    );
+    vault.authorize_trader(&cap, test_constants::user1());
+
+    scenario.next_tx(test_constants::user2());
+    let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
+    vault.swap_quote_to_base<BTC, USDC>(
+        &mut pool,
+        1_000 * test_constants::usdc_multiplier(),
+        0,
+        0,
+        &clock,
+        scenario.ctx(),
+    );
+
+    destroy(vault);
+    destroy(cap);
+    return_shared(pool);
+    destroy(clock);
+    scenario.end();
+}

--- a/packages/margin_liquidation/tests/liquidation_vault_oracle_tests.move
+++ b/packages/margin_liquidation/tests/liquidation_vault_oracle_tests.move
@@ -32,6 +32,10 @@ use margin_liquidation::liquidation_vault::{Self, LiquidationByVault};
 use std::unit_test::destroy;
 use sui::{clock::Clock, test_scenario::{Self as test, return_shared}};
 
+const HEALTHY_BTC_PRICE: u64 = 50_000;
+const STALE_PRICE_AGE_SECS: u64 = 600;
+const WRONG_ABORT_SENTINEL: u64 = 999;
+
 /// A healthy BTC/USDC manager: 1 BTC of collateral against a 40k USDC loan at $50k.
 /// Every test here starts from it, then varies only the feed handed to the vault.
 fun healthy_manager(): (test::Scenario, Clock, ID, ID, ID) {
@@ -484,6 +488,45 @@ fun manager_with_base_debt(): (test::Scenario, Clock, ID, ID) {
     return_shared(pool);
     return_shared(mm);
     (scenario, clock, btc_pool_id, usdc_pool_id)
+}
+
+/// The base-side upgraded entry must validate freshness before its healthy-manager
+/// early return. Otherwise an unsafe pre-check could silently accept a stale feed.
+#[test, expected_failure(abort_code = pyth_upgraded::pyth::E_STALE_PRICE_UPDATE)]
+fun liquidate_base_upgraded_rejects_a_stale_feed() {
+    let (mut scenario, clock, btc_pool_id, usdc_pool_id) = manager_with_base_debt();
+
+    scenario.next_tx(test_constants::admin());
+    let mut vault = liquidation_vault::create_liquidation_vault_for_testing(scenario.ctx());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let registry = scenario.take_shared<MarginRegistry>();
+    let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
+    let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+
+    // At the original $50k price the manager is healthy, so replacing the validated
+    // pre-check with `risk_ratio_unsafe` returns before `liquidate` can reject staleness.
+    let stale_btc = build_stale_btc_price_info_object_upgraded(
+        &mut scenario,
+        HEALTHY_BTC_PRICE,
+        STALE_PRICE_AGE_SECS,
+        &clock,
+    );
+    let usdc = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+
+    vault.liquidate_base_upgraded<BTC, USDC>(
+        &mut mm,
+        &registry,
+        &stale_btc,
+        &usdc,
+        &mut btc_pool,
+        &mut usdc_pool,
+        &mut pool,
+        option::none(),
+        &clock,
+        scenario.ctx(),
+    );
+    abort WRONG_ABORT_SENTINEL
 }
 
 /// The base side of the payout path, which nothing else reaches. Until this existed,

--- a/packages/margin_liquidation/tests/liquidation_vault_oracle_tests.move
+++ b/packages/margin_liquidation/tests/liquidation_vault_oracle_tests.move
@@ -334,7 +334,10 @@ fun liquidate_quote_upgraded_seizes_collateral_and_settles() {
     ) = liquidation_vault::liquidation_event_fields(&events[0]);
     assert!(!base_liquidation);
     assert!(base_in == 0);
-    assert!(quote_in > 0);
+    // `quote_in` is what left the vault: the whole funded balance, since `repay_amount`
+    // was `none`. An exact value here is what distinguishes it from `quote_out`.
+    assert!(quote_in == 50_000_000_000);
+    assert!(liquidation_vault::liquidation_event_margin_pool_id(&events[0]) == usdc_pool_id);
 
     destroy(btc);
     destroy(usdc);
@@ -394,6 +397,216 @@ fun liquidate_quote_settles_the_same_numbers_on_the_legacy_generation() {
     assert!(mm.borrowed_quote_shares() == 5_000_000_000);
     assert!(vault.balance<BTC>() == 0);
     assert!(vault.balance<USDC>() == 50_700_000_000);
+
+    destroy(btc);
+    destroy(usdc);
+    destroy(vault);
+    destroy(cap);
+    return_shared(btc_pool);
+    return_shared(usdc_pool);
+    return_shared(registry);
+    return_shared(pool);
+    return_shared(mm);
+    destroy(clock);
+    scenario.end();
+}
+
+/// A base-debt manager: 50k USDC of collateral against a 0.8 BTC loan opened at $50k.
+fun manager_with_base_debt(): (test::Scenario, Clock, ID, ID) {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        btc_pool_id,
+        usdc_pool_id,
+        _pool_id,
+        registry_id,
+    ) = setup_btc_usd_deepbook_margin();
+
+    scenario.next_tx(test_constants::user1());
+    let pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<deepbook::registry::Registry>(registry_id);
+    margin_manager::new<BTC, USDC>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+    return_shared(pool);
+    return_shared(registry);
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let registry = scenario.take_shared<MarginRegistry>();
+    let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
+    let btc = build_btc_price_info_object(&mut scenario, 50000, &clock);
+    let usdc = build_demo_usdc_price_info_object(&mut scenario, &clock);
+
+    margin_manager::deposit<BTC, USDC, USDC>(
+        &mut mm,
+        &registry,
+        &btc,
+        &usdc,
+        mint_coin<USDC>(50_000 * test_constants::usdc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    margin_manager::borrow_base<BTC, USDC>(
+        &mut mm,
+        &registry,
+        &mut btc_pool,
+        &btc,
+        &usdc,
+        &pool,
+        btc_multiplier() / 10 * 8,
+        &clock,
+        scenario.ctx(),
+    );
+
+    destroy(btc);
+    destroy(usdc);
+    destroy(admin_cap);
+    destroy(maintainer_cap);
+    return_shared(btc_pool);
+    return_shared(registry);
+    return_shared(pool);
+    return_shared(mm);
+    (scenario, clock, btc_pool_id, usdc_pool_id)
+}
+
+/// The base side of the payout path, which nothing else reaches. Until this existed,
+/// `liquidate_base_upgraded` had no execution of any kind, and `settle_base_liquidation`
+/// could transfer the repay coin to `@0x0` — silently losing the liquidated funds — with
+/// the whole suite still green.
+#[test]
+fun liquidate_base_upgraded_pays_out_and_returns_every_coin() {
+    let (mut scenario, clock, btc_pool_id, usdc_pool_id) = manager_with_base_debt();
+
+    scenario.next_tx(test_constants::admin());
+    let mut vault = liquidation_vault::create_liquidation_vault_for_testing(scenario.ctx());
+    let cap = liquidation_vault::create_admin_cap_for_testing(scenario.ctx());
+    vault.deposit(&cap, mint_coin<BTC>(btc_multiplier(), scenario.ctx()));
+
+    scenario.next_tx(test_constants::admin());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let registry = scenario.take_shared<MarginRegistry>();
+    let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
+    let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+    let shares_before = mm.borrowed_base_shares();
+
+    // BTC to $700k: the 0.8 BTC debt is now $560k against $610k of assets, a ratio of
+    // 1.089 - under the 1.10 floor. A base-debt manager is liquidated by BTC rising.
+    let btc = build_btc_price_info_object_upgraded(&mut scenario, 700000, &clock);
+    let usdc = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+
+    vault.liquidate_base_upgraded<BTC, USDC>(
+        &mut mm,
+        &registry,
+        &btc,
+        &usdc,
+        &mut btc_pool,
+        &mut usdc_pool,
+        &mut pool,
+        option::none(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    assert!(shares_before == 80_000_000);
+    assert!(mm.borrowed_base_shares() == 15_714_292);
+    assert!(vault.balance<BTC>() == 101_285_714);
+
+    let events = sui::event::events_by_type<LiquidationByVault>();
+    assert!(events.length() == 1);
+    let (
+        base_in,
+        quote_in,
+        _base_out,
+        _quote_out,
+        _remaining,
+        base_liquidation,
+    ) = liquidation_vault::liquidation_event_fields(&events[0]);
+    assert!(base_liquidation);
+    assert!(quote_in == 0);
+    assert!(base_in == 100_000_000);
+    assert!(liquidation_vault::liquidation_event_margin_pool_id(&events[0]) == btc_pool_id);
+
+    destroy(btc);
+    destroy(usdc);
+    destroy(vault);
+    destroy(cap);
+    return_shared(btc_pool);
+    return_shared(usdc_pool);
+    return_shared(registry);
+    return_shared(pool);
+    return_shared(mm);
+    destroy(clock);
+    scenario.end();
+}
+
+/// The legacy base entry, same fixture and prices, must settle to the same numbers as
+/// its upgraded twin above — the base-side counterpart of
+/// `liquidate_quote_settles_the_same_numbers_on_the_legacy_generation`. It is also the
+/// only coverage of `liquidate_base`'s event, whose `margin_pool_id` would otherwise be
+/// free to report the quote pool.
+#[test]
+fun liquidate_base_settles_the_same_numbers_on_the_legacy_generation() {
+    let (mut scenario, clock, btc_pool_id, usdc_pool_id) = manager_with_base_debt();
+
+    scenario.next_tx(test_constants::admin());
+    let mut vault = liquidation_vault::create_liquidation_vault_for_testing(scenario.ctx());
+    let cap = liquidation_vault::create_admin_cap_for_testing(scenario.ctx());
+    vault.deposit(&cap, mint_coin<BTC>(btc_multiplier(), scenario.ctx()));
+
+    scenario.next_tx(test_constants::admin());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let registry = scenario.take_shared<MarginRegistry>();
+    let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
+    let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+    let shares_before = mm.borrowed_base_shares();
+
+    let btc = build_btc_price_info_object(&mut scenario, 700000, &clock);
+    let usdc = build_demo_usdc_price_info_object(&mut scenario, &clock);
+
+    vault.liquidate_base<BTC, USDC>(
+        &mut mm,
+        &registry,
+        &btc,
+        &usdc,
+        &mut btc_pool,
+        &mut usdc_pool,
+        &mut pool,
+        option::none(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    // Identical to `liquidate_base_upgraded_pays_out_and_returns_every_coin`.
+    assert!(shares_before == 80_000_000);
+    assert!(mm.borrowed_base_shares() == 15_714_292);
+    assert!(vault.balance<BTC>() == 101_285_714);
+
+    let events = sui::event::events_by_type<LiquidationByVault>();
+    assert!(events.length() == 1);
+    let (
+        base_in,
+        quote_in,
+        _base_out,
+        _quote_out,
+        _remaining,
+        base_liquidation,
+    ) = liquidation_vault::liquidation_event_fields(&events[0]);
+    assert!(base_liquidation);
+    assert!(quote_in == 0);
+    assert!(base_in == 100_000_000);
+    assert!(liquidation_vault::liquidation_event_margin_pool_id(&events[0]) == btc_pool_id);
 
     destroy(btc);
     destroy(usdc);

--- a/packages/margin_liquidation/tests/liquidation_vault_oracle_tests.move
+++ b/packages/margin_liquidation/tests/liquidation_vault_oracle_tests.move
@@ -28,7 +28,7 @@ use deepbook_margin::{
         mint_coin,
     }
 };
-use margin_liquidation::liquidation_vault;
+use margin_liquidation::liquidation_vault::{Self, LiquidationByVault};
 use std::unit_test::destroy;
 use sui::{clock::Clock, test_scenario::{Self as test, return_shared}};
 
@@ -247,6 +247,155 @@ fun liquidate_quote_rejects_a_stale_feed() {
     );
 
     destroy(stale_btc);
+    destroy(usdc);
+    destroy(vault);
+    destroy(cap);
+    return_shared(btc_pool);
+    return_shared(usdc_pool);
+    return_shared(registry);
+    return_shared(pool);
+    return_shared(mm);
+    destroy(clock);
+    scenario.end();
+}
+
+/// The full settlement path, which nothing else in the package reaches.
+///
+/// The two `*_rejects_a_stale_feed` tests abort inside `risk_ratio`, and the
+/// healthy-manager test returns at the gate — so `settle_quote_liquidation`, the
+/// `LiquidationByVault` event fields, and the coin routing back into the vault were
+/// entirely unexercised. A transposed `base_out`/`quote_out`, or a repay coin joined
+/// into the wrong balance, would ship green.
+#[test]
+fun liquidate_quote_upgraded_seizes_collateral_and_settles() {
+    let (mut scenario, clock, btc_pool_id, usdc_pool_id, _r) = healthy_manager();
+
+    scenario.next_tx(test_constants::admin());
+    let mut vault = liquidation_vault::create_liquidation_vault_for_testing(scenario.ctx());
+    let cap = liquidation_vault::create_admin_cap_for_testing(scenario.ctx());
+    vault.deposit(
+        &cap,
+        mint_coin<USDC>(50_000 * test_constants::usdc_multiplier(), scenario.ctx()),
+    );
+    let usdc_before = vault.balance<USDC>();
+
+    scenario.next_tx(test_constants::admin());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let registry = scenario.take_shared<MarginRegistry>();
+    let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
+    let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+    let shares_before = mm.borrowed_quote_shares();
+    assert!(shares_before > 0);
+
+    // 1 BTC of collateral against a 40k USDC loan. At $3,000 the manager holds
+    // $43k against $40k of debt - a ratio of 1.075, under the 1.10 floor.
+    let btc = build_btc_price_info_object_upgraded(&mut scenario, 3000, &clock);
+    let usdc = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+
+    vault.liquidate_quote_upgraded<BTC, USDC>(
+        &mut mm,
+        &registry,
+        &btc,
+        &usdc,
+        &mut btc_pool,
+        &mut usdc_pool,
+        &mut pool,
+        option::none(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    // Debt repaid, seized BTC banked, and the USDC actually spent.
+    // 87.5% of the loan is repaid: 40,000 -> 5,000 shares.
+    assert!(shares_before == 40_000_000_000);
+    assert!(mm.borrowed_quote_shares() == 5_000_000_000);
+
+    // The seizure is quote-side, not base-side: the manager's assets are the borrowed
+    // USDC plus 1 BTC now worth only $3k, so `calculate_assets` pays out in quote and
+    // the vault's BTC balance never moves. The vault ends 700 USDC *up* on the
+    // liquidation reward - it spends to repay and is paid more back.
+    assert!(vault.balance<BTC>() == 0);
+    assert!(usdc_before == 50_000_000_000);
+    assert!(vault.balance<USDC>() == 50_700_000_000);
+
+    // The event the off-chain engine accounts from. `base_liquidation: false` and the
+    // `quote_in` side carrying the spend are the discriminators; flipping either
+    // mis-reports every liquidation downstream while the balances still look right.
+    let events = sui::event::events_by_type<LiquidationByVault>();
+    assert!(events.length() == 1);
+    let (
+        base_in,
+        quote_in,
+        _base_out,
+        _quote_out,
+        _remaining,
+        base_liquidation,
+    ) = liquidation_vault::liquidation_event_fields(&events[0]);
+    assert!(!base_liquidation);
+    assert!(base_in == 0);
+    assert!(quote_in > 0);
+
+    destroy(btc);
+    destroy(usdc);
+    destroy(vault);
+    destroy(cap);
+    return_shared(btc_pool);
+    return_shared(usdc_pool);
+    return_shared(registry);
+    return_shared(pool);
+    return_shared(mm);
+    destroy(clock);
+    scenario.end();
+}
+
+/// The legacy entry on the same fixture at the same prices must settle to exactly the
+/// same numbers as its upgraded twin above. Asserting identical literals in both tests
+/// is what makes the twin invariant executable: `scripts/check_upgraded_parity.py`
+/// compares signatures, this compares outcomes. Change one body and one test breaks.
+#[test]
+fun liquidate_quote_settles_the_same_numbers_on_the_legacy_generation() {
+    let (mut scenario, clock, btc_pool_id, usdc_pool_id, _r) = healthy_manager();
+
+    scenario.next_tx(test_constants::admin());
+    let mut vault = liquidation_vault::create_liquidation_vault_for_testing(scenario.ctx());
+    let cap = liquidation_vault::create_admin_cap_for_testing(scenario.ctx());
+    vault.deposit(
+        &cap,
+        mint_coin<USDC>(50_000 * test_constants::usdc_multiplier(), scenario.ctx()),
+    );
+
+    scenario.next_tx(test_constants::admin());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let registry = scenario.take_shared<MarginRegistry>();
+    let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
+    let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+    let shares_before = mm.borrowed_quote_shares();
+
+    let btc = build_btc_price_info_object(&mut scenario, 3000, &clock);
+    let usdc = build_demo_usdc_price_info_object(&mut scenario, &clock);
+
+    vault.liquidate_quote<BTC, USDC>(
+        &mut mm,
+        &registry,
+        &btc,
+        &usdc,
+        &mut btc_pool,
+        &mut usdc_pool,
+        &mut pool,
+        option::none(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    // Identical to `liquidate_quote_upgraded_seizes_collateral_and_settles`.
+    assert!(shares_before == 40_000_000_000);
+    assert!(mm.borrowed_quote_shares() == 5_000_000_000);
+    assert!(vault.balance<BTC>() == 0);
+    assert!(vault.balance<USDC>() == 50_700_000_000);
+
+    destroy(btc);
     destroy(usdc);
     destroy(vault);
     destroy(cap);


### PR DESCRIPTION
Second and final on-chain piece of the Pyth Core upgrade. **Stacked on #1170** — review that first; this diff is against it.

> [!IMPORTANT]
> Same hard deadline as #1170: **2026-08-18**. Without it, the vault's liquidation entrypoints abort permanently at the cutover and our liquidation engine stops.

## Summary
- Adds `liquidate_base_upgraded` and `liquidate_quote_upgraded`, taking the upgraded Core `PriceInfoObject`, alongside the existing pair.
- Links `pyth_upgraded` in `Move.toml` for both environments, the same `rename-from = "pyth"` shape as `deepbook_margin`.
- Factors the non-oracle logic of all four entrypoints into three shared helpers.

## Why
`liquidate_base` / `liquidate_quote` take the legacy `PriceInfoObject` and price through `margin_manager::risk_ratio`, which enforces staleness. When Pyth stops publishing legacy Core, the frozen objects stop updating and **both entrypoints abort permanently** ~`max_age_secs` later (live config: 70s).

Margin positions stay liquidatable — anyone can call `margin_manager_upgraded::liquidate` directly — but this package is the helper our liquidation engine drives, so the engine stops. That is the gap this closes.

## Key decisions
- **Same module, `_upgraded`-suffixed names.** The reverse of `deepbook_margin`'s shape, and for the opposite reason: there, the shared logic already sits in `public(package)` `_core` functions, so a separate module costs nothing. Here the shared gate and settlement are module-private, so a separate module would mean widening them to `public(package)` — the suffix keeps them private. A module cannot hold two functions of one name, hence the suffix.
- **Named `_upgraded`, not `_pro`.** What we link is Pyth's upgraded **Core**. Pyth's contracts page: *"Pyth Core and Pyth Pro are two different products… The 'upgraded' contract is not Pro."*
- **Shared helpers so the pairs cannot drift** — `should_liquidate` (the `can_liquidate` gate plus the dust floor) and `settle_base_liquidation` / `settle_quote_liquidation` (event emission and coin return). The oracle generation is the only difference within each pair.
- **Why the seam is around the oracle calls rather than a shared reading.** `margin_liquidation` is a separate package, so it cannot reach `deepbook_margin`'s `public(package)` cores or the `PythReading` type — it can only call the public entrypoints. That constraint, not preference, sets the seam.
- Both directions of every twin carry `/// Twin: … Edit both.`, and the CI parity check in #1170 enforces the pairing.

## Test plan

`sui move test --path packages/margin_liquidation` — **25/25**.

- [x] `sui move build --build-env {mainnet,testnet}` — both exit 0.
- [x] Public surface is purely additive: two new `public fun`, none removed or changed. The two event accessors added for the tests are `#[test_only]` and are **absent from the release bytecode** — verified by disassembling the mainnet build.
- [x] The `Move.lock` change is the `pyth_upgraded` dependency edge and the manifest digests. (Note the framework/`token` pin movement discussed in #1170 — that lands there, not here.)

**`liquidate_base` and `liquidate_quote` had no test coverage at all** before this — the 16 pre-existing tests are deposits, withdrawals, trader authorisation and swaps. Nine added, each verified by applying the mutation it targets, watching it fail, and restoring:

- [x] **Full settlement, both sides.** Nothing previously reached `settle_*_liquidation`: the stale-feed tests abort inside `risk_ratio` and the healthy-manager test returns at the gate. Transposing `base_out`/`quote_out`, zeroing `repay_balance_remaining`, flipping the `base_liquidation` discriminator, reporting the wrong `margin_pool_id`, or routing either repay coin to `@0x0` all passed before and all fail now.
- [x] **Twin parity by outcome.** The legacy and upgraded entries assert identical literals on identical fixtures, so changing either body breaks one of the two. The CI check compares signatures; these compare results.
- [x] **Oracle generation.** Each upgraded entry rejects a stale feed; downgrading it to `risk_ratio_unsafe` fails the test.
- [x] **Swap authorisation.** Deleting `assert_trader` from `swap_base_to_quote` left all 23 tests green — the three tests named for it call `assert_trader_for_testing` directly, and neither swap function was called anywhere in the suite. That guard is the only thing between an arbitrary address and a swap of the vault's whole inventory at `min_quote_out = 0`. Now covered on both swap entries.

## Review

Reviewed alongside #1170 across ten independent passes. For this package specifically:

- **Refactor fidelity proven by differential execution**, not inspection: the pre-PR bodies were spliced back in and run against the new ones on identical fixtures — same result on every field, across 15 scenarios and 42 gate combinations, including the dust floor being inclusive at exactly 1000.
- The legacy and upgraded bodies are byte-identical after normalising the oracle module and type names.
- **Mixing oracle generations is not representable** — routing one call through the wrong module fails to compile.
- Every asserted number was recomputed from the liquidation arithmetic independently and reproduces exactly.

## Risk / Rollout
- Purely additive on-chain. Neither existing entrypoint changes signature or behaviour.
- The legacy pair keeps working until Pyth stops publishing legacy Core, then fails closed — for a manager **with debt**. A debt-free manager's `risk_ratio` short-circuits before touching the oracle, so a stale feed there is a silent no-op rather than an abort. No funds move either way.
- The engine must be repointed to the `_upgraded` entrypoints **and** the upgraded `PriceInfoObject` ids as part of the same cutover.
- Deploy after #1170, since these call `margin_manager_upgraded`.
