### PR TITLE
predeploy: file the settlement fallback gap as P-29 with a design

### DIFF
--- a/packages/predict/predeploy/open-items.md
+++ b/packages/predict/predeploy/open-items.md
@@ -239,6 +239,101 @@ unsettled — the keeper default and this repo's design record disagree, and
 every per-day figure in the discussion moves with it. Settle the cadence before
 running, or the result is not interpretable.
 
+### P-29: Settlement has no fallback when no admissible print exists at a boundary
+
+**Severity:** High for any non-24/7 underlying; otherwise an unmeasured tail
+with an unbounded consequence. Launch blocker before listing a session-traded
+asset.
+
+Settlement reads one exact key. `try_settle` calls `load_exact_spot_read` at
+`market.expiry`, and the only way to fill that key is
+`pyth_feed::insert_at`, which requires an envelope stamped at exactly that
+millisecond carrying a price generated no more than
+`constants::max_settlement_carry_ms` (2s) earlier. The lane is insert-only:
+`oracle_lane::insert_at` ignores an occupied key without aborting, and there is
+no overwrite or removal.
+
+So a boundary has no admissible settling row, permanently, in either of two
+states:
+
+- **Empty.** Price generation gapped across the boundary by more than the carry
+  window, so every envelope at that millisecond is rejected
+  (`ESettlementCarryExceedsWindow`).
+- **Poisoned.** The first lane-valid observation to claim the key has no
+  normalized projection (`pyth_feed::normalize_raw_spot` returns none on a
+  negative price, a `scale_up` overflow, a negative exponent shifted more than
+  18, or a price that rounds to zero). The doc comment on `insert_at` states
+  the consequence directly: the first lane-valid raw observation owns the key
+  and cannot be replaced, even if its normalized projection is unavailable.
+
+Either way `try_settle` returns false forever, post-expiry live pricing aborts
+`ELivePricingExpired`, and RP-4's response — abort the flush and retry — never
+terminates. RP-4 records this ("Recovery is not guaranteed", risk profile
+`UNMEASURED` for the unrecoverable case) and its reopen clause names the
+remedy: an admin settlement fallback. This item is that remedy.
+
+**Why this is not only a tail.** For a 24/7 crypto underlying the trigger is an
+unmeasured generation-gap tail. For a session-traded underlying — equities,
+futures, FX, metals — a grid boundary landing in a closed session carries from
+beyond the window *by construction*, so the failure is certain rather than
+probabilistic. Listing any such asset without this item resolved ships a known
+permanent pool-wide brick.
+
+**Two properties any fallback must preserve.**
+
+1. **It must not weaken `insert_at`.** First-writer-wins on the oracle lane is
+   what stops a permissionless caller from rewriting settlement history. The
+   fallback therefore records a settlement price on the market and must not
+   mutate or remove a lane row.
+2. **It must not become an admin price lever.** RP-4 refuses a substitute
+   *mark* because an unsettled market has no well-defined value. A fallback
+   avoids that objection only by actually settling the market, and only when
+   normal settlement provably cannot — so the arming condition has to be
+   objective and on-chain checkable, never discretionary.
+
+**Proposed design — two layers, the second only if the first cannot fire.**
+
+*Arming condition (both layers).* `clock.timestamp_ms() >= expiry +
+settlement_grace_ms`, and the exact key is either unfilled or holds a read with
+no normalized projection. Normal settlement always wins inside the grace
+window; the fallback is unreachable for any market that could still settle
+normally.
+
+*Layer 1 — deterministic widened reach, permissionless, no discretion.* Settle
+from the nearest admissible normalized print within a compiled
+`fallback_reach_ms` of the boundary, nearest-preceding first, ties to the
+earlier timestamp. Fully determined by lane contents, so any caller computes
+the same answer and no attestation is needed. This is the layer that answers
+the crypto generation-gap case and the poisoned-key case, because it reads past
+the poisoned key rather than replacing it. It deliberately relaxes the
+"defensible mark for that tick" property the carry bound protects, which is
+exactly why it sits behind the arming condition.
+
+*Layer 2 — attested settlement under a timelock, only when layer 1 finds
+nothing.* An `AdminCap` holder proposes a settlement price; the market enters a
+published `challenge_window_ms` during which it is flagged and settlement is
+not yet recorded; the price takes effect when the window elapses. The check on
+a wrong price is the window plus the existing protocol freeze, not an on-chain
+dispute mechanism — worth stating plainly rather than calling it a challenge
+process it is not. This is the layer that answers the session-closure case,
+where no print exists within any defensible reach, and it is the layer that
+carries a real trust decision.
+
+**What this buys even before layer 2.** Today the flush block is unbounded.
+With the arming condition alone it becomes bounded by `settlement_grace_ms`
+plus the reach lookup, which converts a permanent pool-wide brick into a
+delay of known length.
+
+**Action:** Decide whether layer 2 is in scope for launch or whether launch is
+restricted to 24/7 underlyings with layer 1 only, then implement and graduate
+the decision to `response-policies.md` as an entry resolving this item and
+reopening RP-4. Publish the rule before launch, not during an outage. Pinning
+tests to carry: arming refused inside the grace window; arming refused when the
+exact key holds a normalizable read; layer 1 settling across an empty key;
+layer 1 settling across a poisoned key without mutating it; layer 1 refusing
+beyond `fallback_reach_ms`; and, if layer 2 ships, no effect before the window
+elapses.
+
 ## Access and Governance
 
 ### G-1: Root admin caps have no on-chain revocation or rotation


