### PR TITLE
account: make referral creation PTB-callable (DBU-709)

### DIFF
--- a/packages/account/README.md
+++ b/packages/account/README.md
@@ -54,7 +54,7 @@ The registry creates canonical accounts:
 public fun new(registry: &mut AccountRegistry, ctx: &mut TxContext): AccountWrapper
 public fun new_with_referrer(
     registry: &mut AccountRegistry,
-    referrer: &Account,
+    referrer: &AccountWrapper,
     ctx: &mut TxContext,
 ): AccountWrapper
 public fun new_self_owned(
@@ -66,9 +66,9 @@ public fun new_self_owned(
 
 The returned wrapper must be shared with `account::share`.
 
-`new_with_referrer` records the supplied account's canonical ID on the created
+`new_with_referrer` records the supplied wrapper's canonical account ID on the created
 account and in its `AccountCreated` event. This is caller-selected attribution:
-passing an account proves that it exists, not that its owner authorized or endorsed
+passing a wrapper proves that it exists, not that its owner authorized or endorsed
 the referral. The package does not provide a setter or removal path.
 
 The registry exposes both derived addresses:
@@ -275,8 +275,7 @@ some_app::do_something(account, ...);
 Referred EOA-owned account:
 
 ```move
-let referrer = referrer_wrapper.load_account();
-let wrapper = registry.new_with_referrer(referrer, ctx);
+let wrapper = registry.new_with_referrer(&referrer_wrapper, ctx);
 wrapper.share();
 ```
 

--- a/packages/account/sources/account_registry.move
+++ b/packages/account/sources/account_registry.move
@@ -6,7 +6,7 @@
 /// `account::account` owns wrapper construction, custody, accumulator settlement, and app-data invariants.
 module account::account_registry;
 
-use account::{account::{Self, Account, AccountWrapper, Auth}, account_events};
+use account::{account::{Self, AccountWrapper, Auth}, account_events};
 use std::{internal::Permit, type_name};
 use sui::{derived_object, dynamic_field as df};
 
@@ -76,14 +76,19 @@ public fun new(registry: &mut AccountRegistry, ctx: &mut TxContext): AccountWrap
     registry.new_for_owner(owner, false, option::none(), ctx)
 }
 
-/// Creates the sender's canonical account and permanently records the supplied account as its referrer.
+/// Creates the sender's canonical account and permanently records the supplied wrapper's account as its referrer.
 public fun new_with_referrer(
     registry: &mut AccountRegistry,
-    referrer: &Account,
+    referrer: &AccountWrapper,
     ctx: &mut TxContext,
 ): AccountWrapper {
     let owner = ctx.sender();
-    registry.new_for_owner(owner, false, option::some(referrer.account_id()), ctx)
+    registry.new_for_owner(
+        owner,
+        false,
+        option::some(referrer.load_account().account_id()),
+        ctx,
+    )
 }
 
 /// Creates the canonical account owned by `owner_uid`'s object address, aborting if either derived ID is already claimed.

--- a/packages/account/tests/account_tests.move
+++ b/packages/account/tests/account_tests.move
@@ -73,7 +73,7 @@ fun registry_records_referrer_on_account() {
     let referrer_wrapper_id = registry.derived_wrapper_address(BOB).to_id();
     let referrer_wrapper = scenario.take_shared_by_id<AccountWrapper>(referrer_wrapper_id);
     let referrer_account_id = referrer_wrapper.load_account().account_id();
-    let wrapper = registry.new_with_referrer(referrer_wrapper.load_account(), scenario.ctx());
+    let wrapper = registry.new_with_referrer(&referrer_wrapper, scenario.ctx());
     let wrapper_id = wrapper.id();
 
     assert_eq!(wrapper.load_account().referrer_account_id(), option::some(referrer_account_id));
@@ -127,7 +127,7 @@ fun referral_constructor_cannot_create_second_account_for_same_owner() {
     scenario.next_tx(ALICE);
     let mut registry = scenario.take_shared<AccountRegistry>();
     let first = registry.new(scenario.ctx());
-    let second = registry.new_with_referrer(first.load_account(), scenario.ctx());
+    let second = registry.new_with_referrer(&first, scenario.ctx());
     first.share();
     second.share();
 


### PR DESCRIPTION
## Summary

- Change `account_registry::new_with_referrer` to accept the shared `AccountWrapper` object that a client programmable transaction can supply.
- Preserve the stored and emitted referrer value as the wrapper's canonical account ID.
- Update the focused account tests and public usage documentation for the callable interface.

## Why

The account registry creates canonical accounts used by Predict and other account-based integrations. A client transaction can pass a shared `AccountWrapper`, but it cannot supply a reference to the `Account` value embedded inside that wrapper because Move command results cannot carry references between programmable transaction commands. The previous referral constructor therefore could not be called from a normal client programmable transaction.

## Linear / Context

- [DBU-709](https://linear.app/mysten-labs/issue/DBU-709/make-account-referral-creation-callable-from-ptbs)

## Key decisions

- Keep referral attribution caller-selected and preserve the existing account ID in storage and `AccountCreated`; the wrapper changes only the public input boundary and proves that the referenced canonical account exists.

## Scope / Descoped

- This pull request changes only referral account creation. It does not change account layout, referral authorization, rewards, mutation, or removal behavior.

## Test plan

- [x] `sui move build --path packages/account --warnings-are-errors` — the account package builds without warnings.
- [x] `sui move test --path packages/account --gas-limit 100000000000` — all 13 account unit tests pass, including referral recording and duplicate-owner rejection.
- [x] `git diff --check` — the patch has no whitespace errors.

## Risk / Rollout

This is a public Move function signature change, so source callers must pass an `AccountWrapper` after updating to the new package version. Existing published packages and stored account objects are unaffected; a new package publication adopts the interface, and rollback is publishing from the prior source revision.
