### PR TITLE
predict: add a tick-weighted first moment to the payout tree (DBU-732)

### DIFF
--- a/packages/predict/sources/strike_exposure/index/strike_payout_tree.move
+++ b/packages/predict/sources/strike_exposure/index/strike_payout_tree.move
@@ -38,6 +38,7 @@ use sui::table::{Self, Table};
 const EInsufficientPayoutQuantity: u64 = 0;
 const EMaxPayoutTreeNodes: u64 = 1;
 const ENonMonotonePrice: u64 = 2;
+const EInvertedRange: u64 = 3;
 
 /// Sparse payout-liability tree keyed by finite strike tick.
 public struct StrikePayoutTree has store {
@@ -60,11 +61,12 @@ public struct PayoutSummary has copy, drop, store {
     /// `start` would break shape-independence with no test to catch it, and
     /// would also abort `strike_exposure`'s plain `total - max` subtraction.
     max_payout_prefix_gain: u64,
-    /// Tick-weighted boundary quantities: `sum(tick * local_start)` and
-    /// `sum(tick * local_end)` over the subtree. Their difference is the area
-    /// under the payout profile, which the plain totals cannot express — two
-    /// orders of equal quantity spanning one tick and eighty ticks produce
-    /// identical `start`/`end` but areas differing eighty-fold.
+    /// First moments of the boundary measure: `sum(tick * local_start)` and
+    /// `sum(tick * local_end)` over the subtree. They carry where quantity sits,
+    /// which the plain totals cannot express — two orders of equal quantity
+    /// spanning one tick and eighty ticks produce identical `start`/`end`. They
+    /// are not themselves an area; `range_payout_sum` combines them with the
+    /// range's opening prefix to get one.
     ///
     /// Unlike `max_payout_prefix_gain` these are plain sums, so associativity —
     /// and with it the tree's shape-independence — holds unconditionally rather
@@ -150,8 +152,8 @@ public(package) fun complement_max_payout(
 
 /// Return `sum(W(S))` over the settlement ticks `S` in `(lower_tick, higher_tick]`,
 /// where `W(S)` is the payout owed if the market settles at `S`. This is the area
-/// under the payout profile across the range — the second-moment term a spread
-/// statistic needs, and the one quantity the plain boundary totals cannot express.
+/// across the range — the discrete integral of `W`, or equivalently the area under
+/// the payout profile, which the plain boundary totals cannot express.
 ///
 /// Derivation: `W(S) = W(lower+1) + sum(delta_t)` over boundaries `lower < t < S`,
 /// so summing over the range weights each boundary by how far it reaches:
@@ -160,15 +162,21 @@ public(package) fun complement_max_payout(
 /// `range_max_payout` already performs, so this stays `O(log n)`.
 ///
 /// Callers pass a range already clipped to whatever window they measure over; the
-/// tree imposes no window of its own. The final subtraction is exact rather than
-/// clamped: it underflows only if some `W(S)` in the range is negative, which a
-/// consistent book cannot produce, so the abort is the invariant check.
+/// tree imposes no window of its own — an unterminated `+inf` leg really does span
+/// the rest of the ladder, so where to clip is the caller's policy.
+///
+/// The final subtraction is exact rather than clamped: a consistent book cannot
+/// drive it negative. It is not a desync detector, for the reason the module doc
+/// gives about the settlement walk — it tests the aggregate, not each prefix, so a
+/// book with negative prefixes can still return a positive total. `apply_net_delta`
+/// remains the authority.
 public(package) fun range_payout_sum(
     tree: &StrikePayoutTree,
     lower_tick: u64,
     higher_tick: u64,
 ): u128 {
-    if (higher_tick <= lower_tick) return 0;
+    assert!(higher_tick >= lower_tick, EInvertedRange);
+    if (higher_tick == lower_tick) return 0;
 
     let prefix_at_lower = settlement_prefix_payout(
         &tree.nodes,

--- a/packages/predict/sources/strike_exposure/index/strike_payout_tree.move
+++ b/packages/predict/sources/strike_exposure/index/strike_payout_tree.move
@@ -60,6 +60,18 @@ public struct PayoutSummary has copy, drop, store {
     /// `start` would break shape-independence with no test to catch it, and
     /// would also abort `strike_exposure`'s plain `total - max` subtraction.
     max_payout_prefix_gain: u64,
+    /// Tick-weighted boundary quantities: `sum(tick * local_start)` and
+    /// `sum(tick * local_end)` over the subtree. Their difference is the area
+    /// under the payout profile, which the plain totals cannot express — two
+    /// orders of equal quantity spanning one tick and eighty ticks produce
+    /// identical `start`/`end` but areas differing eighty-fold.
+    ///
+    /// Unlike `max_payout_prefix_gain` these are plain sums, so associativity —
+    /// and with it the tree's shape-independence — holds unconditionally rather
+    /// than by a bound on magnitude. That is also why they are `u128`: a single
+    /// term reaches `pos_inf_tick * max_order_quantity ~= 4.6e22`, past `u64`.
+    weighted_start: u128,
+    weighted_end: u128,
 }
 
 /// Height-balanced node keyed by finite boundary tick.
@@ -134,6 +146,53 @@ public(package) fun complement_max_payout(
         tree.range_max_payout(higher_tick, constants::pos_inf_tick!())
     };
     left.max(right)
+}
+
+/// Return `sum(W(S))` over the settlement ticks `S` in `(lower_tick, higher_tick]`,
+/// where `W(S)` is the payout owed if the market settles at `S`. This is the area
+/// under the payout profile across the range — the second-moment term a spread
+/// statistic needs, and the one quantity the plain boundary totals cannot express.
+///
+/// Derivation: `W(S) = W(lower+1) + sum(delta_t)` over boundaries `lower < t < S`,
+/// so summing over the range weights each boundary by how far it reaches:
+/// `(higher - lower) * W(lower+1) + sum(delta_t * (higher - t))`, and the weighted
+/// summary terms carry `sum(t * delta_t)` directly. Both reads are the same pair
+/// `range_max_payout` already performs, so this stays `O(log n)`.
+///
+/// Callers pass a range already clipped to whatever window they measure over; the
+/// tree imposes no window of its own. The final subtraction is exact rather than
+/// clamped: it underflows only if some `W(S)` in the range is negative, which a
+/// consistent book cannot produce, so the abort is the invariant check.
+public(package) fun range_payout_sum(
+    tree: &StrikePayoutTree,
+    lower_tick: u64,
+    higher_tick: u64,
+): u128 {
+    if (higher_tick <= lower_tick) return 0;
+
+    let prefix_at_lower = settlement_prefix_payout(
+        &tree.nodes,
+        tree.root,
+        lower_tick + 1,
+        tree.base,
+    );
+    let window = window_summary(
+        &tree.nodes,
+        tree.root,
+        lower_tick,
+        higher_tick,
+        0,
+        constants::pos_inf_tick!(),
+    );
+
+    // Start and end sides accumulate separately, as `walk_linear` does: a node's
+    // net boundary delta is signed, so a single running total would underflow
+    // mid-combine even though the range sum itself is non-negative.
+    let span = ((higher_tick - lower_tick) as u128) * (prefix_at_lower as u128);
+    let higher = higher_tick as u128;
+    let rises = span + higher * (window.start as u128) + window.weighted_end;
+    let falls = higher * (window.end as u128) + window.weighted_start;
+    rises - falls
 }
 
 /// Evaluate payout liability at one positive normalized settlement price.
@@ -284,7 +343,7 @@ fun apply_at(
 ): Option<u64> {
     if (root.is_none()) {
         assert!(add, EInsufficientPayoutQuantity);
-        let leaf = new_leaf(quantity, is_start);
+        let leaf = new_leaf(tick, quantity, is_start);
         nodes.add(tick, leaf);
         return option::some(tick)
     };
@@ -317,7 +376,7 @@ fun apply_at(
     option::some(rebalance(nodes, root_tick, node))
 }
 
-fun new_leaf(quantity: u64, is_start: bool): PayoutNode {
+fun new_leaf(tick: u64, quantity: u64, is_start: bool): PayoutNode {
     let (start, end) = if (is_start) {
         (quantity, 0)
     } else {
@@ -330,7 +389,7 @@ fun new_leaf(quantity: u64, is_start: bool): PayoutNode {
         right: option::none(),
         local_start: start,
         local_end: end,
-        summary: boundary_summary(start, end),
+        summary: boundary_summary(tick, start, end),
     }
 }
 
@@ -479,7 +538,7 @@ fun window_summary(
 
     let left = window_summary(nodes, node.left, lower, higher, subtree_low, tick);
     let right = window_summary(nodes, node.right, lower, higher, tick, subtree_high);
-    let boundary = boundary_summary(node.local_start, node.local_end);
+    let boundary = boundary_summary(tick, node.local_start, node.local_end);
     combine_summaries(combine_summaries(left, boundary), right)
 }
 
@@ -541,7 +600,7 @@ fun walk_linear_subtree(
 fun resummarize(nodes: &mut Table<u64, PayoutNode>, tick: u64, mut node: PayoutNode) {
     let (left, left_height) = subtree_facts(nodes, node.left);
     let (right, right_height) = subtree_facts(nodes, node.right);
-    let boundary = boundary_summary(node.local_start, node.local_end);
+    let boundary = boundary_summary(tick, node.local_start, node.local_end);
     node.summary = combine_summaries(combine_summaries(left, boundary), right);
     node.height = 1 + left_height.max(right_height);
     *nodes.borrow_mut(tick) = node;
@@ -566,11 +625,13 @@ fun subtree_height(nodes: &Table<u64, PayoutNode>, root: Option<u64>): u64 {
     nodes[*root.borrow()].height
 }
 
-fun boundary_summary(start: u64, end: u64): PayoutSummary {
+fun boundary_summary(tick: u64, start: u64, end: u64): PayoutSummary {
     PayoutSummary {
         start,
         end,
         max_payout_prefix_gain: positive_net_delta(start, end, 0),
+        weighted_start: (tick as u128) * (start as u128),
+        weighted_end: (tick as u128) * (end as u128),
     }
 }
 
@@ -579,6 +640,8 @@ fun zero_summary(): PayoutSummary {
         start: 0,
         end: 0,
         max_payout_prefix_gain: 0,
+        weighted_start: 0,
+        weighted_end: 0,
     }
 }
 
@@ -593,6 +656,8 @@ fun combine_summaries(left: PayoutSummary, right: PayoutSummary): PayoutSummary 
         start: left.start + right.start,
         end: left.end + right.end,
         max_payout_prefix_gain: left.max_payout_prefix_gain.max(right_gain_after_left),
+        weighted_start: left.weighted_start + right.weighted_start,
+        weighted_end: left.weighted_end + right.weighted_end,
     }
 }
 
@@ -678,11 +743,13 @@ fun assert_subtree_invariant(
     assert!(taller - left_height.min(right_height) <= 1);
     assert!(node.height == 1 + taller);
 
-    let boundary = boundary_summary(node.local_start, node.local_end);
+    let boundary = boundary_summary(tick, node.local_start, node.local_end);
     let summary = combine_summaries(combine_summaries(left_summary, boundary), right_summary);
     assert!(node.summary.start == summary.start);
     assert!(node.summary.end == summary.end);
     assert!(node.summary.max_payout_prefix_gain == summary.max_payout_prefix_gain);
+    assert!(node.summary.weighted_start == summary.weighted_start);
+    assert!(node.summary.weighted_end == summary.weighted_end);
 
     (1 + taller, summary, left_count + right_count + 1)
 }

--- a/packages/predict/tests/strike_exposure/index/strike_payout_tree_balance_tests.move
+++ b/packages/predict/tests/strike_exposure/index/strike_payout_tree_balance_tests.move
@@ -225,6 +225,10 @@ fun boundary_gc_preserves_terms_and_balance() {
     let (rebuilt_max, rebuilt_total) = rebuilt.payout_reserve_terms();
     assert_eq!(gc_max, rebuilt_max);
     assert_eq!(gc_total, rebuilt_total);
+    assert_eq!(
+        tree.range_payout_sum(0, constants::pos_inf_tick!()),
+        rebuilt.range_payout_sum(0, constants::pos_inf_tick!()),
+    );
 
     destroy(tree);
     destroy(rebuilt);

--- a/packages/predict/tests/strike_exposure/index/strike_payout_tree_range_sum_tests.move
+++ b/packages/predict/tests/strike_exposure/index/strike_payout_tree_range_sum_tests.move
@@ -11,6 +11,10 @@ use deepbook_predict::{constants, strike_payout_tree::{Self, StrikePayoutTree}};
 use std::unit_test::{assert_eq, destroy};
 
 const TICK_SIZE: u64 = 1_000;
+/// Hand-summed W(1..10) for each fixture; the derivations sit above each surface.
+const MIXED_SURFACE_AREA: u128 = 320;
+const OPEN_UPPER_SURFACE_AREA: u128 = 395;
+const SHARED_BOUNDARY_SURFACE_AREA: u128 = 240;
 
 /// Sum `W(S)` one settlement tick at a time over `(lower, higher]`, the reference
 /// the logarithmic read must reproduce.
@@ -45,13 +49,20 @@ fun empty_tree_has_zero_area() {
 }
 
 #[test]
-fun empty_or_inverted_range_is_zero() {
+fun empty_range_is_zero() {
     let ctx = &mut tx_context::dummy();
     let tree = mixed_surface(ctx);
 
     assert_eq!(tree.range_payout_sum(5, 5), 0);
-    assert_eq!(tree.range_payout_sum(9, 4), 0);
     destroy(tree);
+}
+
+#[test, expected_failure(abort_code = strike_payout_tree::EInvertedRange)]
+fun inverted_range_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let tree = mixed_surface(ctx);
+    tree.range_payout_sum(9, 4);
+    abort 0
 }
 
 /// The read the plain boundary totals cannot make. Both books carry one order of
@@ -85,7 +96,7 @@ fun area_matches_hand_computed_surface() {
     let tree = mixed_surface(ctx);
 
     // 10 + 50 + 40 + 70 + 70 + 30 + 30 + 0 + 20 + 0
-    assert_eq!(tree.range_payout_sum(0, 10), 320);
+    assert_eq!(tree.range_payout_sum(0, 10), MIXED_SURFACE_AREA);
     // The open-lower prefix alone.
     assert_eq!(tree.range_payout_sum(0, 1), 10);
     // A window whose interior holds no boundary at all.
@@ -110,34 +121,26 @@ fun area_matches_brute_force_over_every_window() {
     destroy(tree);
 }
 
-/// Rotations relink nodes but never re-key them, so the tick-weighted terms must
-/// be invariant to insertion order. Ascending inserts force left-heavy rebalances
-/// that a shape-dependent aggregate would not survive.
+/// The same final book reached by two construction paths must report the same
+/// area: rotation and node-reclaim history must not be observable. Shape-difference
+/// over a churned 66-node tree is covered by `strike_payout_tree_balance_tests`.
 #[test]
-fun area_is_independent_of_insertion_order() {
+fun area_is_independent_of_construction_path() {
     let ctx = &mut tx_context::dummy();
 
-    let mut ascending = strike_payout_tree::new(ctx);
-    ascending.insert_range(1, 5, 40);
-    ascending.insert_range(3, 7, 30);
-    ascending.insert_range(8, 9, 20);
-    ascending.insert_range(0, 2, 10);
+    let mut churned = mixed_surface(ctx);
+    churned.insert_range(2, 11, 77);
+    churned.insert_range(6, 13, 44);
+    churned.remove_range(2, 11, 77);
+    churned.remove_range(6, 13, 44);
 
-    let mut descending = strike_payout_tree::new(ctx);
-    descending.insert_range(8, 9, 20);
-    descending.insert_range(3, 7, 30);
-    descending.insert_range(1, 5, 40);
-    descending.insert_range(0, 2, 10);
+    let direct = mixed_surface(ctx);
 
-    assert_eq!(
-        ascending.range_payout_sum(0, constants::pos_inf_tick!()),
-        descending.range_payout_sum(0, constants::pos_inf_tick!()),
-    );
-    assert_eq!(ascending.range_payout_sum(0, 10), 320);
-    assert_eq!(descending.range_payout_sum(0, 10), 320);
+    assert_eq!(churned.range_payout_sum(0, 20), direct.range_payout_sum(0, 20));
+    assert_eq!(churned.range_payout_sum(0, 20), MIXED_SURFACE_AREA);
 
-    destroy(ascending);
-    destroy(descending);
+    destroy(churned);
+    destroy(direct);
 }
 
 /// Removing an order must return the area to exactly where it started, the same
@@ -148,8 +151,10 @@ fun removing_an_order_restores_the_prior_area() {
     let mut tree = mixed_surface(ctx);
 
     let before = tree.range_payout_sum(0, 20);
+    assert_eq!(before, MIXED_SURFACE_AREA);
+    // `(4,12]` covers settlement ticks 5..12, so the area rises by 8 * 55.
     tree.insert_range(4, 12, 55);
-    assert!(tree.range_payout_sum(0, 20) > before);
+    assert_eq!(tree.range_payout_sum(0, 20), 760);
     tree.remove_range(4, 12, 55);
     assert_eq!(tree.range_payout_sum(0, 20), before);
 
@@ -169,6 +174,82 @@ fun open_upper_range_spans_the_finite_ladder() {
         tree.range_payout_sum(0, constants::pos_inf_tick!()),
         ((constants::pos_inf_tick!() - 10) as u128),
     );
+
+    destroy(tree);
+}
+
+/// An open-upper leg over a nonzero open-lower prefix: a start boundary with no
+/// stored end, which `mixed_surface` never produces.
+/// (-inf,2] 10; (2,3] 50; (3,5] 40; (5,8] 65; (8,+inf] 25.
+fun open_upper_surface(ctx: &mut TxContext): StrikePayoutTree {
+    let mut tree = strike_payout_tree::new(ctx);
+    tree.insert_range(0, 3, 10);
+    tree.insert_range(2, 8, 40);
+    tree.insert_range(5, constants::pos_inf_tick!(), 25);
+    tree
+}
+
+/// Adjacent orders sharing one boundary tick, so a single node carries both a
+/// `local_start` and a `local_end` weighted by the same tick.
+fun shared_boundary_surface(ctx: &mut TxContext): StrikePayoutTree {
+    let mut tree = strike_payout_tree::new(ctx);
+    tree.insert_range(1, 4, 30);
+    tree.insert_range(4, 7, 50);
+    tree
+}
+
+fun assert_matches_brute_force_over_windows(tree: &StrikePayoutTree, limit: u64) {
+    let mut lower = 0;
+    while (lower <= limit) {
+        let mut higher = lower;
+        while (higher <= limit) {
+            assert_eq!(tree.range_payout_sum(lower, higher), brute_force_sum(tree, lower, higher));
+            higher = higher + 1;
+        };
+        lower = lower + 1;
+    };
+}
+
+#[test]
+fun open_upper_area_matches_brute_force_over_every_window() {
+    let ctx = &mut tx_context::dummy();
+    let tree = open_upper_surface(ctx);
+
+    assert_matches_brute_force_over_windows(&tree, 12);
+    // 10 + 10 + 50 + 40 + 40 + 65 + 65 + 65 + 25 + 25
+    assert_eq!(tree.range_payout_sum(0, 10), OPEN_UPPER_SURFACE_AREA);
+    destroy(tree);
+}
+
+#[test]
+fun shared_boundary_area_matches_brute_force_over_every_window() {
+    let ctx = &mut tx_context::dummy();
+    let tree = shared_boundary_surface(ctx);
+
+    assert_matches_brute_force_over_windows(&tree, 10);
+    // (1,4] 30 over ticks 2..4, (4,7] 50 over ticks 5..7.
+    assert_eq!(tree.range_payout_sum(0, 10), SHARED_BOUNDARY_SURFACE_AREA);
+    destroy(tree);
+}
+
+/// Pins the width of the stored weighted terms. The boundary sits at the TOP of the
+/// ladder carrying the largest quantity one order may hold, so the stored term is
+/// `(pos_inf_tick - 1) * quantity ~= 4.6e22` — past `u64`, which would abort in
+/// `boundary_summary`. Placing the same order at a low tick does not pin anything:
+/// the returned sum is built in `u128` regardless of what the fields hold.
+#[test]
+fun ladder_top_boundary_term_exceeds_u64() {
+    let ctx = &mut tx_context::dummy();
+    let mut tree = strike_payout_tree::new(ctx);
+
+    let top_tick = constants::pos_inf_tick!() - 1;
+    let quantity = (std::u32::max_value!() as u64) * constants::position_lot_size!();
+    assert!((top_tick as u128) * (quantity as u128) > (std::u64::max_value!() as u128));
+
+    tree.insert_range(top_tick, constants::pos_inf_tick!(), quantity);
+
+    // Only settlement tick `pos_inf_tick` is covered by the order.
+    assert_eq!(tree.range_payout_sum(0, constants::pos_inf_tick!()), (quantity as u128));
 
     destroy(tree);
 }

--- a/packages/predict/tests/strike_exposure/index/strike_payout_tree_range_sum_tests.move
+++ b/packages/predict/tests/strike_exposure/index/strike_payout_tree_range_sum_tests.move
@@ -1,0 +1,174 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Area-under-the-payout-profile reads for inventory-skew accounting.
+/// `range_payout_sum` must equal the tick-by-tick sum of the settled payout
+/// surface, and must not depend on the order boundaries were inserted in.
+#[test_only]
+module deepbook_predict::strike_payout_tree_range_sum_tests;
+
+use deepbook_predict::{constants, strike_payout_tree::{Self, StrikePayoutTree}};
+use std::unit_test::{assert_eq, destroy};
+
+const TICK_SIZE: u64 = 1_000;
+
+/// Sum `W(S)` one settlement tick at a time over `(lower, higher]`, the reference
+/// the logarithmic read must reproduce.
+fun brute_force_sum(tree: &StrikePayoutTree, lower: u64, higher: u64): u128 {
+    let mut total = 0u128;
+    let mut tick = lower + 1;
+    while (tick <= higher) {
+        total = total + (tree.settled_payout_liability(tick * TICK_SIZE, TICK_SIZE) as u128);
+        tick = tick + 1;
+    };
+    total
+}
+
+/// (-inf,1] 10; (1,2] 50; (2,3] 40; (3,5] 70; (5,7] 30; (7,8] 0; (8,9] 20.
+fun mixed_surface(ctx: &mut TxContext): StrikePayoutTree {
+    let mut tree = strike_payout_tree::new(ctx);
+    tree.insert_range(0, 2, 10);
+    tree.insert_range(1, 5, 40);
+    tree.insert_range(3, 7, 30);
+    tree.insert_range(8, 9, 20);
+    tree
+}
+
+#[test]
+fun empty_tree_has_zero_area() {
+    let ctx = &mut tx_context::dummy();
+    let tree = strike_payout_tree::new(ctx);
+
+    assert_eq!(tree.range_payout_sum(0, constants::pos_inf_tick!()), 0);
+    assert_eq!(tree.range_payout_sum(2, 6), 0);
+    destroy(tree);
+}
+
+#[test]
+fun empty_or_inverted_range_is_zero() {
+    let ctx = &mut tx_context::dummy();
+    let tree = mixed_surface(ctx);
+
+    assert_eq!(tree.range_payout_sum(5, 5), 0);
+    assert_eq!(tree.range_payout_sum(9, 4), 0);
+    destroy(tree);
+}
+
+/// The read the plain boundary totals cannot make. Both books carry one order of
+/// quantity 1, so `start` and `end` are identical; only the tick-weighted terms
+/// separate an eighty-tick span from a one-tick span.
+#[test]
+fun equal_quantity_orders_are_separated_by_span() {
+    let ctx = &mut tx_context::dummy();
+
+    let mut narrow = strike_payout_tree::new(ctx);
+    narrow.insert_range(10, 11, 1);
+
+    let mut wide = strike_payout_tree::new(ctx);
+    wide.insert_range(10, 90, 1);
+
+    let (narrow_max, narrow_total) = narrow.payout_reserve_terms();
+    let (wide_max, wide_total) = wide.payout_reserve_terms();
+    assert_eq!(narrow_max, wide_max);
+    assert_eq!(narrow_total, wide_total);
+
+    assert_eq!(narrow.range_payout_sum(0, constants::pos_inf_tick!()), 1);
+    assert_eq!(wide.range_payout_sum(0, constants::pos_inf_tick!()), 80);
+
+    destroy(narrow);
+    destroy(wide);
+}
+
+#[test]
+fun area_matches_hand_computed_surface() {
+    let ctx = &mut tx_context::dummy();
+    let tree = mixed_surface(ctx);
+
+    // 10 + 50 + 40 + 70 + 70 + 30 + 30 + 0 + 20 + 0
+    assert_eq!(tree.range_payout_sum(0, 10), 320);
+    // The open-lower prefix alone.
+    assert_eq!(tree.range_payout_sum(0, 1), 10);
+    // A window whose interior holds no boundary at all.
+    assert_eq!(tree.range_payout_sum(3, 5), 140);
+    destroy(tree);
+}
+
+#[test]
+fun area_matches_brute_force_over_every_window() {
+    let ctx = &mut tx_context::dummy();
+    let tree = mixed_surface(ctx);
+
+    let mut lower = 0;
+    while (lower <= 11) {
+        let mut higher = lower;
+        while (higher <= 12) {
+            assert_eq!(tree.range_payout_sum(lower, higher), brute_force_sum(&tree, lower, higher));
+            higher = higher + 1;
+        };
+        lower = lower + 1;
+    };
+    destroy(tree);
+}
+
+/// Rotations relink nodes but never re-key them, so the tick-weighted terms must
+/// be invariant to insertion order. Ascending inserts force left-heavy rebalances
+/// that a shape-dependent aggregate would not survive.
+#[test]
+fun area_is_independent_of_insertion_order() {
+    let ctx = &mut tx_context::dummy();
+
+    let mut ascending = strike_payout_tree::new(ctx);
+    ascending.insert_range(1, 5, 40);
+    ascending.insert_range(3, 7, 30);
+    ascending.insert_range(8, 9, 20);
+    ascending.insert_range(0, 2, 10);
+
+    let mut descending = strike_payout_tree::new(ctx);
+    descending.insert_range(8, 9, 20);
+    descending.insert_range(3, 7, 30);
+    descending.insert_range(1, 5, 40);
+    descending.insert_range(0, 2, 10);
+
+    assert_eq!(
+        ascending.range_payout_sum(0, constants::pos_inf_tick!()),
+        descending.range_payout_sum(0, constants::pos_inf_tick!()),
+    );
+    assert_eq!(ascending.range_payout_sum(0, 10), 320);
+    assert_eq!(descending.range_payout_sum(0, 10), 320);
+
+    destroy(ascending);
+    destroy(descending);
+}
+
+/// Removing an order must return the area to exactly where it started, the same
+/// exactness the charge/rebate accounting depends on.
+#[test]
+fun removing_an_order_restores_the_prior_area() {
+    let ctx = &mut tx_context::dummy();
+    let mut tree = mixed_surface(ctx);
+
+    let before = tree.range_payout_sum(0, 20);
+    tree.insert_range(4, 12, 55);
+    assert!(tree.range_payout_sum(0, 20) > before);
+    tree.remove_range(4, 12, 55);
+    assert_eq!(tree.range_payout_sum(0, 20), before);
+
+    destroy(tree);
+}
+
+/// An unbounded upper end contributes across the whole finite ladder, which is why
+/// a skew window has to clip before calling this.
+#[test]
+fun open_upper_range_spans_the_finite_ladder() {
+    let ctx = &mut tx_context::dummy();
+    let mut tree = strike_payout_tree::new(ctx);
+    tree.insert_range(10, constants::pos_inf_tick!(), 1);
+
+    assert_eq!(tree.range_payout_sum(10, 20), 10);
+    assert_eq!(
+        tree.range_payout_sum(0, constants::pos_inf_tick!()),
+        ((constants::pos_inf_tick!() - 10) as u128),
+    );
+
+    destroy(tree);
+}

--- a/packages/predict/tests/strike_exposure/index/strike_payout_tree_range_sum_tests.move
+++ b/packages/predict/tests/strike_exposure/index/strike_payout_tree_range_sum_tests.move
@@ -253,3 +253,84 @@ fun ladder_top_boundary_term_exceeds_u64() {
 
     destroy(tree);
 }
+
+/// Draining every order must return the area to zero, not to a residue left by
+/// reclaimed nodes. The tree also has to stay usable afterwards.
+#[test]
+fun emptying_the_tree_returns_zero_area() {
+    let ctx = &mut tx_context::dummy();
+    let mut tree = mixed_surface(ctx);
+    assert_eq!(tree.range_payout_sum(0, 20), MIXED_SURFACE_AREA);
+
+    tree.remove_range(0, 2, 10);
+    tree.remove_range(1, 5, 40);
+    tree.remove_range(3, 7, 30);
+    tree.remove_range(8, 9, 20);
+
+    assert_eq!(tree.range_payout_sum(0, 20), 0);
+    assert_eq!(tree.range_payout_sum(0, constants::pos_inf_tick!()), 0);
+
+    // Still usable: a fresh order reads back exactly.
+    tree.insert_range(2, 5, 7);
+    assert_eq!(tree.range_payout_sum(0, 20), 21);
+
+    destroy(tree);
+}
+
+/// Several orders sharing one lower boundary aggregate into a single node's
+/// `local_start`, so the tick is weighted once against the summed quantity rather
+/// than once per order.
+#[test]
+fun stacked_orders_at_one_boundary_aggregate_exactly() {
+    let ctx = &mut tx_context::dummy();
+    let mut tree = strike_payout_tree::new(ctx);
+    tree.insert_range(4, 6, 10);
+    tree.insert_range(4, 8, 20);
+    tree.insert_range(4, 10, 30);
+
+    // W: ticks 5,6 -> 60; 7,8 -> 50; 9,10 -> 30; zero elsewhere.
+    assert_eq!(tree.range_payout_sum(0, 12), 280);
+    assert_matches_brute_force_over_windows(&tree, 12);
+
+    // Peeling one order back leaves the other two exact: start@4 drops to 30,
+    // so W is 30,30,20,20 over ticks 5..8.
+    tree.remove_range(4, 10, 30);
+    assert_eq!(tree.range_payout_sum(0, 12), 100);
+    assert_matches_brute_force_over_windows(&tree, 12);
+
+    destroy(tree);
+}
+
+/// A tree deep enough to rotate repeatedly, cross-checked tick by tick. The
+/// fixtures above are small enough to stay near-flat; this one is not.
+#[test]
+fun deep_tree_area_matches_brute_force() {
+    let ctx = &mut tx_context::dummy();
+    let mut tree = strike_payout_tree::new(ctx);
+
+    // Interleave ascending and descending inserts so the shape churns.
+    let mut i = 0;
+    while (i < 20) {
+        tree.insert_range(i * 2 + 1, i * 2 + 9, 100 + i);
+        tree.insert_range(60 - i * 2, 70 - i, 50 + i);
+        i = i + 1;
+    };
+
+    // A full window sweep over this domain is ~10^5 evaluations and times out;
+    // check a spread that covers below, inside, straddling and above the book.
+    let windows = vector[
+        vector[0u64, 75u64],
+        vector[0, 10],
+        vector[12, 40],
+        vector[38, 52],
+        vector[45, 75],
+        vector[70, 75],
+        vector[33, 34],
+    ];
+    windows.do_ref!(|w| {
+        let lower = w[0];
+        let higher = w[1];
+        assert_eq!(tree.range_payout_sum(lower, higher), brute_force_sum(&tree, lower, higher));
+    });
+    destroy(tree);
+}


### PR DESCRIPTION
## Summary

- `PayoutSummary` carries two new `u128` terms per subtree: `sum(tick * local_start)` and `sum(tick * local_end)`.
- New `strike_payout_tree::range_payout_sum(lower_tick, higher_tick)` returns the sum of `W(S)` over settlement ticks in `(lower, higher]` — the area under the payout profile — in `O(log n)`.
- No behavior change to any existing read or write. Nothing calls the new query yet.

## Why

The payout tree indexes what the pool owes at each settlement tick, and the reserve math reads its peak and its total from subtree summaries. Every summary field is a function of the ordered `(local_start, local_end)` pairs alone — no field depends on a node's own tick, which is only a table key. So two orders of equal quantity, one spanning a single tick and one spanning eighty, produce byte-identical summaries despite areas differing eighty-fold.

That makes the area under the payout profile unreadable from the index, and area is the term any statistic about the profile's *shape* needs, as opposed to its level. A follow-up charge on inventory skew needs exactly that read on the trade path, where a linear scan over a `2^30` tick ladder is not affordable.

## Linear / Context

- DBU-732
- Builds on the payout-liability accounting added in #1226.

## Key decisions

- **The new terms are plain sums, deliberately.** `max_payout_prefix_gain` stays associative only because it can never exceed `start` — its `combine_summaries` path runs a `saturating_sub`, and saturating subtraction is not associative in general. Tick-weighted terms *do* outgrow `start`, so they are safe for a different reason: plain `u128` addition is associative and commutative unconditionally, with no magnitude precondition.
- **`u128`, not `u64`.** A single stored term reaches `(pos_inf_tick - 1) * max_order_quantity` ≈ 4.6e22, and `local_start` aggregates many orders at one tick, so the binding bound is the tree total at ≈2e28 against a `u128` ceiling of 3.4e38.
- **An inverted range aborts (`EInvertedRange`); an empty window returns zero.** `higher == lower` is a legitimately empty window — a skew window clipped to nothing. `higher < lower` is only ever swapped arguments, and for a charge computed from this read the silent-zero path would price a trade at nothing.
- **The final subtraction is exact, not clamped.** A consistent book cannot drive it negative. It is deliberately *not* claimed as a desync detector: it tests the aggregate rather than each prefix, so a book with negative prefixes can still return a positive total. `apply_net_delta` remains the authority, consistent with what the module doc already says about the settlement walk.
- **No window is imposed by the tree.** An order with an unbounded upper end genuinely spans the rest of the finite ladder, so where to clip is the consumer's policy, not a natural domain edge.

## Scope / Descoped

- Adds the index capability only. The skew charge, its configuration, escrow, and events are a separate PR, which will also carry the `docs/design/decisions.md` entry for the mechanism this enables.
- No caller reads `range_payout_sum` yet, so this is inert at runtime beyond the per-node storage delta. It is an intermediate step, not a standalone feature.

## Test plan

- [x] `sui move test --path packages/predict --gas-limit 100000000000` under the **CI-pinned `testnet-v1.74.1`** (not just a local newer CLI) — **501 pass**, 486 pre-existing unchanged, 15 new.
- [x] `sui move build --path packages/predict --warnings-are-errors` — clean; no `Move.lock` drift.
- [x] **Width is pinned by mutation, verified:** flipping both fields to `u64` turns `ladder_top_boundary_term_exceeds_u64` red. The order sits at the top of the ladder, where the *stored* term overflows — an order at a low tick does not pin anything, because the returned sum is built in `u128` regardless of what the fields hold.
- [x] `area_matches_brute_force_over_every_window` — the `O(log n)` read equals a tick-by-tick sum of `settled_payout_liability` across every window, on three surfaces: mixed, open-upper over a nonzero open-lower prefix, and adjacent orders sharing a boundary tick. Each is additionally anchored by a hand-computed literal (320 / 395 / 240), so the sweep is not the only oracle.
- [x] `equal_quantity_orders_are_separated_by_span` — asserts the two books have identical `payout_reserve_terms`, then that their areas are 1 and 80.
- [x] `boundary_gc_preserves_terms_and_balance` now also compares `range_payout_sum` between a 66-node rotation-churned tree and a rebuilt one of different shape — this is the shape-independence evidence.
- [x] `inverted_range_aborts`, `empty_range_is_zero`, `removing_an_order_restores_the_prior_area` (exact area, 320 → 760 → 320).
- [x] `emptying_the_tree_returns_zero_area` — draining every order returns exactly zero, with no residue from reclaimed nodes, and the tree stays usable.
- [x] `stacked_orders_at_one_boundary_aggregate_exactly` — three orders sharing a lower boundary weight the tick once against the summed quantity; peeling one back stays exact.
- [x] `deep_tree_area_matches_brute_force` — 40 interleaved ascending/descending inserts, cross-checked on windows below, inside, straddling and above the book.
- [x] **Mutation-tested:** eight single-line mutations to the new arithmetic — swapped weighted terms in `boundary_summary`, `combine_summaries` dropping a child, an off-by-one tick weight, an off-by-one prefix limit, swapped `rises`/`falls`, a dropped `span`, a nonzero `zero_summary`, and an off-by-one window bound — are each killed by the suite.
- [x] `python3 packages/predict/predeploy/check.py` — 0 warnings.
- [x] `checks/format-move.sh` on all three touched files.

## Risk / Rollout

Pre-deploy development. Adding fields to a stored struct is a layout change that Sui's `compatible` upgrade policy rejects, which is fine here: Predict publishes fresh rather than upgrading in place, and there is no mainnet deployment of predict/account/propbook.

The realistic failure mode for a new summary term is shape-dependence — a value that changes under rotation would corrupt reserve math silently. Note what the two checks each cover: `assert_subtree_invariant` recomputes with the same left-to-right fold `resummarize` uses, so it detects a **stale** summary after a rotation or splice, not shape-dependence. Shape-independence is covered by the metamorphic comparison in `boundary_gc_preserves_terms_and_balance`, where the two trees genuinely differ in shape.

Storage: `PayoutSummary` grows 24 → 56 bytes, so `PayoutNode` goes ~66 → ~98 bytes serialized; the stored object is a `Field<u64, PayoutNode>` carrying a UID and key on top, so the object-level increase is proportionally smaller. C-1's binding wall is dynamic-field object *count* (1,000 children per PTB, driven by distinct ticks), which this does not move; the per-node byte delta folds into the next capacity campaign. Sui refunds 99% of storage fees on deletion, so this is a working-capital cost rather than a burn.