### PR TITLE
predict: fix RP-26 evidence classification

### DIFF
--- a/packages/predict/predeploy/response-policies.md
+++ b/packages/predict/predeploy/response-policies.md
@@ -1322,13 +1322,14 @@ Each entry records: **Trigger state** / **Controller** / **Blast radius** /
   0.5 against a returned 1.0. No envelope that admits arbitrage-free surfaces can
   make the shortcut sound, so the shortcut is the thing that had to go. Removing the
   precision loss removes the need for both.
-- **Risk profile:** `MEASURED`. The identity is exact in reals and the fixed-point
+- **Risk profile:** `BEST-GUESS`. The identity is exact in reals and the fixed-point
   error is bounded by two `ln` evaluations instead of one `ln` of a truncated
   quotient, which is strictly better everywhere and unboundedly better in the tails.
   Existing exact-value coverage is unchanged: the four real-scenario reference tests
   and the flat-surface at-the-forward digital all still hold to their derived
   budgets. One differential test moved off a bit-equality that held only for the old
-  path's price low bits (see below).
+  path's price low bits (see below). No dated findings record is filed under
+  `evidence/`, so this entry does not claim a measured risk profile.
 - **Envelope unchanged:** `max_svi_input` stays at 100. It was tightened in an
   earlier draft of this policy and reverted after checking calibrated raw-SVI
   parameters for real BTC surfaces — `b` reaches 0.21 across maturities and 0.10


### PR DESCRIPTION
## Summary

- Reclassify RP-26's risk profile from `MEASURED` to `BEST-GUESS`.
- State explicitly that no dated findings record exists under `packages/predict/predeploy/evidence/`.

## Why

The Predict predeploy register distinguishes analytically supported policies from claims backed by a pre-registered, immutable measurement record. PR #1212 added RP-26 with strong mathematical reasoning and pinning tests, but labeled it `MEASURED` without linking a dated evidence document. The repository checker correctly rejects that unsupported classification, so this follow-up makes the metadata match the evidence that actually exists.

## Linear / Context

- N/A — exempt; documentation-only follow-up to #1212.
- Discovered by the Build and unit tests check on #1226.

## Key decisions

- Preserve RP-26's analytical claims and pinning tests, but classify the risk profile as `BEST-GUESS`. Creating evidence retroactively would bypass the predeploy lifecycle, which requires the measurement question, harness strategy, and decision rule to be recorded before a run.

## Scope / Descoped

- Scope is limited to RP-26's evidence classification and explanatory text.
- No Move code, pricing behavior, numerical envelope, or test behavior changes.
- A future pre-registered measurement campaign may promote the entry back to `MEASURED` with a dated evidence link.

## Test plan

- [x] `python3 packages/predict/predeploy/check.py` — reports that predeploy cross-references are clean with zero warnings.
- [x] `python3 -m unittest discover -s packages/predict/predeploy/tests -p "test_*.py" -v` — all 3 checker tests pass.
- [x] `git diff --check -- packages/predict/predeploy/response-policies.md` — reports no whitespace errors.

## Risk / Rollout

None — documentation/tooling only. The change can be reverted directly if a qualifying dated evidence record is later added, though the preferred path is to file that evidence and deliberately promote the classification.