### PR TITLE
schema: preserve complete OHLCV buckets (DBU-747)

### DIFF
--- a/crates/schema/docs/pg_cron.md
+++ b/crates/schema/docs/pg_cron.md
@@ -11,7 +11,9 @@ Due to our production setup being on a different database than the one the cron 
    - Note: If pg_cron is installed on the same database as your application, you can use `schedule()` instead
 3. Run the SQL commands below to schedule the OHCLV update jobs
 
-The procedure arguments select the buckets to revisit. Each procedure expands that range with the same database-timezone bucket boundaries used to group `order_fills`, so repeated or overlapping ranges can safely replace an aggregate; the newest bucket is partial only because future fills do not exist yet.
+OHLCV writer and reader sessions must use UTC because the `bucket_time` columns do not store a timezone.
+
+The procedure arguments select the buckets to revisit. Each procedure expands that range to complete UTC bucket boundaries before reading `order_fills`, so repeated or overlapping ranges can safely replace an aggregate; the newest bucket is partial only because future fills do not exist yet.
 
 If executions overlap, an older aggregate cannot replace a row whose latest fill timestamp is newer or whose fill count at the same latest timestamp is greater.
 

--- a/crates/schema/docs/pg_cron.md
+++ b/crates/schema/docs/pg_cron.md
@@ -11,6 +11,8 @@ Due to our production setup being on a different database than the one the cron 
    - Note: If pg_cron is installed on the same database as your application, you can use `schedule()` instead
 3. Run the SQL commands below to schedule the OHCLV update jobs
 
+The procedure arguments select the buckets to revisit. Each procedure expands that range to complete bucket boundaries before reading `order_fills`, so overlapping jobs can safely replace an aggregate; the newest bucket is partial only because future fills do not exist yet.
+
 -- Enable pg_cron 
 CREATE EXTENSION IF NOT EXISTS pg_cron;
 

--- a/crates/schema/docs/pg_cron.md
+++ b/crates/schema/docs/pg_cron.md
@@ -11,7 +11,9 @@ Due to our production setup being on a different database than the one the cron 
    - Note: If pg_cron is installed on the same database as your application, you can use `schedule()` instead
 3. Run the SQL commands below to schedule the OHCLV update jobs
 
-The procedure arguments select the buckets to revisit. Each procedure expands that range to complete bucket boundaries before reading `order_fills`, so overlapping jobs can safely replace an aggregate; the newest bucket is partial only because future fills do not exist yet.
+The procedure arguments select the buckets to revisit. Each procedure expands that range to complete UTC bucket boundaries before reading `order_fills`, so repeated or overlapping ranges can safely replace an aggregate; the newest bucket is partial only because future fills do not exist yet.
+
+If executions overlap, an older aggregate cannot replace a row whose latest fill timestamp is newer or whose fill count at the same latest timestamp is greater.
 
 -- Enable pg_cron 
 CREATE EXTENSION IF NOT EXISTS pg_cron;

--- a/crates/schema/docs/pg_cron.md
+++ b/crates/schema/docs/pg_cron.md
@@ -11,7 +11,7 @@ Due to our production setup being on a different database than the one the cron 
    - Note: If pg_cron is installed on the same database as your application, you can use `schedule()` instead
 3. Run the SQL commands below to schedule the OHCLV update jobs
 
-The procedure arguments select the buckets to revisit. Each procedure expands that range to complete UTC bucket boundaries before reading `order_fills`, so repeated or overlapping ranges can safely replace an aggregate; the newest bucket is partial only because future fills do not exist yet.
+The procedure arguments select the buckets to revisit. Each procedure expands that range with the same database-timezone bucket boundaries used to group `order_fills`, so repeated or overlapping ranges can safely replace an aggregate; the newest bucket is partial only because future fills do not exist yet.
 
 If executions overlap, an older aggregate cannot replace a row whose latest fill timestamp is newer or whose fill count at the same latest timestamp is greater.
 

--- a/crates/schema/docs/pg_cron.md
+++ b/crates/schema/docs/pg_cron.md
@@ -17,7 +17,7 @@ The procedure arguments select the buckets to revisit. Each procedure expands th
 
 If executions overlap, an older aggregate cannot replace a row whose latest fill timestamp is newer or whose fill count at the same latest timestamp is greater.
 
-An existing candle keeps its opening price unless a newly observed fill has an earlier timestamp; this keeps `open` and `first_trade_timestamp` consistent when checkpoints are committed out of order without reshuffling fills that share a timestamp.
+Opening and closing prices order fills by checkpoint timestamp and then by the fill's stable unique event digest. The tie-breaker makes every complete snapshot deterministic and lets a refresh repair legacy rows whose opening price does not match the canonical earliest fill.
 
 The migration refreshes each procedure's default range. An execution that started before the migration can finish afterward with the previous definition, so allow one subsequent scheduled execution to finish before treating its recent scheduled range as converged; calling each procedure once after the migration commits also establishes that boundary immediately.
 

--- a/crates/schema/docs/pg_cron.md
+++ b/crates/schema/docs/pg_cron.md
@@ -17,6 +17,10 @@ The procedure arguments select the buckets to revisit. Each procedure expands th
 
 If executions overlap, an older aggregate cannot replace a row whose latest fill timestamp is newer or whose fill count at the same latest timestamp is greater.
 
+An existing candle keeps its opening price unless a newly observed fill has an earlier timestamp; this keeps `open` and `first_trade_timestamp` consistent when checkpoints are committed out of order without reshuffling fills that share a timestamp.
+
+The migration refreshes each procedure's default range. An execution that started before the migration can finish afterward with the previous definition, so allow one subsequent scheduled execution to finish before treating its recent scheduled range as converged; calling each procedure once after the migration commits also establishes that boundary immediately.
+
 -- Enable pg_cron 
 CREATE EXTENSION IF NOT EXISTS pg_cron;
 

--- a/crates/schema/migrations/2026-08-21-000000-0000_align_ohclv_refresh_windows/down.sql
+++ b/crates/schema/migrations/2026-08-21-000000-0000_align_ohclv_refresh_windows/down.sql
@@ -1,0 +1,1 @@
+-- Keep the bucket-aligned procedures in place rather than reintroducing partial refreshes.

--- a/crates/schema/migrations/2026-08-21-000000-0000_align_ohclv_refresh_windows/down.sql
+++ b/crates/schema/migrations/2026-08-21-000000-0000_align_ohclv_refresh_windows/down.sql
@@ -1,1 +1,5 @@
--- Keep the bucket-aligned procedures in place rather than reintroducing partial refreshes.
+DO $$
+BEGIN
+    RAISE EXCEPTION 'This migration cannot be reverted because restoring partial OHLCV refreshes would corrupt candle aggregates';
+END;
+$$;

--- a/crates/schema/migrations/2026-08-21-000000-0000_align_ohclv_refresh_windows/up.sql
+++ b/crates/schema/migrations/2026-08-21-000000-0000_align_ohclv_refresh_windows/up.sql
@@ -4,8 +4,6 @@ CREATE OR REPLACE PROCEDURE update_ohclv_1m(
 )
 LANGUAGE plpgsql
 AS $$
-DECLARE
-    bucket_width_ms CONSTANT BIGINT := 60000;
 BEGIN
     -- Default to last 24 hours if no range specified
     IF start_timestamp IS NULL THEN
@@ -17,8 +15,12 @@ BEGIN
     END IF;
 
     -- The requested range selects buckets to refresh. Read every selected bucket in full.
-    start_timestamp := (start_timestamp / bucket_width_ms) * bucket_width_ms;
-    end_timestamp := ((end_timestamp / bucket_width_ms) + 1) * bucket_width_ms;
+    start_timestamp := (
+        EXTRACT(EPOCH FROM date_trunc('minute', to_timestamp(start_timestamp / 1000.0))) * 1000
+    )::BIGINT;
+    end_timestamp := (
+        EXTRACT(EPOCH FROM date_trunc('minute', to_timestamp(end_timestamp / 1000.0)) + INTERVAL '1 minute') * 1000
+    )::BIGINT;
 
     INSERT INTO ohclv_1m (
         pool_id,
@@ -35,29 +37,29 @@ BEGIN
     )
     SELECT DISTINCT ON (pool_id, bucket_time)
         f.pool_id,
-        date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC') as bucket_time,
+        date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0)) as bucket_time,
         FIRST_VALUE(f.price::numeric / POWER(10, 9 - p.base_asset_decimals + p.quote_asset_decimals))
-            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')
+            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))
                   ORDER BY f.checkpoint_timestamp_ms
                   ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) as open,
         MAX(f.price::numeric / POWER(10, 9 - p.base_asset_decimals + p.quote_asset_decimals))
-            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')) as high,
+            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as high,
         MIN(f.price::numeric / POWER(10, 9 - p.base_asset_decimals + p.quote_asset_decimals))
-            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')) as low,
+            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as low,
         LAST_VALUE(f.price::numeric / POWER(10, 9 - p.base_asset_decimals + p.quote_asset_decimals))
-            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')
+            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))
                   ORDER BY f.checkpoint_timestamp_ms
                   ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) as close,
         SUM(f.base_quantity::numeric / POWER(10, p.base_asset_decimals))
-            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')) as base_volume,
+            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as base_volume,
         SUM(f.quote_quantity::numeric / POWER(10, p.quote_asset_decimals))
-            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')) as quote_volume,
+            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as quote_volume,
         COUNT(*)
-            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')) as trade_count,
+            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as trade_count,
         MIN(f.checkpoint_timestamp_ms)
-            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')) as first_trade_timestamp,
+            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as first_trade_timestamp,
         MAX(f.checkpoint_timestamp_ms)
-            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')) as last_trade_timestamp
+            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as last_trade_timestamp
     FROM order_fills f
     INNER JOIN pools p ON f.pool_id = p.pool_id
     WHERE f.checkpoint_timestamp_ms >= start_timestamp
@@ -87,8 +89,6 @@ CREATE OR REPLACE PROCEDURE update_ohclv_1d(
 )
 LANGUAGE plpgsql
 AS $$
-DECLARE
-    bucket_width_ms CONSTANT BIGINT := 86400000;
 BEGIN
     -- Default to last 7 days if no range specified
     IF start_timestamp IS NULL THEN
@@ -100,8 +100,12 @@ BEGIN
     END IF;
 
     -- The requested range selects buckets to refresh. Read every selected bucket in full.
