### PR TITLE
margin: repair upgraded Pyth lock graph and docs (DBU-668)

### DIFF
--- a/packages/deepbook_margin/sources/helper/oracle.move
+++ b/packages/deepbook_margin/sources/helper/oracle.move
@@ -49,11 +49,11 @@ public struct ConversionConfig has copy, drop {
     pyth_decimals: u8,
 }
 
-/// A price already read out of a Pyth `PriceInfoObject` and validated against this
-/// package's config. Carrying the value rather than the object is what lets the
-/// legacy feed and Pyth's upgraded Core share one pricing path: the two feeds are distinct Move
-/// types, but a reading taken from either is the same value. Every guard lives in the
-/// reader that produces it, so anything downstream of here is pure arithmetic.
+/// A normalized price read from a Pyth `PriceInfoObject`. Carrying the value rather
+/// than the object lets the legacy feed and Pyth's upgraded Core share one pricing
+/// path even though their `PriceInfoObject`s are distinct Move types. Safe readers
+/// enforce staleness, feed id, and EWMA deviation; pricing later enforces the asset
+/// binding and confidence interval before performing arithmetic.
 public struct PythReading has copy, drop {
     price: u64,
     decimals: u8,
@@ -312,8 +312,8 @@ fun price_config<T>(
     }
 }
 
