### PR TITLE
margin: record deepbook_margin v16 and margin_liquidation v4 testnet publication

### DIFF
--- a/packages/deepbook_margin/Published.toml
+++ b/packages/deepbook_margin/Published.toml
@@ -13,9 +13,9 @@ upgrade-capability = "0xd57c7a41b31c0a1fab5e71d296a75daf2e9e09945df383d4745daa49
 
 [published.testnet]
 chain-id = "4c78adac"
-published-at = "0x3a636035f0bbcced1bbc9157654b75a402a09a91ccf0c7e9bd043feaf98b8608"
+published-at = "0xce6ab6290458f597fc078793335f4b1d98479f29ebc02198ae960e9401d0c72f"
 original-id = "0xb8620c24c9ea1a4a41e79613d2b3d1d93648d1bb6f6b789a7c8f261c94110e4b"
-version = 15
-toolchain-version = "1.76.0"
+version = 16
+toolchain-version = "1.77.1"
 build-config = { flavor = "sui", edition = "2024" }
 upgrade-capability = "0x36eb7f6bdbcd7445386eb13f13e24c3cc6248eb4b969c3917cb502f32a65ba6a"

--- a/packages/margin_liquidation/Published.toml
+++ b/packages/margin_liquidation/Published.toml
@@ -13,6 +13,9 @@ upgrade-capability = "0xd1b0608d02814ad1e15ddf6d8bf50bc4b8f375cd99d36f523dadc50c
 
 [published.testnet]
 chain-id = "4c78adac"
-published-at = "0x8d69c3ef3ef580e5bf87b933ce28de19a5d0323588d1a44b9c60b4001741aa24"
+published-at = "0x29bccec5261b7d040555a13e98bbc6bef7bad007d62759aac8b71c19916f6476"
 original-id = "0x829f19f7460c1f2a553724526dd3400acaff308a9e60ab47410b448f11eb252a"
-version = 3
+version = 4
+toolchain-version = "1.77.1"
+build-config = { flavor = "sui", edition = "2024" }
+upgrade-capability = "0x2870cd95133bdb96d373c0f8b24e92d5867abc810dd149a0197c1c0c8d8eee08"


### PR DESCRIPTION
## Summary

- Record the testnet publication of `deepbook_margin` v15 → **v16** (`0xce6ab6290458f597fc078793335f4b1d98479f29ebc02198ae960e9401d0c72f`) and `margin_liquidation` v3 → **v4** (`0x29bccec5261b7d040555a13e98bbc6bef7bad007d62759aac8b71c19916f6476`), both upgraded from `e60da23a`.
- Record `margin_liquidation`'s testnet `upgrade-capability`, which the file has never carried.

## Why

`Published.toml` is this repo's record of which package version is live in each environment, and the SDK and any caller resolve testnet addresses from it. #1170 and #1211 added the upgraded-Pyth entrypoints to the two margin packages, but until the packages are upgraded those entrypoints exist only in source — nothing on testnet can call them, and integrators have no address to target. This PR is the deploy record for that upgrade.

The missing `upgrade-capability` matters for the next deploy: with no recorded id, the only way to find the cap is to enumerate the deployer's `UpgradeCap` objects and decode each one's `package` field looking for a match. That took a 548-object scan this time.

## Linear / Context

- DBU-668 — margin migration to Pyth's upgraded Core; this PR is the testnet deploy record for it.
- Deploys #1170 (`margin`) and #1211 (`margin_liquidation`).

## Key decisions

- **Upgraded from `main` (`e60da23a`), not from either feature branch.** Both PRs are merged, so main is the first tree that contains the two migrations together; deploying a branch would publish a tree no reviewer signed off on as a whole.
- **`enable_version(7)` was called in the same operation** (`Bwqczr5AfiYkYScus9tMWi9YZxAnCbeSfG3j8btRrmd8`). The package version gate is independent of the package upgrade: `margin_constants::MARGIN_VERSION` is now 7, and without the registry's `allowed_versions` containing 7 every margin entrypoint aborts `EPackageVersionDisabled`. The upgrade is not complete without it.
- **Recorded the cap rather than leaving the file as the CLI generated it.** The CLI writes `published-at`/`version`/`toolchain-version` but does not add `upgrade-capability`; `deepbook_margin`'s testnet section and both mainnet sections already carry one, so this makes the four sections consistent.

## Scope / Descoped

- **Testnet only.** No mainnet upgrade; mainnet sections are untouched.
- No SDK package-id bumps — `MARGIN_PACKAGE_ID`/`LIQUIDATION_PACKAGE_ID` live in `@mysten/deepbook-v3`.
- **This does not make the upgraded entrypoints usable on testnet** — see Risk.

## Test plan

- [x] `sui move build --build-env testnet` in both packages — exit 0, `Move.lock` unmodified by the build (this suite's CI has been broken before by builds silently re-resolving pins).
- [x] `sui move test` — `deepbook_margin` 455/455, `margin_liquidation` 26/26.
- [x] `sui client upgrade --dry-run` on both — `execution status: success` before either execution.
- [x] Executed: margin `8YXHdaTtXC1fVJ8rbqrtfEAXEDr7gyu3W7PKRckemAQp`, liquidation `BhqApLyWULPipj6eHu1wZXg852VSBqdQZ5GMLbyeMfF7`, both `success`.
- [x] Read back `MarginRegistryInner.allowed_versions` on chain — `{1, 7}`. `enable_version` asserts the version is absent before inserting, so its success also proves 7 was not previously enabled.
- [x] Read back the new `margin_liquidation` package's on-chain linkage — resolves `deepbook_margin` to `0xce6ab629…` v16, not the superseded v15.

## Risk / Rollout

- Both upgrades are `compatible` (policy 0): existing public signatures are unchanged, so callers pinned to the old package ids keep working and the legacy Pyth entrypoints behave exactly as before.
- **The upgraded-Pyth entrypoints abort on testnet, by design of the current testnet state, not because of this change.** Upgraded Pyth Core on testnet carries *mainnet* feed ids while the testnet `MarginRegistry` is configured with *beta* ids; the two sets are disjoint, so `oracle::read_price_upgraded` → `validate_feed_id` aborts `EPriceFeedIdMismatch` for every configured coin. The upgraded testnet price objects are also unattended and would fail staleness regardless. Closing this needs either the configured feeds created on upgraded testnet Core, or an admin migration of the testnet registry onto mainnet feed ids. Legacy entrypoints are unaffected and remain the working path on testnet.
- Version 1 remains in `allowed_versions` alongside 7. Worth a separate decision about whether to `disable_version(1)`; deliberately not changed here.
- Rollback is a further `compatible` upgrade, not a revert of this file.
