### PR TITLE
sessions: extend grants to spot trading (DBU-712)

### DIFF
--- a/packages/sessions/Move.toml
+++ b/packages/sessions/Move.toml
@@ -6,9 +6,14 @@ version = "0.0.1"
 [dependencies]
 account = { local = "../account" }
 deepbook_predict = { local = "../predict" }
+deepbook_core_account = { local = "../deepbook_core_account" }
+deepbook = { local = "../deepbook" }
 propbook = { local = "../propbook" }
 fixed_math = { local = "../fixed_math" }
 dusdc = { local = "../dusdc" }
+# Predict consumes the in-tree token package while the spot wrapper pins the
+# byte-identical release source. Resolve both through the published in-tree identity.
+token = { local = "../token", override = true }
 # This publishable root repeats Predict's direct Pyth source so the testnet
 # replacement identities below apply to the transitive Pyth/Wormhole graph.
 pyth_lazer = { git = "https://github.com/pyth-network/pyth-crosschain.git", subdir = "lazer/contracts/sui", rev = "f80ff8b1aa2aa9ca17530a9b6294d254f938a5bf" }

--- a/packages/sessions/README.md
+++ b/packages/sessions/README.md
@@ -1,8 +1,8 @@
 # Sessions
 
-`deepbook_sessions` lets the owner of a canonical DeepBook Account authorize an ephemeral address to submit a limited set of Predict transactions for that Account until a fixed expiration time.
+`deepbook_sessions` lets the owner of a canonical DeepBook Account authorize an ephemeral address to submit a limited set of Predict and DeepBook spot transactions for that Account until a fixed expiration time.
 
-The package is an Account app. It stores session grants in the Account's app-local data and generates Account app authorization only inside its Predict wrapper functions. Session callers never receive a reusable `account::Auth`, and the package exposes no withdrawal or arbitrary Account mutation entrypoint.
+The package is an Account app. It stores session grants in the Account's app-local data and generates Account app authorization only inside its trading wrapper functions. Session callers never receive a reusable `account::Auth`, and the package exposes no direct Account withdrawal or arbitrary mutation entrypoint.
 
 ## Authority model
 
@@ -12,7 +12,7 @@ An Account owner opts in by calling `authorize_session` on the Account's shared 
 
 A session grant contains only the session address and its expiration timestamp in milliseconds. Each Account may store at most 20 session addresses. The requested duration must be greater than zero and no more than 30 days. Expiration is calculated from the on-chain `Clock` at execution time, and reauthorizing the same address replaces its stored expiration without consuming another slot.
 
-Every Predict wrapper requires both of these conditions:
+Every trading wrapper requires both of these conditions:
 
 - The transaction sender has a stored session grant for the supplied Account.
 - The current clock timestamp is strictly less than the stored expiration.
@@ -59,7 +59,19 @@ An active session may call these wrappers:
 
 Each wrapper validates the session against the supplied Account, generates app authorization internally, and immediately passes that authorization into the corresponding Predict function. All market parameters remain caller-selected and are validated by Predict.
 
-The session can therefore submit adverse trades for the Account until it expires or is revoked. A grant should be treated as trading authority, not read-only access. Revocation and expiration stop future wrapper calls but do not unwind positions or transactions that already executed.
+## DeepBook spot wrappers
+
+An active session may call these Account-backed DeepBook spot wrappers:
+
+- `place_limit_order`
+- `place_market_order`
+- `cancel_live_order`
+- `cancel_live_orders`
+- `withdraw_settled_amounts`
+
+Each wrapper validates the session against the supplied Account, generates app authorization internally, and immediately passes it into the corresponding `deepbook_core_account` function. Order parameters remain caller-selected and are validated by the Account wrapper and DeepBook core. The permissionless settled-amount withdrawal is not duplicated here because it does not require session authority.
+
+The session can therefore submit adverse Predict and spot trades, cancel the Account's spot orders, and sweep settled spot proceeds back into Account custody until it expires or is revoked. A grant should be treated as trading authority, not read-only access. Revocation and expiration stop future wrapper calls but do not unwind positions, orders, or transactions that already executed.
 
 ## Events
 
