### PR TITLE
predict: add the entropic inventory statistic (DBU-732)

### DIFF
--- a/packages/predict/sources/strike_exposure/inventory_entropic.move
+++ b/packages/predict/sources/strike_exposure/inventory_entropic.move
@@ -1,0 +1,123 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// The entropic inventory statistic: how much more than its fair value the pool's
+/// payout book is worth to a risk-averse holder of it.
+///
+/// `W(S)` is what the pool owes if the market settles at tick `S`, and `q` is the
+/// risk-neutral probability of settling there, frozen when the market is created.
+/// The book's certainty-equivalent cost under exponential utility is
+///
+/// ```text
+/// C(W) = b * ln( sum_S q(S) * exp(W(S)/b) )
+/// ```
+///
+/// and the statistic is that cost less the book's fair value:
+///
+/// ```text
+/// D(W) = C(W) - sum_S q(S) * W(S)
+/// ```
+///
+/// `D` is zero when the pool owes the same at every price and grows with how
+/// unevenly the book is distributed, weighted by where settlement is actually
+/// likely. `b` is the risk tolerance: large `b` approaches `Var(W)/(2b)` and small
+/// `b` approaches the worst case.
+///
+/// Two properties this shape has that a standard deviation does not. Adding a
+/// constant everywhere raises `C` and the fair value by the same amount, so `D` is
+/// unchanged — buying every outcome costs nothing, exactly. And because the total
+/// a trade pays is `(1 - rate) * fair value + rate * C`, a convex combination of
+/// two monotone functions, no rate in `[0, 1]` can price a strictly worse book
+/// lower; the mean-plus-deviation form admits no such rate on a fine ladder.
+///
+/// This module owns only the arithmetic. The accumulators are maintained by
+/// `strike_exposure`, and the range reads they need come from the payout index.
+module deepbook_predict::inventory_entropic;
+
+use fixed_math::{i64, math};
+
+/// `exp` cannot return a value that leaves `u64`, so the exponent is bounded well
+/// inside its input ceiling. `b` is derived from the market's allocation to keep
+/// `W/b` under this by construction rather than by hoping.
+const MAX_EXPONENT_SCALED: u64 = 10_000_000_000;
+
+const EExponentOutOfRange: u64 = 0;
+const EInvalidRiskTolerance: u64 = 1;
+
+/// Running totals over the settlement ladder, both weighted by the frozen
+/// probability of each run. `expo` is `sum q * exp(W/b)` and `mean` is
+/// `sum q * W`; an empty book carries `expo = 1` and `mean = 0`.
+public struct EntropicTerms has copy, drop, store {
+    expo: u128,
+    mean: u128,
+}
+
+public(package) fun zero_terms(): EntropicTerms {
+    EntropicTerms { expo: (math::float_scaling!() as u128), mean: 0 }
+}
+
+public(package) fun expo(terms: &EntropicTerms): u128 { terms.expo }
+
+public(package) fun mean(terms: &EntropicTerms): u128 { terms.mean }
+
+public(package) fun new_terms(expo: u128, mean: u128): EntropicTerms {
+    EntropicTerms { expo, mean }
+}
+
+/// `D(W)`, in payout units. Zero for a book that owes the same everywhere.
+public(package) fun deviation(terms: &EntropicTerms, risk_tolerance: u64): u64 {
+    assert!(risk_tolerance > 0, EInvalidRiskTolerance);
+    // `exp(W/b) >= 1` for every non-negative payout, so `expo >= 1` and the
+    // logarithm is non-negative.
+    let ln_expo = math::ln((terms.expo as u64));
+    let certainty_equivalent = math::mul_down(risk_tolerance, ln_expo.magnitude());
+    // Jensen puts the certainty equivalent at or above the fair value, so the true
+    // difference is never negative — but both terms are floored independently, and
+    // on a book that owes the same everywhere they are the same number, where the
+    // flooring can leave the logarithm a unit short. Clamping rather than aborting
+    // is the policy: the exact answer there is zero, and the clamp can only bind
+    // within the rounding error of a book that carries no unevenness at all.
+    certainty_equivalent.saturating_sub((terms.mean as u64))
+}
+
+/// Fold one range change into the totals.
+///
+/// Adding `payout` across a range multiplies that range's share of `expo` by
+/// `exp(payout/b)` and leaves the rest untouched, which is why the read the caller
+/// supplies is the range's own `sum q * exp(W/b)` rather than anything about the
+/// whole book. `range_mass` is the range's frozen probability.
+public(package) fun fold(
+    terms: &EntropicTerms,
+    range_expo: u128,
+    range_mass: u64,
+    payout: u64,
+    risk_tolerance: u64,
+    adding: bool,
+): EntropicTerms {
+    assert!(risk_tolerance > 0, EInvalidRiskTolerance);
+    if (payout == 0 || range_mass == 0) return *terms;
+
+    let exponent = math::div_down(payout, risk_tolerance);
+    assert!(exponent <= MAX_EXPONENT_SCALED, EExponentOutOfRange);
+    let scale = (math::float_scaling!() as u128);
+
+    if (adding) {
+        let multiplier = (math::exp(&i64::from_u64(exponent)) as u128);
+        // `expo + range_expo * (multiplier - 1)`, with the subtraction taken on the
+        // scaled multiplier so no intermediate leaves `u128`.
+        let lifted = range_expo * multiplier / scale;
+        EntropicTerms {
+            expo: terms.expo + lifted - range_expo,
+            mean: terms.mean + ((math::mul_down(range_mass, payout)) as u128),
+        }
+    } else {
+        let multiplier = (math::exp(&i64::from_parts(exponent, true)) as u128);
+        // Removing shrinks the same share, so the range's post-trade contribution
+        // is what scales down; the result is exact for a book that carries it.
+        let lowered = range_expo * multiplier / scale;
+        EntropicTerms {
+            expo: terms.expo + lowered - range_expo,
+            mean: terms.mean - ((math::mul_down(range_mass, payout)) as u128),
+        }
+    }
+}

