### PR TITLE
ci: move Build Deepbook TX onto the Node 24 actions and clear the tap-trust warning

### DIFF
--- a/.github/workflows/deepbookv3-build-tx.yml
+++ b/.github/workflows/deepbookv3-build-tx.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           echo ${{ inputs.transaction_type }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
@@ -47,6 +47,14 @@ jobs:
         run: |
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
           echo "/home/linuxbrew/.linuxbrew/bin" >> $GITHUB_PATH
+
+      # The macOS runner image ships with aws/tap already tapped. Homebrew's preinstall trust
+      # check warns about every untrusted third-party tap, and that warning surfaces as a job
+      # annotation. This job installs only `sui` from homebrew-core, so recording trust for
+      # the image's own tap on a throwaway runner clears the warning without trusting a tap
+      # we install anything from.
+      - name: Trust the runner image's preinstalled taps
+        run: brew trust aws/tap
 
       - name: Install Sui using Homebrew
         run: brew install sui
@@ -57,9 +65,12 @@ jobs:
           sui client switch --env mainnet-env
 
       - name: NPM BUILD TX Environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
+          # setup-node caches automatically from v5 on. This job installs pnpm in a later
+          # step, so keep the v4 behavior of touching no package manager at all.
+          package-manager-cache: false
 
       - name: Do a global PNPM install
         run: |
@@ -107,7 +118,7 @@ jobs:
           cat scripts/tx/tx-data.txt
 
       - name: Upload Transaction Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: transaction-data
           path: scripts/tx


### PR DESCRIPTION
## Summary

- `Build Deepbook TX` now uses `actions/checkout@v7`, `actions/setup-node@v7` and `actions/upload-artifact@v7`, all of which declare `runs.using: node24`.
- The job trusts the runner image's preinstalled `aws/tap` before `brew install sui`, so Homebrew's preinstall trust check stays quiet.
- `setup-node` is pinned to `package-manager-cache: false`, preserving the v4 behavior of not touching a package manager.

## Why

`Build Deepbook TX` is the manually dispatched workflow that serializes the unsigned protocol/margin/vault package-upgrade transactions the multisig signers execute against mainnet. Every run currently finishes green but posts two annotations, which makes it harder to spot a real problem in a workflow whose output is a mainnet transaction. One annotation is GitHub's Node 20 deprecation notice — the v4 actions declare `node20` and the runner force-runs them on Node 24 today, and will stop doing so. The other is Homebrew: the macOS image arrives with `aws/tap` tapped, and Homebrew's trust check warns about every untrusted third-party tap on `brew install`.

## Linear / Context

- N/A — exempt (CI-only fix).
- Warnings observed on the `dfc74cb` run of `Build Deepbook TX`.

## Key decisions

- `upload-artifact` goes to v7 rather than v5: v5 added Node 24 support but still defaulted to `node20`, so only v6+ actually clears the deprecation. v7 is then the current major for all three actions.
- `package-manager-cache: false` on `setup-node`: v5 introduced automatic caching driven by the `packageManager` field, and v6 narrowed it to npm. This job installs pnpm in a later step, so disabling it keeps the upgrade behavior-neutral instead of relying on the repo never gaining a `packageManager` field.
- `brew trust aws/tap` rather than `brew untap aws/tap`: the image has formulae installed from that tap, so a plain untap refuses non-interactively and `--force` would uninstall runner tooling to silence an annotation. `brew trust` is a no-op write to `~/.homebrew/trust.json` on a throwaway runner, and exits 0 even if a future image drops the tap.
- `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` was rejected: Homebrew documents it as not recommended and slated for removal.

## Scope / Descoped

- Only this workflow. `move_test.yml`, `rust.yml`, `predict-bench.yml`, `move-formatter.yml`, `claude.yml` and `claude-code-review.yml` still call `actions/checkout@v4` / `actions/setup-node@v4` and raise the same Node 20 annotation; that sweep is left for a follow-up so a CI-wide bump does not ride along with this one.
- No change to what the workflow builds, to the gas settings in `scripts/transactions/*.ts`, or to the redundant `Install Homebrew` step (it appends a `linuxbrew` path that is inert on a macOS runner).

## Test plan

- [x] `prettier -c .github/workflows/deepbookv3-build-tx.yml` — passes.
- [x] `actions/{checkout,setup-node,upload-artifact}` `action.yml` at `v7` all declare `runs.using: 'node24'`, and `setup-node@v7` still exposes the `package-manager-cache` input.
- [x] `brew trust aws/tap` verified locally against Homebrew 6.0.17 with an isolated `XDG_CONFIG_HOME`: exits 0 and records the tap even when it is not installed.
- [ ] Dispatch `Build Deepbook TX` (any transaction type) and confirm the run completes with zero annotations and still uploads `transaction-data`.

## Risk / Rollout

- CI-only. The failure mode is a workflow that no longer produces a transaction; it is caught by the dispatch check above before any signer relies on it. Revert is a single-commit revert of this file.