-    start_timestamp := (start_timestamp / bucket_width_ms) * bucket_width_ms;
-    end_timestamp := ((end_timestamp / bucket_width_ms) + 1) * bucket_width_ms;
+    start_timestamp := (
+        EXTRACT(EPOCH FROM date_trunc('day', to_timestamp(start_timestamp / 1000.0))) * 1000
+    )::BIGINT;
+    end_timestamp := (
+        EXTRACT(EPOCH FROM date_trunc('day', to_timestamp(end_timestamp / 1000.0)) + INTERVAL '1 day') * 1000
+    )::BIGINT;
 
     INSERT INTO ohclv_1d (
         pool_id,
@@ -118,29 +122,29 @@ BEGIN
     )
     SELECT DISTINCT ON (pool_id, bucket_time)
         f.pool_id,
-        date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')::DATE as bucket_time,
+        date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))::DATE as bucket_time,
         FIRST_VALUE(f.price::numeric / POWER(10, 9 - p.base_asset_decimals + p.quote_asset_decimals))
-            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')
+            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))
                   ORDER BY f.checkpoint_timestamp_ms
                   ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) as open,
         MAX(f.price::numeric / POWER(10, 9 - p.base_asset_decimals + p.quote_asset_decimals))
-            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')) as high,
+            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as high,
         MIN(f.price::numeric / POWER(10, 9 - p.base_asset_decimals + p.quote_asset_decimals))
-            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')) as low,
+            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as low,
         LAST_VALUE(f.price::numeric / POWER(10, 9 - p.base_asset_decimals + p.quote_asset_decimals))
-            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')
+            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))
                   ORDER BY f.checkpoint_timestamp_ms
                   ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) as close,
         SUM(f.base_quantity::numeric / POWER(10, p.base_asset_decimals))
-            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')) as base_volume,
+            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as base_volume,
         SUM(f.quote_quantity::numeric / POWER(10, p.quote_asset_decimals))
-            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')) as quote_volume,
+            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as quote_volume,
         COUNT(*)
-            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')) as trade_count,
+            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as trade_count,
         MIN(f.checkpoint_timestamp_ms)
-            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')) as first_trade_timestamp,
+            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as first_trade_timestamp,
         MAX(f.checkpoint_timestamp_ms)
-            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')) as last_trade_timestamp
+            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as last_trade_timestamp
     FROM order_fills f
     INNER JOIN pools p ON f.pool_id = p.pool_id
     WHERE f.checkpoint_timestamp_ms >= start_timestamp

--- a/crates/schema/migrations/2026-08-21-000000-0000_align_ohclv_refresh_windows/up.sql
+++ b/crates/schema/migrations/2026-08-21-000000-0000_align_ohclv_refresh_windows/up.sql
@@ -38,7 +38,7 @@ BEGIN
         date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0)) as bucket_time,
         FIRST_VALUE(f.price::numeric / POWER(10, 9 - p.base_asset_decimals + p.quote_asset_decimals))
             OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))
-                  ORDER BY f.checkpoint_timestamp_ms
+                  ORDER BY f.checkpoint_timestamp_ms, f.event_digest
                   ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) as open,
         MAX(f.price::numeric / POWER(10, 9 - p.base_asset_decimals + p.quote_asset_decimals))
             OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as high,
@@ -46,7 +46,7 @@ BEGIN
             OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as low,
         LAST_VALUE(f.price::numeric / POWER(10, 9 - p.base_asset_decimals + p.quote_asset_decimals))
             OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))
-                  ORDER BY f.checkpoint_timestamp_ms
+                  ORDER BY f.checkpoint_timestamp_ms, f.event_digest
                   ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) as close,
         SUM(f.base_quantity::numeric / POWER(10, p.base_asset_decimals))
             OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as base_volume,
@@ -64,10 +64,7 @@ BEGIN
       AND f.checkpoint_timestamp_ms < end_timestamp
     ON CONFLICT (pool_id, bucket_time)
     DO UPDATE SET
-        open = CASE
-            WHEN EXCLUDED.first_trade_timestamp < ohclv_1m.first_trade_timestamp THEN EXCLUDED.open
-            ELSE ohclv_1m.open
-        END,
+        open = EXCLUDED.open,
         high = EXCLUDED.high,
         low = EXCLUDED.low,
         close = EXCLUDED.close,
@@ -80,13 +77,15 @@ BEGIN
        OR (
             EXCLUDED.last_trade_timestamp = ohclv_1m.last_trade_timestamp
             AND EXCLUDED.trade_count > ohclv_1m.trade_count
+       )
+       OR (
+            EXCLUDED.first_trade_timestamp = ohclv_1m.first_trade_timestamp
+            AND EXCLUDED.last_trade_timestamp = ohclv_1m.last_trade_timestamp
+            AND EXCLUDED.trade_count = ohclv_1m.trade_count
+            AND EXCLUDED.open IS DISTINCT FROM ohclv_1m.open
        );
 END;
 $$;
-
--- Repair the recent ranges immediately without turning the migration into a full-history scan.
-CALL update_ohclv_1m(NULL, NULL);
-CALL update_ohclv_1d(NULL, NULL);
 
 CREATE OR REPLACE PROCEDURE update_ohclv_1d(
     start_timestamp BIGINT DEFAULT NULL,
@@ -128,7 +127,7 @@ BEGIN
         date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))::DATE as bucket_time,
         FIRST_VALUE(f.price::numeric / POWER(10, 9 - p.base_asset_decimals + p.quote_asset_decimals))
             OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))
-                  ORDER BY f.checkpoint_timestamp_ms
+                  ORDER BY f.checkpoint_timestamp_ms, f.event_digest
                   ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) as open,
         MAX(f.price::numeric / POWER(10, 9 - p.base_asset_decimals + p.quote_asset_decimals))
             OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as high,
@@ -136,7 +135,7 @@ BEGIN
             OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as low,
         LAST_VALUE(f.price::numeric / POWER(10, 9 - p.base_asset_decimals + p.quote_asset_decimals))
             OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))
-                  ORDER BY f.checkpoint_timestamp_ms
+                  ORDER BY f.checkpoint_timestamp_ms, f.event_digest
                   ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) as close,
         SUM(f.base_quantity::numeric / POWER(10, p.base_asset_decimals))
             OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as base_volume,
@@ -154,10 +153,7 @@ BEGIN
       AND f.checkpoint_timestamp_ms < end_timestamp
     ON CONFLICT (pool_id, bucket_time)
     DO UPDATE SET
-        open = CASE
-            WHEN EXCLUDED.first_trade_timestamp < ohclv_1d.first_trade_timestamp THEN EXCLUDED.open
-            ELSE ohclv_1d.open
-        END,
+        open = EXCLUDED.open,
         high = EXCLUDED.high,
         low = EXCLUDED.low,
         close = EXCLUDED.close,
@@ -170,6 +166,16 @@ BEGIN
        OR (
             EXCLUDED.last_trade_timestamp = ohclv_1d.last_trade_timestamp
             AND EXCLUDED.trade_count > ohclv_1d.trade_count
+       )
+       OR (
+            EXCLUDED.first_trade_timestamp = ohclv_1d.first_trade_timestamp
+            AND EXCLUDED.last_trade_timestamp = ohclv_1d.last_trade_timestamp
+            AND EXCLUDED.trade_count = ohclv_1d.trade_count
+            AND EXCLUDED.open IS DISTINCT FROM ohclv_1d.open
        );
 END;
 $$;
+
+-- Repair the recent ranges immediately without turning the migration into a full-history scan.
+CALL update_ohclv_1m(NULL, NULL);
+CALL update_ohclv_1d(NULL, NULL);

--- a/crates/schema/migrations/2026-08-21-000000-0000_align_ohclv_refresh_windows/up.sql
+++ b/crates/schema/migrations/2026-08-21-000000-0000_align_ohclv_refresh_windows/up.sql
@@ -4,6 +4,8 @@ CREATE OR REPLACE PROCEDURE update_ohclv_1m(
 )
 LANGUAGE plpgsql
 AS $$
+DECLARE
+    bucket_width_ms CONSTANT BIGINT := 60000;
 BEGIN
     -- Default to last 24 hours if no range specified
     IF start_timestamp IS NULL THEN
@@ -15,12 +17,8 @@ BEGIN
     END IF;
 
     -- The requested range selects buckets to refresh. Read every selected bucket in full.
-    start_timestamp := (
-        EXTRACT(EPOCH FROM date_trunc('minute', to_timestamp(start_timestamp / 1000.0))) * 1000
-    )::BIGINT;
-    end_timestamp := (
-        EXTRACT(EPOCH FROM date_trunc('minute', to_timestamp(end_timestamp / 1000.0)) + INTERVAL '1 minute') * 1000
-    )::BIGINT;
+    start_timestamp := (start_timestamp / bucket_width_ms) * bucket_width_ms;
+    end_timestamp := ((end_timestamp / bucket_width_ms) + 1) * bucket_width_ms;
 
     INSERT INTO ohclv_1m (
         pool_id,
@@ -66,7 +64,6 @@ BEGIN
       AND f.checkpoint_timestamp_ms < end_timestamp
     ON CONFLICT (pool_id, bucket_time)
     DO UPDATE SET
-        open = EXCLUDED.open,
         high = EXCLUDED.high,
         low = EXCLUDED.low,
         close = EXCLUDED.close,
@@ -78,7 +75,7 @@ BEGIN
     WHERE EXCLUDED.last_trade_timestamp > ohclv_1m.last_trade_timestamp
        OR (
             EXCLUDED.last_trade_timestamp = ohclv_1m.last_trade_timestamp
-            AND EXCLUDED.trade_count >= ohclv_1m.trade_count
+            AND EXCLUDED.trade_count > ohclv_1m.trade_count
        );
 END;
 $$;
@@ -89,6 +86,8 @@ CREATE OR REPLACE PROCEDURE update_ohclv_1d(
 )
 LANGUAGE plpgsql
 AS $$
+DECLARE
+    bucket_width_ms CONSTANT BIGINT := 86400000;
 BEGIN
     -- Default to last 7 days if no range specified
     IF start_timestamp IS NULL THEN
@@ -100,12 +99,8 @@ BEGIN
     END IF;
 
     -- The requested range selects buckets to refresh. Read every selected bucket in full.
-    start_timestamp := (
-        EXTRACT(EPOCH FROM date_trunc('day', to_timestamp(start_timestamp / 1000.0))) * 1000
-    )::BIGINT;
-    end_timestamp := (
-        EXTRACT(EPOCH FROM date_trunc('day', to_timestamp(end_timestamp / 1000.0)) + INTERVAL '1 day') * 1000
-    )::BIGINT;
+    start_timestamp := (start_timestamp / bucket_width_ms) * bucket_width_ms;
+    end_timestamp := ((end_timestamp / bucket_width_ms) + 1) * bucket_width_ms;
 
     INSERT INTO ohclv_1d (
         pool_id,
@@ -151,7 +146,6 @@ BEGIN
       AND f.checkpoint_timestamp_ms < end_timestamp
     ON CONFLICT (pool_id, bucket_time)
     DO UPDATE SET
-        open = EXCLUDED.open,
         high = EXCLUDED.high,
         low = EXCLUDED.low,
         close = EXCLUDED.close,
@@ -163,7 +157,7 @@ BEGIN
     WHERE EXCLUDED.last_trade_timestamp > ohclv_1d.last_trade_timestamp
        OR (
             EXCLUDED.last_trade_timestamp = ohclv_1d.last_trade_timestamp
-            AND EXCLUDED.trade_count >= ohclv_1d.trade_count
+            AND EXCLUDED.trade_count > ohclv_1d.trade_count
        );
 END;
 $$;

--- a/crates/schema/migrations/2026-08-21-000000-0000_align_ohclv_refresh_windows/up.sql
+++ b/crates/schema/migrations/2026-08-21-000000-0000_align_ohclv_refresh_windows/up.sql
@@ -35,43 +35,49 @@ BEGIN
     )
     SELECT DISTINCT ON (pool_id, bucket_time)
         f.pool_id,
-        date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0)) as bucket_time,
+        date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC') as bucket_time,
         FIRST_VALUE(f.price::numeric / POWER(10, 9 - p.base_asset_decimals + p.quote_asset_decimals))