--- a/packages/predict/tests/strike_exposure/inventory_entropic_tests.move
+++ b/packages/predict/tests/strike_exposure/inventory_entropic_tests.move
@@ -1,0 +1,93 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Unit coverage for the entropic inventory statistic. Expected values are
+/// derived from the definition by hand or in Python against `math.log`/`math.exp`,
+/// never from the contract.
+#[test_only]
+module deepbook_predict::inventory_entropic_tests;
+
+use deepbook_predict::inventory_entropic as entropic;
+use std::unit_test::assert_eq;
+
+/// One unit at the fixed-point scale, used as both the risk tolerance and the
+/// trade size so the exponent is exactly 1 and `e` appears undivided.
+const ONE: u64 = 1_000_000_000;
+/// The whole settlement ladder's probability, and half of it.
+const ALL_MASS: u64 = 1_000_000_000;
+const HALF_MASS: u64 = 500_000_000;
+/// `b*ln(0.5*(1+e)) - 0.5` at the fixed-point scale, computed independently.
+const HALF_COVERED_DEVIATION: u64 = 120_114_506;
+/// `exp` and `ln` are fixed-point approximations whose precision this repository
+/// does not document, so this case is asserted within a bound rather than exactly.
+/// The bound is granularity-derived, not fitted: the exponential carries at most a
+/// few units of error at the fixed-point scale, the logarithm turns that into a
+/// comparable absolute error, and the risk tolerance scales it by one. Every
+/// mathematically exact property of the statistic is pinned by the other tests
+/// here, which assert zero.
+const APPROXIMATION_BOUND: u64 = 32;
+
+#[test]
+fun an_empty_book_owes_the_same_everywhere_and_scores_zero() {
+    assert_eq!(entropic::zero_terms().deviation(ONE), 0);
+}
+
+/// The property the whole design rests on: a payout added at every settlement
+/// price raises the fair value and the certainty equivalent by the same amount, so
+/// buying every outcome is free. Exact, not approximate.
+#[test]
+fun adding_the_same_payout_everywhere_leaves_the_statistic_at_zero() {
+    let terms = entropic::zero_terms();
+    let full_ladder = terms.expo();
+
+    let after = terms.fold(full_ladder, ALL_MASS, ONE, ONE, true);
+
+    assert_eq!(after.deviation(ONE), 0);
+    // The fair value moved by the whole payout even though the statistic did not.
+    assert_eq!(after.mean(), (ONE as u128));
+}
+
+/// A book that owes on half the probability and nothing on the other half.
+/// `expo = 0.5*(1 + e)`, `mean = 0.5`, and the statistic is the gap between the
+/// certainty equivalent and the fair value.
+#[test]
+fun a_half_covered_book_carries_the_gap_between_cost_and_value() {
+    let terms = entropic::zero_terms();
+    let half_ladder = (HALF_MASS as u128);
+
+    let after = terms.fold(half_ladder, HALF_MASS, ONE, ONE, true);
+
+    assert_eq!(after.mean(), (HALF_MASS as u128));
+    let deviation = after.deviation(ONE);
+    assert!(deviation <= HALF_COVERED_DEVIATION);
+    assert!(HALF_COVERED_DEVIATION - deviation <= APPROXIMATION_BOUND);
+}
+
+/// Opening and closing the same range returns the totals, so a round trip collects
+/// nothing. This is what makes the charge refundable.
+#[test]
+fun a_range_opened_and_closed_returns_the_totals() {
+    let terms = entropic::zero_terms();
+    let half_ladder = (HALF_MASS as u128);
+
+    let opened = terms.fold(half_ladder, HALF_MASS, ONE, ONE, true);
+    // The close reads the range's post-trade share, which is what it now carries.
+    let range_after = opened.expo() - ((ALL_MASS - HALF_MASS) as u128);
+    let closed = opened.fold(range_after, HALF_MASS, ONE, ONE, false);
+
+    assert_eq!(closed.mean(), 0);
+    assert_eq!(closed.deviation(ONE), 0);
+}
+
+#[test, expected_failure(abort_code = entropic::EExponentOutOfRange)]
+fun a_payout_far_beyond_the_risk_tolerance_aborts() {
+    let terms = entropic::zero_terms();
+    terms.fold((ALL_MASS as u128), ALL_MASS, 11 * ONE, ONE, true);
+    abort 999
+}
+
+#[test, expected_failure(abort_code = entropic::EInvalidRiskTolerance)]
+fun a_zero_risk_tolerance_aborts() {
+    entropic::zero_terms().deviation(0);
+    abort 999
+}


