### PR TITLE
propbook: emit underlying IDs with oracle observations

### DIFF
--- a/packages/predict/tests/helper/flow_test_helpers.move
+++ b/packages/predict/tests/helper/flow_test_helpers.move
@@ -628,11 +628,11 @@ public fun create_and_rebind_pyth(self: &mut Fixture, source_id: u32): ID {
 
     self.scenario.next_tx(test_constants::admin());
     let mut oracle_registry = self.scenario.take_shared<OracleRegistry>();
-    let pyth = self.scenario.take_shared_by_id<PythFeed>(pyth_id);
+    let mut pyth = self.scenario.take_shared_by_id<PythFeed>(pyth_id);
     propbook_registry::replace_pyth_binding_for_underlying(
         &mut oracle_registry,
         &self.propbook_admin_cap,
-        &pyth,
+        &mut pyth,
         test_constants::propbook_underlying_id(),
     );
     return_shared(pyth);

--- a/packages/predict/tests/helper/oracle_fixture.move
+++ b/packages/predict/tests/helper/oracle_fixture.move
@@ -219,11 +219,11 @@ public fun create_and_rebind_oracle(self: &mut OracleFixture, source_id: u32): O
 
     self.scenario.next_tx(test_constants::admin());
     let mut oracle_registry = self.scenario.take_shared<OracleRegistry>();
-    let pyth = self.scenario.take_shared_by_id<PythFeed>(pyth_id);
+    let mut pyth = self.scenario.take_shared_by_id<PythFeed>(pyth_id);
     propbook_registry::replace_pyth_binding_for_underlying(
         &mut oracle_registry,
         &self.propbook_admin_cap,
-        &pyth,
+        &mut pyth,
         test_constants::propbook_underlying_id(),
     );
     return_shared(pyth);

--- a/packages/predict/tests/helper/test_helpers.move
+++ b/packages/predict/tests/helper/test_helpers.move
@@ -131,11 +131,11 @@ public fun bind_feeds_to_underlying(
     pyth_id: ID,
 ): (ID, ID) {
     let mut oracle_registry = scenario.take_shared<OracleRegistry>();
-    let pyth = scenario.take_shared_by_id<PythFeed>(pyth_id);
+    let mut pyth = scenario.take_shared_by_id<PythFeed>(pyth_id);
     propbook_registry::bind_pyth_to_underlying(
         &mut oracle_registry,
         propbook_admin_cap,
-        &pyth,
+        &mut pyth,
         test_constants::propbook_underlying_id(),
     );
     let bs_pair = propbook_registry::create_and_share_block_scholes_stores(

--- a/packages/predict/tests/registry_guard_tests.move
+++ b/packages/predict/tests/registry_guard_tests.move
@@ -699,11 +699,11 @@ fun assert_market_id(reg: &Registry, expiry: u64, expected_id: ID) {
 /// unbound. Operates within the current (admin) transaction.
 fun bind_only_pyth(scenario: &Scenario, admin_cap: &RegistryAdminCap, pyth_id: ID) {
     let mut oracle_registry = scenario.take_shared<OracleRegistry>();
-    let pyth = scenario.take_shared_by_id<PythFeed>(pyth_id);
+    let mut pyth = scenario.take_shared_by_id<PythFeed>(pyth_id);
     propbook_registry::bind_pyth_to_underlying(
         &mut oracle_registry,
         admin_cap,
-        &pyth,
+        &mut pyth,
         test_constants::propbook_underlying_id(),
     );
     return_shared(pyth);
@@ -713,11 +713,11 @@ fun bind_only_pyth(scenario: &Scenario, admin_cap: &RegistryAdminCap, pyth_id: I
 /// Bind all permanent feeds to the canonical underlying.
 fun bind_pyth_spot_and_surface(scenario: &mut Scenario, admin_cap: &RegistryAdminCap, pyth_id: ID) {
     let mut oracle_registry = scenario.take_shared<OracleRegistry>();
-    let pyth = scenario.take_shared_by_id<PythFeed>(pyth_id);
+    let mut pyth = scenario.take_shared_by_id<PythFeed>(pyth_id);
     propbook_registry::bind_pyth_to_underlying(
         &mut oracle_registry,
         admin_cap,
-        &pyth,
+        &mut pyth,
         test_constants::propbook_underlying_id(),
     );
     propbook_registry::create_and_share_block_scholes_stores(

--- a/packages/propbook/README.md
+++ b/packages/propbook/README.md
@@ -72,6 +72,12 @@ The 1e9-normalized spot reads are derived from those stored fields. This keeps
 the stored oracle data close to what Pyth actually supplied, while still exposing
 a non-aborting normalized view for consumers.
 
+The registry stamps the feed with its canonical Propbook underlying when it is first bound. Live
+and exact observation events carry that assignment as an option: permissionless updates submitted
+before binding report `none`, while updates after binding report `some(propbook_underlying_id)`.
+Replacing the active feed does not clear the old feed's sticky assignment, so off-chain consumers
+must follow `OracleBound` and `OracleRebound` to distinguish the currently active feed.
+
 Pyth Lazer `Update` values are produced by the Pyth verifier package, so the Move
 type system provides provenance for normal Pyth ingestion.
 
@@ -211,8 +217,8 @@ Use `propbook_pyth_id_for_underlying(registry, propbook_underlying_id)`. The Blo
 
 Pyth-backed sources emit generic oracle events:
 
-- `ObservationRecorded<OracleRead<Payload>>`
-- `ObservationInserted<OracleRead<Payload>>`
+- `ObservationRecorded<OracleRead<Payload>>`, including the optional canonical Propbook underlying
+- `ObservationInserted<OracleRead<Payload>>`, including the optional canonical Propbook underlying
 - `OracleSourceRegistered`
 - `OracleBound`
 - `OracleRebound`
@@ -220,8 +226,8 @@ Pyth-backed sources emit generic oracle events:
 Block Scholes stores emit their dedicated event surface:
 
 - `BlockScholesStoresRegistered` records the Propbook underlying, both shared-object IDs, and the immutable provider base asset.
-- `BlockScholesObservationRecorded<Observation>` records every stored observation with its store ID, SID, series kind (`0` spot, `1` forward, `2` SVI), absolute expiry in milliseconds (zero for spot), and observation payload.
-- `BlockScholesBatchIngested` records every verified batch with its store ID, series kind (`0` spot, `1` forward, `2` SVI), provider publication time, verified update count, and applied update count, including batches where no series advanced.
+- `BlockScholesObservationRecorded<Observation>` records every stored observation with its Propbook underlying, store ID, SID, series kind (`0` spot, `1` forward, `2` SVI), absolute expiry in milliseconds (zero for spot), and observation payload.
+- `BlockScholesBatchIngested` records every verified batch with its Propbook underlying, store ID, series kind (`0` spot, `1` forward, `2` SVI), provider publication time, verified update count, and applied update count, including batches where no series advanced.
 
 High-frequency cost caveats:
 

--- a/packages/propbook/sources/feeds/block_scholes_store.move
+++ b/packages/propbook/sources/feeds/block_scholes_store.move
@@ -67,6 +67,7 @@ public struct SVIParams has copy, drop, store {
 /// Latest spot and forward observations for one Block Scholes base asset.
 public struct BlockScholesValueStore has key {
     id: UID,
+    propbook_underlying_id: u32,
     block_scholes_base_asset: String,
     /// Package version this store runs at; writes require an exact match and `migrate` advances it
     /// forward-only after a package upgrade.
@@ -77,6 +78,7 @@ public struct BlockScholesValueStore has key {
 /// Latest SVI observations for one Block Scholes base asset.
 public struct BlockScholesSVIStore has key {
     id: UID,
+    propbook_underlying_id: u32,
     block_scholes_base_asset: String,
     version: u64,
     svis: Table<u256, BsRead<SVIParams>>,
@@ -84,6 +86,7 @@ public struct BlockScholesSVIStore has key {
 
 /// Emitted only for observations that were stored, so its presence means the series advanced.
 public struct BlockScholesObservationRecorded<Observation: copy + drop> has copy, drop {
+    propbook_underlying_id: u32,
     propbook_oracle_id: ID,
     sid: u256,
     /// `0` = spot, `1` = forward, and `2` = SVI.
@@ -97,6 +100,7 @@ public struct BlockScholesObservationRecorded<Observation: copy + drop> has copy
 /// The envelope time advances on every provider flush, so this is what shows the feed is running
 /// during a stretch where no series moved and no observation event is emitted.
 public struct BlockScholesBatchIngested has copy, drop {
+    propbook_underlying_id: u32,
     propbook_oracle_id: ID,
     /// `0` = spot, `1` = forward, and `2` = SVI.
     series_kind: u8,
@@ -296,11 +300,13 @@ public fun migrate_svi_store(store: &mut BlockScholesSVIStore) {
 
 /// Create and share a value store for one immutable Block Scholes base asset.
 public(package) fun create_and_share_value_store(
+    propbook_underlying_id: u32,
     block_scholes_base_asset: String,
     ctx: &mut TxContext,
 ): ID {
     let store = BlockScholesValueStore {
         id: object::new(ctx),
+        propbook_underlying_id,
         block_scholes_base_asset,
         version: constants::current_version!(),
         values: table::new(ctx),
@@ -312,11 +318,13 @@ public(package) fun create_and_share_value_store(
 
 /// Create and share an SVI store for one immutable Block Scholes base asset.
 public(package) fun create_and_share_svi_store(
+    propbook_underlying_id: u32,
     block_scholes_base_asset: String,
     ctx: &mut TxContext,
 ): ID {
     let store = BlockScholesSVIStore {
         id: object::new(ctx),
+        propbook_underlying_id,
         block_scholes_base_asset,
         version: constants::current_version!(),
         svis: table::new(ctx),
@@ -371,6 +379,7 @@ fun apply_checked_value_batch(
     };
 
     event::emit(BlockScholesBatchIngested {
+        propbook_underlying_id: store.propbook_underlying_id,
         propbook_oracle_id: store.value_store_id(),
         series_kind,
         published_at_ms,
@@ -439,6 +448,7 @@ fun apply_checked_svi_batch(
     };
 
     event::emit(BlockScholesBatchIngested {
+        propbook_underlying_id: store.propbook_underlying_id,
         propbook_oracle_id: store.svi_store_id(),
         series_kind: series_kind_svi!(),
         published_at_ms,
@@ -463,8 +473,10 @@ fun apply_value(
 ): bool {
     // `apply_checked_value_batch` validates the store version before entering the batch loop.
     let id = store.value_store_id();
+    let propbook_underlying_id = store.propbook_underlying_id;
     apply(
         &mut store.values,
+        propbook_underlying_id,
         id,
         sid,
         series_kind,
@@ -487,8 +499,10 @@ fun apply_svi(
 ): bool {
     // `apply_checked_svi_batch` validates the store version before entering the batch loop.
     let id = store.svi_store_id();
+    let propbook_underlying_id = store.propbook_underlying_id;
     apply(
         &mut store.svis,
+        propbook_underlying_id,
         id,
         sid,
         series_kind_svi!(),
@@ -513,15 +527,23 @@ fun read<Value: copy + drop + store>(
 #[test_only]
 public fun observation_recorded_fields<Observation: copy + drop>(
     event: &BlockScholesObservationRecorded<Observation>,
-): (ID, u256, u8, u64, Observation) {
-    (event.propbook_oracle_id, event.sid, event.series_kind, event.expiry_ms, event.observation)
+): (u32, ID, u256, u8, u64, Observation) {
+    (
+        event.propbook_underlying_id,
+        event.propbook_oracle_id,
+        event.sid,
+        event.series_kind,
+        event.expiry_ms,
+        event.observation,
+    )
 }
 
 /// The batch event's fields exist for off-chain consumers, which decode them rather than calling
 /// Move, so this reader exists only so tests can assert the decoded fields are right.
 #[test_only]
-public fun batch_ingested_fields(event: &BlockScholesBatchIngested): (ID, u8, u64, u64, u64) {
+public fun batch_ingested_fields(event: &BlockScholesBatchIngested): (u32, ID, u8, u64, u64, u64) {
     (
+        event.propbook_underlying_id,
         event.propbook_oracle_id,
         event.series_kind,
         event.published_at_ms,
@@ -553,6 +575,7 @@ public fun set_store_versions_for_testing(
 /// anchor land on or past expiry, so it is skipped like any other unusable entry.
 fun apply<Value: copy + drop + store>(
     reads: &mut Table<u256, BsRead<Value>>,
+    propbook_underlying_id: u32,
     propbook_oracle_id: ID,
     sid: u256,
     series_kind: u8,
@@ -576,6 +599,7 @@ fun apply<Value: copy + drop + store>(
     };
 
     event::emit(BlockScholesObservationRecorded<BsRead<Value>> {
+        propbook_underlying_id,
         propbook_oracle_id,
         sid,
         series_kind,

--- a/packages/propbook/sources/feeds/pyth_feed.move
+++ b/packages/propbook/sources/feeds/pyth_feed.move
@@ -20,6 +20,7 @@ const ELazerValueUnavailable: u64 = 4;
 const EInsertTimestampNotExactMillisecond: u64 = 5;
 const EFeedTimestampAfterEnvelope: u64 = 6;
 const ESettlementCarryExceedsWindow: u64 = 7;
+const EUnderlyingAlreadyAssigned: u64 = 8;
 
 /// Source-native Pyth Lazer spot fields, including the microsecond time at which Pyth generated this price.
 /// The lane adds Propbook's millisecond ordering key and on-chain recording time around this payload.
@@ -36,6 +37,8 @@ public struct RawSpot has copy, drop, store {
 public struct PythFeed has key {
     id: UID,
     pyth_source_id: u32,
+    /// Assigned by the registry's canonical binding flow; absent before the feed is first bound.
+    propbook_underlying_id: Option<u32>,
     /// Package version this feed runs at; updates require an exact match and
     /// `migrate` advances it forward-only after a package upgrade.
     version: u64,
@@ -132,7 +135,7 @@ public fun update(feed: &mut PythFeed, update: LazerUpdate, clock: &Clock, ctx: 
     assert!(feed.version == constants::current_version!(), EWrongVersion);
     let read = feed.new_read(&update, clock.timestamp_ms(), ctx);
     let id = feed.id();
-    feed.lane.update(read, id);
+    feed.lane.update(read, feed.propbook_underlying_id, id);
 }
 
 /// Insert an exact Pyth Lazer spot observation keyed by its exact millisecond
@@ -148,7 +151,7 @@ public fun insert_at(feed: &mut PythFeed, update: LazerUpdate, clock: &Clock, ct
     assert!(feed.version == constants::current_version!(), EWrongVersion);
     let read = feed.new_insert_read(&update, clock.timestamp_ms(), ctx);
     let id = feed.id();
-    feed.lane.insert_at(read, id);
+    feed.lane.insert_at(read, feed.propbook_underlying_id, id);
 }
 
 /// Migrate this feed to the running package version (forward-only).
@@ -165,12 +168,26 @@ public(package) fun create_and_share(pyth_source_id: u32, ctx: &mut TxContext): 
     let feed = PythFeed {
         id: object::new(ctx),
         pyth_source_id,
+        propbook_underlying_id: option::none(),
         version: constants::current_version!(),
         lane: oracle_lane::new(ctx),
     };
     let id = feed.id();
     transfer::share_object(feed);
     id
+}
+
+/// Record the canonical underlying selected by the registry. A source wrapper remains assigned to
+/// its first underlying even after it stops being the active feed for that underlying.
+public(package) fun assign_underlying(feed: &mut PythFeed, propbook_underlying_id: u32) {
+    if (feed.propbook_underlying_id.is_some()) {
+        assert!(
+            *feed.propbook_underlying_id.borrow() == propbook_underlying_id,
+            EUnderlyingAlreadyAssigned,
+        );
+    } else {
+        feed.propbook_underlying_id = option::some(propbook_underlying_id);
+    };
 }
 
 // === Private Functions ===
@@ -394,8 +411,8 @@ public fun record_raw_for_testing(
     };
     let id = feed.id();
     if (insert_at) {
-        feed.lane.insert_at(read, id);
+        feed.lane.insert_at(read, feed.propbook_underlying_id, id);
     } else {
-        feed.lane.update(read, id);
+        feed.lane.update(read, feed.propbook_underlying_id, id);
     };
 }

--- a/packages/propbook/sources/oracle_lane/oracle_lane.move
+++ b/packages/propbook/sources/oracle_lane/oracle_lane.move
@@ -33,6 +33,8 @@ public struct OracleLane<Payload: copy + drop + store> has store {
 /// Emitted when a feed accepts a source-native observation into its live oracle
 /// state.
 public struct ObservationRecorded<Observation: copy + drop> has copy, drop {
+    /// Canonical Propbook underlying when this source wrapper has been bound.
+    propbook_underlying_id: Option<u32>,
     propbook_oracle_id: ID,
     observation: Observation,
 }
@@ -40,6 +42,8 @@ public struct ObservationRecorded<Observation: copy + drop> has copy, drop {
 /// Emitted when a feed inserts source-native data keyed by exact source
 /// timestamp.
 public struct ObservationInserted<Observation: copy + drop> has copy, drop {
+    /// Canonical Propbook underlying when this source wrapper has been bound.
+    propbook_underlying_id: Option<u32>,
     propbook_oracle_id: ID,
     observation: Observation,
 }
@@ -135,6 +139,7 @@ public(package) fun project_read<FromValue: copy + drop + store, ToValue: copy +
 public(package) fun update<Payload: copy + drop + store>(
     lane: &mut OracleLane<Payload>,
     read: OracleRead<Payload>,
+    propbook_underlying_id: Option<u32>,
     propbook_oracle_id: ID,
 ) {
     if (!read.read_has_valid_timestamp()) return;
@@ -144,6 +149,7 @@ public(package) fun update<Payload: copy + drop + store>(
 
     lane.latest = option::some(read);
     event::emit(ObservationRecorded<OracleRead<Payload>> {
+        propbook_underlying_id,
         propbook_oracle_id,
         observation: read,
     });
@@ -154,6 +160,7 @@ public(package) fun update<Payload: copy + drop + store>(
 public(package) fun insert_at<Payload: copy + drop + store>(
     lane: &mut OracleLane<Payload>,
     read: OracleRead<Payload>,
+    propbook_underlying_id: Option<u32>,
     propbook_oracle_id: ID,
 ) {
     if (!read.read_has_valid_timestamp()) return;
@@ -161,7 +168,22 @@ public(package) fun insert_at<Payload: copy + drop + store>(
 
     lane.exact_reads.add(read.source_timestamp_ms, read);
     event::emit(ObservationInserted<OracleRead<Payload>> {
+        propbook_underlying_id,
         propbook_oracle_id,
         observation: read,
     });
+}
+
+#[test_only]
+public fun observation_recorded_fields<Observation: copy + drop>(
+    event: &ObservationRecorded<Observation>,
+): (Option<u32>, ID, Observation) {
+    (event.propbook_underlying_id, event.propbook_oracle_id, event.observation)
+}
+
+#[test_only]
+public fun observation_inserted_fields<Observation: copy + drop>(
+    event: &ObservationInserted<Observation>,
+): (Option<u32>, ID, Observation) {
+    (event.propbook_underlying_id, event.propbook_oracle_id, event.observation)
 }

--- a/packages/propbook/sources/registry.move
+++ b/packages/propbook/sources/registry.move
@@ -271,10 +271,12 @@ public fun create_and_share_block_scholes_stores(
         EInvalidBlockScholesBaseAsset,
     );
     let value_store_id = block_scholes_store::create_and_share_value_store(
+        propbook_underlying_id,
         copy block_scholes_base_asset,
         ctx,
     );
     let svi_store_id = block_scholes_store::create_and_share_svi_store(
+        propbook_underlying_id,
         copy block_scholes_base_asset,
         ctx,
     );
@@ -297,7 +299,7 @@ public fun create_and_share_block_scholes_stores(
 public fun bind_pyth_to_underlying(
     registry: &mut OracleRegistry,
     admin_cap: &RegistryAdminCap,
-    feed: &PythFeed,
+    feed: &mut PythFeed,
     propbook_underlying_id: u32,
 ) {
     registry.bind_oracle(
@@ -306,6 +308,7 @@ public fun bind_pyth_to_underlying(
         pyth_feed::id(feed),
         pyth_binding_key(propbook_underlying_id),
     );
+    feed.assign_underlying(propbook_underlying_id);
 }
 
 /// Admin-replace the canonical Pyth source feed for a Propbook underlying.
@@ -316,7 +319,7 @@ public fun bind_pyth_to_underlying(
 public fun replace_pyth_binding_for_underlying(
     registry: &mut OracleRegistry,
     admin_cap: &RegistryAdminCap,
-    feed: &PythFeed,
+    feed: &mut PythFeed,
     propbook_underlying_id: u32,
 ) {
     registry.replace_oracle(
@@ -325,6 +328,7 @@ public fun replace_pyth_binding_for_underlying(
         pyth_feed::id(feed),
         pyth_binding_key(propbook_underlying_id),
     );
+    feed.assign_underlying(propbook_underlying_id);
 }
 
 // === Public-Package Functions ===

--- a/packages/propbook/tests/block_scholes/block_scholes_store_tests.move
+++ b/packages/propbook/tests/block_scholes/block_scholes_store_tests.move
@@ -24,6 +24,7 @@ use std::{string::String, unit_test::assert_eq};
 use sui::{clock::{Self, Clock}, event, test_scenario::{Self as test, Scenario, return_shared}};
 
 const ADMIN: address = @0xAD;
+const BTC_UNDERLYING_ID: u32 = 1;
 const SERIES_KIND_SPOT: u8 = 0;
 const SERIES_KIND_FORWARD: u8 = 1;
 const SERIES_KIND_SVI: u8 = 2;
@@ -79,7 +80,8 @@ fun a_spot_observation_lands_with_all_three_clocks() {
     assert_eq!(read.read_published_at_ms(), PUBLISHED_EARLY);
     assert_eq!(read.read_recorded_at_ms(), CHAIN_TIME_MS);
     let events = event::events_by_type<store::BlockScholesBatchIngested>();
-    let (_, series_kind, _, _, _) = store::batch_ingested_fields(&events[0]);
+    let (underlying_id, _, series_kind, _, _, _) = store::batch_ingested_fields(&events[0]);
+    assert_eq!(underlying_id, BTC_UNDERLYING_ID);
     assert_eq!(series_kind, SERIES_KIND_SPOT);
 
     clock::destroy_for_testing(chain_clock);
@@ -106,9 +108,15 @@ fun a_stored_observation_is_what_its_event_reports() {
 
     let events = event::events_by_type<store::BlockScholesObservationRecorded<BsRead<u128>>>();
     assert_eq!(events.length(), 1);
-    let (oracle_id, sid, series_kind, expiry_ms, observation) = store::observation_recorded_fields(
-        &events[0],
-    );
+    let (
+        underlying_id,
+        oracle_id,
+        sid,
+        series_kind,
+        expiry_ms,
+        observation,
+    ) = store::observation_recorded_fields(&events[0]);
+    assert_eq!(underlying_id, BTC_UNDERLYING_ID);
     assert_eq!(oracle_id, value_id);
     assert_eq!(sid, block_scholes_sid::spot(&btc()));
     assert_eq!(series_kind, SERIES_KIND_SPOT);
@@ -218,10 +226,10 @@ fun typed_batches_fill_spot_and_every_forward_expiry_independently() {
     assert_eq!(store::forward(&value_store, EXPIRY_B).destroy_some().read_value(), FORWARD_B);
     let events = event::events_by_type<store::BlockScholesObservationRecorded<BsRead<u128>>>();
     assert_eq!(events.length(), 3);
-    let (_, _, series_kind, expiry_ms, _) = store::observation_recorded_fields(&events[1]);
+    let (_, _, _, series_kind, expiry_ms, _) = store::observation_recorded_fields(&events[1]);
     assert_eq!(series_kind, SERIES_KIND_FORWARD);
     assert_eq!(expiry_ms, EXPIRY_A);
-    let (_, _, series_kind, expiry_ms, _) = store::observation_recorded_fields(&events[2]);
+    let (_, _, _, series_kind, expiry_ms, _) = store::observation_recorded_fields(&events[2]);
     assert_eq!(series_kind, SERIES_KIND_FORWARD);
     assert_eq!(expiry_ms, EXPIRY_B);
 
@@ -352,8 +360,8 @@ fun newer_model_data_in_an_older_envelope_is_skipped() {
 #[test]
 fun a_monotone_provider_stream_stores_the_same_observation_in_any_order() {
     let mut scenario = test::begin(ADMIN);
-    let forward_id = store::create_and_share_value_store(btc(), scenario.ctx());
-    let reversed_id = store::create_and_share_value_store(btc(), scenario.ctx());
+    let forward_id = store::create_and_share_value_store(BTC_UNDERLYING_ID, btc(), scenario.ctx());
+    let reversed_id = store::create_and_share_value_store(BTC_UNDERLYING_ID, btc(), scenario.ctx());
     scenario.next_tx(ADMIN);
     let mut forward_store = scenario.take_shared_by_id<BlockScholesValueStore>(forward_id);
     let mut reversed_store = scenario.take_shared_by_id<BlockScholesValueStore>(reversed_id);
@@ -411,8 +419,8 @@ fun a_monotone_provider_stream_stores_the_same_observation_in_any_order() {
 #[test]
 fun a_regressed_publish_stream_is_first_writer_wins() {
     let mut scenario = test::begin(ADMIN);
-    let forward_id = store::create_and_share_value_store(btc(), scenario.ctx());
-    let reversed_id = store::create_and_share_value_store(btc(), scenario.ctx());
+    let forward_id = store::create_and_share_value_store(BTC_UNDERLYING_ID, btc(), scenario.ctx());
+    let reversed_id = store::create_and_share_value_store(BTC_UNDERLYING_ID, btc(), scenario.ctx());
     scenario.next_tx(ADMIN);
     let mut forward_store = scenario.take_shared_by_id<BlockScholesValueStore>(forward_id);
     let mut reversed_store = scenario.take_shared_by_id<BlockScholesValueStore>(reversed_id);
@@ -486,7 +494,7 @@ fun a_model_time_after_its_own_envelope_is_skipped() {
     assert_eq!(store::forward(&value_store, EXPIRY_B).destroy_some().read_value(), FORWARD_B);
 
     let events = event::events_by_type<store::BlockScholesBatchIngested>();
-    let (_, series_kind, _, update_count, applied) = store::batch_ingested_fields(&events[0]);
+    let (_, _, series_kind, _, update_count, applied) = store::batch_ingested_fields(&events[0]);
     assert_eq!(series_kind, SERIES_KIND_FORWARD);
     assert_eq!(update_count, 2);
     assert_eq!(applied, 1);
@@ -684,7 +692,7 @@ fun an_svi_batch_lands_every_parameter_source_native() {
     assert_eq!(params.svi_m_is_negative(), SVI_M_NEG);
     assert_eq!(read.read_model_timestamp_ms(), MODEL_EARLY);
     let events = event::events_by_type<store::BlockScholesBatchIngested>();
-    let (_, series_kind, _, _, _) = store::batch_ingested_fields(&events[0]);
+    let (_, _, series_kind, _, _, _) = store::batch_ingested_fields(&events[0]);
     assert_eq!(series_kind, SERIES_KIND_SVI);
 
     clock::destroy_for_testing(chain_clock);
@@ -827,6 +835,7 @@ fun an_ingested_batch_reports_what_it_carried_and_stored() {
     let events = event::events_by_type<store::BlockScholesBatchIngested>();
     assert_eq!(events.length(), 2);
     let (
+        underlying_id,
         oracle_id,
         series_kind,
         published_at_ms,
@@ -835,6 +844,7 @@ fun an_ingested_batch_reports_what_it_carried_and_stored() {
     ) = store::batch_ingested_fields(
         &events[1],
     );
+    assert_eq!(underlying_id, BTC_UNDERLYING_ID);
     assert_eq!(oracle_id, value_id);
     assert_eq!(series_kind, SERIES_KIND_FORWARD);
     assert_eq!(published_at_ms, PUBLISHED_MID);
@@ -873,7 +883,7 @@ fun a_series_repeated_within_one_batch_resolves_by_model_time() {
     assert_eq!(read.read_model_timestamp_ms(), MODEL_MID);
 
     let events = event::events_by_type<store::BlockScholesBatchIngested>();
-    let (_, series_kind, _, update_count, applied) = store::batch_ingested_fields(&events[0]);
+    let (_, _, series_kind, _, update_count, applied) = store::batch_ingested_fields(&events[0]);
     assert_eq!(series_kind, SERIES_KIND_FORWARD);
     assert_eq!(update_count, 3);
     assert_eq!(applied, 2);
@@ -946,8 +956,16 @@ fun migrating_an_svi_store_already_at_the_running_version_aborts() {
 
 fun setup_stores(): (Scenario, ID, ID) {
     let mut scenario = test::begin(ADMIN);
-    let value_id = store::create_and_share_value_store(btc(), scenario.ctx());
-    let svi_id = store::create_and_share_svi_store(btc(), scenario.ctx());
+    let value_id = store::create_and_share_value_store(
+        BTC_UNDERLYING_ID,
+        btc(),
+        scenario.ctx(),
+    );
+    let svi_id = store::create_and_share_svi_store(
+        BTC_UNDERLYING_ID,
+        btc(),
+        scenario.ctx(),
+    );
     scenario.next_tx(ADMIN);
     (scenario, value_id, svi_id)
 }

--- a/packages/propbook/tests/oracle_lane_tests.move
+++ b/packages/propbook/tests/oracle_lane_tests.move
@@ -28,8 +28,8 @@ fun update_accepts_newer_latest_without_exact_insert() {
     let ctx = &mut tx_context::dummy();
     let mut lane = new_lane(ctx);
 
-    lane.update(new_read(SPOT_A, T_EARLY, UPDATE_EARLY, ctx), oracle_id());
-    lane.update(new_read(SPOT_B, T_MID, UPDATE_MID, ctx), oracle_id());
+    lane.update(new_read(SPOT_A, T_EARLY, UPDATE_EARLY, ctx), option::none(), oracle_id());
+    lane.update(new_read(SPOT_B, T_MID, UPDATE_MID, ctx), option::none(), oracle_id());
 
     let latest = lane.latest_read().destroy_some();
     assert_eq!(latest.read_source_timestamp_ms(), T_MID);
@@ -46,11 +46,11 @@ fun update_stale_future_and_zero_sources_are_no_ops() {
     let ctx = &mut tx_context::dummy();
     let mut lane = new_lane(ctx);
 
-    lane.update(new_read(SPOT_A, T_MID, UPDATE_MID, ctx), oracle_id());
-    lane.update(new_read(SPOT_B, T_MID, UPDATE_LATE, ctx), oracle_id());
-    lane.update(new_read(SPOT_B, T_EARLY, UPDATE_LATE, ctx), oracle_id());
-    lane.update(new_read(SPOT_B, T_LATE, T_EARLY, ctx), oracle_id());
-    lane.update(new_read(SPOT_B, T_ZERO, UPDATE_LATE, ctx), oracle_id());
+    lane.update(new_read(SPOT_A, T_MID, UPDATE_MID, ctx), option::none(), oracle_id());
+    lane.update(new_read(SPOT_B, T_MID, UPDATE_LATE, ctx), option::none(), oracle_id());
+    lane.update(new_read(SPOT_B, T_EARLY, UPDATE_LATE, ctx), option::none(), oracle_id());
+    lane.update(new_read(SPOT_B, T_LATE, T_EARLY, ctx), option::none(), oracle_id());
+    lane.update(new_read(SPOT_B, T_ZERO, UPDATE_LATE, ctx), option::none(), oracle_id());
 
     let latest = lane.latest_read().destroy_some();
     assert_eq!(latest.read_source_timestamp_ms(), T_MID);
@@ -65,7 +65,7 @@ fun insert_at_records_exact_read_without_latest() {
     let ctx = &mut tx_context::dummy();
     let mut lane = new_lane(ctx);
 
-    lane.insert_at(new_read(SPOT_A, T_EARLY, UPDATE_EARLY, ctx), oracle_id());
+    lane.insert_at(new_read(SPOT_A, T_EARLY, UPDATE_EARLY, ctx), option::none(), oracle_id());
 
     assert!(lane.latest_read().is_none());
     let exact = lane.read_at(T_EARLY).destroy_some();
@@ -82,10 +82,10 @@ fun insert_at_duplicate_future_and_zero_sources_are_no_ops() {
     let ctx = &mut tx_context::dummy();
     let mut lane = new_lane(ctx);
 
-    lane.insert_at(new_read(SPOT_A, T_EARLY, UPDATE_EARLY, ctx), oracle_id());
-    lane.insert_at(new_read(SPOT_B, T_EARLY, UPDATE_LATE, ctx), oracle_id());
-    lane.insert_at(new_read(SPOT_B, T_LATE, T_EARLY, ctx), oracle_id());
-    lane.insert_at(new_read(SPOT_B, T_ZERO, UPDATE_LATE, ctx), oracle_id());
+    lane.insert_at(new_read(SPOT_A, T_EARLY, UPDATE_EARLY, ctx), option::none(), oracle_id());
+    lane.insert_at(new_read(SPOT_B, T_EARLY, UPDATE_LATE, ctx), option::none(), oracle_id());
+    lane.insert_at(new_read(SPOT_B, T_LATE, T_EARLY, ctx), option::none(), oracle_id());
+    lane.insert_at(new_read(SPOT_B, T_ZERO, UPDATE_LATE, ctx), option::none(), oracle_id());
 
     let exact = lane.read_at(T_EARLY).destroy_some();
     assert_eq!(exact.read_source_timestamp_ms(), T_EARLY);

--- a/packages/propbook/tests/pyth/pyth_feed_tests.move
+++ b/packages/propbook/tests/pyth/pyth_feed_tests.move
@@ -4,11 +4,17 @@
 #[test_only]
 module propbook::pyth_feed_tests;
 
-use propbook::{constants, pyth_feed::{Self, PythFeed}, registry::{Self, OracleRegistry}};
-use std::unit_test::assert_eq;
-use sui::test_scenario::{Self as test, Scenario, return_shared};
+use propbook::{
+    constants,
+    oracle_lane::{Self, OracleRead},
+    pyth_feed::{Self, PythFeed, RawSpot},
+    registry::{Self, OracleRegistry, RegistryAdminCap}
+};
+use std::unit_test::{assert_eq, destroy};
+use sui::{event, test_scenario::{Self as test, Scenario, return_shared}};
 
 const ADMIN: address = @0xAD;
+const BTC_UNDERLYING_ID: u32 = 1;
 const BTC_SOURCE_ID: u32 = 1;
 const UNKNOWN_SOURCE_ID: u32 = 999;
 const SPOT_65K: u64 = 65_000_000_000_000;
@@ -65,6 +71,73 @@ fun registry_records_created_pyth_source() {
     assert!(registry.propbook_pyth_id_for_source(UNKNOWN_SOURCE_ID).is_none());
 
     return_shared(registry);
+    scenario.end();
+}
+
+#[test]
+fun bound_feed_observation_events_include_the_underlying() {
+    let (scenario, feed_obj_id) = setup_feed();
+    let admin_cap = scenario.take_from_sender<RegistryAdminCap>();
+    let mut registry = scenario.take_shared<OracleRegistry>();
+    let mut feed = scenario.take_shared_by_id<PythFeed>(feed_obj_id);
+
+    registry.bind_pyth_to_underlying(&admin_cap, &mut feed, BTC_UNDERLYING_ID);
+    store_raw(
+        &mut feed,
+        SPOT_65K,
+        false,
+        EXPONENT_NEG_9,
+        true,
+        SOURCE_TS_1_US,
+        UPDATE_1_MS,
+    );
+    insert_raw(
+        &mut feed,
+        SPOT_65K,
+        false,
+        EXPONENT_NEG_9,
+        true,
+        SOURCE_TS_2_US,
+        UPDATE_2_MS,
+    );
+
+    let recorded = event::events_by_type<oracle_lane::ObservationRecorded<OracleRead<RawSpot>>>();
+    let (underlying_id, oracle_id, _) = oracle_lane::observation_recorded_fields(&recorded[0]);
+    assert_eq!(underlying_id.destroy_some(), BTC_UNDERLYING_ID);
+    assert_eq!(oracle_id, feed_obj_id);
+
+    let inserted = event::events_by_type<oracle_lane::ObservationInserted<OracleRead<RawSpot>>>();
+    let (underlying_id, oracle_id, _) = oracle_lane::observation_inserted_fields(&inserted[0]);
+    assert_eq!(underlying_id.destroy_some(), BTC_UNDERLYING_ID);
+    assert_eq!(oracle_id, feed_obj_id);
+
+    return_shared(feed);
+    return_shared(registry);
+    destroy(admin_cap);
+    scenario.end();
+}
+
+#[test]
+fun unbound_feed_observation_event_has_no_underlying() {
+    let (scenario, feed_obj_id) = setup_feed();
+    let mut feed = scenario.take_shared_by_id<PythFeed>(feed_obj_id);
+
+    store_raw(
+        &mut feed,
+        SPOT_65K,
+        false,
+        EXPONENT_NEG_9,
+        true,
+        SOURCE_TS_1_US,
+        UPDATE_1_MS,
+    );
+
+    let recorded = event::events_by_type<oracle_lane::ObservationRecorded<OracleRead<RawSpot>>>();
+    let (underlying_id, oracle_id, _) = oracle_lane::observation_recorded_fields(&recorded[0]);
+    assert!(underlying_id.is_none());
+    assert_eq!(oracle_id, feed_obj_id);
+
+    return_shared(feed);
     scenario.end();
 }
 

--- a/packages/propbook/tests/pyth/pyth_feed_tests.move
+++ b/packages/propbook/tests/pyth/pyth_feed_tests.move
@@ -15,7 +15,9 @@ use sui::{event, test_scenario::{Self as test, Scenario, return_shared}};
 
 const ADMIN: address = @0xAD;
 const BTC_UNDERLYING_ID: u32 = 1;
+const ETH_UNDERLYING_ID: u32 = 2;
 const BTC_SOURCE_ID: u32 = 1;
+const BTC_REPLACEMENT_SOURCE_ID: u32 = 2;
 const UNKNOWN_SOURCE_ID: u32 = 999;
 const SPOT_65K: u64 = 65_000_000_000_000;
 const BTC_PYTH_MAGNITUDE: u64 = 6_500_012_345_678;
@@ -139,6 +141,83 @@ fun unbound_feed_observation_event_has_no_underlying() {
 
     return_shared(feed);
     scenario.end();
+}
+
+#[test]
+fun replacement_and_replaced_feed_observations_keep_the_underlying() {
+    let (mut scenario, replaced_feed_id) = setup_feed();
+    let mut registry = scenario.take_shared<OracleRegistry>();
+    let replacement_feed_id = registry::create_and_share_pyth_feed(
+        &mut registry,
+        BTC_REPLACEMENT_SOURCE_ID,
+        scenario.ctx(),
+    );
+    return_shared(registry);
+    scenario.next_tx(ADMIN);
+
+    let admin_cap = scenario.take_from_sender<RegistryAdminCap>();
+    let mut registry = scenario.take_shared<OracleRegistry>();
+    let mut replaced_feed = scenario.take_shared_by_id<PythFeed>(replaced_feed_id);
+    let mut replacement_feed = scenario.take_shared_by_id<PythFeed>(replacement_feed_id);
+
+    registry.bind_pyth_to_underlying(&admin_cap, &mut replaced_feed, BTC_UNDERLYING_ID);
+    registry.replace_pyth_binding_for_underlying(
+        &admin_cap,
+        &mut replacement_feed,
+        BTC_UNDERLYING_ID,
+    );
+    store_raw(
+        &mut replaced_feed,
+        SPOT_65K,
+        false,
+        EXPONENT_NEG_9,
+        true,
+        SOURCE_TS_1_US,
+        UPDATE_1_MS,
+    );
+    store_raw(
+        &mut replacement_feed,
+        SPOT_65K,
+        false,
+        EXPONENT_NEG_9,
+        true,
+        SOURCE_TS_2_US,
+        UPDATE_2_MS,
+    );
+
+    let mut recorded = event::events_by_type<
+        oracle_lane::ObservationRecorded<OracleRead<RawSpot>>,
+    >();
+    let replacement_event = recorded.pop_back();
+    let replaced_event = recorded.pop_back();
+    assert!(recorded.is_empty());
+
+    let (underlying_id, oracle_id, _) = oracle_lane::observation_recorded_fields(&replaced_event);
+    assert_eq!(underlying_id.destroy_some(), BTC_UNDERLYING_ID);
+    assert_eq!(oracle_id, replaced_feed_id);
+
+    let (underlying_id, oracle_id, _) = oracle_lane::observation_recorded_fields(
+        &replacement_event,
+    );
+    assert_eq!(underlying_id.destroy_some(), BTC_UNDERLYING_ID);
+    assert_eq!(oracle_id, replacement_feed_id);
+
+    return_shared(replacement_feed);
+    return_shared(replaced_feed);
+    return_shared(registry);
+    destroy(admin_cap);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = pyth_feed::EUnderlyingAlreadyAssigned)]
+fun assigning_feed_to_a_different_underlying_aborts() {
+    let (scenario, feed_obj_id) = setup_feed();
+    let mut feed = scenario.take_shared_by_id<PythFeed>(feed_obj_id);
+
+    feed.assign_underlying(BTC_UNDERLYING_ID);
+    feed.assign_underlying(ETH_UNDERLYING_ID);
+
+    abort 999
 }
 
 #[test, expected_failure(abort_code = registry::ESourceAlreadyExists)]

--- a/packages/propbook/tests/registry_tests.move
+++ b/packages/propbook/tests/registry_tests.move
@@ -23,9 +23,9 @@ fun bind_pyth_to_underlying_records_typed_lookup_and_metadata() {
     let (scenario, pyth_a_id, _pyth_b_id) = setup_registry_with_feeds();
     let admin_cap = scenario.take_from_sender<RegistryAdminCap>();
     let mut registry = scenario.take_shared<OracleRegistry>();
-    let pyth = scenario.take_shared_by_id<PythFeed>(pyth_a_id);
+    let mut pyth = scenario.take_shared_by_id<PythFeed>(pyth_a_id);
 
-    registry.bind_pyth_to_underlying(&admin_cap, &pyth, BTC_UNDERLYING_ID);
+    registry.bind_pyth_to_underlying(&admin_cap, &mut pyth, BTC_UNDERLYING_ID);
 
     assert_eq!(
         registry.propbook_pyth_id_for_underlying(BTC_UNDERLYING_ID).destroy_some(),
@@ -50,11 +50,11 @@ fun replace_pyth_binding_updates_typed_lookup_and_metadata() {
     let (scenario, pyth_a_id, pyth_b_id) = setup_registry_with_feeds();
     let admin_cap = scenario.take_from_sender<RegistryAdminCap>();
     let mut registry = scenario.take_shared<OracleRegistry>();
-    let pyth_a = scenario.take_shared_by_id<PythFeed>(pyth_a_id);
-    let pyth_b = scenario.take_shared_by_id<PythFeed>(pyth_b_id);
+    let mut pyth_a = scenario.take_shared_by_id<PythFeed>(pyth_a_id);
+    let mut pyth_b = scenario.take_shared_by_id<PythFeed>(pyth_b_id);
 
-    registry.bind_pyth_to_underlying(&admin_cap, &pyth_a, BTC_UNDERLYING_ID);
-    registry.replace_pyth_binding_for_underlying(&admin_cap, &pyth_b, BTC_UNDERLYING_ID);
+    registry.bind_pyth_to_underlying(&admin_cap, &mut pyth_a, BTC_UNDERLYING_ID);
+    registry.replace_pyth_binding_for_underlying(&admin_cap, &mut pyth_b, BTC_UNDERLYING_ID);
 
     assert_eq!(
         registry.propbook_pyth_id_for_underlying(BTC_UNDERLYING_ID).destroy_some(),
@@ -81,9 +81,9 @@ fun bind_source_with_wrong_propbook_object_aborts() {
     scenario.next_tx(ADMIN);
     let admin_cap = scenario.take_from_sender<RegistryAdminCap>();
     let mut registry = scenario.take_shared<OracleRegistry>();
-    let rogue_pyth = scenario.take_shared_by_id<PythFeed>(rogue_pyth_id);
+    let mut rogue_pyth = scenario.take_shared_by_id<PythFeed>(rogue_pyth_id);
 
-    registry.bind_pyth_to_underlying(&admin_cap, &rogue_pyth, BTC_UNDERLYING_ID);
+    registry.bind_pyth_to_underlying(&admin_cap, &mut rogue_pyth, BTC_UNDERLYING_ID);
 
     abort 999
 }
@@ -95,9 +95,9 @@ fun bind_unregistered_source_aborts() {
     scenario.next_tx(ADMIN);
     let admin_cap = scenario.take_from_sender<RegistryAdminCap>();
     let mut registry = scenario.take_shared<OracleRegistry>();
-    let unregistered_pyth = scenario.take_shared_by_id<PythFeed>(unregistered_pyth_id);
+    let mut unregistered_pyth = scenario.take_shared_by_id<PythFeed>(unregistered_pyth_id);
 
-    registry.bind_pyth_to_underlying(&admin_cap, &unregistered_pyth, BTC_UNDERLYING_ID);
+    registry.bind_pyth_to_underlying(&admin_cap, &mut unregistered_pyth, BTC_UNDERLYING_ID);
 
     abort 999
 }
@@ -107,9 +107,9 @@ fun replace_pyth_binding_without_existing_binding_aborts() {
     let (scenario, pyth_a_id, _pyth_b_id) = setup_registry_with_feeds();
     let admin_cap = scenario.take_from_sender<RegistryAdminCap>();
     let mut registry = scenario.take_shared<OracleRegistry>();
-    let pyth = scenario.take_shared_by_id<PythFeed>(pyth_a_id);
+    let mut pyth = scenario.take_shared_by_id<PythFeed>(pyth_a_id);
 
-    registry.replace_pyth_binding_for_underlying(&admin_cap, &pyth, BTC_UNDERLYING_ID);
+    registry.replace_pyth_binding_for_underlying(&admin_cap, &mut pyth, BTC_UNDERLYING_ID);
 
     abort 999
 }
@@ -119,12 +119,12 @@ fun replace_pyth_binding_to_source_bound_to_other_underlying_aborts() {
     let (scenario, pyth_a_id, pyth_b_id) = setup_registry_with_feeds();
     let admin_cap = scenario.take_from_sender<RegistryAdminCap>();
     let mut registry = scenario.take_shared<OracleRegistry>();
-    let pyth_a = scenario.take_shared_by_id<PythFeed>(pyth_a_id);
-    let pyth_b = scenario.take_shared_by_id<PythFeed>(pyth_b_id);
+    let mut pyth_a = scenario.take_shared_by_id<PythFeed>(pyth_a_id);
+    let mut pyth_b = scenario.take_shared_by_id<PythFeed>(pyth_b_id);
 
-    registry.bind_pyth_to_underlying(&admin_cap, &pyth_a, BTC_UNDERLYING_ID);
-    registry.bind_pyth_to_underlying(&admin_cap, &pyth_b, ETH_UNDERLYING_ID);
-    registry.replace_pyth_binding_for_underlying(&admin_cap, &pyth_b, BTC_UNDERLYING_ID);
+    registry.bind_pyth_to_underlying(&admin_cap, &mut pyth_a, BTC_UNDERLYING_ID);
+    registry.bind_pyth_to_underlying(&admin_cap, &mut pyth_b, ETH_UNDERLYING_ID);
+    registry.replace_pyth_binding_for_underlying(&admin_cap, &mut pyth_b, BTC_UNDERLYING_ID);
 
     abort 999
 }
@@ -134,12 +134,12 @@ fun replaced_pyth_source_stays_bound_to_original_underlying() {
     let (scenario, pyth_a_id, pyth_b_id) = setup_registry_with_feeds();
     let admin_cap = scenario.take_from_sender<RegistryAdminCap>();
     let mut registry = scenario.take_shared<OracleRegistry>();
-    let pyth_a = scenario.take_shared_by_id<PythFeed>(pyth_a_id);
-    let pyth_b = scenario.take_shared_by_id<PythFeed>(pyth_b_id);
+    let mut pyth_a = scenario.take_shared_by_id<PythFeed>(pyth_a_id);
+    let mut pyth_b = scenario.take_shared_by_id<PythFeed>(pyth_b_id);
 
-    registry.bind_pyth_to_underlying(&admin_cap, &pyth_a, BTC_UNDERLYING_ID);
-    registry.replace_pyth_binding_for_underlying(&admin_cap, &pyth_b, BTC_UNDERLYING_ID);
-    registry.bind_pyth_to_underlying(&admin_cap, &pyth_a, ETH_UNDERLYING_ID);
+    registry.bind_pyth_to_underlying(&admin_cap, &mut pyth_a, BTC_UNDERLYING_ID);
+    registry.replace_pyth_binding_for_underlying(&admin_cap, &mut pyth_b, BTC_UNDERLYING_ID);
+    registry.bind_pyth_to_underlying(&admin_cap, &mut pyth_a, ETH_UNDERLYING_ID);
 
     abort 999
 }
@@ -149,10 +149,10 @@ fun same_source_cannot_bind_to_two_underlyings() {
     let (scenario, pyth_a_id, _pyth_b_id) = setup_registry_with_feeds();
     let admin_cap = scenario.take_from_sender<RegistryAdminCap>();
     let mut registry = scenario.take_shared<OracleRegistry>();
-    let pyth = scenario.take_shared_by_id<PythFeed>(pyth_a_id);
+    let mut pyth = scenario.take_shared_by_id<PythFeed>(pyth_a_id);
 
-    registry.bind_pyth_to_underlying(&admin_cap, &pyth, BTC_UNDERLYING_ID);
-    registry.bind_pyth_to_underlying(&admin_cap, &pyth, ETH_UNDERLYING_ID);
+    registry.bind_pyth_to_underlying(&admin_cap, &mut pyth, BTC_UNDERLYING_ID);
+    registry.bind_pyth_to_underlying(&admin_cap, &mut pyth, ETH_UNDERLYING_ID);
 
     abort 999
 }
@@ -162,11 +162,11 @@ fun rebinding_bound_underlying_aborts() {
     let (scenario, pyth_a_id, pyth_b_id) = setup_registry_with_feeds();
     let admin_cap = scenario.take_from_sender<RegistryAdminCap>();
     let mut registry = scenario.take_shared<OracleRegistry>();
-    let pyth_a = scenario.take_shared_by_id<PythFeed>(pyth_a_id);
-    let pyth_b = scenario.take_shared_by_id<PythFeed>(pyth_b_id);
+    let mut pyth_a = scenario.take_shared_by_id<PythFeed>(pyth_a_id);
+    let mut pyth_b = scenario.take_shared_by_id<PythFeed>(pyth_b_id);
 
-    registry.bind_pyth_to_underlying(&admin_cap, &pyth_a, BTC_UNDERLYING_ID);
-    registry.bind_pyth_to_underlying(&admin_cap, &pyth_b, BTC_UNDERLYING_ID);
+    registry.bind_pyth_to_underlying(&admin_cap, &mut pyth_a, BTC_UNDERLYING_ID);
+    registry.bind_pyth_to_underlying(&admin_cap, &mut pyth_b, BTC_UNDERLYING_ID);
 
     abort 999
 }


### PR DESCRIPTION
## Summary

- Add `propbook_underlying_id` to Propbook oracle observation events so downstream indexers can build one series per underlying instead of per oracle object.
- Keep the Pyth underlying optional until the feed is bound; emit the required underlying directly from Block Scholes value and SVI stores.
- Update Propbook and Predict call sites and tests for the refreshed event ABI.

## Why

Propbook observation events are the source for downstream pricing history. Oracle object IDs are not the public series identity: one underlying spans Pyth spot and multiple expiry-specific Block Scholes stores, and the active Pyth oracle can be rebound. The new package deployment needs to expose that identity directly so indexers do not reconstruct it with database joins.

## Linear / Context

- [Pricing-series request](https://app.notion.com/p/mystenlabs/Request-one-bucketed-pricing-series-endpoint-on-propbook-server-3b86d9dcb4e98049b5a1eb82901f3ae4)

## Key decisions

- Pyth events use `Option<u32>` because a feed can emit before registry binding. Binding and rebinding assign a sticky underlying ID to the feed.
- Block Scholes stores receive the underlying at creation, so their events always emit it. Expiry remains a separate series dimension for forward and SVI values.

## Scope / Descoped

- This PR changes only Propbook package event data and the Move tests and helpers required by that ABI change.
- Indexer schema, projections, and API behavior are implemented in the stacked DeepBook Services PRs.

## Test plan

- [x] `sui move test --path packages/propbook` with Sui 1.74.1 — 80 tests passed.
- [x] `sui move test --path packages/predict` with Sui 1.74.1 — 486 tests passed.
- [x] `pnpm format:move` — changed Move files are formatted.

## Risk / Rollout

This changes the BCS layout of emitted events and is intentionally for the planned full new package deployment. Deploy the new package and the matching indexer ABI together; an indexer configured for this layout must not decode events from the previous package as the new type.