-            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))
+            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')
                   ORDER BY f.checkpoint_timestamp_ms
                   ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) as open,
         MAX(f.price::numeric / POWER(10, 9 - p.base_asset_decimals + p.quote_asset_decimals))
-            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as high,
+            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')) as high,
         MIN(f.price::numeric / POWER(10, 9 - p.base_asset_decimals + p.quote_asset_decimals))
-            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as low,
+            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')) as low,
         LAST_VALUE(f.price::numeric / POWER(10, 9 - p.base_asset_decimals + p.quote_asset_decimals))
-            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))
+            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')
                   ORDER BY f.checkpoint_timestamp_ms
                   ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) as close,
         SUM(f.base_quantity::numeric / POWER(10, p.base_asset_decimals))
-            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as base_volume,
+            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')) as base_volume,
         SUM(f.quote_quantity::numeric / POWER(10, p.quote_asset_decimals))
-            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as quote_volume,
+            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')) as quote_volume,
         COUNT(*)
-            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as trade_count,
+            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')) as trade_count,
         MIN(f.checkpoint_timestamp_ms)
-            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as first_trade_timestamp,
+            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')) as first_trade_timestamp,
         MAX(f.checkpoint_timestamp_ms)
-            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as last_trade_timestamp
+            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')) as last_trade_timestamp
     FROM order_fills f
     INNER JOIN pools p ON f.pool_id = p.pool_id
     WHERE f.checkpoint_timestamp_ms >= start_timestamp
       AND f.checkpoint_timestamp_ms < end_timestamp
     ON CONFLICT (pool_id, bucket_time)
     DO UPDATE SET
-        high = GREATEST(EXCLUDED.high, ohclv_1m.high),
-        low = LEAST(EXCLUDED.low, ohclv_1m.low),
+        open = EXCLUDED.open,
+        high = EXCLUDED.high,
+        low = EXCLUDED.low,
         close = EXCLUDED.close,
         base_volume = EXCLUDED.base_volume,
         quote_volume = EXCLUDED.quote_volume,
         trade_count = EXCLUDED.trade_count,
-        first_trade_timestamp = LEAST(EXCLUDED.first_trade_timestamp, ohclv_1m.first_trade_timestamp),
-        last_trade_timestamp = GREATEST(EXCLUDED.last_trade_timestamp, ohclv_1m.last_trade_timestamp);
+        first_trade_timestamp = EXCLUDED.first_trade_timestamp,
+        last_trade_timestamp = EXCLUDED.last_trade_timestamp
+    WHERE EXCLUDED.last_trade_timestamp > ohclv_1m.last_trade_timestamp
+       OR (
+            EXCLUDED.last_trade_timestamp = ohclv_1m.last_trade_timestamp
+            AND EXCLUDED.trade_count >= ohclv_1m.trade_count
+       );
 END;
 $$;
 
@@ -112,43 +118,49 @@ BEGIN
     )
     SELECT DISTINCT ON (pool_id, bucket_time)
         f.pool_id,
-        date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))::DATE as bucket_time,
+        date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')::DATE as bucket_time,
         FIRST_VALUE(f.price::numeric / POWER(10, 9 - p.base_asset_decimals + p.quote_asset_decimals))
-            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))
+            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')
                   ORDER BY f.checkpoint_timestamp_ms
                   ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) as open,
         MAX(f.price::numeric / POWER(10, 9 - p.base_asset_decimals + p.quote_asset_decimals))
-            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as high,
+            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')) as high,
         MIN(f.price::numeric / POWER(10, 9 - p.base_asset_decimals + p.quote_asset_decimals))
-            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as low,
+            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')) as low,
         LAST_VALUE(f.price::numeric / POWER(10, 9 - p.base_asset_decimals + p.quote_asset_decimals))
-            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))
+            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')
                   ORDER BY f.checkpoint_timestamp_ms
                   ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) as close,
         SUM(f.base_quantity::numeric / POWER(10, p.base_asset_decimals))
-            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as base_volume,
+            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')) as base_volume,
         SUM(f.quote_quantity::numeric / POWER(10, p.quote_asset_decimals))
-            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as quote_volume,
+            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')) as quote_volume,
         COUNT(*)
-            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as trade_count,
+            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')) as trade_count,
         MIN(f.checkpoint_timestamp_ms)
-            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as first_trade_timestamp,
+            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')) as first_trade_timestamp,
         MAX(f.checkpoint_timestamp_ms)
-            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as last_trade_timestamp
+            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0) AT TIME ZONE 'UTC')) as last_trade_timestamp
     FROM order_fills f
     INNER JOIN pools p ON f.pool_id = p.pool_id
     WHERE f.checkpoint_timestamp_ms >= start_timestamp
       AND f.checkpoint_timestamp_ms < end_timestamp
     ON CONFLICT (pool_id, bucket_time)
     DO UPDATE SET
-        high = GREATEST(EXCLUDED.high, ohclv_1d.high),
-        low = LEAST(EXCLUDED.low, ohclv_1d.low),
+        open = EXCLUDED.open,
+        high = EXCLUDED.high,
+        low = EXCLUDED.low,
         close = EXCLUDED.close,
         base_volume = EXCLUDED.base_volume,
         quote_volume = EXCLUDED.quote_volume,
         trade_count = EXCLUDED.trade_count,
-        first_trade_timestamp = LEAST(EXCLUDED.first_trade_timestamp, ohclv_1d.first_trade_timestamp),
-        last_trade_timestamp = GREATEST(EXCLUDED.last_trade_timestamp, ohclv_1d.last_trade_timestamp);
+        first_trade_timestamp = EXCLUDED.first_trade_timestamp,
+        last_trade_timestamp = EXCLUDED.last_trade_timestamp
+    WHERE EXCLUDED.last_trade_timestamp > ohclv_1d.last_trade_timestamp
+       OR (
+            EXCLUDED.last_trade_timestamp = ohclv_1d.last_trade_timestamp
+            AND EXCLUDED.trade_count >= ohclv_1d.trade_count
+       );
 END;
 $$;
 

--- a/crates/schema/migrations/2026-08-21-000000-0000_align_ohclv_refresh_windows/up.sql
+++ b/crates/schema/migrations/2026-08-21-000000-0000_align_ohclv_refresh_windows/up.sql
@@ -82,7 +82,10 @@ BEGIN
             EXCLUDED.first_trade_timestamp = ohclv_1m.first_trade_timestamp
             AND EXCLUDED.last_trade_timestamp = ohclv_1m.last_trade_timestamp
             AND EXCLUDED.trade_count = ohclv_1m.trade_count
-            AND EXCLUDED.open IS DISTINCT FROM ohclv_1m.open
+            AND (
+                EXCLUDED.open IS DISTINCT FROM ohclv_1m.open
+                OR EXCLUDED.close IS DISTINCT FROM ohclv_1m.close
+            )
        );
 END;
 $$;
@@ -171,7 +174,10 @@ BEGIN
             EXCLUDED.first_trade_timestamp = ohclv_1d.first_trade_timestamp
             AND EXCLUDED.last_trade_timestamp = ohclv_1d.last_trade_timestamp
             AND EXCLUDED.trade_count = ohclv_1d.trade_count
-            AND EXCLUDED.open IS DISTINCT FROM ohclv_1d.open
+            AND (
+                EXCLUDED.open IS DISTINCT FROM ohclv_1d.open
+                OR EXCLUDED.close IS DISTINCT FROM ohclv_1d.close
+            )
        );
 END;
 $$;