@@ -83,11 +95,11 @@ public struct SessionRevoked has copy, drop {
 }
 ```
 
-Expiration emits no event, and a no-op revocation emits no event. Predict continues to emit the underlying mint and redeem events; the wrappers do not duplicate them.
+Expiration emits no event, and a no-op revocation emits no event. Predict and DeepBook core continue to emit their underlying trading events; the wrappers do not duplicate them.
 
 ## Integration requirements
 
-Before Sessions can be used, the package must be published against the intended Account, Predict, and Propbook package lineage, and `SessionsApp` must be authorized in the corresponding Account registry. Publication, registry configuration, SDK transaction construction, ephemeral-key storage, indexing, and deployment are outside this package.
+Before Sessions can be used, the package must be published against the intended Account, Predict, Propbook, DeepBook core, and `deepbook_core_account` package lineages. `SessionsApp` must be authorized in the corresponding Account registry, while `DeepbookCoreAccountApp` must be authorized in the supplied DeepBook registry for spot order placement. Publication, registry configuration, SDK transaction construction, ephemeral-key storage, indexing, and deployment are outside this package.
 
 If the package is published with an upgrade capability, custody of that capability is part of the trust boundary because an upgrade can change the behavior of an authorized Account app.
 

--- a/packages/sessions/sources/sessions.move
+++ b/packages/sessions/sources/sessions.move
@@ -1,12 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Owns time-limited Predict session grants attached to canonical Accounts.
+/// Owns time-limited trading session grants attached to canonical Accounts.
 /// Account owners grant and revoke sessions; an active session can only generate
-/// app auth inside the four Predict wrappers exposed here.
+/// app auth inside the Predict and DeepBook spot wrappers exposed here.
 module deepbook_sessions::sessions;
 
 use account::{account::{Self, AccountWrapper, Auth}, account_registry::AccountRegistry};
+use deepbook::{order_info::OrderInfo, pool::Pool, registry::Registry};
+use deepbook_core_account::deepbook_core_account;
 use deepbook_predict::{
     expiry_market::ExpiryMarket,
     pricing::Pricer,
@@ -96,6 +98,116 @@ public fun revoke_session(wrapper: &mut AccountWrapper, session: address, ctx: &
     if (!data.sessions.contains(&session)) return;
     let (_, expires_at_ms) = data.sessions.remove(&session);
     event::emit(SessionRevoked { account_id, session, expires_at_ms });
+}
+
+/// Place a DeepBook spot limit order for an Account with an active session.
+public fun place_limit_order<BaseAsset, QuoteAsset>(
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    deepbook_registry: &Registry,
+    account_registry: &AccountRegistry,
+    wrapper: &mut AccountWrapper,
+    client_order_id: u64,
+    order_type: u8,
+    self_matching_option: u8,
+    price: u64,
+    quantity: u64,
+    is_bid: bool,
+    pay_with_deep: bool,
+    expire_timestamp: u64,
+    root: &AccumulatorRoot,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): OrderInfo {
+    let auth = generate_auth_as_session(account_registry, wrapper, clock, ctx);
+    deepbook_core_account::place_limit_order(
+        pool,
+        deepbook_registry,
+        wrapper,
+        auth,
+        client_order_id,
+        order_type,
+        self_matching_option,
+        price,
+        quantity,
+        is_bid,
+        pay_with_deep,
+        expire_timestamp,
+        root,
+        clock,
+        ctx,
+    )
+}
+
+/// Place a DeepBook spot market order for an Account with an active session.
+public fun place_market_order<BaseAsset, QuoteAsset>(
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    deepbook_registry: &Registry,
+    account_registry: &AccountRegistry,
+    wrapper: &mut AccountWrapper,
+    client_order_id: u64,
+    self_matching_option: u8,
+    quantity: u64,
+    price_limit: u64,
+    is_bid: bool,
+    pay_with_deep: bool,
+    root: &AccumulatorRoot,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): OrderInfo {
+    let auth = generate_auth_as_session(account_registry, wrapper, clock, ctx);
+    deepbook_core_account::place_market_order(
+        pool,
+        deepbook_registry,
+        wrapper,
+        auth,
+        client_order_id,
+        self_matching_option,
+        quantity,
+        price_limit,
+        is_bid,
+        pay_with_deep,
+        root,
+        clock,
+        ctx,
+    )
+}
+
+/// Cancel a DeepBook spot order for an Account with an active session.
+public fun cancel_live_order<BaseAsset, QuoteAsset>(
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    account_registry: &AccountRegistry,
+    wrapper: &mut AccountWrapper,
+    order_id: u128,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    let auth = generate_auth_as_session(account_registry, wrapper, clock, ctx);
+    deepbook_core_account::cancel_live_order(pool, wrapper, auth, order_id, clock, ctx);
+}
+
+/// Cancel multiple DeepBook spot orders for an Account with an active session.
+public fun cancel_live_orders<BaseAsset, QuoteAsset>(
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    account_registry: &AccountRegistry,
+    wrapper: &mut AccountWrapper,
+    order_ids: vector<u128>,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    let auth = generate_auth_as_session(account_registry, wrapper, clock, ctx);
+    deepbook_core_account::cancel_live_orders(pool, wrapper, auth, order_ids, clock, ctx);
+}
+
+/// Sweep settled DeepBook spot proceeds into an Account with an active session.
+public fun withdraw_settled_amounts<BaseAsset, QuoteAsset>(
+    pool: &mut Pool<BaseAsset, QuoteAsset>,
+    account_registry: &AccountRegistry,
+    wrapper: &mut AccountWrapper,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    let auth = generate_auth_as_session(account_registry, wrapper, clock, ctx);
+    deepbook_core_account::withdraw_settled_amounts(pool, wrapper, auth, ctx);
 }
 
 /// Mint an exact Predict position quantity for an Account with an active session.

--- a/packages/sessions/tests/spot_sessions_tests.move
+++ b/packages/sessions/tests/spot_sessions_tests.move
@@ -1,0 +1,652 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module deepbook_sessions::spot_sessions_tests;
+
+use account::{
+    account::{Self as account, AccountWrapper},
+    account_registry::{Self as account_registry, AccountAdminCap, AccountRegistry}
+};
+use deepbook::{
+    balance_manager::{Self as balance_manager, BalanceManager},
+    constants,
+    order_info::OrderInfo,
+    pool::{Self as pool, Pool},
+    registry::{Self as registry, Registry}
+};
+use deepbook_core_account::{
+    account_data::{Self as account_data, DeepbookCoreAccountApp},
+    deepbook_core_account as dca
+};
+use deepbook_sessions::sessions::{Self as sessions, SessionsApp};
+use std::unit_test::{assert_eq, destroy};
+use sui::{
+    accumulator::{Self as accumulator, AccumulatorRoot},
+    clock::{Self as clock, Clock},
+    coin,
+    test_scenario::{Self as test, Scenario, return_shared},
+    transfer
+};
+use token::deep::DEEP;
+
+const ADMIN: address = @0xAD;
+const ALICE: address = @0xA11CE;
+const BOB: address = @0xB0B;
+const SESSION: address = @0x5E5510;
+
+const NOW_MS: u64 = 1_000;
+const SESSION_DURATION_MS: u64 = 60_000;
+const SESSION_EXPIRES_AT_MS: u64 = 61_000; // 1_000 + 60_000.
+const ACCOUNT_BALANCE: u64 = 5_000_000_000;
+const LIMIT_ORDER_CLIENT_ID: u64 = 11;
+const SECOND_LIMIT_ORDER_CLIENT_ID: u64 = 12;
+const THIRD_LIMIT_ORDER_CLIENT_ID: u64 = 13;
+const MARKET_MAKER_CLIENT_ID: u64 = 21;
+const MARKET_TAKER_CLIENT_ID: u64 = 22;
+const FILLING_BID_CLIENT_ID: u64 = 31;
+const NO_OPEN_ORDERS: u64 = 0;
+const ONE_OPEN_ORDER: u64 = 1;
+const TWO_OPEN_ORDERS: u64 = 2;
+const ZERO_BALANCE: u64 = 0;
+const ZERO_ORDER_ID: u128 = 0;
+const EUnexpectedSuccess: u64 = 999;
+
+public struct BASE has store {}
+public struct QUOTE has store {}
+
+public struct SpotFixture {
+    scenario: Scenario,
+    registry_id: ID,
+    pool_id: ID,
+    wrapper_id: ID,
+}
+
+#[test]
+fun session_places_and_cancels_spot_limit_orders() {
+    let mut fixture = setup_spot_fixture();
+    authorize_session(&mut fixture);
+    let registry_id = fixture.registry_id;
+    let pool_id = fixture.pool_id;
+    let wrapper_id = fixture.wrapper_id;
+    let trade_amount = constants::min_size();
+
+    fixture.scenario.next_tx(SESSION);
+    let registry = fixture.scenario.take_shared_by_id<Registry>(registry_id);
+    let account_registry = fixture.scenario.take_shared<AccountRegistry>();
+    let mut pool = fixture.scenario.take_shared_by_id<Pool<BASE, QUOTE>>(pool_id);
+    let mut wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let root = fixture.scenario.take_shared<AccumulatorRoot>();
+    let clock = fixture.scenario.take_shared<Clock>();
+    let first = sessions::place_limit_order<BASE, QUOTE>(
+        &mut pool,
+        &registry,
+        &account_registry,
+        &mut wrapper,
+        LIMIT_ORDER_CLIENT_ID,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        constants::float_scaling(),
+        trade_amount,
+        false,
+        true,
+        constants::max_u64(),
+        &root,
+        &clock,
+        fixture.scenario.ctx(),
+    );
+    let first_id = first.order_id();
+    assert_eq!(first.status(), constants::live());
+    assert!(first.order_inserted());
+    assert_eq!(
+        dca::pool_account_open_orders<BASE, QUOTE>(&pool, wrapper.load_account()).length(),
+        ONE_OPEN_ORDER,
+    );
+    let (base_locked, quote_locked, deep_locked) = dca::locked_balance<BASE, QUOTE>(
+        &pool,
+        wrapper.load_account(),
+    );
+    assert_eq!(base_locked, trade_amount);
+    assert_eq!(quote_locked, ZERO_BALANCE);
+    assert_eq!(deep_locked, ZERO_BALANCE);
+    return_shared(clock);
+    return_shared(root);
+    return_shared(wrapper);
+    return_shared(pool);
+    return_shared(account_registry);
+    return_shared(registry);
+
+    fixture.scenario.next_tx(SESSION);
+    let account_registry = fixture.scenario.take_shared<AccountRegistry>();
+    let mut pool = fixture.scenario.take_shared_by_id<Pool<BASE, QUOTE>>(pool_id);
+    let mut wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let root = fixture.scenario.take_shared<AccumulatorRoot>();
+    let clock = fixture.scenario.take_shared<Clock>();
+    sessions::cancel_live_order<BASE, QUOTE>(
+        &mut pool,
+        &account_registry,
+        &mut wrapper,
+        first_id,
+        &clock,
+        fixture.scenario.ctx(),
+    );
+    assert_eq!(
+        dca::pool_account_open_orders<BASE, QUOTE>(&pool, wrapper.load_account()).length(),
+        NO_OPEN_ORDERS,
+    );
+    assert_eq!(wrapper.load_account().balance<BASE>(&root, &clock), ACCOUNT_BALANCE);
+    return_shared(clock);
+    return_shared(root);
+    return_shared(wrapper);
+    return_shared(pool);
+    return_shared(account_registry);
+
+    fixture.scenario.next_tx(SESSION);
+    let registry = fixture.scenario.take_shared_by_id<Registry>(registry_id);
+    let account_registry = fixture.scenario.take_shared<AccountRegistry>();
+    let mut pool = fixture.scenario.take_shared_by_id<Pool<BASE, QUOTE>>(pool_id);
+    let mut wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let root = fixture.scenario.take_shared<AccumulatorRoot>();
+    let clock = fixture.scenario.take_shared<Clock>();
+    let second = sessions::place_limit_order<BASE, QUOTE>(
+        &mut pool,
+        &registry,
+        &account_registry,
+        &mut wrapper,
+        SECOND_LIMIT_ORDER_CLIENT_ID,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        constants::float_scaling(),
+        trade_amount,
+        false,
+        true,
+        constants::max_u64(),
+        &root,
+        &clock,
+        fixture.scenario.ctx(),
+    );
+    let third = sessions::place_limit_order<BASE, QUOTE>(
+        &mut pool,
+        &registry,
+        &account_registry,
+        &mut wrapper,
+        THIRD_LIMIT_ORDER_CLIENT_ID,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        constants::float_scaling(),
+        trade_amount,
+        false,
+        true,
+        constants::max_u64(),
+        &root,
+        &clock,
+        fixture.scenario.ctx(),
+    );
+    assert_eq!(
+        dca::pool_account_open_orders<BASE, QUOTE>(&pool, wrapper.load_account()).length(),
+        TWO_OPEN_ORDERS,
+    );
+    let second_id = second.order_id();
+    let third_id = third.order_id();
+    return_shared(clock);
+    return_shared(root);
+    return_shared(wrapper);
+    return_shared(pool);
+    return_shared(account_registry);
+    return_shared(registry);
+
+    fixture.scenario.next_tx(SESSION);
+    let account_registry = fixture.scenario.take_shared<AccountRegistry>();
+    let mut pool = fixture.scenario.take_shared_by_id<Pool<BASE, QUOTE>>(pool_id);
+    let mut wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let root = fixture.scenario.take_shared<AccumulatorRoot>();
+    let clock = fixture.scenario.take_shared<Clock>();
+    sessions::cancel_live_orders<BASE, QUOTE>(
+        &mut pool,
+        &account_registry,
+        &mut wrapper,
+        vector[second_id, third_id],
+        &clock,
+        fixture.scenario.ctx(),
+    );
+    assert_eq!(
+        dca::pool_account_open_orders<BASE, QUOTE>(&pool, wrapper.load_account()).length(),
+        NO_OPEN_ORDERS,
+    );
+    assert_eq!(wrapper.load_account().balance<BASE>(&root, &clock), ACCOUNT_BALANCE);
+    return_shared(clock);
+    return_shared(root);
+    return_shared(wrapper);
+    return_shared(pool);
+    return_shared(account_registry);
+    finish_spot_fixture(fixture);
+}
+
+#[test]
+fun session_places_spot_market_order() {
+    let mut fixture = setup_spot_fixture();
+    let maker_id = create_balance_manager_with_funds(&mut fixture);
+    let trade_amount = constants::min_size();
+    let maker = place_manager_limit_order(
+        &mut fixture,
+        maker_id,
+        MARKET_MAKER_CLIENT_ID,
+        trade_amount,
+        false,
+    );
+    assert_eq!(maker.status(), constants::live());
+    assert!(maker.order_inserted());
+    authorize_session(&mut fixture);
+    let registry_id = fixture.registry_id;
+    let pool_id = fixture.pool_id;
+    let wrapper_id = fixture.wrapper_id;
+
+    fixture.scenario.next_tx(SESSION);
+    let registry = fixture.scenario.take_shared_by_id<Registry>(registry_id);
+    let account_registry = fixture.scenario.take_shared<AccountRegistry>();
+    let mut pool = fixture.scenario.take_shared_by_id<Pool<BASE, QUOTE>>(pool_id);
+    let mut wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let root = fixture.scenario.take_shared<AccumulatorRoot>();
+    let clock = fixture.scenario.take_shared<Clock>();
+    let fill = sessions::place_market_order<BASE, QUOTE>(
+        &mut pool,
+        &registry,
+        &account_registry,
+        &mut wrapper,
+        MARKET_TAKER_CLIENT_ID,
+        constants::self_matching_allowed(),
+        trade_amount,
+        constants::float_scaling(),
+        true,
+        true,
+        &root,
+        &clock,
+        fixture.scenario.ctx(),
+    );
+    assert_eq!(fill.status(), constants::filled());
+    assert_eq!(fill.executed_quantity(), trade_amount);
+    assert_eq!(fill.cumulative_quote_quantity(), trade_amount);
+    assert_eq!(wrapper.load_account().balance<BASE>(&root, &clock), ACCOUNT_BALANCE + trade_amount);
+    assert_eq!(
+        wrapper.load_account().balance<QUOTE>(&root, &clock),
+        ACCOUNT_BALANCE - trade_amount,
+    );
+    assert_eq!(account_data::balance_manager_balance<BASE>(wrapper.load_account()), ZERO_BALANCE);
+    assert_eq!(account_data::balance_manager_balance<QUOTE>(wrapper.load_account()), ZERO_BALANCE);
+    assert_eq!(account_data::balance_manager_balance<DEEP>(wrapper.load_account()), ZERO_BALANCE);
+    return_shared(clock);
+    return_shared(root);
+    return_shared(wrapper);
+    return_shared(pool);
+    return_shared(account_registry);
+    return_shared(registry);
+    finish_spot_fixture(fixture);
+}
+
+#[test]
+fun session_withdraws_settled_spot_amounts() {
+    let mut fixture = setup_spot_fixture();
+    let bob_manager_id = create_balance_manager_with_funds(&mut fixture);
+    authorize_session(&mut fixture);
+    let registry_id = fixture.registry_id;
+    let pool_id = fixture.pool_id;
+    let wrapper_id = fixture.wrapper_id;
+    let trade_amount = constants::min_size();
+
+    fixture.scenario.next_tx(SESSION);
+    let registry = fixture.scenario.take_shared_by_id<Registry>(registry_id);
+    let account_registry = fixture.scenario.take_shared<AccountRegistry>();
+    let mut pool = fixture.scenario.take_shared_by_id<Pool<BASE, QUOTE>>(pool_id);
+    let mut wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let root = fixture.scenario.take_shared<AccumulatorRoot>();
+    let clock = fixture.scenario.take_shared<Clock>();
+    let ask = sessions::place_limit_order<BASE, QUOTE>(
+        &mut pool,
+        &registry,
+        &account_registry,
+        &mut wrapper,
+        LIMIT_ORDER_CLIENT_ID,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        constants::float_scaling(),
+        trade_amount,
+        false,
+        true,
+        constants::max_u64(),
+        &root,
+        &clock,
+        fixture.scenario.ctx(),
+    );
+    assert_eq!(ask.status(), constants::live());
+    assert!(ask.order_inserted());
+    assert_eq!(wrapper.load_account().balance<BASE>(&root, &clock), ACCOUNT_BALANCE - trade_amount);
+    return_shared(clock);
+    return_shared(root);
+    return_shared(wrapper);
+    return_shared(pool);
+    return_shared(account_registry);
+    return_shared(registry);
+
+    let fill = place_manager_market_order(
+        &mut fixture,
+        bob_manager_id,
+        FILLING_BID_CLIENT_ID,
+        trade_amount,
+        true,
+    );
+    assert_eq!(fill.status(), constants::filled());
+    assert_eq!(fill.executed_quantity(), trade_amount);
+
+    fixture.scenario.next_tx(SESSION);
+    let account_registry = fixture.scenario.take_shared<AccountRegistry>();
+    let mut pool = fixture.scenario.take_shared_by_id<Pool<BASE, QUOTE>>(pool_id);
+    let mut wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let root = fixture.scenario.take_shared<AccumulatorRoot>();
+    let clock = fixture.scenario.take_shared<Clock>();
+    assert_eq!(wrapper.load_account().balance<QUOTE>(&root, &clock), ACCOUNT_BALANCE);
+    sessions::withdraw_settled_amounts<BASE, QUOTE>(
+        &mut pool,
+        &account_registry,
+        &mut wrapper,
+        &clock,
+        fixture.scenario.ctx(),
+    );
+    assert_eq!(wrapper.load_account().balance<BASE>(&root, &clock), ACCOUNT_BALANCE - trade_amount);
+    assert_eq!(
+        wrapper.load_account().balance<QUOTE>(&root, &clock),
+        ACCOUNT_BALANCE + trade_amount,
+    );
+    assert_eq!(account_data::balance_manager_balance<BASE>(wrapper.load_account()), ZERO_BALANCE);
+    assert_eq!(account_data::balance_manager_balance<QUOTE>(wrapper.load_account()), ZERO_BALANCE);
+    assert_eq!(account_data::balance_manager_balance<DEEP>(wrapper.load_account()), ZERO_BALANCE);
+    return_shared(clock);
+    return_shared(root);
+    return_shared(wrapper);
+    return_shared(pool);
+    return_shared(account_registry);
+    finish_spot_fixture(fixture);
+}
+
+#[test, expected_failure(abort_code = sessions::ESessionNotAuthorized)]
+fun unapproved_session_cannot_place_spot_order() {
+    let mut fixture = setup_spot_fixture();
+    let registry_id = fixture.registry_id;
+    let pool_id = fixture.pool_id;
+    let wrapper_id = fixture.wrapper_id;
+
+    fixture.scenario.next_tx(SESSION);
+    let registry = fixture.scenario.take_shared_by_id<Registry>(registry_id);
+    let account_registry = fixture.scenario.take_shared<AccountRegistry>();
+    let mut pool = fixture.scenario.take_shared_by_id<Pool<BASE, QUOTE>>(pool_id);
+    let mut wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let root = fixture.scenario.take_shared<AccumulatorRoot>();
+    let clock = fixture.scenario.take_shared<Clock>();
+    let _ = sessions::place_limit_order<BASE, QUOTE>(
+        &mut pool,
+        &registry,
+        &account_registry,
+        &mut wrapper,
+        LIMIT_ORDER_CLIENT_ID,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        constants::float_scaling(),
+        constants::min_size(),
+        false,
+        true,
+        constants::max_u64(),
+        &root,
+        &clock,
+        fixture.scenario.ctx(),
+    );
+    abort EUnexpectedSuccess
+}
+
+#[test, expected_failure(abort_code = sessions::ESessionNotAuthorized)]
+fun session_at_exact_expiration_cannot_place_spot_market_order() {
+    let mut fixture = setup_spot_fixture();
+    authorize_session(&mut fixture);
+    set_clock(&mut fixture, SESSION_EXPIRES_AT_MS);
+    let registry_id = fixture.registry_id;
+    let pool_id = fixture.pool_id;
+    let wrapper_id = fixture.wrapper_id;
+
+    fixture.scenario.next_tx(SESSION);
+    let registry = fixture.scenario.take_shared_by_id<Registry>(registry_id);
+    let account_registry = fixture.scenario.take_shared<AccountRegistry>();
+    let mut pool = fixture.scenario.take_shared_by_id<Pool<BASE, QUOTE>>(pool_id);
+    let mut wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let root = fixture.scenario.take_shared<AccumulatorRoot>();
+    let clock = fixture.scenario.take_shared<Clock>();
+    let _ = sessions::place_market_order<BASE, QUOTE>(
+        &mut pool,
+        &registry,
+        &account_registry,
+        &mut wrapper,
+        MARKET_TAKER_CLIENT_ID,
+        constants::self_matching_allowed(),
+        constants::min_size(),
+        constants::float_scaling(),
+        true,
+        true,
+        &root,
+        &clock,
+        fixture.scenario.ctx(),
+    );
+    abort EUnexpectedSuccess
+}
+
+#[test, expected_failure(abort_code = sessions::ESessionNotAuthorized)]
+fun revoked_session_cannot_cancel_spot_order() {
+    let mut fixture = setup_spot_fixture();
+    authorize_session(&mut fixture);
+    revoke_session(&mut fixture);
+    let pool_id = fixture.pool_id;
+    let wrapper_id = fixture.wrapper_id;
+
+    fixture.scenario.next_tx(SESSION);
+    let account_registry = fixture.scenario.take_shared<AccountRegistry>();
+    let mut pool = fixture.scenario.take_shared_by_id<Pool<BASE, QUOTE>>(pool_id);
+    let mut wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let clock = fixture.scenario.take_shared<Clock>();
+    sessions::cancel_live_order<BASE, QUOTE>(
+        &mut pool,
+        &account_registry,
+        &mut wrapper,
+        ZERO_ORDER_ID,
+        &clock,
+        fixture.scenario.ctx(),
+    );
+    abort EUnexpectedSuccess
+}
+
+fun setup_spot_fixture(): SpotFixture {
+    let mut scenario = test::begin(ADMIN);
+
+    scenario.next_tx(@0x0);
+    accumulator::create_for_testing(scenario.ctx());
+
+    scenario.next_tx(ADMIN);
+    let registry_id = registry::test_registry(scenario.ctx());
+    account_registry::init_for_testing(scenario.ctx());
+    let mut clock = clock::create_for_testing(scenario.ctx());
+    clock.set_for_testing(NOW_MS);
+    clock.share_for_testing();
+    let pool_id = create_pool(&mut scenario, registry_id);
+    authorize_core_app(&mut scenario, registry_id);
+    authorize_sessions_app(&mut scenario);
+
+    scenario.next_tx(ALICE);
+    let mut account_registry = scenario.take_shared<AccountRegistry>();
+    let mut wrapper = account_registry.new(scenario.ctx());
+    let account = wrapper.load_account_mut(account::generate_auth(scenario.ctx()));
+    account.deposit<BASE>(coin::mint_for_testing<BASE>(ACCOUNT_BALANCE, scenario.ctx()));
+    account.deposit<QUOTE>(coin::mint_for_testing<QUOTE>(ACCOUNT_BALANCE, scenario.ctx()));
+    account.deposit<DEEP>(coin::mint_for_testing<DEEP>(ACCOUNT_BALANCE, scenario.ctx()));
+    let wrapper_id = wrapper.id();
+    wrapper.share();
+    return_shared(account_registry);
+
+    SpotFixture { scenario, registry_id, pool_id, wrapper_id }
+}
+
+fun authorize_session(fixture: &mut SpotFixture) {
+    let wrapper_id = fixture.wrapper_id;
+    fixture.scenario.next_tx(ALICE);
+    let mut wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let clock = fixture.scenario.take_shared<Clock>();
+    sessions::authorize_session(
+        &mut wrapper,
+        SESSION,
+        SESSION_DURATION_MS,
+        &clock,
+        fixture.scenario.ctx(),
+    );
+    assert_eq!(
+        sessions::session_expiration_ms(&wrapper, SESSION),
+        option::some(SESSION_EXPIRES_AT_MS),
+    );
+    return_shared(clock);
+    return_shared(wrapper);
+}
+
+fun revoke_session(fixture: &mut SpotFixture) {
+    let wrapper_id = fixture.wrapper_id;
+    fixture.scenario.next_tx(ALICE);
+    let mut wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    sessions::revoke_session(&mut wrapper, SESSION, fixture.scenario.ctx());
+    assert!(sessions::session_expiration_ms(&wrapper, SESSION).is_none());
+    return_shared(wrapper);
+}
+
+fun set_clock(fixture: &mut SpotFixture, timestamp_ms: u64) {
+    fixture.scenario.next_tx(ADMIN);
+    let mut clock = fixture.scenario.take_shared<Clock>();
+    clock.set_for_testing(timestamp_ms);
+    assert_eq!(clock.timestamp_ms(), timestamp_ms);
+    return_shared(clock);
+}
+
+fun create_balance_manager_with_funds(fixture: &mut SpotFixture): ID {
+    fixture.scenario.next_tx(BOB);
+    let mut manager = balance_manager::new(fixture.scenario.ctx());
+    manager.deposit<BASE>(
+        coin::mint_for_testing<BASE>(ACCOUNT_BALANCE, fixture.scenario.ctx()),
+        fixture.scenario.ctx(),
+    );
+    manager.deposit<QUOTE>(
+        coin::mint_for_testing<QUOTE>(ACCOUNT_BALANCE, fixture.scenario.ctx()),
+        fixture.scenario.ctx(),
+    );
+    manager.deposit<DEEP>(
+        coin::mint_for_testing<DEEP>(ACCOUNT_BALANCE, fixture.scenario.ctx()),
+        fixture.scenario.ctx(),
+    );
+    let manager_id = manager.id();
+    transfer::public_share_object(manager);
+    manager_id
+}
+
+fun place_manager_limit_order(
+    fixture: &mut SpotFixture,
+    manager_id: ID,
+    client_order_id: u64,
+    quantity: u64,
+    is_bid: bool,
+): OrderInfo {
+    let pool_id = fixture.pool_id;
+    fixture.scenario.next_tx(BOB);
+    let mut pool = fixture.scenario.take_shared_by_id<Pool<BASE, QUOTE>>(pool_id);
+    let clock = fixture.scenario.take_shared<Clock>();
+    let mut manager = fixture.scenario.take_shared_by_id<BalanceManager>(manager_id);
+    let proof = manager.generate_proof_as_owner(fixture.scenario.ctx());
+    let info = pool.place_limit_order<BASE, QUOTE>(
+        &mut manager,
+        &proof,
+        client_order_id,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        constants::float_scaling(),
+        quantity,
+        is_bid,
+        true,
+        constants::max_u64(),
+        &clock,
+        fixture.scenario.ctx(),
+    );
+    return_shared(manager);
+    return_shared(clock);
+    return_shared(pool);
+    info
+}
+
+fun place_manager_market_order(
+    fixture: &mut SpotFixture,
+    manager_id: ID,
+    client_order_id: u64,
+    quantity: u64,
+    is_bid: bool,
+): OrderInfo {
+    let pool_id = fixture.pool_id;
+    fixture.scenario.next_tx(BOB);
+    let mut pool = fixture.scenario.take_shared_by_id<Pool<BASE, QUOTE>>(pool_id);
+    let clock = fixture.scenario.take_shared<Clock>();
+    let mut manager = fixture.scenario.take_shared_by_id<BalanceManager>(manager_id);
+    let proof = manager.generate_proof_as_owner(fixture.scenario.ctx());
+    let info = pool.place_market_order<BASE, QUOTE>(
+        &mut manager,
+        &proof,
+        client_order_id,
+        constants::self_matching_allowed(),
+        quantity,
+        is_bid,
+        true,
+        &clock,
+        fixture.scenario.ctx(),
+    );
+    return_shared(manager);
+    return_shared(clock);
+    return_shared(pool);
+    info
+}
+
+fun authorize_core_app(scenario: &mut Scenario, registry_id: ID) {
+    scenario.next_tx(ADMIN);
+    let admin_cap = registry::get_admin_cap_for_testing(scenario.ctx());
+    let mut registry = scenario.take_shared_by_id<Registry>(registry_id);
+    registry.authorize_app<DeepbookCoreAccountApp>(&admin_cap);
+    return_shared(registry);
+    destroy(admin_cap);
+}
+
+fun authorize_sessions_app(scenario: &mut Scenario) {
+    scenario.next_tx(ADMIN);
+    let admin_cap = scenario.take_from_sender<AccountAdminCap>();
+    let mut registry = scenario.take_shared<AccountRegistry>();
+    registry.authorize_app<SessionsApp>(&admin_cap);
+    return_shared(registry);
+    destroy(admin_cap);
+}
+
+fun create_pool(scenario: &mut Scenario, registry_id: ID): ID {
+    scenario.next_tx(ADMIN);
+    let admin_cap = registry::get_admin_cap_for_testing(scenario.ctx());
+    let mut registry = scenario.take_shared_by_id<Registry>(registry_id);
+    let pool_id = pool::create_pool_admin<BASE, QUOTE>(
+        &mut registry,
+        constants::tick_size(),
+        constants::lot_size(),
+        constants::min_size(),
+        true,
+        false,
+        &admin_cap,
+        scenario.ctx(),
+    );
+    return_shared(registry);
+    destroy(admin_cap);
+    pool_id
+}
+
+fun finish_spot_fixture(fixture: SpotFixture) {
+    let SpotFixture { scenario, registry_id: _, pool_id: _, wrapper_id: _ } = fixture;
+    scenario.end();
+}


### PR DESCRIPTION
## Summary

- Add session-authorized wrappers for the five Account-backed DeepBook spot write operations.
- Preserve the existing grant lifecycle while extending active grants to place, cancel, and settle spot orders.
- Add integration coverage for limit orders, market orders, cancellation, settled proceeds, expiry, and revocation.

## Why

The Sessions package lets an Account owner delegate bounded trading authority to an ephemeral signer without exposing reusable Account authorization. It currently supports Predict only, so the same session cannot trade the Account's DeepBook spot balances through the Account wrapper. This change adds the corresponding spot transaction surface while retaining the same on-chain expiry and revocation checks.

## Linear / Context

- [DBU-712](https://linear.app/mysten-labs/issue/DBU-712/extend-account-sessions-to-deepbook-spot-trading)

## Key decisions

- Existing unexpired grants gain spot trading authority because the grant carries one trading capability rather than a product-specific permission set.
- The package wraps the five Account-authorized spot writes and does not duplicate the permissionless settled-amount withdrawal.
- Session authorization is generated and consumed inside each wrapper; callers never receive an `account::Auth` value.

## Scope / Descoped

- This PR changes only the Sessions package and its documentation and tests.
- Testnet deployment and deployment metadata are handled on the Testnet deployment branch.
- DeepBook application, SDK, indexer, API, Account, and DeepBook core changes are out of scope.

## Test plan

- [x] `sui move build --path packages/sessions --warnings-are-errors` — the combined Predict, Account, and DeepBook spot dependency graph builds without warnings.
- [x] `sui move test --path packages/sessions --gas-limit 100000000000` — all 24 tests pass, including all five spot wrappers and missing, exact-expiry, and revoked session failures.
- [x] `checks/format-move.sh .../packages/sessions/sources/sessions.move .../packages/sessions/tests/spot_sessions_tests.move` — changed Move files match the repository-pinned formatter.

## Risk / Rollout

The new public functions are additive and do not change `SessionsApp`, `SessionsData`, existing events, error codes, or public signatures. A compatible package upgrade preserves existing Account-local grants, and those grants intentionally gain the added spot authority. Testnet rollout and live order smoke tests will occur through a separate deployment PR before this PR is merged.
