### PR TITLE
margin v7: register mainnet package 0x55ee8099

### DIFF
--- a/packages/deepbook_margin/Published.toml
+++ b/packages/deepbook_margin/Published.toml
@@ -4,9 +4,9 @@
 
 [published.mainnet]
 chain-id = "35834a8a"
-published-at = "0x8af25e44bcdfb8b19ceffef5a1bd457a89a4270b8237e1025f30cd26acb4edbe"
+published-at = "0x55ee8099674e46266df2bf0ffed9569e1511aa269f2a9b8c63a2c72f16404e72"
 original-id = "0x97d9473771b01f77b0940c589484184b49f6444627ec121314fae6a6d36fb86b"
-version = 6
+version = 7
 toolchain-version = "1.63.1"
 build-config = { flavor = "sui", edition = "2024" }
 upgrade-capability = "0xd57c7a41b31c0a1fab5e71d296a75daf2e9e09945df383d4745daa49f06d9c56"


### PR DESCRIPTION
## Summary

- Records the `deepbook_margin` mainnet upgrade to package version 7 in `packages/deepbook_margin/Published.toml`: `published-at` `0x8af25e44…` → `0x55ee8099674e46266df2bf0ffed9569e1511aa269f2a9b8c63a2c72f16404e72`, `version` 6 → 7.
- No other field changes: `original-id`, `upgrade-capability`, `chain-id`, `toolchain-version` and `build-config` are unchanged.

## Why

`Published.toml` is this package's durable publication history, and every consumer that resolves `deepbook_margin` on mainnet — dependent builds, `verify-source`, and off-chain callers that read the file for the package address — resolves whatever it records. Mainnet was upgraded to v7 on 2026-08-17, so the file now points one version behind the live package, and anything built against it links the superseded v6. This records what is deployed.

## Linear / Context

- N/A — exempt: publication record for an upgrade that already happened, no source or behavior change.
- Follows the same shape as the v5 (#1018) and v6 (#1128) mainnet registrations, and the testnet v16 record (#1232).

## Key decisions

- `toolchain-version` left at `1.63.1`. The field records the toolchain of the historical publication, and the CLI used for the v7 upgrade is not recoverable from chain, so it is not overwritten with a guess — same call as #1128.

## Scope / Descoped

- Record only. `MARGIN_VERSION` is already 7 on `main`; the on-chain `enable_version(7)` and the later `disable_version(6)` are separate admin actions behind the mainnet multisig and are not part of this PR.
- Testnet entry untouched (still v16). `margin_liquidation` untouched — its mainnet `UpgradeCap` still points at v4 `0xf17bff1b…`, so no bump is due.

## Test plan

- [x] `0x55ee8099…` reads back as a package with `version: 7`, and mainnet `UpgradeCap` `0xd57c7a41…` reports `package: 0x55ee8099…`, `version: 7` — confirms it is an upgrade of the recorded lineage, not a lookalike.
- [x] `sui move build` in `packages/deepbook_margin` on this branch (mainnet env, CLI 1.77.1) produces 14 modules byte-identical to the 14 modules fetched from the on-chain package — main's source is exactly what is deployed. `sui client verify-source` cannot be used here: it still calls JSON-RPC, which public fullnodes have removed.
- [x] Upgrade transaction `yYNue3o2pnSmSGJ9ZJDKXdHRAUKudeZadCamjUGRFwy` (2026-08-17T15:52:49Z) is the package's `previousTransaction`.

## Risk / Rollout

- None — metadata only, no Move source change. Builds that previously linked v6 will link v7 after this lands, which is the intent; v7 is already live and reachable on chain.