### PR TITLE
predict: allow one-minute expiry fee windows (DBU-717)

### DIFF
--- a/packages/predict/sources/config/config_constants.move
+++ b/packages/predict/sources/config/config_constants.move
@@ -290,13 +290,13 @@ public(package) fun assert_min_fee(value: u64) {
 }
 
 /// Window before expiry over which trade fees ramp up to the per-expiry max
-/// multiplier. Five minutes is the shortest admin-tunable window.
+/// multiplier. One minute is the shortest admin-tunable window.
 public(package) macro fun default_expiry_fee_window_ms(): u64 {
     deepbook_predict::constants::one_day_ms!()
 }
 
 public(package) macro fun min_expiry_fee_window_ms(): u64 {
-    deepbook_predict::constants::five_minutes_ms!()
+    deepbook_predict::constants::one_minute_ms!()
 }
 
 public(package) macro fun max_expiry_fee_window_ms(): u64 {

--- a/packages/predict/tests/config/protocol_config_bounds_tests.move
+++ b/packages/predict/tests/config/protocol_config_bounds_tests.move
@@ -20,6 +20,7 @@ module deepbook_predict::protocol_config_bounds_tests;
 use deepbook_predict::{
     admin::{Self, AdminCap},
     config_constants,
+    constants,
     flow_test_helpers as helpers,
     protocol_config::{Self, ProtocolConfig},
     test_constants
@@ -116,7 +117,7 @@ fun template_expiry_fee_window_below_min_aborts() {
     let mut config = scenario.take_shared_by_id<ProtocolConfig>(config_id);
     config.set_template_expiry_fee_window_ms(
         &admin_cap,
-        config_constants::min_expiry_fee_window_ms!() - 1,
+        constants::one_minute_ms!() - 1,
     );
     abort 999
 }
@@ -264,7 +265,7 @@ fun strike_exposure_template_setters_accept_envelope_boundaries() {
     );
     config.set_template_expiry_fee_window_ms(
         &admin_cap,
-        config_constants::min_expiry_fee_window_ms!(),
+        constants::one_minute_ms!(),
     );
     config.set_template_expiry_fee_max_multiplier(
         &admin_cap,
@@ -292,7 +293,7 @@ fun strike_exposure_template_setters_accept_envelope_boundaries() {
         snapshot.max_entry_probability(),
         config_constants::min_min_entry_probability!() + 1,
     );
-    assert_eq!(snapshot.expiry_fee_window_ms(), config_constants::min_expiry_fee_window_ms!());
+    assert_eq!(snapshot.expiry_fee_window_ms(), constants::one_minute_ms!());
     assert_eq!(
         snapshot.expiry_fee_max_multiplier(),
         config_constants::min_expiry_fee_max_multiplier!(),


### PR DESCRIPTION
## Summary

- Allow Predict expiry-fee ramp windows as short as one minute.
- Pin the exact 60,000 ms lower boundary through the real `ProtocolConfig` admin setter.

## Why

Predict expiry markets can increase trading fees linearly during a configured window before expiry. With the existing five-minute minimum, a one-minute market begins with the ramp already 80% of the way from its base multiplier to its expiry multiplier, leaving little difference between the fee at 60 seconds remaining and the fee at expiry. Fee calibration therefore needs the option to align the ramp window with the market's one-minute lifetime.

## Linear / Context

- [DBU-717](https://linear.app/mysten-labs/issue/DBU-717/allow-one-minute-predict-expiry-fee-windows)

## Key decisions

- Only the minimum accepted window changes. The 24-hour default, one-year maximum, 1x–10x multiplier envelope, and linear fee formula remain unchanged.
- The tests use the independent one-minute time constant rather than deriving their expectation from the bound under test.

## Scope / Descoped

- No package publication or admin configuration transaction.
- No change to existing expiry markets, which retain their snapshotted fee settings.
- No public API, event schema, SDK, indexer, simulation, or numeric public-documentation change.

## Test plan

- [x] `bash checks/format-move.sh <changed Move files>` — both files conform to the repository-pinned formatter.
- [x] `sui move test --path packages/predict protocol_config_bounds_tests --gas-limit 100000000000` — all 31 configuration-boundary tests pass.
- [x] Mutation check: restore the former five-minute validator and run `strike_exposure_template_setters_accept_envelope_boundaries` — the test fails with `EInvalidExpiryFeeWindowMs`; restore the one-minute validator and rerun — the test passes.
- [x] `sui move build --path packages/predict --warnings-are-errors` — the Predict package builds without warnings.
- [x] `sui move test --path packages/predict --gas-limit 100000000000` — all 582 Predict contract tests pass.

## Review

- One independent `gpt-5.6-sol` reviewer at high effort examined validator ownership, exact and off-by-one boundaries, test independence, unchanged fee behavior, snapshot semantics, downstream consistency, and standalone landability. No findings.

## Risk / Rollout

The change only widens the admin validation envelope; it does not alter the current template or any existing market. A future package publication is required before an admin can select a one-minute window, and only markets created after that template update would snapshot it.