--- a/crates/schema/migrations/2026-08-21-000000-0000_align_ohclv_refresh_windows/up.sql
+++ b/crates/schema/migrations/2026-08-21-000000-0000_align_ohclv_refresh_windows/up.sql
@@ -1,0 +1,157 @@
+CREATE OR REPLACE PROCEDURE update_ohclv_1m(
+    start_timestamp BIGINT DEFAULT NULL,
+    end_timestamp BIGINT DEFAULT NULL
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    bucket_width_ms CONSTANT BIGINT := 60000;
+BEGIN
+    -- Default to last 24 hours if no range specified
+    IF start_timestamp IS NULL THEN
+        start_timestamp := (EXTRACT(EPOCH FROM NOW() - INTERVAL '24 hours') * 1000)::BIGINT;
+    END IF;
+
+    IF end_timestamp IS NULL THEN
+        end_timestamp := (EXTRACT(EPOCH FROM NOW()) * 1000)::BIGINT;
+    END IF;
+
+    -- The requested range selects buckets to refresh. Read every selected bucket in full.
+    start_timestamp := (start_timestamp / bucket_width_ms) * bucket_width_ms;
+    end_timestamp := ((end_timestamp / bucket_width_ms) + 1) * bucket_width_ms;
+
+    INSERT INTO ohclv_1m (
+        pool_id,
+        bucket_time,
+        open,
+        high,
+        low,
+        close,
+        base_volume,
+        quote_volume,
+        trade_count,
+        first_trade_timestamp,
+        last_trade_timestamp
+    )
+    SELECT DISTINCT ON (pool_id, bucket_time)
+        f.pool_id,
+        date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0)) as bucket_time,
+        FIRST_VALUE(f.price::numeric / POWER(10, 9 - p.base_asset_decimals + p.quote_asset_decimals))
+            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))
+                  ORDER BY f.checkpoint_timestamp_ms
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) as open,
+        MAX(f.price::numeric / POWER(10, 9 - p.base_asset_decimals + p.quote_asset_decimals))
+            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as high,
+        MIN(f.price::numeric / POWER(10, 9 - p.base_asset_decimals + p.quote_asset_decimals))
+            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as low,
+        LAST_VALUE(f.price::numeric / POWER(10, 9 - p.base_asset_decimals + p.quote_asset_decimals))
+            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))
+                  ORDER BY f.checkpoint_timestamp_ms
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) as close,
+        SUM(f.base_quantity::numeric / POWER(10, p.base_asset_decimals))
+            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as base_volume,
+        SUM(f.quote_quantity::numeric / POWER(10, p.quote_asset_decimals))
+            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as quote_volume,
+        COUNT(*)
+            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as trade_count,
+        MIN(f.checkpoint_timestamp_ms)
+            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as first_trade_timestamp,
+        MAX(f.checkpoint_timestamp_ms)
+            OVER (PARTITION BY f.pool_id, date_trunc('minute', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as last_trade_timestamp
+    FROM order_fills f
+    INNER JOIN pools p ON f.pool_id = p.pool_id
+    WHERE f.checkpoint_timestamp_ms >= start_timestamp
+      AND f.checkpoint_timestamp_ms < end_timestamp
+    ON CONFLICT (pool_id, bucket_time)
+    DO UPDATE SET
+        high = GREATEST(EXCLUDED.high, ohclv_1m.high),
+        low = LEAST(EXCLUDED.low, ohclv_1m.low),
+        close = EXCLUDED.close,
+        base_volume = EXCLUDED.base_volume,
+        quote_volume = EXCLUDED.quote_volume,
+        trade_count = EXCLUDED.trade_count,
+        first_trade_timestamp = LEAST(EXCLUDED.first_trade_timestamp, ohclv_1m.first_trade_timestamp),
+        last_trade_timestamp = GREATEST(EXCLUDED.last_trade_timestamp, ohclv_1m.last_trade_timestamp);
+END;
+$$;
+
+CREATE OR REPLACE PROCEDURE update_ohclv_1d(
+    start_timestamp BIGINT DEFAULT NULL,
+    end_timestamp BIGINT DEFAULT NULL
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    bucket_width_ms CONSTANT BIGINT := 86400000;
+BEGIN
+    -- Default to last 7 days if no range specified
+    IF start_timestamp IS NULL THEN
+        start_timestamp := (EXTRACT(EPOCH FROM NOW() - INTERVAL '7 days') * 1000)::BIGINT;
+    END IF;
+
+    IF end_timestamp IS NULL THEN
+        end_timestamp := (EXTRACT(EPOCH FROM NOW()) * 1000)::BIGINT;
+    END IF;
+
+    -- The requested range selects buckets to refresh. Read every selected bucket in full.
+    start_timestamp := (start_timestamp / bucket_width_ms) * bucket_width_ms;
+    end_timestamp := ((end_timestamp / bucket_width_ms) + 1) * bucket_width_ms;
+
+    INSERT INTO ohclv_1d (
+        pool_id,
+        bucket_time,
+        open,
+        high,
+        low,
+        close,
+        base_volume,
+        quote_volume,
+        trade_count,
+        first_trade_timestamp,
+        last_trade_timestamp
+    )
+    SELECT DISTINCT ON (pool_id, bucket_time)
+        f.pool_id,
+        date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))::DATE as bucket_time,
+        FIRST_VALUE(f.price::numeric / POWER(10, 9 - p.base_asset_decimals + p.quote_asset_decimals))
+            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))
+                  ORDER BY f.checkpoint_timestamp_ms
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) as open,
+        MAX(f.price::numeric / POWER(10, 9 - p.base_asset_decimals + p.quote_asset_decimals))
+            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as high,
+        MIN(f.price::numeric / POWER(10, 9 - p.base_asset_decimals + p.quote_asset_decimals))
+            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as low,
+        LAST_VALUE(f.price::numeric / POWER(10, 9 - p.base_asset_decimals + p.quote_asset_decimals))
+            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))
+                  ORDER BY f.checkpoint_timestamp_ms
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) as close,
+        SUM(f.base_quantity::numeric / POWER(10, p.base_asset_decimals))
+            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as base_volume,
+        SUM(f.quote_quantity::numeric / POWER(10, p.quote_asset_decimals))
+            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as quote_volume,
+        COUNT(*)
+            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as trade_count,
+        MIN(f.checkpoint_timestamp_ms)
+            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as first_trade_timestamp,
+        MAX(f.checkpoint_timestamp_ms)
+            OVER (PARTITION BY f.pool_id, date_trunc('day', to_timestamp(f.checkpoint_timestamp_ms / 1000.0))) as last_trade_timestamp
+    FROM order_fills f
+    INNER JOIN pools p ON f.pool_id = p.pool_id
+    WHERE f.checkpoint_timestamp_ms >= start_timestamp
+      AND f.checkpoint_timestamp_ms < end_timestamp
+    ON CONFLICT (pool_id, bucket_time)
+    DO UPDATE SET
+        high = GREATEST(EXCLUDED.high, ohclv_1d.high),
+        low = LEAST(EXCLUDED.low, ohclv_1d.low),
+        close = EXCLUDED.close,
+        base_volume = EXCLUDED.base_volume,
+        quote_volume = EXCLUDED.quote_volume,
+        trade_count = EXCLUDED.trade_count,
+        first_trade_timestamp = LEAST(EXCLUDED.first_trade_timestamp, ohclv_1d.first_trade_timestamp),
+        last_trade_timestamp = GREATEST(EXCLUDED.last_trade_timestamp, ohclv_1d.last_trade_timestamp);
+END;
+$$;
+
+-- Repair the recent ranges immediately without turning the migration into a full-history scan.
+CALL update_ohclv_1m(NULL, NULL);
+CALL update_ohclv_1d(NULL, NULL);

--- a/crates/schema/migrations/2026-08-21-000000-0000_align_ohclv_refresh_windows/up.sql
+++ b/crates/schema/migrations/2026-08-21-000000-0000_align_ohclv_refresh_windows/up.sql
@@ -64,6 +64,10 @@ BEGIN
       AND f.checkpoint_timestamp_ms < end_timestamp
     ON CONFLICT (pool_id, bucket_time)
     DO UPDATE SET
+        open = CASE
+            WHEN EXCLUDED.first_trade_timestamp < ohclv_1m.first_trade_timestamp THEN EXCLUDED.open
+            ELSE ohclv_1m.open
+        END,
         high = EXCLUDED.high,
         low = EXCLUDED.low,
         close = EXCLUDED.close,
@@ -79,6 +83,10 @@ BEGIN
        );
 END;
 $$;
+
+-- Repair the recent ranges immediately without turning the migration into a full-history scan.
+CALL update_ohclv_1m(NULL, NULL);
+CALL update_ohclv_1d(NULL, NULL);
 
 CREATE OR REPLACE PROCEDURE update_ohclv_1d(
     start_timestamp BIGINT DEFAULT NULL,
@@ -146,6 +154,10 @@ BEGIN
       AND f.checkpoint_timestamp_ms < end_timestamp
     ON CONFLICT (pool_id, bucket_time)
     DO UPDATE SET
+        open = CASE
+            WHEN EXCLUDED.first_trade_timestamp < ohclv_1d.first_trade_timestamp THEN EXCLUDED.open
+            ELSE ohclv_1d.open
+        END,
         high = EXCLUDED.high,
         low = EXCLUDED.low,
         close = EXCLUDED.close,
@@ -161,7 +173,3 @@ BEGIN
        );
 END;
 $$;
-
--- Repair the recent ranges immediately without turning the migration into a full-history scan.
-CALL update_ohclv_1m(NULL, NULL);
-CALL update_ohclv_1d(NULL, NULL);

--- a/crates/server/tests/ohclv_materialization_tests.rs
+++ b/crates/server/tests/ohclv_materialization_tests.rs
@@ -6,10 +6,9 @@ use sui_pg_db::{Db, DbArgs};
 use url::Url;
 
 const POOL_ID: &str = "pool-1";
-// 2023-11-05 is a 25-hour day in America/Detroit.
-const DAY_START_MS: i64 = 1_699_156_800_000;
-const NEXT_DAY_START_MS: i64 = 1_699_246_800_000;
+const DAY_START_MS: i64 = 1_700_006_400_000;
 const MINUTE_MS: i64 = 60_000;