### PR DESCRIPTION
## Summary

- Adds `inventory_entropic`, the arithmetic for an inventory charge on the certainty-equivalent cost of the pool's payout book, weighted by where settlement is actually likely.
- **Nothing calls it.** The module owns the statistic and its incremental fold; the accumulators and the range reads they need are a separate change.
- Draft: this is the first of two, and it is opened now so the shape can be argued about before the index work is done.

```text
D(W) = b * ln( sum q(S) * exp(W(S)/b) )  -  sum q(S) * W(S)
```

`W(S)` is what the pool owes if the market settles at tick `S`; `q` is the risk-neutral probability of settling there, frozen at market creation; `b` is the risk tolerance. `D` is zero when the pool owes the same at every price and grows with how unevenly the book sits, weighted by likelihood.

## Why this shape

Two properties the mean-plus-standard-deviation form cannot have.

**Buying every outcome is free, exactly.** Adding a payout at every settlement price raises the certainty equivalent and the fair value by the same amount, so the difference is unchanged. Asserted as an equality, not within a tolerance.

**No rate can misprice a strictly worse book.** A trade's total is `(1 - rate) * fair value + rate * certainty equivalent`, a convex combination of two monotone functions, so it is monotone for any rate in `[0, 1]` with no dependence on the ladder. The deviation form admits no such rate once the ladder is fine: its monotonicity bound is `rate <= sqrt(q_min / (1 - q_min))`, set by the *smallest* bucket, which collapses toward zero as the ladder refines. Standard deviation is also positively homogeneous, so worst-case loss is unbounded; here it is bounded by `b * ln(1/q_min)`.

The large-`b` limit of this statistic is the probability-weighted variance over `2b`, so the deviation form is its leading term. The square root is what buys positive homogeneity, and positive homogeneity is what forfeits the bound.

## Key decisions

- **The fold is multiplicative, not additive.** Adding a payout across a range multiplies that range's share of the exponential total by `exp(payout/b)` and leaves the rest alone, so the read a trade needs is the range's own share rather than anything about the whole book.
- **The exponent is bounded well inside `exp`'s input ceiling.** `exp` cannot return a value outside `u64` and aborts rather than wrapping. Deriving `b` from the market's allocation keeps `W/b` inside the bound by construction; that wiring is owed by the next change and the module asserts the bound in the meantime.
- **The statistic clamps at zero rather than aborting.** Jensen puts the true difference at or above zero, but both terms are floored independently, and on a book that owes the same everywhere they are the same number — the flooring can leave the logarithm a unit short. The clamp can only bind within the rounding error of a book carrying no unevenness at all.
- **Probability weights are frozen at creation.** A moving weight would score the two legs of a round trip against different measures and the refund would stop being exact.

## Scope / Descoped

- In scope: the statistic, the fold, and unit coverage.
- **Descoped, and owed by the follow-up:** the accumulators on `StrikeExposure`, the range read from the payout index (a multiplicative monoid over boundaries, not the additive one that exists), the frozen surface snapshot at market creation, the config knob deriving `b` from the allocation, and the charge wiring into mint and close.
- Not decided here: whether a trade that flattens the book is paid, and what rate this would run at. It ships unreachable either way.

## Test plan

- [x] `sui move test --path packages/predict --gas-limit 100000000000` — **492 pass**, no `Move.lock` drift.
- [x] `sui move build --path packages/predict --warnings-are-errors` — clean.
- [x] `adding_the_same_payout_everywhere_leaves_the_statistic_at_zero` — the property the design rests on, asserted exactly.
- [x] `a_range_opened_and_closed_returns_the_totals` — a round trip returns both accumulators, so it collects nothing.
- [x] `an_empty_book_owes_the_same_everywhere_and_scores_zero`.
- [x] `a_half_covered_book_carries_the_gap_between_cost_and_value` — expected value derived independently from `math.log`/`math.exp`. Asserted within a granularity-derived bound rather than exactly, because this repository does not document the precision of its fixed-point `exp` and `ln`; every mathematically exact property is pinned by the tests above.
- [x] Both abort codes covered.

## Risk / Rollout

Unreachable — no caller. The module is inert until the follow-up wires it, and any charge it eventually feeds would ship at a zero rate like the two mechanisms already open.

An empirical comparison of this statistic against the two open designs, on real BTC price paths, is in progress and will be posted here. If it does not beat them this branch should be closed rather than continued.