### PR DESCRIPTION
## Summary

- Files **P-29** in `packages/predict/predeploy/open-items.md`: settlement has no fallback when no admissible print exists at a market's expiry boundary.
- Carries the proposed design inline — an objective arming condition, a deterministic layer that needs no attestation, and an attested layer that is stated as an open trust decision rather than assumed.
- Design and register only. No contract code, no decision taken.

## Why

Settlement reads exactly one key. `try_settle` calls `load_exact_spot_read` at `market.expiry`, and the only way to fill that key is `pyth_feed::insert_at`, which needs an envelope stamped at exactly that millisecond carrying a price generated no more than 2s earlier. The lane is insert-only — an occupied key is ignored without aborting, and there is no overwrite or removal — so a boundary can end up permanently unsettleable in two ways: **empty**, when price generation gapped across it by more than the carry window, or **poisoned**, when the first lane-valid observation to claim the key has no normalized projection. `insert_at`'s own doc comment states the second case: the first lane-valid raw observation owns the key and cannot be replaced, even if its normalized projection is unavailable.

When that happens `try_settle` returns false forever, post-expiry live pricing aborts `ELivePricingExpired`, and RP-4's response — abort the flush and retry — never terminates, so LP fills stop pool-wide with no on-chain way back. RP-4 already records this outcome and its reopen clause already names an admin settlement fallback as the remedy, but no item tracked building one, so the work was invisible to the register.

The reason to file it now rather than after the carry-availability measurement: on a 24/7 crypto underlying this is an unmeasured tail, but on a session-traded underlying — equities, futures, FX, metals — a grid boundary landing in a closed session carries from beyond the window *by construction*. Listing any such asset without this resolved ships a known permanent pool-wide brick, and that is a listing decision that could otherwise be made without anyone seeing the constraint.

## Linear / Context

- N/A — exempt. Register entry only; no runtime behavior.
- Interacts with RP-4 (`response-policies.md`), whose reopen clause this item is written against.

## Key decisions

- **Filed as a contract finding, not a deploy gate.** The existing S-gates all close by an answer or an inspection; this one closes by shipping code plus a decision, which is the contract-finding lifecycle.
- **The fallback must not weaken `insert_at`.** First-writer-wins on the oracle lane is what stops a permissionless caller rewriting settlement history, so the design records a settlement price on the market and reads *past* a poisoned key rather than mutating or removing the row.
- **Layer 1 is deterministic on purpose.** Nearest admissible print within a compiled reach, nearest-preceding, ties to the earlier timestamp — fully determined by lane contents, so it needs no attestation and no discretion, and any caller computes the same answer.
- **Layer 2's check is named honestly.** The timelock plus the existing freeze is what guards a wrong attested price; there is no on-chain dispute mechanism, so the entry says that rather than calling it a challenge process.
- **The arming condition is objective.** Grace period elapsed *and* the exact key unfilled or non-normalizable. Normal settlement always wins inside the grace window, which is what keeps this from becoming a general admin price lever — the objection RP-4 raises against a substitute mark.

## Scope / Descoped

- No contract code. The item is intake plus a design for review.
- Does not decide whether layer 2 ships for launch; that is stated as the open question, since it is the part that carries a trust change.
- Does not modify RP-4. Its reopen happens in the register entry that eventually resolves this item.

## Test plan

- [x] `python3 packages/predict/predeploy/check.py` — **0 new warnings** from this change. Note the run reports one pre-existing FATAL unrelated to this diff (see below).
- [x] Verified the same FATAL reproduces on clean `origin/main` with this change stashed, so it is not introduced here.
- [x] No `.move` files touched, so no build, suite, or formatting run applies.

## Risk / Rollout

None — documentation only, no runtime impact.

**Pre-existing lint failure worth flagging separately:** `check.py` currently fails on `origin/main` with `RP-26 … claims MEASURED but links no existing findings doc in its risk profile`. RP-26 arrived in #1212 (`1073047e`) with an analytic justification and no `evidence/` record, which is the condition the checker treats as fatal. Either the tag should not be `MEASURED` or the findings doc is missing. Not fixed here to keep this diff scoped — happy to take it as a follow-up.