-/// Reads a fully validated price from the legacy Pyth feed: staleness, feed id,
-/// confidence interval, and EWMA deviation.
+/// Reads the legacy Pyth feed with staleness, feed-id, and EWMA checks, carrying its
+/// confidence interval for validation when the reading is converted to a price.
 public(package) fun read_price<T>(
     price_info_object: &PriceInfoObject,
     registry: &MarginRegistry,

--- a/packages/deepbook_margin/sources/pool_proxy.move
+++ b/packages/deepbook_margin/sources/pool_proxy.move
@@ -49,7 +49,7 @@ public fun update_current_price<BaseAsset, QuoteAsset>(
     quote_price_info_object: &PriceInfoObject,
     clock: &Clock,
 ) {
-    // Safe reads: staleness, feed id, confidence and EWMA are all enforced here.
+    // Safe reads enforce staleness, feed id, and EWMA. Price conversion enforces confidence.
     let base_reading = oracle::read_price<BaseAsset>(base_price_info_object, registry, clock);
     let quote_reading = oracle::read_price<QuoteAsset>(quote_price_info_object, registry, clock);
 

--- a/packages/deepbook_margin/sources/pool_proxy_upgraded.move
+++ b/packages/deepbook_margin/sources/pool_proxy_upgraded.move
@@ -28,7 +28,7 @@ public fun update_current_price<BaseAsset, QuoteAsset>(
     quote_price_info_object: &PriceInfoObjectUpgraded,
     clock: &Clock,
 ) {
-    // Safe reads: staleness, feed id, confidence and EWMA are all enforced here.
+    // Safe reads enforce staleness, feed id, and EWMA. Price conversion enforces confidence.
     let base_reading = oracle::read_price_upgraded<BaseAsset>(
         base_price_info_object,
         registry,

--- a/packages/deepbook_margin/tests/dual_feed_window_tests.move
+++ b/packages/deepbook_margin/tests/dual_feed_window_tests.move
@@ -119,7 +119,7 @@ fun open_1btc_40k_usdc(): (test::Scenario, Clock, MarginAdminCap, MaintainerCap,
 /// EXPLOIT ATTEMPT — dual-feed liquidation.
 /// The same manager is priced through two live feeds in the same block: the
 /// legacy Core feed puts BTC at $4100 (risk 1.1025, NOT liquidatable) while the
-/// Pyth's upgraded Core feed puts BTC at $3900 (risk 1.0975, liquidatable). If the Pro feed
+/// Pyth's upgraded Core feed puts BTC at $3900 (risk 1.0975, liquidatable). If the upgraded feed
 /// alone suffices to liquidate a manager the Core feed calls healthy, the
 /// liquidation goes through and the liquidator walks away with collateral.
 #[test]
@@ -157,16 +157,16 @@ fun dual_feed_window_permits_liquidating_on_the_lower_feed() {
     assert!(core_risk >= liq_threshold, 100); // Core: NOT liquidatable
     assert!(!registry.can_liquidate(pool.id(), core_risk), 101);
 
-    // Pro feed: BTC $3900. Liquidate through the Pro entrypoint in the same block.
-    let pro_btc = build_btc_price_info_object_upgraded(&mut scenario, 3900, &clock);
-    let pro_usdc = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    // Upgraded feed: BTC $3900. Liquidate through the upgraded entrypoint in the same block.
+    let upgraded_btc = build_btc_price_info_object_upgraded(&mut scenario, 3900, &clock);
+    let upgraded_usdc = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
     let repay = mint_coin<USDC>(100_000_000_000, scenario.ctx());
 
     let (base_coin, quote_coin, remaining) = margin_manager_upgraded::liquidate<BTC, USDC, USDC>(
         &mut mm,
         &registry,
-        &pro_btc,
-        &pro_usdc,
+        &upgraded_btc,
+        &upgraded_usdc,
         &mut usdc_pool,
         &mut pool,
         repay,
@@ -181,7 +181,7 @@ fun dual_feed_window_permits_liquidating_on_the_lower_feed() {
 
     destroy_3!(base_coin, quote_coin, remaining);
     destroy_2!(core_btc, core_usdc);
-    destroy_2!(pro_btc, pro_usdc);
+    destroy_2!(upgraded_btc, upgraded_usdc);
     return_shared(btc_pool);
     return_shared(usdc_pool);
     return_shared(pool);
@@ -189,9 +189,9 @@ fun dual_feed_window_permits_liquidating_on_the_lower_feed() {
     cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
 }
 
-/// GUARD — a debt-carrying position cannot be evaluated on a stale Pro feed.
-/// Liquidation through the Pro entrypoint with a stale BTC feed must abort in the
-/// Pro reader's staleness check (get_price_no_older_than).
+/// GUARD — a debt-carrying position cannot be evaluated on a stale upgraded feed.
+/// Liquidation through the upgraded entrypoint with a stale BTC feed must abort in the
+/// upgraded reader's staleness check (get_price_no_older_than).
 #[test, expected_failure(abort_code = pyth_upgraded::pyth::E_STALE_PRICE_UPDATE)]
 fun dual_feed_window_still_enforces_staleness_on_each_feed() {
     let (
@@ -211,15 +211,15 @@ fun dual_feed_window_still_enforces_staleness_on_each_feed() {
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
 
     // Stale by 10 minutes; max age is 60s.
-    let pro_btc = build_stale_btc_price_info_object_upgraded(&mut scenario, 3900, 600, &clock);
-    let pro_usdc = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let upgraded_btc = build_stale_btc_price_info_object_upgraded(&mut scenario, 3900, 600, &clock);
+    let upgraded_usdc = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
     let repay = mint_coin<USDC>(100_000_000_000, scenario.ctx());
 
     let (base_coin, quote_coin, remaining) = margin_manager_upgraded::liquidate<BTC, USDC, USDC>(
         &mut mm,
         &registry,
-        &pro_btc,
-        &pro_usdc,
+        &upgraded_btc,
+        &upgraded_usdc,
         &mut usdc_pool,
         &mut pool,
         repay,
@@ -228,7 +228,7 @@ fun dual_feed_window_still_enforces_staleness_on_each_feed() {
     );
 
     destroy_3!(base_coin, quote_coin, remaining);
-    destroy_2!(pro_btc, pro_usdc);
+    destroy_2!(upgraded_btc, upgraded_usdc);
     return_shared(usdc_pool);
     return_shared(pool);
     return_shared(mm);
@@ -315,18 +315,18 @@ fun dual_feed_window_fires_a_stop_on_the_lower_feed_alone() {
     assert!(legacy_filled.is_empty());
     assert!(mm.conditional_order_ids().length() == 1);
 
-    // Pro feed at $44k, same block, same manager. Re-anchoring the order-validation
+    // Upgraded feed at $44k, same block, same manager. Re-anchoring the order-validation
     // band is itself permissionless, so the same caller does it with the same feed.
-    let pro_44k = build_btc_price_info_object_upgraded(&mut scenario, 44000, &clock);
-    let pro_usdc = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let upgraded_44k = build_btc_price_info_object_upgraded(&mut scenario, 44000, &clock);
+    let upgraded_usdc = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
     deepbook_margin::pool_proxy_upgraded::update_current_price<BTC, USDC>(
         &mut registry,
         &pool,
-        &pro_44k,
-        &pro_usdc,
+        &upgraded_44k,
+        &upgraded_usdc,
         &clock,
     );
-    let pro_filled: vector<OrderInfo> = margin_manager_upgraded::execute_conditional_orders_v2<
+    let upgraded_filled: vector<OrderInfo> = margin_manager_upgraded::execute_conditional_orders_v2<
         BTC,
         USDC,
     >(
@@ -334,20 +334,20 @@ fun dual_feed_window_fires_a_stop_on_the_lower_feed_alone() {
         &mut pool,
         &btc_pool,
         &usdc_pool,
-        &pro_44k,
-        &pro_usdc,
+        &upgraded_44k,
+        &upgraded_usdc,
         &registry,
         10,
         &clock,
         scenario.ctx(),
     );
-    assert!(pro_filled.length() == 1);
+    assert!(upgraded_filled.length() == 1);
     assert!(mm.conditional_order_ids().is_empty());
 
     std::unit_test::destroy(legacy_filled);
-    std::unit_test::destroy(pro_filled);
+    std::unit_test::destroy(upgraded_filled);
     destroy_2!(legacy_48k, legacy_usdc);
-    destroy_2!(pro_44k, pro_usdc);
+    destroy_2!(upgraded_44k, upgraded_usdc);
     destroy_2!(btc_50k, usdc);
     return_shared(btc_pool);
     return_shared(usdc_pool);

--- a/packages/deepbook_margin/tests/helper/oracle_tests.move
+++ b/packages/deepbook_margin/tests/helper/oracle_tests.move
@@ -703,7 +703,7 @@ fun test_read_price_upgraded_matches_legacy_reader() {
     registry.add_config(&admin_cap, pyth_config);
 
     // Same feed id, price, conf, exponent and timestamp through both packages. The
-    // two readers must produce an identical `PythReading`, or the Pro entrypoints
+    // two readers must produce an identical `PythReading`, or the upgraded entrypoints
     // price differently from the legacy ones they shadow.
     let legacy_info = build_pyth_price_info_object(
         &mut scenario,
@@ -713,7 +713,7 @@ fun test_read_price_upgraded_matches_legacy_reader() {
         8,
         clock.timestamp_ms() / 1000,
     );
-    let pro_info = build_pyth_upgraded_price_info_object(
+    let upgraded_info = build_pyth_upgraded_price_info_object(
         &mut scenario,
         test_constants::usdc_price_feed_id(),
         10000000000,
@@ -723,18 +723,18 @@ fun test_read_price_upgraded_matches_legacy_reader() {
     );
 
     let legacy_reading = read_price<USDC>(&legacy_info, &registry, &clock);
-    let pro_reading = read_price_upgraded<USDC>(&pro_info, &registry, &clock);
-    assert!(pro_reading.price() == legacy_reading.price());
-    assert!(pro_reading.decimals() == legacy_reading.decimals());
+    let upgraded_reading = read_price_upgraded<USDC>(&upgraded_info, &registry, &clock);
+    assert!(upgraded_reading.price() == legacy_reading.price());
+    assert!(upgraded_reading.decimals() == legacy_reading.decimals());
 
     let legacy_usd = calculate_usd_price<USDC>(legacy_reading, &registry, 1000000);
-    let pro_usd = calculate_usd_price<USDC>(pro_reading, &registry, 1000000); // 1 USDC
-    assert!(pro_usd == legacy_usd);
-    assert!(pro_usd == 100_000_000_000);
+    let upgraded_usd = calculate_usd_price<USDC>(upgraded_reading, &registry, 1000000); // 1 USDC
+    assert!(upgraded_usd == legacy_usd);
+    assert!(upgraded_usd == 100_000_000_000);
 
     destroy(admin_cap);
     destroy(legacy_info);
-    destroy(pro_info);
+    destroy(upgraded_info);
     test_scenario::return_shared(registry);
     test_scenario::return_shared(clock);
     scenario.end();
@@ -891,7 +891,7 @@ fun test_unvalidated_reading_skips_confidence_bound() {
 }
 
 // === Pyth's upgraded Core EWMA divergence ===
-// `build_pyth_upgraded_price_info_object` sets `ema == spot`, so every other Pro test
+// `build_pyth_upgraded_price_info_object` sets `ema == spot`, so every other upgraded test
 // leaves the divergence guard a tautology. These are the only tests that execute it,
 // and the only thing standing between a mutated `read_price_upgraded` ewma argument and a
 // green CI run.

--- a/packages/deepbook_margin/tests/helper/test_helpers.move
+++ b/packages/deepbook_margin/tests/helper/test_helpers.move
@@ -1675,9 +1675,9 @@ public fun build_pyth_upgraded_price_info_object(
     price_info_upgraded::new_price_info_object_for_test(price_info, scenario.ctx())
 }
 
-/// Pro object whose EWMA price differs from the spot price. The builder above sets
+/// Upgraded-Core object whose EWMA price differs from the spot price. The builder above sets
 /// `ema == spot`, which makes the divergence guard a tautology; every test that means
-/// to exercise `max_ewma_difference_bps` on a Pro feed must come through here.
+/// to exercise `max_ewma_difference_bps` on the upgraded feed must come through here.
 public fun build_pyth_upgraded_price_info_with_ewma(
     scenario: &mut Scenario,
     id: vector<u8>,
@@ -1711,7 +1711,7 @@ public fun build_pyth_upgraded_price_info_with_ewma(
 
 // === Pyth's upgraded Core price object builders ===
 // Twins of the legacy builders above. Pyth's upgraded Core is a separately published package, so
-// its `PriceInfoObject` is a distinct Move type and the Pro entrypoints cannot be
+// its `PriceInfoObject` is a distinct Move type and the upgraded entrypoints cannot be
 // exercised with the legacy objects.
 
 public fun build_demo_usdc_price_info_object_upgraded(
@@ -1757,7 +1757,7 @@ public fun build_btc_price_info_object_upgraded(
     )
 }
 
-/// Stale by `stale_seconds`, for asserting that the Pro readers still enforce
+/// Stale by `stale_seconds`, for asserting that the upgraded readers still enforce
 /// staleness on the paths that validated it before the migration.
 public fun build_stale_btc_price_info_object_upgraded(
     scenario: &mut Scenario,

--- a/packages/deepbook_margin/tests/margin_manager_upgraded_tests.move
+++ b/packages/deepbook_margin/tests/margin_manager_upgraded_tests.move
@@ -5,7 +5,7 @@
 ///
 /// Pyth's upgraded Core is a separately published package, so its `PriceInfoObject` is a distinct
 /// Move type and no legacy test reaches these entrypoints. Each test drives the same
-/// flow as its legacy twin through the Pro feed, so a wrong `_core` target, a swapped
+/// flow as its legacy twin through the upgraded feed, so a wrong `_core` target, a swapped
 /// base/quote argument, or a downgraded reader fails here rather than merely
 /// compiling.
 #[test_only]
@@ -35,7 +35,7 @@ use deepbook_margin::{
 };
 use sui::test_scenario::{Self as test, return_shared};
 
-/// Deposits USDC collateral through the Pro entrypoint and asserts it landed.
+/// Deposits USDC collateral through the upgraded entrypoint and asserts it landed.
 #[test]
 fun deposit_upgraded_credits_collateral() {
     let (
@@ -85,8 +85,8 @@ fun deposit_upgraded_credits_collateral() {
     cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
 }
 
-/// Borrows base through the Pro entrypoint, then reads the position back through the
-/// Pro `risk_ratio`, `manager_state` and `manager_states` views.
+/// Borrows base through the upgraded entrypoint, then reads the position back through the
+/// upgraded `risk_ratio`, `manager_state` and `manager_states` views.
 #[test]
 fun borrow_base_upgraded_and_upgraded_views_agree() {
     let (
@@ -144,7 +144,7 @@ fun borrow_base_upgraded_and_upgraded_views_agree() {
     );
     assert!(mm.borrowed_base_shares() > 0);
 
-    // Pro views must return a real ratio, not the debt-free MAX short-circuit, and it
+    // Upgraded views must return a real ratio, not the debt-free MAX short-circuit, and it
     // must be the *right* ratio: $100k USDC collateral plus the 1 BTC drawn at $100k
     // is $200k of assets against $100k of debt, exactly 2.0. A range assertion would
     // sit still while the two feeds were transposed; this does not.
@@ -225,8 +225,8 @@ fun borrow_base_upgraded_and_upgraded_views_agree() {
     cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
 }
 
-/// A debt-free manager must be able to withdraw with a stale Pro feed: the risk check
-/// does not run, so no price is needed. Pins the lazy-read fix on the Pro path.
+/// A debt-free manager must be able to withdraw with a stale upgraded feed: the risk check
+/// does not run, so no price is needed. Pins the lazy-read fix on the upgraded path.
 #[test]
 fun withdraw_upgraded_no_debt_tolerates_stale_feed() {
     let (
@@ -299,7 +299,7 @@ fun withdraw_upgraded_no_debt_tolerates_stale_feed() {
     cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
 }
 
-/// A debt-free manager's Pro `risk_ratio` view returns MAX without touching the feed.
+/// A debt-free manager's upgraded `risk_ratio` view returns MAX without touching the feed.
 #[test]
 fun risk_ratio_upgraded_no_debt_returns_max_with_stale_feed() {
     let (
@@ -365,7 +365,7 @@ fun risk_ratio_upgraded_no_debt_returns_max_with_stale_feed() {
     cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
 }
 
-/// Borrows quote through the Pro entrypoint. Mirrors `borrow_base_upgraded`, on the other
+/// Borrows quote through the upgraded entrypoint. Mirrors `borrow_base_upgraded`, on the other
 /// side of the pair, so a base/quote transposition in either wrapper is caught.
 #[test]
 fun borrow_quote_upgraded_takes_a_loan() {
@@ -429,7 +429,7 @@ fun borrow_quote_upgraded_takes_a_loan() {
     cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
 }
 
-/// A healthy manager cannot be liquidated. Asserts the Pro `liquidate` reaches the
+/// A healthy manager cannot be liquidated. Asserts the upgraded `liquidate` reaches the
 /// shared core's solvency gate rather than some other path.
 #[test, expected_failure(abort_code = deepbook_margin::margin_manager::ECannotLiquidate)]
 fun liquidate_upgraded_rejects_a_healthy_manager() {
@@ -506,7 +506,7 @@ fun liquidate_upgraded_rejects_a_healthy_manager() {
     cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
 }
 
-/// With no conditional orders registered, both Pro executors return an empty batch.
+/// With no conditional orders registered, both upgraded executors return an empty batch.
 /// Exercises the delegation into the shared cores for v2 and v3.
 #[test]
 fun execute_conditional_orders_upgraded_with_no_orders_returns_empty() {
@@ -577,7 +577,7 @@ fun execute_conditional_orders_upgraded_with_no_orders_returns_empty() {
     cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
 }
 
-/// Registers a conditional order through the Pro entrypoint and reads it back.
+/// Registers a conditional order through the upgraded entrypoint and reads it back.
 #[test]
 fun add_conditional_order_upgraded_registers_the_order() {
     let (
@@ -777,8 +777,8 @@ fun withdraw_upgraded_with_wide_confidence_still_emits() {
     cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
 }
 
-// === `withdraw` with debt: the solvency gate on the Pro path ===
-// Both shipped Pro withdraw tests deposit and never borrow, so `withdraw_needs_risk_check`
+// === `withdraw` with debt: the solvency gate on the upgraded path ===
+// Both shipped upgraded withdraw tests deposit and never borrow, so `withdraw_needs_risk_check`
 // is false and the entire risk branch - the gate deciding whether value may leave a
 // leveraged manager - never executes. These three run it, either side of the floor.
 
@@ -1039,7 +1039,7 @@ fun withdraw_upgraded_with_debt_rejects_stale_feed() {
     cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
 }
 
-// === Reader-choice pins for the remaining Pro entrypoints ===
+// === Reader-choice pins for the remaining upgraded entrypoints ===
 // Each of these reads the oracle unconditionally through the *validated* reader. With
 // no test standing on that choice, swapping in `read_price_upgraded_unsafe` silently drops
 // staleness, EWMA-divergence and confidence enforcement and leaves CI green - on
@@ -1359,7 +1359,7 @@ fun liquidate_upgraded_rejects_stale_feed() {
 }
 
 #[test, expected_failure(abort_code = pyth_upgraded::pyth::E_STALE_PRICE_UPDATE)]
-fun execute_conditional_orders_v2_pro_rejects_stale_feed() {
+fun execute_conditional_orders_v2_upgraded_rejects_stale_feed() {
     let (
         mut scenario,
         clock,
@@ -1438,7 +1438,7 @@ fun execute_conditional_orders_v2_pro_rejects_stale_feed() {
 }
 
 #[test, expected_failure(abort_code = pyth_upgraded::pyth::E_STALE_PRICE_UPDATE)]
-fun execute_conditional_orders_v3_pro_rejects_stale_feed() {
+fun execute_conditional_orders_v3_upgraded_rejects_stale_feed() {
     let (
         mut scenario,
         clock,

--- a/packages/deepbook_margin/tests/pool_proxy_upgraded_tests.move
+++ b/packages/deepbook_margin/tests/pool_proxy_upgraded_tests.move
@@ -4,7 +4,7 @@
 /// Behavioural coverage for `pool_proxy_upgraded`.
 ///
 /// Mirrors the legacy `pool_proxy_tests` happy paths through the Pyth's upgraded Core feed. The
-/// Pro entrypoints are a distinct Move type surface, so nothing in the legacy suite
+/// Upgraded entrypoints are a distinct Move type surface, so nothing in the legacy suite
 /// reaches them; without these, a wrong `_core` target or a downgraded reader would
 /// still compile and still pass CI.
 #[test_only]
@@ -37,7 +37,7 @@ use std::unit_test::destroy;
 use sui::test_scenario::return_shared;
 
 /// `update_current_price` is the permissionless refresh the order-validation path
-/// depends on. Without a Pro twin, price updates would stop at the cutover.
+/// depends on. Without an upgraded twin, price updates would stop at the cutover.
 #[test]
 fun update_current_price_upgraded_refreshes_the_registry() {
     let (
@@ -123,11 +123,11 @@ fun update_current_price_upgraded_holds_base_quote_order() {
     cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
 }
 
-/// A debt-free manager places a limit order through the Pro entrypoint. Also pins the
+/// A debt-free manager places a limit order through the upgraded entrypoint. Also pins the
 /// lazy-read fix: the feeds here are stale, and a debt-free manager must not need
 /// them, exactly as before the migration.
 #[test]
-fun place_limit_order_v2_pro_no_debt_tolerates_stale_feed() {
+fun place_limit_order_v2_upgraded_no_debt_tolerates_stale_feed() {
     let (
         mut scenario,
         clock,
@@ -212,9 +212,9 @@ fun place_limit_order_v2_pro_no_debt_tolerates_stale_feed() {
     cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
 }
 
-/// Market order through the Pro entrypoint, debt-free, with a fresh feed.
+/// Market order through the upgraded entrypoint, debt-free, with a fresh feed.
 #[test]
-fun place_market_order_v2_pro_places_an_order() {
+fun place_market_order_v2_upgraded_places_an_order() {
     let (
         mut scenario,
         clock,
@@ -291,10 +291,10 @@ fun place_market_order_v2_pro_places_an_order() {
     cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
 }
 
-/// Reduce-only limit order through the Pro entrypoint. A bid requires base debt, so
+/// Reduce-only limit order through the upgraded entrypoint. A bid requires base debt, so
 /// these entries always read the oracle - unlike the plain v2 entries.
 #[test]
-fun place_reduce_only_limit_order_v2_pro_places_an_order() {
+fun place_reduce_only_limit_order_v2_upgraded_places_an_order() {
     let (
         mut scenario,
         clock,
@@ -382,12 +382,12 @@ fun place_reduce_only_limit_order_v2_pro_places_an_order() {
     cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
 }
 
-/// Reduce-only market order through the Pro entrypoint. Like its legacy twin
+/// Reduce-only market order through the upgraded entrypoint. Like its legacy twin
 /// (`pool_proxy_tests::test_place_reduce_only_market_order_ok`), this is an
 /// `expected_failure`: a market close pays the spread, and the monotonic gate fires on
 /// the swap-only intermediate state before any repay. Documented in `move.md`.
 #[test, expected_failure(abort_code = deepbook_margin::pool_proxy::ERiskRatioMustNotWorsen)]
-fun place_reduce_only_market_order_v2_pro_aborts_on_worsened_ratio() {
+fun place_reduce_only_market_order_v2_upgraded_aborts_on_worsened_ratio() {
     let (
         mut scenario,
         clock,
@@ -468,7 +468,7 @@ fun place_reduce_only_market_order_v2_pro_aborts_on_worsened_ratio() {
     cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
 }
 
-/// Reduce-only limit close + repay through the Pro entrypoint. A bid requires base
+/// Reduce-only limit close + repay through the upgraded entrypoint. A bid requires base
 /// debt, which the setup establishes.
 #[test]
 fun place_reduce_only_limit_order_and_repay_loan_upgraded_places_an_order() {
@@ -566,7 +566,7 @@ fun place_reduce_only_limit_order_and_repay_loan_upgraded_places_an_order() {
 /// Reduce-only market close *with* the repay included. Unlike the swap-only
 /// `place_reduce_only_market_order_v2` above - which trips the monotonic gate on the
 /// spread - including the repay lifts the ratio, so this succeeds. That contrast is
-/// the behaviour `move.md` documents, and it holds on the Pro path too.
+/// the behaviour `move.md` documents, and it holds on the upgraded path too.
 #[test]
 fun place_reduce_only_market_order_and_repay_loan_upgraded_closes_and_repays() {
     let (
@@ -654,7 +654,7 @@ fun place_reduce_only_market_order_and_repay_loan_upgraded_closes_and_repays() {
     cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
 }
 
-/// Non-reduce-only market close + repay through the Pro entrypoint. Shares the
+/// Non-reduce-only market close + repay through the upgraded entrypoint. Shares the
 /// monotonic gate with the reduce-only entries; the repay carries it.
 #[test]
 fun place_market_order_and_repay_loan_upgraded_closes_and_repays() {
@@ -749,7 +749,7 @@ fun place_market_order_and_repay_loan_upgraded_closes_and_repays() {
 // drops the read entirely and always passes `none` would still be green.
 
 #[test, expected_failure(abort_code = pyth_upgraded::pyth::E_STALE_PRICE_UPDATE)]
-fun place_limit_order_v2_pro_with_debt_rejects_stale_feed() {
+fun place_limit_order_v2_upgraded_with_debt_rejects_stale_feed() {
     let (
         mut scenario,
         clock,
@@ -834,7 +834,7 @@ fun place_limit_order_v2_pro_with_debt_rejects_stale_feed() {
 }
 
 #[test, expected_failure(abort_code = pyth_upgraded::pyth::E_STALE_PRICE_UPDATE)]
-fun place_market_order_v2_pro_with_debt_rejects_stale_feed() {
+fun place_market_order_v2_upgraded_with_debt_rejects_stale_feed() {
     let (
         mut scenario,
         clock,
@@ -1005,7 +1005,7 @@ fun place_market_order_and_repay_loan_upgraded_with_debt_rejects_stale_feed() {
 // of the validated reader, so a downgrade to `read_price_upgraded_unsafe` passed CI.
 
 #[test, expected_failure(abort_code = pyth_upgraded::pyth::E_STALE_PRICE_UPDATE)]
-fun place_reduce_only_limit_order_v2_pro_rejects_stale_feed() {
+fun place_reduce_only_limit_order_v2_upgraded_rejects_stale_feed() {
     let (
         mut scenario,
         clock,
@@ -1091,7 +1091,7 @@ fun place_reduce_only_limit_order_v2_pro_rejects_stale_feed() {
 }
 
 #[test, expected_failure(abort_code = pyth_upgraded::pyth::E_STALE_PRICE_UPDATE)]
-fun place_reduce_only_market_order_v2_pro_rejects_stale_feed() {
+fun place_reduce_only_market_order_v2_upgraded_rejects_stale_feed() {
     let (
         mut scenario,
         clock,
@@ -1382,7 +1382,7 @@ fun update_current_price_upgraded_rejects_stale_feed() {
 // readings are used - which is exactly where transposing them would show up.
 
 #[test]
-fun place_limit_order_v2_pro_with_debt_places_an_order() {
+fun place_limit_order_v2_upgraded_with_debt_places_an_order() {
     let (
         mut scenario,
         clock,
@@ -1472,7 +1472,7 @@ fun place_limit_order_v2_pro_with_debt_places_an_order() {
 }
 
 #[test]
-fun place_market_order_v2_pro_with_debt_places_an_order() {
+fun place_market_order_v2_upgraded_with_debt_places_an_order() {
     let (
         mut scenario,
         clock,

--- a/packages/margin_liquidation/Move.lock
+++ b/packages/margin_liquidation/Move.lock
@@ -61,8 +61,8 @@ deps = { std = "MoveStdlib", sui = "Sui", token = "token" }
 [pinned.mainnet.deepbook_margin]
 source = { local = "../deepbook_margin" }
 use_environment = "mainnet"
-manifest_digest = "E968042AE197611B52E36277EC7F179E2D242F5AC9C381BC26476601EF5001D4"
-deps = { deepbook = "deepbook", pyth = "Pyth", pyth_pro = "PythProCompatible", std = "MoveStdlib", sui = "Sui", token = "token" }
+manifest_digest = "8ED26F045E5709DA6928A6E0EF280725AC17A66AC8038CF26139B0AF9DD41FED"
+deps = { deepbook = "deepbook", pyth = "Pyth", pyth_upgraded = "PythProCompatible", std = "MoveStdlib", sui = "Sui", token = "token" }
 
 [pinned.mainnet.margin_liquidation]
 source = { root = true }
@@ -77,7 +77,7 @@ manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5E
 deps = { std = "MoveStdlib", sui = "Sui" }
 
 [pinned.testnet.MoveStdlib]
-source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "d50b78880fdacb1bbde92e6974ed71a7650c1090" }
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "85400e2bd37b490fcd057776e700d3fdca643396" }
 use_environment = "testnet"
 manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
 deps = {}
@@ -101,7 +101,7 @@ manifest_digest = "AEAC3FAD5DCF925755E55B4498F4CED3B564F87B638049EF0A7C4E9F2EA7E
 deps = { Sui = "Sui_1", WormholeSimpleMajority = "WormholeSimpleMajority" }
 
 [pinned.testnet.Sui]
-source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "d50b78880fdacb1bbde92e6974ed71a7650c1090" }
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "85400e2bd37b490fcd057776e700d3fdca643396" }
 use_environment = "testnet"
 manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
 deps = { MoveStdlib = "MoveStdlib" }
@@ -143,7 +143,7 @@ manifest_digest = "56AC82023B117F89A629BF2EB76AAF63841990AE835AC41AB35CC5AF466AC
 deps = { deepbook = "deepbook", deepbook_margin = "deepbook_margin", pyth = "Pyth", std = "MoveStdlib", sui = "Sui", token = "token" }
 
 [pinned.testnet.token]
-source = { git = "https://github.com/MystenLabs/deepbookv3.git", subdir = "packages/token", rev = "bf07845bb9f597f57cc77f781a1badf3b5594a85" }
+source = { git = "https://github.com/MystenLabs/deepbookv3.git", subdir = "packages/token", rev = "2e0a88f860f1ae64f709b3978f1e206a91771169" }
 use_environment = "testnet"
 manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
 deps = { std = "MoveStdlib", sui = "Sui" }


### PR DESCRIPTION
## Summary
- Repair the `margin_liquidation` mainnet and testnet lock graphs after the upgraded Pyth dependency was added to `deepbook_margin`.
- Rename remaining test-only Pyth Pro terminology to upgraded Pyth terminology and correct oracle validation comments.

## Why
- `margin_liquidation` depends on `deepbook_margin`, so its lockfile must represent the parent PR's added `pyth_upgraded` dependency in both environments. The parent branch currently pins unrelated testnet dependency revisions that make 13 of the 16 liquidation tests abort with `MISSING_DEPENDENCY`, while its mainnet lock still records the old dependency alias and digest.
- A few tests and comments still call the upgraded Pyth Core package "Pro" or imply that confidence is validated while the feed is read. That makes the migration harder to review because Pyth Pro is a different product and confidence is applied later during price conversion.

## Key decisions
- Preserve the previously working Sui and token revisions and update only the `deepbook_margin` lock entries required by the upgraded Pyth dependency.
- Keep this follow-up mechanical: no public API, stored object, oracle behavior, parity checker, CI workflow, or broader architecture changes.

## Test plan
- [x] Build `deepbook_margin` and `margin_liquidation` for both mainnet and testnet; confirm neither `Move.lock` changes.
- [x] `sui move test --path packages/margin_liquidation --gas-limit 100000000000`
- [x] `sui move test --path packages/deepbook_margin --gas-limit 100000000000`
- [x] `corepack pnpm --ignore-workspace run format:move:check`
- [x] `python3 scripts/check_upgraded_parity.py`