+const DAY_MS: i64 = 86_400_000;
 
 #[derive(Debug, PartialEq, QueryableByName)]
 struct CandleAggregate {
@@ -92,7 +91,7 @@ async fn insert_fill(db: &Db, tag: &str, timestamp_ms: i64, price: i64, volume: 
 
 async fn call_materializer(db: &Db, procedure: &str, start_ms: i64, end_ms: i64) {
     let mut conn = db.connect().await.unwrap();
-    diesel::sql_query("SET TIME ZONE 'America/Detroit'")
+    diesel::sql_query("SET TIME ZONE 'UTC'")
         .execute(&mut conn)
         .await
         .unwrap();
@@ -106,7 +105,7 @@ async fn corrupt_candle(db: &Db, table: &str, bucket_predicate: &str) {
     let mut conn = db.connect().await.unwrap();
     diesel::sql_query(format!(
         "UPDATE {table}
-         SET open = 99, high = 99, low = 1, close = 99,
+         SET open = 10, high = 99, low = 1, close = 99,
              base_volume = 99, quote_volume = 99, trade_count = 99,
              first_trade_timestamp = 1, last_trade_timestamp = 2
          WHERE pool_id = '{POOL_ID}' AND {bucket_predicate}"
@@ -191,6 +190,25 @@ async fn load_candle_count(db: &Db, table: &str) -> i64 {
     .count
 }
 
+async fn load_row_version(db: &Db, table: &str, bucket_predicate: &str) -> i64 {
+    #[derive(QueryableByName)]
+    struct Version {
+        #[diesel(sql_type = BigInt)]
+        version: i64,
+    }
+
+    let mut conn = db.connect().await.unwrap();
+    diesel::sql_query(format!(
+        "SELECT xmin::TEXT::BIGINT AS version
+         FROM {table}
+         WHERE pool_id = '{POOL_ID}' AND {bucket_predicate}"
+    ))
+    .get_result::<Version>(&mut conn)
+    .await
+    .unwrap()
+    .version
+}
+
 fn expected(first_ms: i64, last_ms: i64) -> CandleAggregate {
     CandleAggregate {
         open: 10.0,
@@ -231,7 +249,7 @@ async fn partial_minute_refresh_recomputes_the_complete_bucket() {
 
     call_materializer(&db, "update_ohclv_1m", DAY_START_MS, next_minute_ms - 1).await;
     let bucket_predicate = format!(
-        "bucket_time = date_trunc('minute', to_timestamp({DAY_START_MS}::DOUBLE PRECISION / 1000) AT TIME ZONE 'America/Detroit')"
+        "bucket_time = date_trunc('minute', to_timestamp({DAY_START_MS}::DOUBLE PRECISION / 1000) AT TIME ZONE 'UTC')"
     );
     corrupt_candle(&db, "ohclv_1m", &bucket_predicate).await;
     call_materializer(&db, "update_ohclv_1m", last_ms, last_ms).await;
@@ -250,14 +268,14 @@ async fn partial_daily_refresh_recomputes_the_complete_bucket() {
     let (_temp_db, db) = setup().await;
     let first_ms = DAY_START_MS + 5 * MINUTE_MS;
     let last_ms = DAY_START_MS + 23 * 60 * MINUTE_MS;
-    let next_day_ms = NEXT_DAY_START_MS;
+    let next_day_ms = DAY_START_MS + DAY_MS;
     insert_fill(&db, "day-first", first_ms, 10, 2).await;
     insert_fill(&db, "day-last", last_ms, 12, 3).await;
     insert_fill(&db, "day-boundary", next_day_ms, 20, 7).await;
 
     call_materializer(&db, "update_ohclv_1d", DAY_START_MS, next_day_ms - 1).await;
     let bucket_predicate = format!(
-        "bucket_time = (to_timestamp({DAY_START_MS}::DOUBLE PRECISION / 1000) AT TIME ZONE 'America/Detroit')::DATE"
+        "bucket_time = (to_timestamp({DAY_START_MS}::DOUBLE PRECISION / 1000) AT TIME ZONE 'UTC')::DATE"
     );
     corrupt_candle(&db, "ohclv_1d", &bucket_predicate).await;
     call_materializer(&db, "update_ohclv_1d", last_ms, last_ms).await;
@@ -281,10 +299,10 @@ async fn stale_refresh_does_not_replace_a_newer_materialization() {
     insert_fill(&db, "stale-last", snapshot_last_ms, 12, 3).await;
 
     let minute_predicate = format!(
-        "bucket_time = date_trunc('minute', to_timestamp({DAY_START_MS}::DOUBLE PRECISION / 1000) AT TIME ZONE 'America/Detroit')"
+        "bucket_time = date_trunc('minute', to_timestamp({DAY_START_MS}::DOUBLE PRECISION / 1000) AT TIME ZONE 'UTC')"
     );
     let daily_predicate = format!(
-        "bucket_time = (to_timestamp({DAY_START_MS}::DOUBLE PRECISION / 1000) AT TIME ZONE 'America/Detroit')::DATE"
+        "bucket_time = (to_timestamp({DAY_START_MS}::DOUBLE PRECISION / 1000) AT TIME ZONE 'UTC')::DATE"
     );
     call_materializer(&db, "update_ohclv_1m", first_ms, snapshot_last_ms).await;
     call_materializer(&db, "update_ohclv_1d", first_ms, snapshot_last_ms).await;
@@ -311,5 +329,47 @@ async fn stale_refresh_does_not_replace_a_newer_materialization() {
     assert_eq!(
         load_candle(&db, "ohclv_1d", &daily_predicate).await,
         expected_newer(first_ms, snapshot_last_ms)
+    );
+}
+
+#[tokio::test]
+async fn identical_snapshot_does_not_rewrite_a_candle() {
+    let (_temp_db, db) = setup().await;
+    let timestamp_ms = DAY_START_MS + 5_000;
+    insert_fill(&db, "same-time-first", timestamp_ms, 10, 2).await;
+    insert_fill(&db, "same-time-second", timestamp_ms, 12, 3).await;
+
+    let minute_predicate = format!(
+        "bucket_time = date_trunc('minute', to_timestamp({DAY_START_MS}::DOUBLE PRECISION / 1000) AT TIME ZONE 'UTC')"
+    );
+    let daily_predicate = format!(
+        "bucket_time = (to_timestamp({DAY_START_MS}::DOUBLE PRECISION / 1000) AT TIME ZONE 'UTC')::DATE"
+    );
+    call_materializer(&db, "update_ohclv_1m", timestamp_ms, timestamp_ms).await;
+    call_materializer(&db, "update_ohclv_1d", timestamp_ms, timestamp_ms).await;
+
+    let minute_before = load_candle(&db, "ohclv_1m", &minute_predicate).await;
+    let minute_version = load_row_version(&db, "ohclv_1m", &minute_predicate).await;
+    let daily_before = load_candle(&db, "ohclv_1d", &daily_predicate).await;
+    let daily_version = load_row_version(&db, "ohclv_1d", &daily_predicate).await;
+
+    call_materializer(&db, "update_ohclv_1m", timestamp_ms, timestamp_ms).await;
+    call_materializer(&db, "update_ohclv_1d", timestamp_ms, timestamp_ms).await;
+
+    assert_eq!(
+        load_candle(&db, "ohclv_1m", &minute_predicate).await,
+        minute_before
+    );
+    assert_eq!(
+        load_row_version(&db, "ohclv_1m", &minute_predicate).await,
+        minute_version
+    );
+    assert_eq!(
+        load_candle(&db, "ohclv_1d", &daily_predicate).await,
+        daily_before
+    );
+    assert_eq!(
+        load_row_version(&db, "ohclv_1d", &daily_predicate).await,
+        daily_version
     );
 }

--- a/crates/server/tests/ohclv_materialization_tests.rs
+++ b/crates/server/tests/ohclv_materialization_tests.rs
@@ -6,12 +6,21 @@ use sui_pg_db::{Db, DbArgs};
 use url::Url;
 
 const POOL_ID: &str = "pool-1";
-const DAY_START_MS: i64 = 1_700_006_400_000;
+// 2023-11-05 00:00:00 UTC crosses the America/Detroit daylight-saving transition.
+const DAY_START_MS: i64 = 1_699_142_400_000;
 const MINUTE_MS: i64 = 60_000;
 const DAY_MS: i64 = 86_400_000;
 
 #[derive(Debug, PartialEq, QueryableByName)]
 struct CandleAggregate {
+    #[diesel(sql_type = Double)]
+    open: f64,
+    #[diesel(sql_type = Double)]
+    high: f64,
+    #[diesel(sql_type = Double)]
+    low: f64,
+    #[diesel(sql_type = Double)]
+    close: f64,
     #[diesel(sql_type = Double)]
     base_volume: f64,
     #[diesel(sql_type = Double)]
@@ -83,16 +92,58 @@ async fn insert_fill(db: &Db, tag: &str, timestamp_ms: i64, price: i64, volume: 
 
 async fn call_materializer(db: &Db, procedure: &str, start_ms: i64, end_ms: i64) {
     let mut conn = db.connect().await.unwrap();
+    diesel::sql_query("SET TIME ZONE 'America/Detroit'")
+        .execute(&mut conn)
+        .await
+        .unwrap();
     diesel::sql_query(format!("CALL {procedure}({start_ms}, {end_ms})"))
         .execute(&mut conn)
         .await
         .unwrap();
 }
 
+async fn corrupt_candle(db: &Db, table: &str, bucket_predicate: &str) {
+    let mut conn = db.connect().await.unwrap();
+    diesel::sql_query(format!(
+        "UPDATE {table}
+         SET open = 99, high = 99, low = 1, close = 99,
+             base_volume = 99, quote_volume = 99, trade_count = 99,
+             first_trade_timestamp = 1, last_trade_timestamp = 2
+         WHERE pool_id = '{POOL_ID}' AND {bucket_predicate}"
+    ))
+    .execute(&mut conn)
+    .await
+    .unwrap();
+}
+
+async fn store_newer_candle(
+    db: &Db,
+    table: &str,
+    bucket_predicate: &str,
+    first_ms: i64,
+    last_ms: i64,
+) {
+    let mut conn = db.connect().await.unwrap();
+    diesel::sql_query(format!(
+        "UPDATE {table}
+         SET open = 10, high = 20, low = 10, close = 20,
+             base_volume = 12, quote_volume = 196, trade_count = 3,
+             first_trade_timestamp = {first_ms}, last_trade_timestamp = {last_ms}
+         WHERE pool_id = '{POOL_ID}' AND {bucket_predicate}"
+    ))
+    .execute(&mut conn)
+    .await
+    .unwrap();
+}
+
 async fn load_candle(db: &Db, table: &str, bucket_predicate: &str) -> CandleAggregate {
     let mut conn = db.connect().await.unwrap();
     diesel::sql_query(format!(
         "SELECT
+            open::DOUBLE PRECISION AS open,
+            high::DOUBLE PRECISION AS high,
+            low::DOUBLE PRECISION AS low,
+            close::DOUBLE PRECISION AS close,
             base_volume::DOUBLE PRECISION AS base_volume,
             quote_volume::DOUBLE PRECISION AS quote_volume,
             trade_count,
@@ -142,9 +193,27 @@ async fn load_candle_count(db: &Db, table: &str) -> i64 {
 
 fn expected(first_ms: i64, last_ms: i64) -> CandleAggregate {
     CandleAggregate {
+        open: 10.0,
+        high: 12.0,
+        low: 10.0,
+        close: 12.0,
         base_volume: 5.0,
         quote_volume: 56.0,
         trade_count: 2,
+        first_trade_timestamp: first_ms,
+        last_trade_timestamp: last_ms,
+    }
+}
+
+fn expected_newer(first_ms: i64, last_ms: i64) -> CandleAggregate {
+    CandleAggregate {
+        open: 10.0,
+        high: 20.0,
+        low: 10.0,
+        close: 20.0,
+        base_volume: 12.0,
+        quote_volume: 196.0,
+        trade_count: 3,
         first_trade_timestamp: first_ms,
         last_trade_timestamp: last_ms,
     }
@@ -161,15 +230,14 @@ async fn partial_minute_refresh_recomputes_the_complete_bucket() {
     insert_fill(&db, "minute-boundary", next_minute_ms, 20, 7).await;
 
     call_materializer(&db, "update_ohclv_1m", DAY_START_MS, next_minute_ms - 1).await;
+    let bucket_predicate = format!(
+        "bucket_time = date_trunc('minute', to_timestamp({DAY_START_MS}::DOUBLE PRECISION / 1000) AT TIME ZONE 'UTC')"
+    );
+    corrupt_candle(&db, "ohclv_1m", &bucket_predicate).await;
     call_materializer(&db, "update_ohclv_1m", last_ms, last_ms).await;
     call_materializer(&db, "update_ohclv_1m", last_ms, last_ms).await;
 
-    let first_bucket = load_candle(
-        &db,
-        "ohclv_1m",
-        &format!("bucket_time = to_timestamp({DAY_START_MS}::DOUBLE PRECISION / 1000)::TIMESTAMP"),
-    )
-    .await;
+    let first_bucket = load_candle(&db, "ohclv_1m", &bucket_predicate).await;
     assert_eq!(first_bucket, expected(first_ms, last_ms));
     assert_eq!(load_candle_count(&db, "ohclv_1m").await, 1);
 
@@ -188,18 +256,60 @@ async fn partial_daily_refresh_recomputes_the_complete_bucket() {
     insert_fill(&db, "day-boundary", next_day_ms, 20, 7).await;
 
     call_materializer(&db, "update_ohclv_1d", DAY_START_MS, next_day_ms - 1).await;
+    let bucket_predicate = format!(
+        "bucket_time = (to_timestamp({DAY_START_MS}::DOUBLE PRECISION / 1000) AT TIME ZONE 'UTC')::DATE"
+    );
+    corrupt_candle(&db, "ohclv_1d", &bucket_predicate).await;
     call_materializer(&db, "update_ohclv_1d", last_ms, last_ms).await;
     call_materializer(&db, "update_ohclv_1d", last_ms, last_ms).await;
 
-    let first_bucket = load_candle(
-        &db,
-        "ohclv_1d",
-        &format!("bucket_time = to_timestamp({DAY_START_MS}::DOUBLE PRECISION / 1000)::DATE"),
-    )
-    .await;
+    let first_bucket = load_candle(&db, "ohclv_1d", &bucket_predicate).await;
     assert_eq!(first_bucket, expected(first_ms, last_ms));
     assert_eq!(load_candle_count(&db, "ohclv_1d").await, 1);
 
     call_materializer(&db, "update_ohclv_1d", next_day_ms, next_day_ms).await;
     assert_eq!(load_total_trade_count(&db, "ohclv_1d").await, 3);
+}
+
+#[tokio::test]
+async fn stale_refresh_does_not_replace_a_newer_materialization() {
+    let (_temp_db, db) = setup().await;
+    let first_ms = DAY_START_MS + 5_000;
+    let snapshot_last_ms = DAY_START_MS + 50_000;
+    let stored_last_ms = DAY_START_MS + 55_000;
+    insert_fill(&db, "stale-first", first_ms, 10, 2).await;
+    insert_fill(&db, "stale-last", snapshot_last_ms, 12, 3).await;
+
+    let minute_predicate = format!(
+        "bucket_time = date_trunc('minute', to_timestamp({DAY_START_MS}::DOUBLE PRECISION / 1000) AT TIME ZONE 'UTC')"
+    );
+    let daily_predicate = format!(
+        "bucket_time = (to_timestamp({DAY_START_MS}::DOUBLE PRECISION / 1000) AT TIME ZONE 'UTC')::DATE"
+    );
+    call_materializer(&db, "update_ohclv_1m", first_ms, snapshot_last_ms).await;
+    call_materializer(&db, "update_ohclv_1d", first_ms, snapshot_last_ms).await;
+
+    // Represents a concurrent refresh that observed a later fill than this raw-fill snapshot.
+    store_newer_candle(&db, "ohclv_1m", &minute_predicate, first_ms, stored_last_ms).await;
+    store_newer_candle(
+        &db,
+        "ohclv_1d",
+        &daily_predicate,
+        first_ms,
+        snapshot_last_ms,
+    )
+    .await;
+
+    call_materializer(&db, "update_ohclv_1m", first_ms, snapshot_last_ms).await;
+    call_materializer(&db, "update_ohclv_1d", first_ms, snapshot_last_ms).await;
+
+    let expected = expected_newer(first_ms, stored_last_ms);
+    assert_eq!(
+        load_candle(&db, "ohclv_1m", &minute_predicate).await,
+        expected
+    );
+    assert_eq!(
+        load_candle(&db, "ohclv_1d", &daily_predicate).await,
+        expected_newer(first_ms, snapshot_last_ms)
+    );
 }

--- a/crates/server/tests/ohclv_materialization_tests.rs
+++ b/crates/server/tests/ohclv_materialization_tests.rs
@@ -6,10 +6,10 @@ use sui_pg_db::{Db, DbArgs};
 use url::Url;
 
 const POOL_ID: &str = "pool-1";
-// 2023-11-05 00:00:00 UTC crosses the America/Detroit daylight-saving transition.
-const DAY_START_MS: i64 = 1_699_142_400_000;
+// 2023-11-05 is a 25-hour day in America/Detroit.
+const DAY_START_MS: i64 = 1_699_156_800_000;
+const NEXT_DAY_START_MS: i64 = 1_699_246_800_000;
 const MINUTE_MS: i64 = 60_000;
-const DAY_MS: i64 = 86_400_000;
 
 #[derive(Debug, PartialEq, QueryableByName)]
 struct CandleAggregate {
@@ -231,7 +231,7 @@ async fn partial_minute_refresh_recomputes_the_complete_bucket() {
 
     call_materializer(&db, "update_ohclv_1m", DAY_START_MS, next_minute_ms - 1).await;
     let bucket_predicate = format!(
-        "bucket_time = date_trunc('minute', to_timestamp({DAY_START_MS}::DOUBLE PRECISION / 1000) AT TIME ZONE 'UTC')"
+        "bucket_time = date_trunc('minute', to_timestamp({DAY_START_MS}::DOUBLE PRECISION / 1000) AT TIME ZONE 'America/Detroit')"
     );
     corrupt_candle(&db, "ohclv_1m", &bucket_predicate).await;
     call_materializer(&db, "update_ohclv_1m", last_ms, last_ms).await;
@@ -250,14 +250,14 @@ async fn partial_daily_refresh_recomputes_the_complete_bucket() {
     let (_temp_db, db) = setup().await;
     let first_ms = DAY_START_MS + 5 * MINUTE_MS;
     let last_ms = DAY_START_MS + 23 * 60 * MINUTE_MS;
-    let next_day_ms = DAY_START_MS + DAY_MS;
+    let next_day_ms = NEXT_DAY_START_MS;
     insert_fill(&db, "day-first", first_ms, 10, 2).await;
     insert_fill(&db, "day-last", last_ms, 12, 3).await;
     insert_fill(&db, "day-boundary", next_day_ms, 20, 7).await;
 
     call_materializer(&db, "update_ohclv_1d", DAY_START_MS, next_day_ms - 1).await;
     let bucket_predicate = format!(
-        "bucket_time = (to_timestamp({DAY_START_MS}::DOUBLE PRECISION / 1000) AT TIME ZONE 'UTC')::DATE"
+        "bucket_time = (to_timestamp({DAY_START_MS}::DOUBLE PRECISION / 1000) AT TIME ZONE 'America/Detroit')::DATE"
     );
     corrupt_candle(&db, "ohclv_1d", &bucket_predicate).await;
     call_materializer(&db, "update_ohclv_1d", last_ms, last_ms).await;
@@ -281,10 +281,10 @@ async fn stale_refresh_does_not_replace_a_newer_materialization() {
     insert_fill(&db, "stale-last", snapshot_last_ms, 12, 3).await;
 
     let minute_predicate = format!(
-        "bucket_time = date_trunc('minute', to_timestamp({DAY_START_MS}::DOUBLE PRECISION / 1000) AT TIME ZONE 'UTC')"
+        "bucket_time = date_trunc('minute', to_timestamp({DAY_START_MS}::DOUBLE PRECISION / 1000) AT TIME ZONE 'America/Detroit')"
     );
     let daily_predicate = format!(
-        "bucket_time = (to_timestamp({DAY_START_MS}::DOUBLE PRECISION / 1000) AT TIME ZONE 'UTC')::DATE"
+        "bucket_time = (to_timestamp({DAY_START_MS}::DOUBLE PRECISION / 1000) AT TIME ZONE 'America/Detroit')::DATE"
     );
     call_materializer(&db, "update_ohclv_1m", first_ms, snapshot_last_ms).await;
     call_materializer(&db, "update_ohclv_1d", first_ms, snapshot_last_ms).await;

--- a/crates/server/tests/ohclv_materialization_tests.rs
+++ b/crates/server/tests/ohclv_materialization_tests.rs
@@ -373,3 +373,32 @@ async fn identical_snapshot_does_not_rewrite_a_candle() {
         daily_version
     );
 }
+
+#[tokio::test]
+async fn delayed_earlier_fill_replaces_the_opening_price() {
+    let (_temp_db, db) = setup().await;
+    let first_ms = DAY_START_MS + 5_000;
+    let last_ms = DAY_START_MS + 50_000;
+    insert_fill(&db, "late-arrival-later", last_ms, 12, 3).await;
+    call_materializer(&db, "update_ohclv_1m", last_ms, last_ms).await;
+    call_materializer(&db, "update_ohclv_1d", last_ms, last_ms).await;
+
+    insert_fill(&db, "late-arrival-earlier", first_ms, 10, 2).await;
+    call_materializer(&db, "update_ohclv_1m", first_ms, last_ms).await;
+    call_materializer(&db, "update_ohclv_1d", first_ms, last_ms).await;
+
+    let minute_predicate = format!(
+        "bucket_time = date_trunc('minute', to_timestamp({DAY_START_MS}::DOUBLE PRECISION / 1000) AT TIME ZONE 'UTC')"
+    );
+    let daily_predicate = format!(
+        "bucket_time = (to_timestamp({DAY_START_MS}::DOUBLE PRECISION / 1000) AT TIME ZONE 'UTC')::DATE"
+    );
+    assert_eq!(
+        load_candle(&db, "ohclv_1m", &minute_predicate).await,
+        expected(first_ms, last_ms)
+    );
+    assert_eq!(
+        load_candle(&db, "ohclv_1d", &daily_predicate).await,
+        expected(first_ms, last_ms)
+    );
+}

--- a/crates/server/tests/ohclv_materialization_tests.rs
+++ b/crates/server/tests/ohclv_materialization_tests.rs
@@ -1,0 +1,205 @@
+use diesel::sql_types::{BigInt, Double, Integer};
+use diesel::QueryableByName;
+use diesel_async::RunQueryDsl;
+use sui_pg_db::temp::TempDb;
+use sui_pg_db::{Db, DbArgs};
+use url::Url;
+
+const POOL_ID: &str = "pool-1";
+const DAY_START_MS: i64 = 1_700_006_400_000;
+const MINUTE_MS: i64 = 60_000;
+const DAY_MS: i64 = 86_400_000;
+
+#[derive(Debug, PartialEq, QueryableByName)]
+struct CandleAggregate {
+    #[diesel(sql_type = Double)]
+    base_volume: f64,
+    #[diesel(sql_type = Double)]
+    quote_volume: f64,
+    #[diesel(sql_type = Integer)]
+    trade_count: i32,
+    #[diesel(sql_type = BigInt)]
+    first_trade_timestamp: i64,
+    #[diesel(sql_type = BigInt)]
+    last_trade_timestamp: i64,
+}
+
+async fn setup() -> (TempDb, Db) {
+    let temp_db = TempDb::new().expect("postgres binaries must be on PATH");
+    let url: Url = temp_db.database().url().clone();
+    let db = Db::for_write(url, DbArgs::default()).await.unwrap();
+    db.run_migrations(Some(&deepbook_schema::MIGRATIONS))
+        .await
+        .unwrap();
+
+    let mut conn = db.connect().await.unwrap();
+    diesel::sql_query(
+        "INSERT INTO pools (
+            pool_id, pool_name,
+            base_asset_id, base_asset_decimals, base_asset_symbol, base_asset_name,
+            quote_asset_id, quote_asset_decimals, quote_asset_symbol, quote_asset_name,
+            min_size, lot_size, tick_size
+        ) VALUES (
+            'pool-1', 'BASE_USDC',
+            'base-coin', 9, 'BASE', 'Base Coin',
+            'quote-coin', 9, 'USDC', 'USD Coin',
+            1, 1, 1
+        )",
+    )
+    .execute(&mut conn)
+    .await
+    .unwrap();
+    drop(conn);
+
+    (temp_db, db)
+}
+
+async fn insert_fill(db: &Db, tag: &str, timestamp_ms: i64, price: i64, volume: i64) {
+    let mut conn = db.connect().await.unwrap();
+    diesel::sql_query(format!(
+        "INSERT INTO order_fills (
+            event_digest, digest, sender, checkpoint, checkpoint_timestamp_ms, package,
+            pool_id, maker_order_id, taker_order_id,
+            maker_client_order_id, taker_client_order_id,
+            price, taker_fee, taker_fee_is_deep, maker_fee, maker_fee_is_deep,
+            taker_is_bid, base_quantity, quote_quantity,
+            maker_balance_manager_id, taker_balance_manager_id, onchain_timestamp
+        ) VALUES (
+            'fill-{tag}', 'tx-{tag}', 'sender', 1, {timestamp_ms}, 'package',
+            '{POOL_ID}', 'maker-order-{tag}', 'taker-order-{tag}',
+            1, 2,
+            {price}, 0, false, 0, false,
+            false, {base_quantity}, {quote_quantity},
+            'maker-manager', 'taker-manager', {timestamp_ms}
+        )",
+        price = price * 1_000_000_000,
+        base_quantity = volume * 1_000_000_000,
+        quote_quantity = price * volume * 1_000_000_000,
+    ))
+    .execute(&mut conn)
+    .await
+    .unwrap();
+}
+
+async fn call_materializer(db: &Db, procedure: &str, start_ms: i64, end_ms: i64) {
+    let mut conn = db.connect().await.unwrap();
+    diesel::sql_query(format!("CALL {procedure}({start_ms}, {end_ms})"))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+}
+
+async fn load_candle(db: &Db, table: &str, bucket_predicate: &str) -> CandleAggregate {
+    let mut conn = db.connect().await.unwrap();
+    diesel::sql_query(format!(
+        "SELECT
+            base_volume::DOUBLE PRECISION AS base_volume,
+            quote_volume::DOUBLE PRECISION AS quote_volume,
+            trade_count,
+            first_trade_timestamp,
+            last_trade_timestamp
+         FROM {table}
+         WHERE pool_id = '{POOL_ID}' AND {bucket_predicate}"
+    ))
+    .get_result(&mut conn)
+    .await
+    .unwrap()
+}
+
+async fn load_total_trade_count(db: &Db, table: &str) -> i64 {
+    #[derive(QueryableByName)]
+    struct Count {
+        #[diesel(sql_type = BigInt)]
+        count: i64,
+    }
+
+    let mut conn = db.connect().await.unwrap();
+    diesel::sql_query(format!(
+        "SELECT SUM(trade_count)::BIGINT AS count FROM {table} WHERE pool_id = '{POOL_ID}'"
+    ))
+    .get_result::<Count>(&mut conn)
+    .await
+    .unwrap()
+    .count
+}
+
+async fn load_candle_count(db: &Db, table: &str) -> i64 {
+    #[derive(QueryableByName)]
+    struct Count {
+        #[diesel(sql_type = BigInt)]
+        count: i64,
+    }
+
+    let mut conn = db.connect().await.unwrap();
+    diesel::sql_query(format!(
+        "SELECT COUNT(*) AS count FROM {table} WHERE pool_id = '{POOL_ID}'"
+    ))
+    .get_result::<Count>(&mut conn)
+    .await
+    .unwrap()
+    .count
+}
+
+fn expected(first_ms: i64, last_ms: i64) -> CandleAggregate {
+    CandleAggregate {
+        base_volume: 5.0,
+        quote_volume: 56.0,
+        trade_count: 2,
+        first_trade_timestamp: first_ms,
+        last_trade_timestamp: last_ms,
+    }
+}
+
+#[tokio::test]
+async fn partial_minute_refresh_recomputes_the_complete_bucket() {
+    let (_temp_db, db) = setup().await;
+    let first_ms = DAY_START_MS + 5_000;
+    let last_ms = DAY_START_MS + 50_000;
+    let next_minute_ms = DAY_START_MS + MINUTE_MS;
+    insert_fill(&db, "minute-first", first_ms, 10, 2).await;
+    insert_fill(&db, "minute-last", last_ms, 12, 3).await;
+    insert_fill(&db, "minute-boundary", next_minute_ms, 20, 7).await;
+
+    call_materializer(&db, "update_ohclv_1m", DAY_START_MS, next_minute_ms - 1).await;
+    call_materializer(&db, "update_ohclv_1m", last_ms, last_ms).await;
+    call_materializer(&db, "update_ohclv_1m", last_ms, last_ms).await;
+
+    let first_bucket = load_candle(
+        &db,
+        "ohclv_1m",
+        &format!("bucket_time = to_timestamp({DAY_START_MS}::DOUBLE PRECISION / 1000)::TIMESTAMP"),
+    )
+    .await;
+    assert_eq!(first_bucket, expected(first_ms, last_ms));
+    assert_eq!(load_candle_count(&db, "ohclv_1m").await, 1);
+
+    call_materializer(&db, "update_ohclv_1m", next_minute_ms, next_minute_ms).await;
+    assert_eq!(load_total_trade_count(&db, "ohclv_1m").await, 3);
+}
+
+#[tokio::test]
+async fn partial_daily_refresh_recomputes_the_complete_bucket() {
+    let (_temp_db, db) = setup().await;
+    let first_ms = DAY_START_MS + 5 * MINUTE_MS;
+    let last_ms = DAY_START_MS + 23 * 60 * MINUTE_MS;
+    let next_day_ms = DAY_START_MS + DAY_MS;
+    insert_fill(&db, "day-first", first_ms, 10, 2).await;
+    insert_fill(&db, "day-last", last_ms, 12, 3).await;
+    insert_fill(&db, "day-boundary", next_day_ms, 20, 7).await;
+
+    call_materializer(&db, "update_ohclv_1d", DAY_START_MS, next_day_ms - 1).await;
+    call_materializer(&db, "update_ohclv_1d", last_ms, last_ms).await;
+    call_materializer(&db, "update_ohclv_1d", last_ms, last_ms).await;
+
+    let first_bucket = load_candle(
+        &db,
+        "ohclv_1d",
+        &format!("bucket_time = to_timestamp({DAY_START_MS}::DOUBLE PRECISION / 1000)::DATE"),
+    )
+    .await;
+    assert_eq!(first_bucket, expected(first_ms, last_ms));
+    assert_eq!(load_candle_count(&db, "ohclv_1d").await, 1);
+
+    call_materializer(&db, "update_ohclv_1d", next_day_ms, next_day_ms).await;
+    assert_eq!(load_total_trade_count(&db, "ohclv_1d").await, 3);
+}

--- a/crates/server/tests/ohclv_materialization_tests.rs
+++ b/crates/server/tests/ohclv_materialization_tests.rs
@@ -133,6 +133,18 @@ async fn store_legacy_open(db: &Db, table: &str, bucket_predicate: &str, open: i
     .unwrap();
 }
 
+async fn store_legacy_close(db: &Db, table: &str, bucket_predicate: &str, close: i64) {
+    let mut conn = db.connect().await.unwrap();
+    diesel::sql_query(format!(
+        "UPDATE {table}
+         SET close = {close}
+         WHERE pool_id = '{POOL_ID}' AND {bucket_predicate}"
+    ))
+    .execute(&mut conn)
+    .await
+    .unwrap();
+}
+
 async fn store_newer_candle(
     db: &Db,
     table: &str,
@@ -450,6 +462,63 @@ async fn complete_snapshot_repairs_a_legacy_inconsistent_open() {
     assert_eq!(
         load_candle(&db, "ohclv_1d", &daily_predicate).await,
         expected(first_ms, last_ms)
+    );
+}
+
+#[tokio::test]
+async fn complete_snapshot_repairs_a_legacy_tied_close_once() {
+    let (_temp_db, db) = setup().await;
+    let first_ms = DAY_START_MS + 5_000;
+    let last_ms = DAY_START_MS + 50_000;
+    insert_fill(&db, "legacy-close-first", first_ms, 10, 2).await;
+    insert_fill(&db, "legacy-close-latest-a", last_ms, 11, 1).await;
+    insert_fill(&db, "legacy-close-latest-b", last_ms, 12, 2).await;
+    call_materializer(&db, "update_ohclv_1m", first_ms, last_ms).await;
+    call_materializer(&db, "update_ohclv_1d", first_ms, last_ms).await;
+
+    let minute_predicate = format!(
+        "bucket_time = date_trunc('minute', to_timestamp({DAY_START_MS}::DOUBLE PRECISION / 1000) AT TIME ZONE 'UTC')"
+    );
+    let daily_predicate = format!(
+        "bucket_time = (to_timestamp({DAY_START_MS}::DOUBLE PRECISION / 1000) AT TIME ZONE 'UTC')::DATE"
+    );
+    store_legacy_close(&db, "ohclv_1m", &minute_predicate, 11).await;
+    store_legacy_close(&db, "ohclv_1d", &daily_predicate, 11).await;
+
+    call_materializer(&db, "update_ohclv_1m", first_ms, last_ms).await;
+    call_materializer(&db, "update_ohclv_1d", first_ms, last_ms).await;
+
+    let expected = CandleAggregate {
+        open: 10.0,
+        high: 12.0,
+        low: 10.0,
+        close: 12.0,
+        base_volume: 5.0,
+        quote_volume: 55.0,
+        trade_count: 3,
+        first_trade_timestamp: first_ms,
+        last_trade_timestamp: last_ms,
+    };
+    assert_eq!(
+        load_candle(&db, "ohclv_1m", &minute_predicate).await,
+        expected
+    );
+    assert_eq!(
+        load_candle(&db, "ohclv_1d", &daily_predicate).await,
+        expected
+    );
+    let minute_version = load_row_version(&db, "ohclv_1m", &minute_predicate).await;
+    let daily_version = load_row_version(&db, "ohclv_1d", &daily_predicate).await;
+
+    call_materializer(&db, "update_ohclv_1m", first_ms, last_ms).await;
+    call_materializer(&db, "update_ohclv_1d", first_ms, last_ms).await;
+    assert_eq!(
+        load_row_version(&db, "ohclv_1m", &minute_predicate).await,
+        minute_version
+    );
+    assert_eq!(
+        load_row_version(&db, "ohclv_1d", &daily_predicate).await,
+        daily_version
     );
 }
 

--- a/crates/server/tests/ohclv_materialization_tests.rs
+++ b/crates/server/tests/ohclv_materialization_tests.rs
@@ -1,11 +1,17 @@
 use diesel::sql_types::{BigInt, Double, Integer};
 use diesel::QueryableByName;
-use diesel_async::RunQueryDsl;
+use diesel_async::{RunQueryDsl, SimpleAsyncConnection};
 use sui_pg_db::temp::TempDb;
 use sui_pg_db::{Db, DbArgs};
 use url::Url;
 
 const POOL_ID: &str = "pool-1";
+const PREVIOUS_OHLCV_MIGRATION: &str = include_str!(
+    "../../schema/migrations/2025-10-13-194059-0000_fix_ohclv_price_calculation/up.sql"
+);
+const CURRENT_OHLCV_MIGRATION: &str = include_str!(
+    "../../schema/migrations/2026-08-21-000000-0000_align_ohclv_refresh_windows/up.sql"
+);
 const DAY_START_MS: i64 = 1_700_006_400_000;
 const MINUTE_MS: i64 = 60_000;
 const DAY_MS: i64 = 86_400_000;
@@ -108,6 +114,18 @@ async fn corrupt_candle(db: &Db, table: &str, bucket_predicate: &str) {
          SET open = 10, high = 99, low = 1, close = 99,
              base_volume = 99, quote_volume = 99, trade_count = 99,
              first_trade_timestamp = 1, last_trade_timestamp = 2
+         WHERE pool_id = '{POOL_ID}' AND {bucket_predicate}"
+    ))
+    .execute(&mut conn)
+    .await
+    .unwrap();
+}
+
+async fn store_legacy_open(db: &Db, table: &str, bucket_predicate: &str, open: i64) {
+    let mut conn = db.connect().await.unwrap();
+    diesel::sql_query(format!(
+        "UPDATE {table}
+         SET open = {open}
          WHERE pool_id = '{POOL_ID}' AND {bucket_predicate}"
     ))
     .execute(&mut conn)
@@ -396,6 +414,82 @@ async fn delayed_earlier_fill_replaces_the_opening_price() {
     assert_eq!(
         load_candle(&db, "ohclv_1m", &minute_predicate).await,
         expected(first_ms, last_ms)
+    );
+    assert_eq!(
+        load_candle(&db, "ohclv_1d", &daily_predicate).await,
+        expected(first_ms, last_ms)
+    );
+}
+
+#[tokio::test]
+async fn complete_snapshot_repairs_a_legacy_inconsistent_open() {
+    let (_temp_db, db) = setup().await;
+    let first_ms = DAY_START_MS + 5_000;
+    let last_ms = DAY_START_MS + 50_000;
+    insert_fill(&db, "legacy-open-first", first_ms, 10, 2).await;
+    insert_fill(&db, "legacy-open-last", last_ms, 12, 3).await;
+    call_materializer(&db, "update_ohclv_1m", first_ms, last_ms).await;
+    call_materializer(&db, "update_ohclv_1d", first_ms, last_ms).await;
+
+    let minute_predicate = format!(
+        "bucket_time = date_trunc('minute', to_timestamp({DAY_START_MS}::DOUBLE PRECISION / 1000) AT TIME ZONE 'UTC')"
+    );
+    let daily_predicate = format!(
+        "bucket_time = (to_timestamp({DAY_START_MS}::DOUBLE PRECISION / 1000) AT TIME ZONE 'UTC')::DATE"
+    );
+    store_legacy_open(&db, "ohclv_1m", &minute_predicate, 12).await;
+    store_legacy_open(&db, "ohclv_1d", &daily_predicate, 12).await;
+
+    call_materializer(&db, "update_ohclv_1m", first_ms, last_ms).await;
+    call_materializer(&db, "update_ohclv_1d", first_ms, last_ms).await;
+
+    assert_eq!(
+        load_candle(&db, "ohclv_1m", &minute_predicate).await,
+        expected(first_ms, last_ms)
+    );
+    assert_eq!(
+        load_candle(&db, "ohclv_1d", &daily_predicate).await,
+        expected(first_ms, last_ms)
+    );
+}
+
+#[tokio::test]
+async fn migration_repairs_the_oldest_day_in_its_default_range() {
+    let (_temp_db, db) = setup().await;
+    let mut migration_conn = db.connect().await.unwrap();
+    migration_conn
+        .batch_execute("SET TIME ZONE 'UTC'")
+        .await
+        .unwrap();
+    migration_conn
+        .batch_execute(PREVIOUS_OHLCV_MIGRATION)
+        .await
+        .unwrap();
+
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as i64;
+    let day_start_ms = (now_ms / DAY_MS - 7) * DAY_MS;
+    let first_ms = day_start_ms;
+    let last_ms = day_start_ms + DAY_MS - 1;
+    insert_fill(&db, "upgrade-edge-first", first_ms, 10, 2).await;
+    insert_fill(&db, "upgrade-edge-last", last_ms, 12, 3).await;
+    call_materializer(
+        &db,
+        "update_ohclv_1d",
+        day_start_ms,
+        day_start_ms + DAY_MS - 1,
+    )
+    .await;
+
+    migration_conn
+        .batch_execute(CURRENT_OHLCV_MIGRATION)
+        .await
+        .unwrap();
+
+    let daily_predicate = format!(
+        "bucket_time = (to_timestamp({day_start_ms}::DOUBLE PRECISION / 1000) AT TIME ZONE 'UTC')::DATE"
     );
     assert_eq!(
         load_candle(&db, "ohclv_1d", &daily_predicate).await,


### PR DESCRIPTION
## Summary

- Recompute every selected 1-minute and 1-day candle from the complete UTC raw-fill bucket before replacing its refreshable aggregate fields.
- Prevent an older or identical overlapping refresh snapshot from rewriting a materialization that has already reached the same or a later set of fills.
- Repair the recent 24-hour minute range and 7-day daily range during migration without changing cron schedules, tables, stored key representation, or the HTTP response shape.

## Why

The OHLCV tables materialize order fills for candlestick consumers. A recent refresh can request a range that begins inside a minute or day; the existing upsert then replaces volume and trade count with only that partial slice, shrinking a candle that was previously complete. Daily and weekly consumers consequently receive incorrect historical volume until a later full refresh happens to repair the row.

## Linear / Context

- https://linear.app/mysten-labs/issue/DBU-747/prevent-partial-ohlcv-refreshes-from-shrinking-candle-volume

## Key decisions

- Keep the current cron cadence and upsert model, but define procedure arguments as bucket selectors: align the start down, align the end past the selected bucket, and read fills with a half-open boundary.
- Make the existing UTC session requirement explicit. The candle keys do not store a timezone, so writers and readers must agree on UTC.
- Order `open` and `close` by checkpoint timestamp and then by the fill's stable unique event digest. This makes tied timestamps deterministic, lets complete snapshots repair legacy endpoint-price mismatches, and keeps identical canonical snapshots as database no-ops.
- Replace high, low, close, volumes, count, and timestamp watermarks only when the raw snapshot has a later last-fill timestamp or more fills at the same last-fill timestamp. An identical snapshot performs no database update.
- Keep the migration repair bounded to the procedures' existing defaults; the existing weekly full refresh remains responsible for older history.

## Scope / Descoped

- This changes only the raw-fill ranges and conflict replacement used by `update_ohclv_1m` and `update_ohclv_1d`, plus their operational documentation and tests.
- It does not change endpoint range semantics, live-candle overlay behavior, cron schedules, stored schemas, or candle-key representation.
- It does not redesign the growing weekly full-history refresh or add a new event-order column; the existing unique event digest only resolves otherwise indistinguishable timestamp ties.

## Test plan

- [x] `cargo test -p deepbook-server --test ohclv_materialization_tests` — complete minute and daily aggregates survive partial and repeated refreshes, exact boundaries remain half-open, stale snapshots cannot regress newer rows, identical canonical snapshots do not physically rewrite a candle, delayed earlier fills and legacy open/close mismatches heal, and a predecessor-to-head upgrade repairs the oldest day in the default range.
- [x] `cargo test -p deepbook-server` — all server unit and PostgreSQL integration tests pass.
- [x] `cargo build -p deepbook-server` — the server and embedded migrations compile.
- [x] `cargo fmt -p deepbook-server -- --check` — Rust coverage is formatted.
- [x] Read-only representative `EXPLAIN ANALYZE` checks — both bounded refresh shapes retain the existing timestamp index and complete within their cron cadence.

## Risk / Rollout

The migration replaces both procedures and refreshes their default recent windows: 24 hours for minute candles and 7 days for daily candles. A procedure execution already running at commit can finish with the previous definition and temporarily overwrite part of that repair; the first subsequent minute or hourly execution uses the new definition and restores its scheduled range, or operators can call both procedures once after migration commit to establish the boundary immediately. Aligning to complete buckets adds at most one minute to a minute refresh and up to two partial days around a daily refresh, so work remains proportional to fills in a bounded time range. The stale-snapshot guard relies on `order_fills` remaining append-only; a future destructive raw-fill correction would need an explicit repair path. The migration is intentionally irreversible because restoring the previous procedures would resume partial aggregate corruption; recover by rolling forward with corrected procedure definitions.
