### PR TITLE
sessions: retire outdated package versions (DBU-746)

### DIFF
--- a/packages/sessions/README.md
+++ b/packages/sessions/README.md
@@ -14,6 +14,7 @@ A session grant contains only the session address and its expiration timestamp i
 
 Every trading wrapper requires both of these conditions:
 
+- The executing Sessions package version is at or above the shared `SessionsConfig.version_watermark`.
 - The transaction sender has a stored session grant for the supplied Account.
 - The current clock timestamp is strictly less than the stored expiration.
 
@@ -29,6 +30,7 @@ public fun session_expiration_ms(
 
 public fun authorize_session(
     wrapper: &mut AccountWrapper,
+    sessions_config: &SessionsConfig,
     session: address,
     duration_ms: u64,
     clock: &Clock,
@@ -48,6 +50,16 @@ The shared `AccountWrapper` can be supplied as an object input in a programmable
 
 Revoking a known session removes it from the session map immediately, whether it is active or already expired, and frees its slot for another address. Once the Sessions app-data slot has been attached to an Account, it remains attached even when the session map becomes empty. Revoking an unknown session is a no-op. Expired entries are not removed automatically because time passing does not execute Move code; they continue to count toward the 20-session limit until the owner revokes them, while reauthorization replaces the expiration in place.
 
+Session reads and revocation remain available after a package version is retired so owners can inspect and remove grants without using a trading-capable package version.
+
+## Version governance
+
+Publishing Sessions creates a shared `SessionsConfig` at the package's compiled-in version and transfers a `SessionsAdminCap` to the publisher. `authorize_session` and every trading wrapper require the shared config and reject package versions below its watermark.
+
+Each package upgrade must increment `current_version!()`. After clients have moved to the new package, the `SessionsAdminCap` holder calls that package's `bump_version_watermark`; the function derives the target from the executing package and only advances the watermark, so callers cannot select an arbitrary version or use an older package to retire a newer one.
+
+Advancing the watermark retires authorization and trading entrypoints in older package versions. Account-level deauthorization of `SessionsApp` remains the lineage-wide emergency stop because it prevents every version of the app from generating Account authorization.
+
 ## Predict wrappers
 
 An active session may call these wrappers:
@@ -57,7 +69,7 @@ An active session may call these wrappers:
 - `redeem_live`
 - `redeem_settled`
 
-Each wrapper validates the session against the supplied Account, generates app authorization internally, and immediately passes that authorization into the corresponding Predict function. All market parameters remain caller-selected and are validated by Predict.
+Each wrapper validates the package version and session against the supplied Account, generates app authorization internally, and immediately passes that authorization into the corresponding Predict function. All market parameters remain caller-selected and are validated by Predict.
 
 ## DeepBook spot wrappers
 
@@ -69,7 +81,7 @@ An active session may call these Account-backed DeepBook spot wrappers:
 - `cancel_live_orders`
 - `withdraw_settled_amounts`
 
-Each wrapper validates the session against the supplied Account, generates app authorization internally, and immediately passes it into the corresponding `deepbook_core_account` function. Order parameters remain caller-selected and are validated by the Account wrapper and DeepBook core. The permissionless settled-amount withdrawal is not duplicated here because it does not require session authority.
+Each wrapper validates the package version and session against the supplied Account, generates app authorization internally, and immediately passes it into the corresponding `deepbook_core_account` function. Order parameters remain caller-selected and are validated by the Account wrapper and DeepBook core. The permissionless settled-amount withdrawal is not duplicated here because it does not require session authority.
 
 The session can therefore submit adverse Predict and spot trades, cancel the Account's spot orders, and sweep settled spot proceeds back into Account custody until it expires or is revoked. A grant should be treated as trading authority, not read-only access. Revocation and expiration stop future wrapper calls but do not unwind positions, orders, or transactions that already executed.
 
@@ -99,9 +111,9 @@ Expiration emits no event, and a no-op revocation emits no event. Predict and De
 
 ## Integration requirements
 
-Before Sessions can be used, the package must be published against the intended Account, Predict, Propbook, DeepBook core, and `deepbook_core_account` package lineages. `SessionsApp` must be authorized in the corresponding Account registry, while `DeepbookCoreAccountApp` must be authorized in the supplied DeepBook registry for spot order placement. Publication, registry configuration, SDK transaction construction, ephemeral-key storage, indexing, and deployment are outside this package.
+Before Sessions can be used, the package must be published against the intended Account, Predict, Propbook, DeepBook core, and `deepbook_core_account` package lineages. Integrations must discover the published shared `SessionsConfig` and supply it to session authorization and every trading wrapper. `SessionsApp` must be authorized in the corresponding Account registry, while `DeepbookCoreAccountApp` must be authorized in the supplied DeepBook registry for spot order placement. Publication, registry configuration, SDK transaction construction, ephemeral-key storage, indexing, and deployment are outside this package.
 
-If the package is published with an upgrade capability, custody of that capability is part of the trust boundary because an upgrade can change the behavior of an authorized Account app.
+Custody of `SessionsAdminCap` and any package upgrade capability is part of the trust boundary: the admin cap can retire older package versions, while an upgrade can change the behavior of an authorized Account app.
 
 ## Build and test
 

--- a/packages/sessions/sources/session_config.move
+++ b/packages/sessions/sources/session_config.move
@@ -1,0 +1,87 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Owns the Sessions package version floor and the authority that advances it.
+module deepbook_sessions::session_config;
+
+// === Errors ===
+
+const EPackageVersionDisabled: u64 = 0;
+const EVersionWatermarkNotAdvanced: u64 = 1;
+
+// === Constants ===
+
+/// Every package upgrade must advance this compiled-in version.
+macro fun current_version(): u64 { 1 }
+
+// === Structs ===
+
+/// Shared package-wide version floor used by session grant and trading entrypoints.
+public struct SessionsConfig has key {
+    id: UID,
+    version_watermark: u64,
+}
+
+/// Root authority for advancing the Sessions package version floor.
+public struct SessionsAdminCap has key, store {
+    id: UID,
+}
+
+/// Create the shared version config and transfer its administration capability to the publisher.
+fun init(ctx: &mut TxContext) {
+    let (_, admin_cap) = create_and_share(ctx);
+    transfer::public_transfer(admin_cap, ctx.sender());
+}
+
+// === Public Functions ===
+
+/// Return the config object ID for external PTB construction.
+public fun id(config: &SessionsConfig): ID {
+    config.id.to_inner()
+}
+
+/// Return the minimum Sessions package version accepted by gated entrypoints.
+public fun version_watermark(config: &SessionsConfig): u64 {
+    config.version_watermark
+}
+
+/// Advance the version floor to this package's compiled-in version.
+/// This is ungated so an upgraded package can retire older versions, and it cannot accept a caller-selected target.
+public fun bump_version_watermark(config: &mut SessionsConfig, _admin_cap: &SessionsAdminCap) {
+    let version = current_version!();
+    assert!(version > config.version_watermark, EVersionWatermarkNotAdvanced);
+    config.version_watermark = version;
+}
+
+// === Public-Package Functions ===
+
+/// Abort when the executing package version is below the configured floor.
+public(package) fun assert_version(config: &SessionsConfig) {
+    assert!(current_version!() >= config.version_watermark, EPackageVersionDisabled);
+}
+
+// === Private Functions ===
+
+fun create_and_share(ctx: &mut TxContext): (ID, SessionsAdminCap) {
+    let config = SessionsConfig {
+        id: object::new(ctx),
+        version_watermark: current_version!(),
+    };
+    let id = config.id();
+    transfer::share_object(config);
+    (id, SessionsAdminCap { id: object::new(ctx) })
+}
+
+// === Test-Only Functions ===
+
+#[test_only]
+/// Create test-only package state and return the config ID with its administration capability.
+public fun init_for_testing(ctx: &mut TxContext): (ID, SessionsAdminCap) {
+    create_and_share(ctx)
+}
+
+#[test_only]
+/// Emulate a watermark written by another package version, which one compiled test package cannot produce.
+public fun set_version_watermark_for_testing(config: &mut SessionsConfig, version_watermark: u64) {
+    config.version_watermark = version_watermark;
+}

--- a/packages/sessions/sources/sessions.move
+++ b/packages/sessions/sources/sessions.move
@@ -14,6 +14,7 @@ use deepbook_predict::{
     pricing::Pricer,
     protocol_config::ProtocolConfig
 };
+use deepbook_sessions::session_config::{Self, SessionsConfig};
 use std::internal::permit;
 use sui::{accumulator::AccumulatorRoot, clock::Clock, event, vec_map::{Self, VecMap}};
 
@@ -67,11 +68,13 @@ public fun session_expiration_ms(wrapper: &AccountWrapper, session: address): Op
 /// Accounts may store at most 20 addresses; reauthorization replaces in place.
 public fun authorize_session(
     wrapper: &mut AccountWrapper,
+    sessions_config: &SessionsConfig,
     session: address,
     duration_ms: u64,
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
+    sessions_config.assert_version();
     assert!(duration_ms > 0 && duration_ms <= max_session_duration_ms!(), EInvalidSessionDuration);
     let expires_at_ms = clock.timestamp_ms() + duration_ms;
     let account = wrapper.load_account_mut(account::generate_auth(ctx));
@@ -106,6 +109,7 @@ public fun place_limit_order<BaseAsset, QuoteAsset>(
     deepbook_registry: &Registry,
     account_registry: &AccountRegistry,
     wrapper: &mut AccountWrapper,
+    sessions_config: &SessionsConfig,
     client_order_id: u64,
     order_type: u8,
     self_matching_option: u8,
@@ -118,7 +122,7 @@ public fun place_limit_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ): OrderInfo {
-    let auth = generate_auth_as_session(account_registry, wrapper, clock, ctx);
+    let auth = generate_auth_as_session(sessions_config, account_registry, wrapper, clock, ctx);
     deepbook_core_account::place_limit_order(
         pool,
         deepbook_registry,
@@ -144,6 +148,7 @@ public fun place_market_order<BaseAsset, QuoteAsset>(
     deepbook_registry: &Registry,
     account_registry: &AccountRegistry,
     wrapper: &mut AccountWrapper,
+    sessions_config: &SessionsConfig,
     client_order_id: u64,
     self_matching_option: u8,
     quantity: u64,
@@ -154,7 +159,7 @@ public fun place_market_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ): OrderInfo {
-    let auth = generate_auth_as_session(account_registry, wrapper, clock, ctx);
+    let auth = generate_auth_as_session(sessions_config, account_registry, wrapper, clock, ctx);
     deepbook_core_account::place_market_order(
         pool,
         deepbook_registry,
@@ -177,11 +182,12 @@ public fun cancel_live_order<BaseAsset, QuoteAsset>(
     pool: &mut Pool<BaseAsset, QuoteAsset>,
     account_registry: &AccountRegistry,
     wrapper: &mut AccountWrapper,
+    sessions_config: &SessionsConfig,
     order_id: u128,
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    let auth = generate_auth_as_session(account_registry, wrapper, clock, ctx);
+    let auth = generate_auth_as_session(sessions_config, account_registry, wrapper, clock, ctx);
     deepbook_core_account::cancel_live_order(pool, wrapper, auth, order_id, clock, ctx);
 }
 
@@ -190,11 +196,12 @@ public fun cancel_live_orders<BaseAsset, QuoteAsset>(
     pool: &mut Pool<BaseAsset, QuoteAsset>,
     account_registry: &AccountRegistry,
     wrapper: &mut AccountWrapper,
+    sessions_config: &SessionsConfig,
     order_ids: vector<u128>,
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    let auth = generate_auth_as_session(account_registry, wrapper, clock, ctx);
+    let auth = generate_auth_as_session(sessions_config, account_registry, wrapper, clock, ctx);
     deepbook_core_account::cancel_live_orders(pool, wrapper, auth, order_ids, clock, ctx);
 }
 
@@ -203,10 +210,11 @@ public fun withdraw_settled_amounts<BaseAsset, QuoteAsset>(
     pool: &mut Pool<BaseAsset, QuoteAsset>,
     account_registry: &AccountRegistry,
     wrapper: &mut AccountWrapper,
+    sessions_config: &SessionsConfig,
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    let auth = generate_auth_as_session(account_registry, wrapper, clock, ctx);
+    let auth = generate_auth_as_session(sessions_config, account_registry, wrapper, clock, ctx);
     deepbook_core_account::withdraw_settled_amounts(pool, wrapper, auth, ctx);
 }
 
@@ -215,6 +223,7 @@ public fun mint_exact_quantity(
     market: &mut ExpiryMarket,
     account_registry: &AccountRegistry,
     wrapper: &mut AccountWrapper,
+    sessions_config: &SessionsConfig,
     config: &ProtocolConfig,
     pricer: &Pricer,
     lower_tick: u64,
@@ -226,7 +235,7 @@ public fun mint_exact_quantity(
     clock: &Clock,
     ctx: &mut TxContext,
 ): u256 {
-    let auth = generate_auth_as_session(account_registry, wrapper, clock, ctx);
+    let auth = generate_auth_as_session(sessions_config, account_registry, wrapper, clock, ctx);
     market.mint_exact_quantity(
         wrapper,
         auth,
@@ -248,6 +257,7 @@ public fun mint_exact_amount(
     market: &mut ExpiryMarket,
     account_registry: &AccountRegistry,
     wrapper: &mut AccountWrapper,
+    sessions_config: &SessionsConfig,
     config: &ProtocolConfig,
     pricer: &Pricer,
     lower_tick: u64,
@@ -259,7 +269,7 @@ public fun mint_exact_amount(
     clock: &Clock,
     ctx: &mut TxContext,
 ): u256 {
-    let auth = generate_auth_as_session(account_registry, wrapper, clock, ctx);
+    let auth = generate_auth_as_session(sessions_config, account_registry, wrapper, clock, ctx);
     market.mint_exact_amount(
         wrapper,
         auth,
@@ -281,6 +291,7 @@ public fun redeem_live(
     market: &mut ExpiryMarket,
     account_registry: &AccountRegistry,
     wrapper: &mut AccountWrapper,
+    sessions_config: &SessionsConfig,
     config: &ProtocolConfig,
     pricer: &Pricer,
     order_id: u256,
@@ -291,7 +302,7 @@ public fun redeem_live(
     clock: &Clock,
     ctx: &mut TxContext,
 ): Option<u256> {
-    let auth = generate_auth_as_session(account_registry, wrapper, clock, ctx);
+    let auth = generate_auth_as_session(sessions_config, account_registry, wrapper, clock, ctx);
     market.redeem_live(
         wrapper,
         auth,
@@ -312,13 +323,14 @@ public fun redeem_settled(
     market: &mut ExpiryMarket,
     account_registry: &AccountRegistry,
     wrapper: &mut AccountWrapper,
+    sessions_config: &SessionsConfig,
     config: &ProtocolConfig,
     order_id: u256,
     root: &AccumulatorRoot,
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    let auth = generate_auth_as_session(account_registry, wrapper, clock, ctx);
+    let auth = generate_auth_as_session(sessions_config, account_registry, wrapper, clock, ctx);
     market.redeem_settled(
         wrapper,
         auth,
@@ -333,11 +345,13 @@ public fun redeem_settled(
 // === Private Functions ===
 
 fun generate_auth_as_session(
+    sessions_config: &SessionsConfig,
     account_registry: &AccountRegistry,
     wrapper: &AccountWrapper,
     clock: &Clock,
     ctx: &TxContext,
 ): Auth {
+    sessions_config.assert_version();
     let expiration = session_expiration_ms(wrapper, ctx.sender());
     assert!(expiration.is_some(), ESessionNotAuthorized);
     assert!(clock.timestamp_ms() < *expiration.borrow(), ESessionNotAuthorized);

--- a/packages/sessions/tests/session_config_tests.move
+++ b/packages/sessions/tests/session_config_tests.move
@@ -1,0 +1,57 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module deepbook_sessions::session_config_tests;
+
+use deepbook_sessions::session_config::{Self, SessionsConfig};
+use std::unit_test::{assert_eq, destroy};
+use sui::test_scenario::{Self as test, return_shared};
+
+const ADMIN: address = @0xAD;
+const OLDER_VERSION: u64 = 0;
+const CURRENT_VERSION: u64 = 1;
+const EUnexpectedSuccess: u64 = 999;
+
+#[test]
+fun config_initializes_at_the_current_version() {
+    let mut scenario = test::begin(ADMIN);
+    let (config_id, admin_cap) = session_config::init_for_testing(scenario.ctx());
+    scenario.next_tx(ADMIN);
+    let config = scenario.take_shared_by_id<SessionsConfig>(config_id);
+
+    assert_eq!(config.id(), config_id);
+    assert_eq!(config.version_watermark(), CURRENT_VERSION);
+
+    return_shared(config);
+    destroy(admin_cap);
+    scenario.end();
+}
+
+#[test]
+fun bump_advances_an_older_watermark_to_the_current_version() {
+    let mut scenario = test::begin(ADMIN);
+    let (config_id, admin_cap) = session_config::init_for_testing(scenario.ctx());
+    scenario.next_tx(ADMIN);
+    let mut config = scenario.take_shared_by_id<SessionsConfig>(config_id);
+    session_config::set_version_watermark_for_testing(&mut config, OLDER_VERSION);
+    assert_eq!(config.version_watermark(), OLDER_VERSION);
+
+    config.bump_version_watermark(&admin_cap);
+    assert_eq!(config.version_watermark(), CURRENT_VERSION);
+
+    return_shared(config);
+    destroy(admin_cap);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = session_config::EVersionWatermarkNotAdvanced)]
+fun bump_at_the_current_version_aborts() {
+    let mut scenario = test::begin(ADMIN);
+    let (config_id, admin_cap) = session_config::init_for_testing(scenario.ctx());
+    scenario.next_tx(ADMIN);
+    let mut config = scenario.take_shared_by_id<SessionsConfig>(config_id);
+
+    config.bump_version_watermark(&admin_cap);
+    abort EUnexpectedSuccess
+}

--- a/packages/sessions/tests/sessions_tests.move
+++ b/packages/sessions/tests/sessions_tests.move
@@ -17,7 +17,10 @@ use deepbook_predict::{
     protocol_config::ProtocolConfig,
     test_constants
 };
-use deepbook_sessions::sessions::{Self as sessions, SessionAuthorized, SessionRevoked, SessionsApp};
+use deepbook_sessions::{
+    session_config::{Self as session_config, SessionsConfig},
+    sessions::{Self as sessions, SessionAuthorized, SessionRevoked, SessionsApp}
+};
 use dusdc::dusdc::DUSDC;
 use propbook::{
     block_scholes_store::{BlockScholesSVIStore, BlockScholesValueStore},
@@ -91,6 +94,7 @@ const ZERO_PREMIUM: u64 = 0;
 const ZERO_PROBABILITY: u64 = 0;
 const MISSING_ORDER_ID: u256 = 1;
 const CLOSE_QUANTITY: u64 = 1;
+const FUTURE_VERSION: u64 = 2;
 
 public struct ExpectedSessionAuthorized has copy, drop {
     account_id: ID,
@@ -110,6 +114,7 @@ public struct SessionFlowFixture {
     market_id: ID,
     owner: address,
     wrapper_id: ID,
+    sessions_config_id: ID,
     config_id: ID,
     pyth_id: ID,
     bs_values_id: ID,
@@ -120,6 +125,7 @@ public struct LiveInputs {
     market: ExpiryMarket,
     account_registry: AccountRegistry,
     wrapper: AccountWrapper,
+    sessions_config: SessionsConfig,
     config: ProtocolConfig,
     pricer: Pricer,
     root: AccumulatorRoot,
@@ -129,20 +135,23 @@ public struct SettledInputs {
     market: ExpiryMarket,
     account_registry: AccountRegistry,
     wrapper: AccountWrapper,
+    sessions_config: SessionsConfig,
     config: ProtocolConfig,
     root: AccumulatorRoot,
 }
 
 #[test]
 fun owner_authorizes_reauthorizes_and_revokes_session() {
-    let (mut scenario, mut clock, wrapper_id) = setup_account();
+    let (mut scenario, mut clock, wrapper_id, sessions_config_id) = setup_account();
 
     scenario.next_tx(ALICE);
     let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let sessions_config = scenario.take_shared_by_id<SessionsConfig>(sessions_config_id);
     let account_id = wrapper.load_account().account_id();
     assert!(sessions::session_expiration_ms(&wrapper, SESSION).is_none());
     sessions::authorize_session(
         &mut wrapper,
+        &sessions_config,
         SESSION,
         SESSION_DURATION_MS,
         &clock,
@@ -160,13 +169,16 @@ fun owner_authorizes_reauthorizes_and_revokes_session() {
         SESSION,
         SESSION_EXPIRES_AT_MS,
     );
+    return_shared(sessions_config);
     return_shared(wrapper);
 
     scenario.next_tx(ALICE);
     clock.set_for_testing(REAUTH_NOW_MS);
     let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let sessions_config = scenario.take_shared_by_id<SessionsConfig>(sessions_config_id);
     sessions::authorize_session(
         &mut wrapper,
+        &sessions_config,
         SESSION,
         REAUTH_DURATION_MS,
         &clock,
@@ -184,6 +196,7 @@ fun owner_authorizes_reauthorizes_and_revokes_session() {
         SESSION,
         REAUTH_EXPIRES_AT_MS,
     );
+    return_shared(sessions_config);
     return_shared(wrapper);
 
     scenario.next_tx(ALICE);
@@ -214,12 +227,14 @@ fun owner_authorizes_reauthorizes_and_revokes_session() {
 
 #[test]
 fun maximum_session_duration_is_accepted() {
-    let (mut scenario, clock, wrapper_id) = setup_account();
+    let (mut scenario, clock, wrapper_id, sessions_config_id) = setup_account();
     scenario.next_tx(ALICE);
     let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let sessions_config = scenario.take_shared_by_id<SessionsConfig>(sessions_config_id);
 
     sessions::authorize_session(
         &mut wrapper,
+        &sessions_config,
         SESSION,
         MAX_SESSION_DURATION_MS,
         &clock,
@@ -230,6 +245,7 @@ fun maximum_session_duration_is_accepted() {
         sessions::session_expiration_ms(&wrapper, SESSION),
         option::some(MAX_SESSION_EXPIRES_AT_MS),
     );
+    return_shared(sessions_config);
     return_shared(wrapper);
     clock.destroy_for_testing();
     scenario.end();
@@ -237,14 +253,16 @@ fun maximum_session_duration_is_accepted() {
 
 #[test]
 fun session_limit_allows_reauthorization_and_reuse_after_revocation() {
-    let (mut scenario, mut clock, wrapper_id) = setup_account();
+    let (mut scenario, mut clock, wrapper_id, sessions_config_id) = setup_account();
     scenario.next_tx(ALICE);
     let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let sessions_config = scenario.take_shared_by_id<SessionsConfig>(sessions_config_id);
     let session_addresses = session_addresses();
     let mut index = FIRST_SESSION_INDEX;
     while (index < MAX_SESSIONS) {
         sessions::authorize_session(
             &mut wrapper,
+            &sessions_config,
             session_addresses[index],
             SESSION_DURATION_MS,
             &clock,
@@ -264,6 +282,7 @@ fun session_limit_allows_reauthorization_and_reuse_after_revocation() {
     clock.set_for_testing(REAUTH_NOW_MS);
     sessions::authorize_session(
         &mut wrapper,
+        &sessions_config,
         session_addresses[LAST_SESSION_INDEX],
         REAUTH_DURATION_MS,
         &clock,
@@ -284,6 +303,7 @@ fun session_limit_allows_reauthorization_and_reuse_after_revocation() {
     );
     sessions::authorize_session(
         &mut wrapper,
+        &sessions_config,
         session_addresses[EXCESS_SESSION_INDEX],
         SESSION_DURATION_MS,
         &clock,
@@ -298,6 +318,7 @@ fun session_limit_allows_reauthorization_and_reuse_after_revocation() {
         option::some(REAUTH_EXPIRES_AT_MS),
     );
 
+    return_shared(sessions_config);
     return_shared(wrapper);
     clock.destroy_for_testing();
     scenario.end();
@@ -305,14 +326,16 @@ fun session_limit_allows_reauthorization_and_reuse_after_revocation() {
 
 #[test, expected_failure(abort_code = sessions::ESessionLimitExceeded)]
 fun twenty_first_distinct_session_aborts() {
-    let (mut scenario, clock, wrapper_id) = setup_account();
+    let (mut scenario, clock, wrapper_id, sessions_config_id) = setup_account();
     scenario.next_tx(ALICE);
     let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let sessions_config = scenario.take_shared_by_id<SessionsConfig>(sessions_config_id);
     let session_addresses = session_addresses();
     let mut index = FIRST_SESSION_INDEX;
     while (index < MAX_SESSIONS) {
         sessions::authorize_session(
             &mut wrapper,
+            &sessions_config,
             session_addresses[index],
             SESSION_DURATION_MS,
             &clock,
@@ -327,6 +350,7 @@ fun twenty_first_distinct_session_aborts() {
 
     sessions::authorize_session(
         &mut wrapper,
+        &sessions_config,
         session_addresses[EXCESS_SESSION_INDEX],
         SESSION_DURATION_MS,
         &clock,
@@ -338,12 +362,14 @@ fun twenty_first_distinct_session_aborts() {
 
 #[test, expected_failure(abort_code = sessions::EInvalidSessionDuration)]
 fun zero_session_duration_aborts() {
-    let (mut scenario, clock, wrapper_id) = setup_account();
+    let (mut scenario, clock, wrapper_id, sessions_config_id) = setup_account();
     scenario.next_tx(ALICE);
     let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let sessions_config = scenario.take_shared_by_id<SessionsConfig>(sessions_config_id);
 
     sessions::authorize_session(
         &mut wrapper,
+        &sessions_config,
         SESSION,
         ZERO_DURATION_MS,
         &clock,
@@ -355,12 +381,14 @@ fun zero_session_duration_aborts() {
 
 #[test, expected_failure(abort_code = sessions::EInvalidSessionDuration)]
 fun session_duration_above_maximum_aborts() {
-    let (mut scenario, clock, wrapper_id) = setup_account();
+    let (mut scenario, clock, wrapper_id, sessions_config_id) = setup_account();
     scenario.next_tx(ALICE);
     let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let sessions_config = scenario.take_shared_by_id<SessionsConfig>(sessions_config_id);
 
     sessions::authorize_session(
         &mut wrapper,
+        &sessions_config,
         SESSION,
         ABOVE_MAX_SESSION_DURATION_MS,
         &clock,
@@ -372,12 +400,14 @@ fun session_duration_above_maximum_aborts() {
 
 #[test, expected_failure(abort_code = account::EInvalidOwner)]
 fun non_owner_cannot_authorize_session() {
-    let (mut scenario, clock, wrapper_id) = setup_account();
+    let (mut scenario, clock, wrapper_id, sessions_config_id) = setup_account();
     scenario.next_tx(BOB);
     let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let sessions_config = scenario.take_shared_by_id<SessionsConfig>(sessions_config_id);
 
     sessions::authorize_session(
         &mut wrapper,
+        &sessions_config,
         SESSION,
         SESSION_DURATION_MS,
         &clock,
@@ -389,16 +419,19 @@ fun non_owner_cannot_authorize_session() {
 
 #[test, expected_failure(abort_code = account::EInvalidOwner)]
 fun non_owner_cannot_revoke_session() {
-    let (mut scenario, clock, wrapper_id) = setup_account();
+    let (mut scenario, clock, wrapper_id, sessions_config_id) = setup_account();
     scenario.next_tx(ALICE);
     let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let sessions_config = scenario.take_shared_by_id<SessionsConfig>(sessions_config_id);
     sessions::authorize_session(
         &mut wrapper,
+        &sessions_config,
         SESSION,
         SESSION_DURATION_MS,
         &clock,
         scenario.ctx(),
     );
+    return_shared(sessions_config);
     return_shared(wrapper);
 
     scenario.next_tx(BOB);
@@ -408,6 +441,63 @@ fun non_owner_cannot_revoke_session() {
     abort EUnexpectedSuccess
 }
 
+#[test, expected_failure(abort_code = session_config::EPackageVersionDisabled)]
+fun retired_package_version_cannot_authorize_session() {
+    let (mut scenario, clock, wrapper_id, sessions_config_id) = setup_account();
+    scenario.next_tx(ALICE);
+    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let mut sessions_config = scenario.take_shared_by_id<SessionsConfig>(sessions_config_id);
+    session_config::set_version_watermark_for_testing(&mut sessions_config, FUTURE_VERSION);
+
+    sessions::authorize_session(
+        &mut wrapper,
+        &sessions_config,
+        SESSION,
+        SESSION_DURATION_MS,
+        &clock,
+        scenario.ctx(),
+    );
+
+    abort EUnexpectedSuccess
+}
+
+#[test]
+fun retired_package_version_keeps_reads_and_revocation_available() {
+    let (mut scenario, clock, wrapper_id, sessions_config_id) = setup_account();
+    scenario.next_tx(ALICE);
+    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let sessions_config = scenario.take_shared_by_id<SessionsConfig>(sessions_config_id);
+    sessions::authorize_session(
+        &mut wrapper,
+        &sessions_config,
+        SESSION,
+        SESSION_DURATION_MS,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(sessions_config);
+    return_shared(wrapper);
+
+    scenario.next_tx(ADMIN);
+    let mut sessions_config = scenario.take_shared_by_id<SessionsConfig>(sessions_config_id);
+    session_config::set_version_watermark_for_testing(&mut sessions_config, FUTURE_VERSION);
+    assert_eq!(sessions_config.version_watermark(), FUTURE_VERSION);
+    return_shared(sessions_config);
+
+    scenario.next_tx(ALICE);
+    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    assert_eq!(
+        sessions::session_expiration_ms(&wrapper, SESSION),
+        option::some(SESSION_EXPIRES_AT_MS),
+    );
+    sessions::revoke_session(&mut wrapper, SESSION, scenario.ctx());
+    assert!(sessions::session_expiration_ms(&wrapper, SESSION).is_none());
+    return_shared(wrapper);
+
+    clock.destroy_for_testing();
+    scenario.end();
+}
+
 #[test, expected_failure(abort_code = sessions::ESessionNotAuthorized)]
 fun unapproved_session_cannot_use_predict_wrapper() {
     let mut fixture = setup_flow_fixture(test_constants::default_expiry_ms());
@@ -415,6 +505,7 @@ fun unapproved_session_cannot_use_predict_wrapper() {
         mut market,
         account_registry,
         mut wrapper,
+        sessions_config,
         config,
         root,
     } = begin_settled_tx(&mut fixture, SESSION);
@@ -425,6 +516,7 @@ fun unapproved_session_cannot_use_predict_wrapper() {
         &mut market,
         &account_registry,
         &mut wrapper,
+        &sessions_config,
         &config,
         MISSING_ORDER_ID,
         &root,
@@ -441,6 +533,7 @@ fun unapproved_session_cannot_mint_exact_quantity() {
         mut market,
         account_registry,
         mut wrapper,
+        sessions_config,
         config,
         pricer,
         root,
@@ -452,6 +545,7 @@ fun unapproved_session_cannot_mint_exact_quantity() {
         &mut market,
         &account_registry,
         &mut wrapper,
+        &sessions_config,
         &config,
         &pricer,
         predict_helpers::strike_tick(),
@@ -475,6 +569,7 @@ fun unapproved_session_cannot_mint_exact_amount() {
         mut market,
         account_registry,
         mut wrapper,
+        sessions_config,
         config,
         pricer,
         root,
@@ -486,6 +581,7 @@ fun unapproved_session_cannot_mint_exact_amount() {
         &mut market,
         &account_registry,
         &mut wrapper,
+        &sessions_config,
         &config,
         &pricer,
         predict_helpers::strike_tick(),
@@ -509,6 +605,7 @@ fun unapproved_session_cannot_redeem_live() {
         mut market,
         account_registry,
         mut wrapper,
+        sessions_config,
         config,
         pricer,
         root,
@@ -520,6 +617,7 @@ fun unapproved_session_cannot_redeem_live() {
         &mut market,
         &account_registry,
         &mut wrapper,
+        &sessions_config,
         &config,
         &pricer,
         MISSING_ORDER_ID,
@@ -544,6 +642,7 @@ fun session_at_exact_expiration_cannot_use_predict_wrapper() {
         mut market,
         account_registry,
         mut wrapper,
+        sessions_config,
         config,
         root,
     } = begin_settled_tx(&mut fixture, SESSION);
@@ -554,6 +653,7 @@ fun session_at_exact_expiration_cannot_use_predict_wrapper() {
         &mut market,
         &account_registry,
         &mut wrapper,
+        &sessions_config,
         &config,
         MISSING_ORDER_ID,
         &root,
@@ -572,6 +672,7 @@ fun revoked_session_cannot_use_predict_wrapper() {
         mut market,
         account_registry,
         mut wrapper,
+        sessions_config,
         config,
         root,
     } = begin_settled_tx(&mut fixture, SESSION);
@@ -582,6 +683,7 @@ fun revoked_session_cannot_use_predict_wrapper() {
         &mut market,
         &account_registry,
         &mut wrapper,
+        &sessions_config,
         &config,
         MISSING_ORDER_ID,
         &root,
@@ -599,6 +701,7 @@ fun another_signer_cannot_use_an_approved_session() {
         mut market,
         account_registry,
         mut wrapper,
+        sessions_config,
         config,
         root,
     } = begin_settled_tx(&mut fixture, BOB);
@@ -609,6 +712,7 @@ fun another_signer_cannot_use_an_approved_session() {
         &mut market,
         &account_registry,
         &mut wrapper,
+        &sessions_config,
         &config,
         MISSING_ORDER_ID,
         &root,
@@ -627,6 +731,7 @@ fun session_mints_exact_quantity_and_redeems_live() {
         mut market,
         account_registry,
         mut wrapper,
+        sessions_config,
         config,
         pricer,
         root,
@@ -653,6 +758,7 @@ fun session_mints_exact_quantity_and_redeems_live() {
         &mut market,
         &account_registry,
         &mut wrapper,
+        &sessions_config,
         &config,
         &pricer,
         predict_helpers::strike_tick(),
@@ -672,13 +778,22 @@ fun session_mints_exact_quantity_and_redeems_live() {
         sessions::session_expiration_ms(&wrapper, SESSION),
         option::some(FLOW_SESSION_EXPIRES_AT_MS),
     );
-    return_live_inputs(LiveInputs { market, account_registry, wrapper, config, pricer, root });
+    return_live_inputs(LiveInputs {
+        market,
+        account_registry,
+        wrapper,
+        sessions_config,
+        config,
+        pricer,
+        root,
+    });
 
     fixture.clock.set_for_testing(LIVE_REDEEM_MS);
     let LiveInputs {
         mut market,
         account_registry,
         mut wrapper,
+        sessions_config,
         config,
         pricer,
         root,
@@ -690,6 +805,7 @@ fun session_mints_exact_quantity_and_redeems_live() {
         &mut market,
         &account_registry,
         &mut wrapper,
+        &sessions_config,
         &config,
         &pricer,
         order_id,
@@ -712,7 +828,15 @@ fun session_mints_exact_quantity_and_redeems_live() {
         sessions::session_expiration_ms(&wrapper, SESSION),
         option::some(FLOW_SESSION_EXPIRES_AT_MS),
     );
-    return_live_inputs(LiveInputs { market, account_registry, wrapper, config, pricer, root });
+    return_live_inputs(LiveInputs {
+        market,
+        account_registry,
+        wrapper,
+        sessions_config,
+        config,
+        pricer,
+        root,
+    });
     finish_flow_fixture(fixture);
 }
 
@@ -725,6 +849,7 @@ fun session_mints_exact_amount() {
         mut market,
         account_registry,
         mut wrapper,
+        sessions_config,
         config,
         pricer,
         root,
@@ -765,6 +890,7 @@ fun session_mints_exact_amount() {
         &mut market,
         &account_registry,
         &mut wrapper,
+        &sessions_config,
         &config,
         &pricer,
         predict_helpers::strike_tick(),
@@ -787,7 +913,15 @@ fun session_mints_exact_amount() {
         sessions::session_expiration_ms(&wrapper, SESSION),
         option::some(FLOW_SESSION_EXPIRES_AT_MS),
     );
-    return_live_inputs(LiveInputs { market, account_registry, wrapper, config, pricer, root });
+    return_live_inputs(LiveInputs {
+        market,
+        account_registry,
+        wrapper,
+        sessions_config,
+        config,
+        pricer,
+        root,
+    });
     finish_flow_fixture(fixture);
 }
 
@@ -803,6 +937,7 @@ fun session_redeems_settled_order() {
         mut market,
         account_registry,
         mut wrapper,
+        sessions_config,
         config,
         pricer,
         root,
@@ -828,6 +963,7 @@ fun session_redeems_settled_order() {
         &mut market,
         &account_registry,
         &mut wrapper,
+        &sessions_config,
         &config,
         &pricer,
         lower_tick,
@@ -842,7 +978,15 @@ fun session_redeems_settled_order() {
     let post_mint_balance = test_constants::mint_deposit() - quote.all_in_cost();
     assert_eq!(wrapper.load_account().balance<DUSDC>(&root, clock), post_mint_balance);
     assert!(predict_account::has_position(wrapper.load_account(), market_id, order_id));
-    return_live_inputs(LiveInputs { market, account_registry, wrapper, config, pricer, root });
+    return_live_inputs(LiveInputs {
+        market,
+        account_registry,
+        wrapper,
+        sessions_config,
+        config,
+        pricer,
+        root,
+    });
 
     fixture.clock.set_for_testing(expiry_ms);
     fixture.predict.set_clock_for_testing(expiry_ms);
@@ -853,6 +997,7 @@ fun session_redeems_settled_order() {
         mut market,
         account_registry,
         mut wrapper,
+        sessions_config,
         config,
         root,
     } = begin_settled_tx(&mut fixture, SESSION);
@@ -863,6 +1008,7 @@ fun session_redeems_settled_order() {
         &mut market,
         &account_registry,
         &mut wrapper,
+        &sessions_config,
         &config,
         order_id,
         &root,
@@ -879,7 +1025,14 @@ fun session_redeems_settled_order() {
         sessions::session_expiration_ms(&wrapper, SESSION),
         option::some(SETTLEMENT_SESSION_EXPIRES_AT_MS),
     );
-    return_settled_inputs(SettledInputs { market, account_registry, wrapper, config, root });
+    return_settled_inputs(SettledInputs {
+        market,
+        account_registry,
+        wrapper,
+        sessions_config,
+        config,
+        root,
+    });
     finish_flow_fixture(fixture);
 }
 
@@ -909,9 +1062,11 @@ fun session_addresses(): vector<address> {
     ]
 }
 
-fun setup_account(): (Scenario, Clock, ID) {
+fun setup_account(): (Scenario, Clock, ID, ID) {
     let mut scenario = test::begin(ADMIN);
     account_registry::init_for_testing(scenario.ctx());
+    let (sessions_config_id, sessions_admin_cap) = session_config::init_for_testing(scenario.ctx());
+    destroy(sessions_admin_cap);
     let mut clock = clock::create_for_testing(scenario.ctx());
     clock.set_for_testing(NOW_MS);
 
@@ -923,7 +1078,7 @@ fun setup_account(): (Scenario, Clock, ID) {
     return_shared(registry);
     scenario.next_tx(ADMIN);
 
-    (scenario, clock, wrapper_id)
+    (scenario, clock, wrapper_id, sessions_config_id)
 }
 
 fun assert_session_authorized_event(
@@ -953,6 +1108,10 @@ fun setup_flow_fixture(expiry_ms: u64): SessionFlowFixture {
     );
     predict.authorize_account_app<SessionsApp>();
     let owner = predict_helpers::owner(&trader);
+    let (sessions_config_id, sessions_admin_cap) = session_config::init_for_testing(predict
+        .scenario_mut()
+        .ctx());
+    destroy(sessions_admin_cap);
     let config_id = predict.config_id();
     let pyth_id = predict.pyth_id();
     let now_ms = predict.clock().timestamp_ms();
@@ -979,6 +1138,7 @@ fun setup_flow_fixture(expiry_ms: u64): SessionFlowFixture {
         market_id,
         owner,
         wrapper_id,
+        sessions_config_id,
         config_id,
         pyth_id,
         bs_values_id,
@@ -991,7 +1151,16 @@ fun authorize_flow_session(fixture: &mut SessionFlowFixture, duration_ms: u64) {
     let scenario = fixture.predict.scenario_mut();
     scenario.next_tx(fixture.owner);
     let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(fixture.wrapper_id);
-    sessions::authorize_session(&mut wrapper, SESSION, duration_ms, clock, scenario.ctx());
+    let sessions_config = scenario.take_shared_by_id<SessionsConfig>(fixture.sessions_config_id);
+    sessions::authorize_session(
+        &mut wrapper,
+        &sessions_config,
+        SESSION,
+        duration_ms,
+        clock,
+        scenario.ctx(),
+    );
+    return_shared(sessions_config);
     return_shared(wrapper);
     scenario.next_tx(test_constants::admin());
 }
@@ -1033,6 +1202,7 @@ fun begin_live_tx(fixture: &mut SessionFlowFixture, sender: address): LiveInputs
         market,
         account_registry: scenario.take_shared<AccountRegistry>(),
         wrapper: scenario.take_shared_by_id<AccountWrapper>(fixture.wrapper_id),
+        sessions_config: scenario.take_shared_by_id<SessionsConfig>(fixture.sessions_config_id),
         config,
         pricer,
         root: scenario.take_shared<AccumulatorRoot>(),
@@ -1040,10 +1210,19 @@ fun begin_live_tx(fixture: &mut SessionFlowFixture, sender: address): LiveInputs
 }
 
 fun return_live_inputs(inputs: LiveInputs) {
-    let LiveInputs { market, account_registry, wrapper, config, pricer: _, root } = inputs;
+    let LiveInputs {
+        market,
+        account_registry,
+        wrapper,
+        sessions_config,
+        config,
+        pricer: _,
+        root,
+    } = inputs;
     return_shared(market);
     return_shared(account_registry);
     return_shared(wrapper);
+    return_shared(sessions_config);
     return_shared(config);
     return_shared(root);
 }
@@ -1055,16 +1234,18 @@ fun begin_settled_tx(fixture: &mut SessionFlowFixture, sender: address): Settled
         market: scenario.take_shared_by_id<ExpiryMarket>(fixture.market_id),
         account_registry: scenario.take_shared<AccountRegistry>(),
         wrapper: scenario.take_shared_by_id<AccountWrapper>(fixture.wrapper_id),
+        sessions_config: scenario.take_shared_by_id<SessionsConfig>(fixture.sessions_config_id),
         config: scenario.take_shared_by_id<ProtocolConfig>(fixture.config_id),
         root: scenario.take_shared<AccumulatorRoot>(),
     }
 }
 
 fun return_settled_inputs(inputs: SettledInputs) {
-    let SettledInputs { market, account_registry, wrapper, config, root } = inputs;
+    let SettledInputs { market, account_registry, wrapper, sessions_config, config, root } = inputs;
     return_shared(market);
     return_shared(account_registry);
     return_shared(wrapper);
+    return_shared(sessions_config);
     return_shared(config);
     return_shared(root);
 }
@@ -1103,6 +1284,7 @@ fun finish_flow_fixture(fixture: SessionFlowFixture) {
         market_id: _,
         owner: _,
         wrapper_id: _,
+        sessions_config_id: _,
         config_id: _,
         pyth_id: _,
         bs_values_id: _,

--- a/packages/sessions/tests/spot_sessions_tests.move
+++ b/packages/sessions/tests/spot_sessions_tests.move
@@ -19,7 +19,10 @@ use deepbook_core_account::{
     account_data::{Self as account_data, DeepbookCoreAccountApp},
     deepbook_core_account as dca
 };
-use deepbook_sessions::sessions::{Self as sessions, SessionsApp};
+use deepbook_sessions::{
+    session_config::{Self as session_config, SessionsConfig},
+    sessions::{Self as sessions, SessionsApp}
+};
 use std::unit_test::{assert_eq, destroy};
 use sui::{
     accumulator::{Self as accumulator, AccumulatorRoot},
@@ -51,6 +54,7 @@ const TWO_OPEN_ORDERS: u64 = 2;
 const ZERO_BALANCE: u64 = 0;
 const ZERO_ORDER_ID: u128 = 0;
 const EUnexpectedSuccess: u64 = 999;
+const FUTURE_VERSION: u64 = 2;
 
 public struct BASE has store {}
 public struct QUOTE has store {}
@@ -60,6 +64,7 @@ public struct SpotFixture {
     registry_id: ID,
     pool_id: ID,
     wrapper_id: ID,
+    sessions_config_id: ID,
 }
 
 #[test]
@@ -76,6 +81,9 @@ fun session_places_and_cancels_spot_limit_orders() {
     let account_registry = fixture.scenario.take_shared<AccountRegistry>();
     let mut pool = fixture.scenario.take_shared_by_id<Pool<BASE, QUOTE>>(pool_id);
     let mut wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let sessions_config = fixture
+        .scenario
+        .take_shared_by_id<SessionsConfig>(fixture.sessions_config_id);
     let root = fixture.scenario.take_shared<AccumulatorRoot>();
     let clock = fixture.scenario.take_shared<Clock>();
     let first = sessions::place_limit_order<BASE, QUOTE>(
@@ -83,6 +91,7 @@ fun session_places_and_cancels_spot_limit_orders() {
         &registry,
         &account_registry,
         &mut wrapper,
+        &sessions_config,
         LIMIT_ORDER_CLIENT_ID,
         constants::no_restriction(),
         constants::self_matching_allowed(),
@@ -111,6 +120,7 @@ fun session_places_and_cancels_spot_limit_orders() {
     assert_eq!(deep_locked, ZERO_BALANCE);
     return_shared(clock);
     return_shared(root);
+    return_shared(sessions_config);
     return_shared(wrapper);
     return_shared(pool);
     return_shared(account_registry);
@@ -120,12 +130,16 @@ fun session_places_and_cancels_spot_limit_orders() {
     let account_registry = fixture.scenario.take_shared<AccountRegistry>();
     let mut pool = fixture.scenario.take_shared_by_id<Pool<BASE, QUOTE>>(pool_id);
     let mut wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let sessions_config = fixture
+        .scenario
+        .take_shared_by_id<SessionsConfig>(fixture.sessions_config_id);
     let root = fixture.scenario.take_shared<AccumulatorRoot>();
     let clock = fixture.scenario.take_shared<Clock>();
     sessions::cancel_live_order<BASE, QUOTE>(
         &mut pool,
         &account_registry,
         &mut wrapper,
+        &sessions_config,
         first_id,
         &clock,
         fixture.scenario.ctx(),
@@ -137,6 +151,7 @@ fun session_places_and_cancels_spot_limit_orders() {
     assert_eq!(wrapper.load_account().balance<BASE>(&root, &clock), ACCOUNT_BALANCE);
     return_shared(clock);
     return_shared(root);
+    return_shared(sessions_config);
     return_shared(wrapper);
     return_shared(pool);
     return_shared(account_registry);
@@ -146,6 +161,9 @@ fun session_places_and_cancels_spot_limit_orders() {
     let account_registry = fixture.scenario.take_shared<AccountRegistry>();
     let mut pool = fixture.scenario.take_shared_by_id<Pool<BASE, QUOTE>>(pool_id);
     let mut wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let sessions_config = fixture
+        .scenario
+        .take_shared_by_id<SessionsConfig>(fixture.sessions_config_id);
     let root = fixture.scenario.take_shared<AccumulatorRoot>();
     let clock = fixture.scenario.take_shared<Clock>();
     let second = sessions::place_limit_order<BASE, QUOTE>(
@@ -153,6 +171,7 @@ fun session_places_and_cancels_spot_limit_orders() {
         &registry,
         &account_registry,
         &mut wrapper,
+        &sessions_config,
         SECOND_LIMIT_ORDER_CLIENT_ID,
         constants::no_restriction(),
         constants::self_matching_allowed(),
@@ -170,6 +189,7 @@ fun session_places_and_cancels_spot_limit_orders() {
         &registry,
         &account_registry,
         &mut wrapper,
+        &sessions_config,
         THIRD_LIMIT_ORDER_CLIENT_ID,
         constants::no_restriction(),
         constants::self_matching_allowed(),
@@ -190,6 +210,7 @@ fun session_places_and_cancels_spot_limit_orders() {
     let third_id = third.order_id();
     return_shared(clock);
     return_shared(root);
+    return_shared(sessions_config);
     return_shared(wrapper);
     return_shared(pool);
     return_shared(account_registry);
@@ -199,12 +220,16 @@ fun session_places_and_cancels_spot_limit_orders() {
     let account_registry = fixture.scenario.take_shared<AccountRegistry>();
     let mut pool = fixture.scenario.take_shared_by_id<Pool<BASE, QUOTE>>(pool_id);
     let mut wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let sessions_config = fixture
+        .scenario
+        .take_shared_by_id<SessionsConfig>(fixture.sessions_config_id);
     let root = fixture.scenario.take_shared<AccumulatorRoot>();
     let clock = fixture.scenario.take_shared<Clock>();
     sessions::cancel_live_orders<BASE, QUOTE>(
         &mut pool,
         &account_registry,
         &mut wrapper,
+        &sessions_config,
         vector[second_id, third_id],
         &clock,
         fixture.scenario.ctx(),
@@ -216,6 +241,7 @@ fun session_places_and_cancels_spot_limit_orders() {
     assert_eq!(wrapper.load_account().balance<BASE>(&root, &clock), ACCOUNT_BALANCE);
     return_shared(clock);
     return_shared(root);
+    return_shared(sessions_config);
     return_shared(wrapper);
     return_shared(pool);
     return_shared(account_registry);
@@ -246,6 +272,9 @@ fun session_places_spot_market_order() {
     let account_registry = fixture.scenario.take_shared<AccountRegistry>();
     let mut pool = fixture.scenario.take_shared_by_id<Pool<BASE, QUOTE>>(pool_id);
     let mut wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let sessions_config = fixture
+        .scenario
+        .take_shared_by_id<SessionsConfig>(fixture.sessions_config_id);
     let root = fixture.scenario.take_shared<AccumulatorRoot>();
     let clock = fixture.scenario.take_shared<Clock>();
     let fill = sessions::place_market_order<BASE, QUOTE>(
@@ -253,6 +282,7 @@ fun session_places_spot_market_order() {
         &registry,
         &account_registry,
         &mut wrapper,
+        &sessions_config,
         MARKET_TAKER_CLIENT_ID,
         constants::self_matching_allowed(),
         trade_amount,
@@ -276,6 +306,7 @@ fun session_places_spot_market_order() {
     assert_eq!(account_data::balance_manager_balance<DEEP>(wrapper.load_account()), ZERO_BALANCE);
     return_shared(clock);
     return_shared(root);
+    return_shared(sessions_config);
     return_shared(wrapper);
     return_shared(pool);
     return_shared(account_registry);
@@ -298,6 +329,9 @@ fun session_withdraws_settled_spot_amounts() {
     let account_registry = fixture.scenario.take_shared<AccountRegistry>();
     let mut pool = fixture.scenario.take_shared_by_id<Pool<BASE, QUOTE>>(pool_id);
     let mut wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let sessions_config = fixture
+        .scenario
+        .take_shared_by_id<SessionsConfig>(fixture.sessions_config_id);
     let root = fixture.scenario.take_shared<AccumulatorRoot>();
     let clock = fixture.scenario.take_shared<Clock>();
     let ask = sessions::place_limit_order<BASE, QUOTE>(
@@ -305,6 +339,7 @@ fun session_withdraws_settled_spot_amounts() {
         &registry,
         &account_registry,
         &mut wrapper,
+        &sessions_config,
         LIMIT_ORDER_CLIENT_ID,
         constants::no_restriction(),
         constants::self_matching_allowed(),
@@ -322,6 +357,7 @@ fun session_withdraws_settled_spot_amounts() {
     assert_eq!(wrapper.load_account().balance<BASE>(&root, &clock), ACCOUNT_BALANCE - trade_amount);
     return_shared(clock);
     return_shared(root);
+    return_shared(sessions_config);
     return_shared(wrapper);
     return_shared(pool);
     return_shared(account_registry);
@@ -341,6 +377,9 @@ fun session_withdraws_settled_spot_amounts() {
     let account_registry = fixture.scenario.take_shared<AccountRegistry>();
     let mut pool = fixture.scenario.take_shared_by_id<Pool<BASE, QUOTE>>(pool_id);
     let mut wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let sessions_config = fixture
+        .scenario
+        .take_shared_by_id<SessionsConfig>(fixture.sessions_config_id);
     let root = fixture.scenario.take_shared<AccumulatorRoot>();
     let clock = fixture.scenario.take_shared<Clock>();
     assert_eq!(wrapper.load_account().balance<QUOTE>(&root, &clock), ACCOUNT_BALANCE);
@@ -348,6 +387,7 @@ fun session_withdraws_settled_spot_amounts() {
         &mut pool,
         &account_registry,
         &mut wrapper,
+        &sessions_config,
         &clock,
         fixture.scenario.ctx(),
     );
@@ -361,6 +401,7 @@ fun session_withdraws_settled_spot_amounts() {
     assert_eq!(account_data::balance_manager_balance<DEEP>(wrapper.load_account()), ZERO_BALANCE);
     return_shared(clock);
     return_shared(root);
+    return_shared(sessions_config);
     return_shared(wrapper);
     return_shared(pool);
     return_shared(account_registry);
@@ -379,6 +420,9 @@ fun unapproved_session_cannot_place_spot_order() {
     let account_registry = fixture.scenario.take_shared<AccountRegistry>();
     let mut pool = fixture.scenario.take_shared_by_id<Pool<BASE, QUOTE>>(pool_id);
     let mut wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let sessions_config = fixture
+        .scenario
+        .take_shared_by_id<SessionsConfig>(fixture.sessions_config_id);
     let root = fixture.scenario.take_shared<AccumulatorRoot>();
     let clock = fixture.scenario.take_shared<Clock>();
     let _ = sessions::place_limit_order<BASE, QUOTE>(
@@ -386,6 +430,7 @@ fun unapproved_session_cannot_place_spot_order() {
         &registry,
         &account_registry,
         &mut wrapper,
+        &sessions_config,
         LIMIT_ORDER_CLIENT_ID,
         constants::no_restriction(),
         constants::self_matching_allowed(),
@@ -415,6 +460,9 @@ fun session_at_exact_expiration_cannot_place_spot_market_order() {
     let account_registry = fixture.scenario.take_shared<AccountRegistry>();
     let mut pool = fixture.scenario.take_shared_by_id<Pool<BASE, QUOTE>>(pool_id);
     let mut wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let sessions_config = fixture
+        .scenario
+        .take_shared_by_id<SessionsConfig>(fixture.sessions_config_id);
     let root = fixture.scenario.take_shared<AccumulatorRoot>();
     let clock = fixture.scenario.take_shared<Clock>();
     let _ = sessions::place_market_order<BASE, QUOTE>(
@@ -422,6 +470,7 @@ fun session_at_exact_expiration_cannot_place_spot_market_order() {
         &registry,
         &account_registry,
         &mut wrapper,
+        &sessions_config,
         MARKET_TAKER_CLIENT_ID,
         constants::self_matching_allowed(),
         constants::min_size(),
@@ -447,11 +496,48 @@ fun revoked_session_cannot_cancel_spot_order() {
     let account_registry = fixture.scenario.take_shared<AccountRegistry>();
     let mut pool = fixture.scenario.take_shared_by_id<Pool<BASE, QUOTE>>(pool_id);
     let mut wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let sessions_config = fixture
+        .scenario
+        .take_shared_by_id<SessionsConfig>(fixture.sessions_config_id);
     let clock = fixture.scenario.take_shared<Clock>();
     sessions::cancel_live_order<BASE, QUOTE>(
         &mut pool,
         &account_registry,
         &mut wrapper,
+        &sessions_config,
+        ZERO_ORDER_ID,
+        &clock,
+        fixture.scenario.ctx(),
+    );
+    abort EUnexpectedSuccess
+}
+
+#[test, expected_failure(abort_code = session_config::EPackageVersionDisabled)]
+fun retired_package_version_cannot_use_spot_wrapper() {
+    let mut fixture = setup_spot_fixture();
+    authorize_session(&mut fixture);
+    let sessions_config_id = fixture.sessions_config_id;
+    let pool_id = fixture.pool_id;
+    let wrapper_id = fixture.wrapper_id;
+
+    fixture.scenario.next_tx(ADMIN);
+    let mut sessions_config = fixture
+        .scenario
+        .take_shared_by_id<SessionsConfig>(sessions_config_id);
+    session_config::set_version_watermark_for_testing(&mut sessions_config, FUTURE_VERSION);
+    return_shared(sessions_config);
+
+    fixture.scenario.next_tx(SESSION);
+    let account_registry = fixture.scenario.take_shared<AccountRegistry>();
+    let mut pool = fixture.scenario.take_shared_by_id<Pool<BASE, QUOTE>>(pool_id);
+    let mut wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let sessions_config = fixture.scenario.take_shared_by_id<SessionsConfig>(sessions_config_id);
+    let clock = fixture.scenario.take_shared<Clock>();
+    sessions::cancel_live_order<BASE, QUOTE>(
+        &mut pool,
+        &account_registry,
+        &mut wrapper,
+        &sessions_config,
         ZERO_ORDER_ID,
         &clock,
         fixture.scenario.ctx(),
@@ -468,6 +554,8 @@ fun setup_spot_fixture(): SpotFixture {
     scenario.next_tx(ADMIN);
     let registry_id = registry::test_registry(scenario.ctx());
     account_registry::init_for_testing(scenario.ctx());
+    let (sessions_config_id, sessions_admin_cap) = session_config::init_for_testing(scenario.ctx());
+    destroy(sessions_admin_cap);
     let mut clock = clock::create_for_testing(scenario.ctx());
     clock.set_for_testing(NOW_MS);
     clock.share_for_testing();
@@ -486,16 +574,20 @@ fun setup_spot_fixture(): SpotFixture {
     wrapper.share();
     return_shared(account_registry);
 
-    SpotFixture { scenario, registry_id, pool_id, wrapper_id }
+    SpotFixture { scenario, registry_id, pool_id, wrapper_id, sessions_config_id }
 }
 
 fun authorize_session(fixture: &mut SpotFixture) {
     let wrapper_id = fixture.wrapper_id;
     fixture.scenario.next_tx(ALICE);
     let mut wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let sessions_config = fixture
+        .scenario
+        .take_shared_by_id<SessionsConfig>(fixture.sessions_config_id);
     let clock = fixture.scenario.take_shared<Clock>();
     sessions::authorize_session(
         &mut wrapper,
+        &sessions_config,
         SESSION,
         SESSION_DURATION_MS,
         &clock,
@@ -506,6 +598,7 @@ fun authorize_session(fixture: &mut SpotFixture) {
         option::some(SESSION_EXPIRES_AT_MS),
     );
     return_shared(clock);
+    return_shared(sessions_config);
     return_shared(wrapper);
 }
 
@@ -647,6 +740,12 @@ fun create_pool(scenario: &mut Scenario, registry_id: ID): ID {
 }
 
 fun finish_spot_fixture(fixture: SpotFixture) {
-    let SpotFixture { scenario, registry_id: _, pool_id: _, wrapper_id: _ } = fixture;
+    let SpotFixture {
+        scenario,
+        registry_id: _,
+        pool_id: _,
+        wrapper_id: _,
+        sessions_config_id: _,
+    } = fixture;
     scenario.end();
 }


### PR DESCRIPTION
## Summary

- Add a shared `SessionsConfig` and Sessions-owned `SessionsAdminCap` that let an upgraded package retire older package versions with a monotonic watermark.
- Require the config for session authorization and every Predict and DeepBook spot trading wrapper, while keeping session reads and revocation available after retirement.

## Why

The Sessions package lets Account owners grant temporary trading authority to another address, and clients call its wrappers for Predict and DeepBook spot actions. Account app authorization applies across the package lineage, so publishing a safer Sessions version did not stop older authorized bytecode from creating grants or trading. The next deployment is a full redeploy, which lets Sessions establish version governance without preserving existing package state.

## Linear / Context

- [DBU-746](https://linear.app/mysten-labs/issue/DBU-746/retire-outdated-sessions-package-versions)

## Key decisions

- The watermark is owned by Sessions instead of Account or Predict, keeping retirement authority aligned with the package whose entrypoints it disables.
- `bump_version_watermark` derives the target from the executing package and requires a strictly higher value; it does not accept a caller-selected version.
- Authorization and all trading wrappers are gated because an old authorization path could otherwise create grants consumed by newer wrappers. Reads and revocation stay ungated so owners retain cleanup access.

## Scope / Descoped

- This PR changes only Sessions Move sources, Move tests, and the package README.
- Deployment transactions, SDK call-site updates, package publication, and Account registry configuration are intentionally outside this PR.
- Existing Sessions state is not migrated because rollout will use a fresh deployment.

## Test plan

- [x] CI-pinned Sui `testnet-v1.74.1`: `sui move build --path packages/sessions --warnings-are-errors` — the Sessions package builds cleanly with no warnings.
- [x] CI-pinned Sui `testnet-v1.74.1`: `sui move test --path packages/sessions --gas-limit 100000000000` — all 30 tests pass, including version initialization, monotonic bumping, retired-version rejection, and ungated read/revoke coverage.
- [ ] `Predict Gas Benchmark / trigger-benchmark` — the external simulator failed twice with `sim exited with code 1`. Current `main` fails the same workflow with the same error, and the benchmark's published package closure excludes Sessions; all repository-local Predict harness checks passed.

## Risk / Rollout

This intentionally breaks every `authorize_session` and trading-wrapper call site by adding the shared config input. Publish the fresh Account package and `AccountRegistry` with the dependency set and Sessions package, authorize `SessionsApp` and `DeepbookCoreAccountApp` in their new registries, then switch clients to the new package and `SessionsConfig`. For later upgrades, publish and move clients first, then call the new package's `bump_version_watermark` to retire older versions; rollback before the bump is a client switch, while rollback after the bump requires another package version because the watermark cannot decrease.
