### PR TITLE
margin: retire the legacy Pyth entrypoints (DBU-756)

### DIFF
--- a/.github/scripts/check_upgraded_parity.py
+++ b/.github/scripts/check_upgraded_parity.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
 """Fails if a legacy Pyth entrypoint and its upgraded twin drift apart.
 
-The legacy and upgraded surfaces have to be edited together, forever: the legacy
-one takes `pyth::price_info::PriceInfoObject`, the upgraded one Pyth's upgraded
-Core type, and both delegate to the same shared logic. Nothing in the compiler
-ties them together, so adding a parameter to one and not the other compiles clean
-and ships a surface that silently disagrees with itself.
+The legacy surface is retired — every legacy entry's body is now
+`abort EDeprecatedUseUpgradedPyth` — but its *signatures* are frozen forever by Sui's
+`compatible` upgrade policy, and each one still has to match the upgraded entry that
+replaced it. The legacy one takes `pyth::price_info::PriceInfoObject`, the upgraded one
+Pyth's upgraded Core type. Nothing in the compiler ties them together, so adding a
+parameter to one and not the other compiles clean and ships a surface that silently
+disagrees with itself: an integrator reading the retired entry's abort message is sent
+to a twin whose arguments no longer line up.
 
 The check is driven from the LEGACY side on purpose. An earlier version walked
 the `*_upgraded.move` glob, which meant renaming or deleting an upgraded file
@@ -63,6 +66,10 @@ def params(src: str, name: str) -> str | None:
                 break
         j += 1
     text = src[i + 1:j].replace('PriceInfoObjectUpgraded', 'PriceInfoObject')
+    # A leading `_` marks a parameter the body does not read — which is every parameter
+    # of a retired entry — and is not part of the frozen signature. Strip it so the
+    # comparison stays on types and order.
+    text = re.sub(r'(^\s*|[(,]\s*)_(\w+\s*:)', r'\1\2', text)
     return re.sub(r'\s+', ' ', text).strip()
 
 

--- a/packages/deepbook_margin/sources/helper/margin_constants.move
+++ b/packages/deepbook_margin/sources/helper/margin_constants.move
@@ -6,7 +6,12 @@ module deepbook_margin::margin_constants;
 // Bump ahead of EVERY on-chain package upgrade. After the upgrade the admin must
 // also call `enable_version(N)` on the live `MarginRegistry` (and later
 // `disable_version(N-1)`), or all entries abort `EPackageVersionDisabled`.
-const MARGIN_VERSION: u64 = 7;
+//
+// v8 retires the legacy-Pyth entrypoints: they abort `EDeprecatedUseUpgradedPyth`
+// rather than pricing off legacy Core. `disable_version(7)` is what actually takes
+// them off chain — a dependent published against v7 keeps calling v7's bodies
+// through its own linkage table until that version stops being allowed.
+const MARGIN_VERSION: u64 = 8;
 const MAX_RISK_RATIO: u64 = 1_000 * 1_000_000_000; // Risk ratio above 1000 will be considered as 1000
 const DEFAULT_USER_LIQUIDATION_REWARD: u64 = 10_000_000; // 1%
 const DEFAULT_POOL_LIQUIDATION_REWARD: u64 = 40_000_000; // 4%

--- a/packages/deepbook_margin/sources/helper/oracle.move
+++ b/packages/deepbook_margin/sources/helper/oracle.move
@@ -6,7 +6,6 @@ module deepbook_margin::oracle;
 
 use deepbook::{constants, math};
 use deepbook_margin::{margin_constants, margin_registry::MarginRegistry};
-use pyth::{price_info::PriceInfoObject, pyth};
 use pyth_upgraded::{
     price_info::PriceInfoObject as PriceInfoObjectUpgraded,
     pyth as pyth_upgraded_api
@@ -49,11 +48,11 @@ public struct ConversionConfig has copy, drop {
     pyth_decimals: u8,
 }
 
-/// A normalized price read from a Pyth `PriceInfoObject`. Carrying the value rather
-/// than the object lets the legacy feed and Pyth's upgraded Core share one pricing
-/// path even though their `PriceInfoObject`s are distinct Move types. Safe readers
-/// enforce staleness, feed id, and EWMA deviation; pricing later enforces the asset
-/// binding and confidence interval before performing arithmetic.
+/// A normalized price read from an upgraded-Core `PriceInfoObject`. Carrying the value
+/// rather than the object keeps the pricing path independent of the reader, which is why
+/// the entrypoint families could be migrated one at a time. Safe readers enforce
+/// staleness, feed id, and EWMA deviation; pricing later enforces the asset binding and
+/// confidence interval before performing arithmetic.
 public struct PythReading has copy, drop {
     price: u64,
     decimals: u8,
@@ -312,56 +311,12 @@ fun price_config<T>(
     }
 }
 
-/// Reads the legacy Pyth feed with staleness, feed-id, and EWMA checks, carrying its
+/// Reads Pyth's upgraded Core with staleness, feed-id, and EWMA checks, carrying its
 /// confidence interval for validation when the reading is converted to a price.
-public(package) fun read_price<T>(
-    price_info_object: &PriceInfoObject,
-    registry: &MarginRegistry,
-    clock: &Clock,
-): PythReading {
-    let config = registry.get_config<PythConfig>();
-    let type_config = registry.get_config_for_type<T>();
-
-    let price = pyth::get_price_no_older_than(
-        price_info_object,
-        clock,
-        config.max_age_secs,
-    );
-    let price_info = price_info_object.get_price_info_from_price_info_object();
-    let ewma_price_object = price_info.get_price_feed().get_ema_price();
-
-    validate_reading(
-        price_info.get_price_identifier().get_bytes(),
-        price.get_price().get_magnitude_if_positive(),
-        price.get_expo().get_magnitude_if_negative() as u8,
-        price.get_conf(),
-        ewma_price_object.get_price().get_magnitude_if_positive(),
-        type_config,
-    )
-}
-
-/// Legacy Pyth feed without staleness, confidence, or EWMA validation.
-/// Only the price feed id is checked.
-public(package) fun read_price_unsafe<T>(
-    price_info_object: &PriceInfoObject,
-    registry: &MarginRegistry,
-): PythReading {
-    let type_config = registry.get_config_for_type<T>();
-    let price = pyth::get_price_unsafe(price_info_object);
-    let price_info = price_info_object.get_price_info_from_price_info_object();
-
-    validate_feed_id(price_info.get_price_identifier().get_bytes(), type_config);
-
-    PythReading {
-        price: price.get_price().get_magnitude_if_positive(),
-        decimals: price.get_expo().get_magnitude_if_negative() as u8,
-        conf: option::none(),
-        coin_type: type_config.type_name,
-    }
-}
-
-/// `read_price` against Pyth's upgraded Core. Pyth's upgraded Core is a separate published package, so its
-/// `PriceInfoObject` is a distinct Move type; the validation is identical.
+///
+/// There is no legacy-Core counterpart: the readers that took a legacy `PriceInfoObject`
+/// were removed when the legacy entrypoints were retired, so no code path in this package
+/// can price a position off a feed Pyth no longer maintains for us.
 public(package) fun read_price_upgraded<T>(
     price_info_object: &PriceInfoObjectUpgraded,
     registry: &MarginRegistry,
@@ -388,7 +343,8 @@ public(package) fun read_price_upgraded<T>(
     )
 }
 
-/// `read_price_unsafe` against Pyth's upgraded Core.
+/// Pyth's upgraded Core without staleness, confidence, or EWMA validation.
+/// Only the price feed id is checked.
 public(package) fun read_price_upgraded_unsafe<T>(
     price_info_object: &PriceInfoObjectUpgraded,
     registry: &MarginRegistry,
@@ -407,7 +363,7 @@ public(package) fun read_price_upgraded_unsafe<T>(
     }
 }
 
-/// Shared guards for a validated reading, so both feeds enforce one policy.
+/// Guards applied to every validated reading.
 fun validate_reading(
     price_feed_id: vector<u8>,
     pyth_price: u64,

--- a/packages/deepbook_margin/sources/margin_manager.move
+++ b/packages/deepbook_margin/sources/margin_manager.move
@@ -26,13 +26,7 @@ use deepbook_margin::{
     margin_constants,
     margin_pool::MarginPool,
     margin_registry::MarginRegistry,
-    oracle::{
-        PythReading,
-        calculate_target_currency,
-        calculate_price,
-        read_price,
-        read_price_unsafe,
-    },
+    oracle::{PythReading, calculate_target_currency, calculate_price},
     tpsl::{Self, TakeProfitStopLoss, PendingOrder, Condition, ConditionalOrder}
 };
 use pyth::price_info::PriceInfoObject;
@@ -72,6 +66,9 @@ const EDeprecatedUseV2: u64 = 20;
 /// `cancel_maker` can remove the manager's own resting orders and fill deeper
 /// into worse liquidity, so we re-check the *actual* executed price.
 const EFillOutsidePriceBounds: u64 = 21;
+/// A retired legacy-Pyth entry was called. Use the `margin_manager_upgraded`
+/// twin, which takes an upgraded-Core `PriceInfoObject`.
+const EDeprecatedUseUpgradedPyth: u64 = 22;
 
 // === Structs ===
 /// Witness type for authorizing MarginManager to call protected features of the DeepBook
@@ -173,42 +170,24 @@ public struct WithdrawCollateralEvent has copy, drop {
 }
 
 // === Functions - Take Profit Stop Loss ===
-/// Add a conditional order (take-profit / stop-loss). Specifies the condition
-/// under which it triggers and the pending order to place when it does.
+/// RETIRED. Use `margin_manager_upgraded::add_conditional_order`.
 ///
-/// Lifetime: the conditional order itself is never clamped — it rests in the
-/// queue until it triggers or is cancelled. A *market* pending order
-/// (`tpsl::new_pending_market_order`) has no expiry, so it is the "until
-/// cancelled" stop: it waits indefinitely and, when triggered, fires and
-/// deleverages via `execute_conditional_orders_v3` (so it can protect even in
-/// the danger band). A *limit* pending order is intentionally transient — when
-/// it triggers, the resting order it places is clamped to `max_order_ttl_ms`
-/// (default 3 days) by `clamp_expire_timestamp`, the same stale-price guard as
-/// any margin limit order. For a permanent stop, use a market pending order.
-/// Twin: `margin_manager_upgraded::add_conditional_order`. Edit both.
+/// Legacy-Pyth entry. See the module-level note in `margin_manager_upgraded` for
+/// why the whole legacy family aborts and what has to happen on chain for it to
+/// stop being reachable.
 public fun add_conditional_order<BaseAsset, QuoteAsset>(
-    self: &mut MarginManager<BaseAsset, QuoteAsset>,
-    pool: &Pool<BaseAsset, QuoteAsset>,
-    base_price_info_object: &PriceInfoObject,
-    quote_price_info_object: &PriceInfoObject,
-    registry: &MarginRegistry,
-    conditional_order_id: u64,
-    condition: Condition,
-    pending_order: PendingOrder,
-    clock: &Clock,
-    ctx: &mut TxContext,
+    _self: &mut MarginManager<BaseAsset, QuoteAsset>,
+    _pool: &Pool<BaseAsset, QuoteAsset>,
+    _base_price_info_object: &PriceInfoObject,
+    _quote_price_info_object: &PriceInfoObject,
+    _registry: &MarginRegistry,
+    _conditional_order_id: u64,
+    _condition: Condition,
+    _pending_order: PendingOrder,
+    _clock: &Clock,
+    _ctx: &mut TxContext,
 ) {
-    self.add_conditional_order_core(
-        pool,
-        read_price<BaseAsset>(base_price_info_object, registry, clock),
-        read_price<QuoteAsset>(quote_price_info_object, registry, clock),
-        registry,
-        conditional_order_id,
-        condition,
-        pending_order,
-        clock,
-        ctx,
-    )
+    abort EDeprecatedUseUpgradedPyth
 }
 
 /// Cancel all conditional orders.
@@ -254,74 +233,41 @@ public fun execute_conditional_orders<BaseAsset, QuoteAsset>(
     abort EDeprecatedUseV2
 }
 
-/// Execute conditional orders and return the order infos.
-/// This is a permissionless function that can be called by anyone.
+/// RETIRED. Use `margin_manager_upgraded::execute_conditional_orders_v2`.
 ///
-/// v2 adds `base_margin_pool` + `quote_margin_pool` parameters and enforces
-/// a post-fill `risk_ratio >= min_borrow_risk_ratio` invariant inside the
-/// inner loop. If any single triggered fill would breach that floor, the
-/// entire txn aborts — no partial-state landing.
-/// Twin: `margin_manager_upgraded::execute_conditional_orders_v2`. Edit both.
+/// Legacy-Pyth entry. This one was the widest leg of the dual-feed window it
+/// closes: permissionless, needing no capital and no danger band.
 public fun execute_conditional_orders_v2<BaseAsset, QuoteAsset>(
-    self: &mut MarginManager<BaseAsset, QuoteAsset>,
-    pool: &mut Pool<BaseAsset, QuoteAsset>,
-    base_margin_pool: &MarginPool<BaseAsset>,
-    quote_margin_pool: &MarginPool<QuoteAsset>,
-    base_price_info_object: &PriceInfoObject,
-    quote_price_info_object: &PriceInfoObject,
-    registry: &MarginRegistry,
-    max_orders_to_execute: u64,
-    clock: &Clock,
-    ctx: &TxContext,
+    _self: &mut MarginManager<BaseAsset, QuoteAsset>,
+    _pool: &mut Pool<BaseAsset, QuoteAsset>,
+    _base_margin_pool: &MarginPool<BaseAsset>,
+    _quote_margin_pool: &MarginPool<QuoteAsset>,
+    _base_price_info_object: &PriceInfoObject,
+    _quote_price_info_object: &PriceInfoObject,
+    _registry: &MarginRegistry,
+    _max_orders_to_execute: u64,
+    _clock: &Clock,
+    _ctx: &TxContext,
 ): vector<OrderInfo> {
-    self.execute_conditional_orders_v2_core(
-        pool,
-        base_margin_pool,
-        quote_margin_pool,
-        read_price<BaseAsset>(base_price_info_object, registry, clock),
-        read_price<QuoteAsset>(quote_price_info_object, registry, clock),
-        registry,
-        max_orders_to_execute,
-        clock,
-        ctx,
-    )
+    abort EDeprecatedUseUpgradedPyth
 }
 
-/// Execute conditional orders, deleveraging on each market-type fill.
-/// Permissionless, like `execute_conditional_orders_v2`, with the same trigger
-/// and cancellation handling — but takes the margin pools as `&mut` and repays
-/// the loan with the market proceeds before gating on the net (post-repay)
-/// `risk_ratio` being at least the pre-fill ratio.
+/// RETIRED. Use `margin_manager_upgraded::execute_conditional_orders_v3`.
 ///
-/// This is what lets a stop-loss fire in the `liquidation..min_borrow` danger
-/// band: a swap alone only lowers the oracle-valued ratio (so the v2 borrow-floor
-/// gate rejects it), while repaying actually improves it. If a single triggered
-/// fill would worsen net solvency the whole txn aborts — no partial-state
-/// landing.
-/// Twin: `margin_manager_upgraded::execute_conditional_orders_v3`. Edit both.
+/// Legacy-Pyth entry. Permissionless and capital-free, like the v2 twin above.
 public fun execute_conditional_orders_v3<BaseAsset, QuoteAsset>(
-    self: &mut MarginManager<BaseAsset, QuoteAsset>,
-    pool: &mut Pool<BaseAsset, QuoteAsset>,
-    base_margin_pool: &mut MarginPool<BaseAsset>,
-    quote_margin_pool: &mut MarginPool<QuoteAsset>,
-    base_price_info_object: &PriceInfoObject,
-    quote_price_info_object: &PriceInfoObject,
-    registry: &MarginRegistry,
-    max_orders_to_execute: u64,
-    clock: &Clock,
-    ctx: &mut TxContext,
+    _self: &mut MarginManager<BaseAsset, QuoteAsset>,
+    _pool: &mut Pool<BaseAsset, QuoteAsset>,
+    _base_margin_pool: &mut MarginPool<BaseAsset>,
+    _quote_margin_pool: &mut MarginPool<QuoteAsset>,
+    _base_price_info_object: &PriceInfoObject,
+    _quote_price_info_object: &PriceInfoObject,
+    _registry: &MarginRegistry,
+    _max_orders_to_execute: u64,
+    _clock: &Clock,
+    _ctx: &mut TxContext,
 ): vector<OrderInfo> {
-    self.execute_conditional_orders_v3_core(
-        pool,
-        base_margin_pool,
-        quote_margin_pool,
-        read_price<BaseAsset>(base_price_info_object, registry, clock),
-        read_price<QuoteAsset>(quote_price_info_object, registry, clock),
-        registry,
-        max_orders_to_execute,
-        clock,
-        ctx,
-    )
+    abort EDeprecatedUseUpgradedPyth
 }
 
 // === Public Functions - Margin Manager ===
@@ -438,133 +384,71 @@ public fun unset_referral<BaseAsset, QuoteAsset>(
 }
 
 // === Public Functions - Margin Manager ===
-/// Deposit a coin into the margin manager. The coin must be of the same type as either the base, quote, or DEEP.
-/// Twin: `margin_manager_upgraded::deposit`. Edit both.
+/// RETIRED. Use `margin_manager_upgraded::deposit`.
+///
+/// Legacy-Pyth entry.
 public fun deposit<BaseAsset, QuoteAsset, DepositAsset>(
-    self: &mut MarginManager<BaseAsset, QuoteAsset>,
-    registry: &MarginRegistry,
-    base_oracle: &PriceInfoObject,
-    quote_oracle: &PriceInfoObject,
-    coin: Coin<DepositAsset>,
-    clock: &Clock,
-    ctx: &mut TxContext,
+    _self: &mut MarginManager<BaseAsset, QuoteAsset>,
+    _registry: &MarginRegistry,
+    _base_oracle: &PriceInfoObject,
+    _quote_oracle: &PriceInfoObject,
+    _coin: Coin<DepositAsset>,
+    _clock: &Clock,
+    _ctx: &mut TxContext,
 ) {
-    let event_reading = if (!emits_collateral_event<BaseAsset, QuoteAsset, DepositAsset>()) {
-        option::none()
-    } else if (type_name::with_defining_ids<DepositAsset>() == type_name::with_defining_ids<BaseAsset>()) {
-        option::some(read_price<BaseAsset>(base_oracle, registry, clock))
-    } else {
-        option::some(read_price<QuoteAsset>(quote_oracle, registry, clock))
-    };
-
-    self.deposit_core(
-        registry,
-        event_reading,
-        coin,
-        clock,
-        ctx,
-    )
+    abort EDeprecatedUseUpgradedPyth
 }
 
-/// Withdraw a specified amount of an asset from the margin manager. The asset must be of the same type as either the base, quote, or DEEP.
-/// The withdrawal is subject to the risk ratio limit.
-/// Twin: `margin_manager_upgraded::withdraw`. Edit both.
+/// RETIRED. Use `margin_manager_upgraded::withdraw`.
+///
+/// Legacy-Pyth entry.
 public fun withdraw<BaseAsset, QuoteAsset, WithdrawAsset>(
-    self: &mut MarginManager<BaseAsset, QuoteAsset>,
-    registry: &MarginRegistry,
-    base_margin_pool: &MarginPool<BaseAsset>,
-    quote_margin_pool: &MarginPool<QuoteAsset>,
-    base_oracle: &PriceInfoObject,
-    quote_oracle: &PriceInfoObject,
-    pool: &Pool<BaseAsset, QuoteAsset>,
-    withdraw_amount: u64,
-    clock: &Clock,
-    ctx: &mut TxContext,
+    _self: &mut MarginManager<BaseAsset, QuoteAsset>,
+    _registry: &MarginRegistry,
+    _base_margin_pool: &MarginPool<BaseAsset>,
+    _quote_margin_pool: &MarginPool<QuoteAsset>,
+    _base_oracle: &PriceInfoObject,
+    _quote_oracle: &PriceInfoObject,
+    _pool: &Pool<BaseAsset, QuoteAsset>,
+    _withdraw_amount: u64,
+    _clock: &Clock,
+    _ctx: &mut TxContext,
 ): Coin<WithdrawAsset> {
-    let (risk_base_reading, risk_quote_reading) = if (
-        self.withdraw_needs_risk_check(base_margin_pool, quote_margin_pool)
-    ) {
-        (
-            option::some(read_price<BaseAsset>(base_oracle, registry, clock)),
-            option::some(read_price<QuoteAsset>(quote_oracle, registry, clock)),
-        )
-    } else {
-        (option::none(), option::none())
-    };
-    let (event_base_reading, event_quote_reading) = if (
-        emits_collateral_event<BaseAsset, QuoteAsset, WithdrawAsset>()
-    ) {
-        (
-            option::some(read_price_unsafe<BaseAsset>(base_oracle, registry)),
-            option::some(read_price_unsafe<QuoteAsset>(quote_oracle, registry)),
-        )
-    } else {
-        (option::none(), option::none())
-    };
-
-    self.withdraw_core(
-        registry,
-        base_margin_pool,
-        quote_margin_pool,
-        risk_base_reading,
-        risk_quote_reading,
-        event_base_reading,
-        event_quote_reading,
-        pool,
-        withdraw_amount,
-        clock,
-        ctx,
-    )
+    abort EDeprecatedUseUpgradedPyth
 }
 
-/// Borrow the base asset using the margin manager.
-/// Twin: `margin_manager_upgraded::borrow_base`. Edit both.
+/// RETIRED. Use `margin_manager_upgraded::borrow_base`.
+///
+/// Legacy-Pyth entry.
 public fun borrow_base<BaseAsset, QuoteAsset>(
-    self: &mut MarginManager<BaseAsset, QuoteAsset>,
-    registry: &MarginRegistry,
-    base_margin_pool: &mut MarginPool<BaseAsset>,
-    base_oracle: &PriceInfoObject,
-    quote_oracle: &PriceInfoObject,
-    pool: &Pool<BaseAsset, QuoteAsset>,
-    loan_amount: u64,
-    clock: &Clock,
-    ctx: &mut TxContext,
+    _self: &mut MarginManager<BaseAsset, QuoteAsset>,
+    _registry: &MarginRegistry,
+    _base_margin_pool: &mut MarginPool<BaseAsset>,
+    _base_oracle: &PriceInfoObject,
+    _quote_oracle: &PriceInfoObject,
+    _pool: &Pool<BaseAsset, QuoteAsset>,
+    _loan_amount: u64,
+    _clock: &Clock,
+    _ctx: &mut TxContext,
 ) {
-    self.borrow_base_core(
-        registry,
-        base_margin_pool,
-        read_price<BaseAsset>(base_oracle, registry, clock),
-        read_price<QuoteAsset>(quote_oracle, registry, clock),
-        pool,
-        loan_amount,
-        clock,
-        ctx,
-    )
+    abort EDeprecatedUseUpgradedPyth
 }
 
-/// Borrow the quote asset using the margin manager.
-/// Twin: `margin_manager_upgraded::borrow_quote`. Edit both.
+/// RETIRED. Use `margin_manager_upgraded::borrow_quote`.
+///
+/// Legacy-Pyth entry.
 public fun borrow_quote<BaseAsset, QuoteAsset>(
-    self: &mut MarginManager<BaseAsset, QuoteAsset>,
-    registry: &MarginRegistry,
-    quote_margin_pool: &mut MarginPool<QuoteAsset>,
-    base_oracle: &PriceInfoObject,
-    quote_oracle: &PriceInfoObject,
-    pool: &Pool<BaseAsset, QuoteAsset>,
-    loan_amount: u64,
-    clock: &Clock,
-    ctx: &mut TxContext,
+    _self: &mut MarginManager<BaseAsset, QuoteAsset>,
+    _registry: &MarginRegistry,
+    _quote_margin_pool: &mut MarginPool<QuoteAsset>,
+    _base_oracle: &PriceInfoObject,
+    _quote_oracle: &PriceInfoObject,
+    _pool: &Pool<BaseAsset, QuoteAsset>,
+    _loan_amount: u64,
+    _clock: &Clock,
+    _ctx: &mut TxContext,
 ) {
-    self.borrow_quote_core(
-        registry,
-        quote_margin_pool,
-        read_price<BaseAsset>(base_oracle, registry, clock),
-        read_price<QuoteAsset>(quote_oracle, registry, clock),
-        pool,
-        loan_amount,
-        clock,
-        ctx,
-    )
+    abort EDeprecatedUseUpgradedPyth
 }
 
 /// Repay the base asset loan using the margin manager.
@@ -612,85 +496,55 @@ public fun repay_quote<BaseAsset, QuoteAsset>(
 }
 
 // === Public Functions - Liquidation - Receive Assets After Liquidation ===
-/// Twin: `margin_manager_upgraded::liquidate`. Edit both.
+/// RETIRED. Use `margin_manager_upgraded::liquidate`.
+///
+/// Legacy-Pyth entry.
 public fun liquidate<BaseAsset, QuoteAsset, DebtAsset>(
-    self: &mut MarginManager<BaseAsset, QuoteAsset>,
-    registry: &MarginRegistry,
-    base_oracle: &PriceInfoObject,
-    quote_oracle: &PriceInfoObject,
-    margin_pool: &mut MarginPool<DebtAsset>,
-    pool: &mut Pool<BaseAsset, QuoteAsset>,
-    repay_coin: Coin<DebtAsset>,
-    clock: &Clock,
-    ctx: &mut TxContext,
+    _self: &mut MarginManager<BaseAsset, QuoteAsset>,
+    _registry: &MarginRegistry,
+    _base_oracle: &PriceInfoObject,
+    _quote_oracle: &PriceInfoObject,
+    _margin_pool: &mut MarginPool<DebtAsset>,
+    _pool: &mut Pool<BaseAsset, QuoteAsset>,
+    _repay_coin: Coin<DebtAsset>,
+    _clock: &Clock,
+    _ctx: &mut TxContext,
 ): (Coin<BaseAsset>, Coin<QuoteAsset>, Coin<DebtAsset>) {
-    self.liquidate_core(
-        registry,
-        read_price<BaseAsset>(base_oracle, registry, clock),
-        read_price<QuoteAsset>(quote_oracle, registry, clock),
-        margin_pool,
-        pool,
-        repay_coin,
-        clock,
-        ctx,
-    )
+    abort EDeprecatedUseUpgradedPyth
 }
 
-// Returns the risk ratio of the margin manager given the corresponding margin pools.
-/// Twin: `margin_manager_upgraded::risk_ratio`. Edit both.
+/// RETIRED. Use `margin_manager_upgraded::risk_ratio`.
+///
+/// Legacy-Pyth entry. Read-only, but retired with the rest of the family: an
+/// off-chain liquidator or UI reading a ratio off one feed while acting on the
+/// other is the same divergence, one step removed.
 public fun risk_ratio<BaseAsset, QuoteAsset>(
-    self: &MarginManager<BaseAsset, QuoteAsset>,
-    registry: &MarginRegistry,
-    base_oracle: &PriceInfoObject,
-    quote_oracle: &PriceInfoObject,
-    pool: &Pool<BaseAsset, QuoteAsset>,
-    base_margin_pool: &MarginPool<BaseAsset>,
-    quote_margin_pool: &MarginPool<QuoteAsset>,
-    clock: &Clock,
+    _self: &MarginManager<BaseAsset, QuoteAsset>,
+    _registry: &MarginRegistry,
+    _base_oracle: &PriceInfoObject,
+    _quote_oracle: &PriceInfoObject,
+    _pool: &Pool<BaseAsset, QuoteAsset>,
+    _base_margin_pool: &MarginPool<BaseAsset>,
+    _quote_margin_pool: &MarginPool<QuoteAsset>,
+    _clock: &Clock,
 ): u64 {
-    // No debt means no oracle is needed: `assets_in_debt_unit` short-circuits and the
-    // ratio is MAX regardless of price. Returning here keeps a stale feed from
-    // breaking a read-only query, as it did before Pyth's upgraded Core.
-    if (self.margin_pool_id.is_none()) return margin_constants::max_risk_ratio();
-
-    self.risk_ratio_core(
-        registry,
-        read_price<BaseAsset>(base_oracle, registry, clock),
-        read_price<QuoteAsset>(quote_oracle, registry, clock),
-        pool,
-        base_margin_pool,
-        quote_margin_pool,
-        clock,
-    )
+    abort EDeprecatedUseUpgradedPyth
 }
 
-/// Returns the risk ratio without validating staleness, EWMA divergence or confidence - only the feed id is checked.
-/// Use for read-only queries where stale prices are acceptable.
-/// Twin: `margin_manager_upgraded::risk_ratio_unsafe`. Edit both.
+/// RETIRED. Use `margin_manager_upgraded::risk_ratio_unsafe`.
+///
+/// Legacy-Pyth entry.
 public fun risk_ratio_unsafe<BaseAsset, QuoteAsset>(
-    self: &MarginManager<BaseAsset, QuoteAsset>,
-    registry: &MarginRegistry,
-    base_oracle: &PriceInfoObject,
-    quote_oracle: &PriceInfoObject,
-    pool: &Pool<BaseAsset, QuoteAsset>,
-    base_margin_pool: &MarginPool<BaseAsset>,
-    quote_margin_pool: &MarginPool<QuoteAsset>,
-    clock: &Clock,
+    _self: &MarginManager<BaseAsset, QuoteAsset>,
+    _registry: &MarginRegistry,
+    _base_oracle: &PriceInfoObject,
+    _quote_oracle: &PriceInfoObject,
+    _pool: &Pool<BaseAsset, QuoteAsset>,
+    _base_margin_pool: &MarginPool<BaseAsset>,
+    _quote_margin_pool: &MarginPool<QuoteAsset>,
+    _clock: &Clock,
 ): u64 {
-    // No debt means no oracle is needed: `assets_in_debt_unit` short-circuits and the
-    // ratio is MAX regardless of price. Returning here keeps a stale feed from
-    // breaking a read-only query, as it did before Pyth's upgraded Core.
-    if (self.margin_pool_id.is_none()) return margin_constants::max_risk_ratio();
-
-    self.risk_ratio_core(
-        registry,
-        read_price_unsafe<BaseAsset>(base_oracle, registry),
-        read_price_unsafe<QuoteAsset>(quote_oracle, registry),
-        pool,
-        base_margin_pool,
-        quote_margin_pool,
-        clock,
-    )
+    abort EDeprecatedUseUpgradedPyth
 }
 
 // === Public Functions - Read Only ===
@@ -762,46 +616,34 @@ public fun calculate_debts<BaseAsset, QuoteAsset, DebtAsset>(
     (base_debt, quote_debt)
 }
 
-/// Returns comprehensive state information for a margin manager.
-/// Returns (manager_id, deepbook_pool_id, risk_ratio, base_asset, quote_asset,
-///          base_debt, quote_debt, base_pyth_price, base_pyth_decimals,
-///          quote_pyth_price, quote_pyth_decimals, current_price,
-///          lowest_trigger_above_price, highest_trigger_below_price)
-/// Twin: `margin_manager_upgraded::manager_state`. Edit both.
+/// RETIRED. Use `margin_manager_upgraded::manager_state`.
+///
+/// Legacy-Pyth entry.
 public fun manager_state<BaseAsset, QuoteAsset>(
-    self: &MarginManager<BaseAsset, QuoteAsset>,
-    registry: &MarginRegistry,
-    base_oracle: &PriceInfoObject,
-    quote_oracle: &PriceInfoObject,
-    pool: &Pool<BaseAsset, QuoteAsset>,
-    base_margin_pool: &MarginPool<BaseAsset>,
-    quote_margin_pool: &MarginPool<QuoteAsset>,
-    clock: &Clock,
+    _self: &MarginManager<BaseAsset, QuoteAsset>,
+    _registry: &MarginRegistry,
+    _base_oracle: &PriceInfoObject,
+    _quote_oracle: &PriceInfoObject,
+    _pool: &Pool<BaseAsset, QuoteAsset>,
+    _base_margin_pool: &MarginPool<BaseAsset>,
+    _quote_margin_pool: &MarginPool<QuoteAsset>,
+    _clock: &Clock,
 ): (ID, ID, u64, u64, u64, u64, u64, u64, u8, u64, u8, u64, u64, u64) {
-    self.manager_state_core(
-        registry,
-        read_price_unsafe<BaseAsset>(base_oracle, registry),
-        read_price_unsafe<QuoteAsset>(quote_oracle, registry),
-        pool,
-        base_margin_pool,
-        quote_margin_pool,
-        clock,
-    )
+    abort EDeprecatedUseUpgradedPyth
 }
 
-/// Returns comprehensive state information for multiple margin managers.
-/// Same as manager_state but takes a vector and returns vectors of all values.
-/// All managers must be of the same type.
-/// Twin: `margin_manager_upgraded::manager_states`. Edit both.
+/// RETIRED. Use `margin_manager_upgraded::manager_states`.
+///
+/// Legacy-Pyth entry.
 public fun manager_states<BaseAsset, QuoteAsset>(
-    margin_managers: &vector<MarginManager<BaseAsset, QuoteAsset>>,
-    registry: &MarginRegistry,
-    base_oracle: &PriceInfoObject,
-    quote_oracle: &PriceInfoObject,
-    pool: &Pool<BaseAsset, QuoteAsset>,
-    base_margin_pool: &MarginPool<BaseAsset>,
-    quote_margin_pool: &MarginPool<QuoteAsset>,
-    clock: &Clock,
+    _margin_managers: &vector<MarginManager<BaseAsset, QuoteAsset>>,
+    _registry: &MarginRegistry,
+    _base_oracle: &PriceInfoObject,
+    _quote_oracle: &PriceInfoObject,
+    _pool: &Pool<BaseAsset, QuoteAsset>,
+    _base_margin_pool: &MarginPool<BaseAsset>,
+    _quote_margin_pool: &MarginPool<QuoteAsset>,
+    _clock: &Clock,
 ): (
     vector<ID>,
     vector<ID>,
@@ -818,16 +660,7 @@ public fun manager_states<BaseAsset, QuoteAsset>(
     vector<u64>,
     vector<u64>,
 ) {
-    manager_states_core<BaseAsset, QuoteAsset>(
-        margin_managers,
-        registry,
-        read_price_unsafe<BaseAsset>(base_oracle, registry),
-        read_price_unsafe<QuoteAsset>(quote_oracle, registry),
-        pool,
-        base_margin_pool,
-        quote_margin_pool,
-        clock,
-    )
+    abort EDeprecatedUseUpgradedPyth
 }
 
 public fun id<BaseAsset, QuoteAsset>(self: &MarginManager<BaseAsset, QuoteAsset>): ID {

--- a/packages/deepbook_margin/sources/margin_manager_upgraded.move
+++ b/packages/deepbook_margin/sources/margin_manager_upgraded.move
@@ -1,13 +1,27 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Pyth's upgraded Core entrypoints for `margin_manager`.
+/// The oracle-taking entrypoints for `margin_manager`.
 ///
-/// Pyth Core is being replaced by a separately published package, so its
-/// `PriceInfoObject` is a distinct Move type from the legacy one and the frozen
-/// signatures in `margin_manager` can never accept it. The upgraded surface therefore lives
-/// here, under the same function names. Each entry reads the upgraded feed and delegates
-/// to the shared core in `margin_manager`, so both feeds run identical logic.
+/// Pyth replaced Core with a separately published package, so its `PriceInfoObject` is a
+/// distinct Move type from the legacy one and the frozen signatures in `margin_manager`
+/// can never accept it. The oracle surface therefore lives here, under the same function
+/// names; each entry reads the upgraded feed and delegates to the shared core in
+/// `margin_manager`.
+///
+/// The legacy-Pyth twins in `margin_manager` and `pool_proxy` are retired: they abort
+/// `EDeprecatedUseUpgradedPyth` instead of reading a feed. Until that landed, both
+/// families were live and authoritative and `PythReading` erased which feed produced it,
+/// so a caller chose per call between two independently-enforced staleness windows with
+/// no cross-feed comparison — one leg could be a full window stale while the other was
+/// fresh. The expectation that this self-closed at Pyth's cutover did not hold: legacy
+/// objects for most configured currencies stayed fresh past it, refreshed by third
+/// parties DeepBook does not control.
+///
+/// Retiring the bodies is only half of it. A package published against an older
+/// `deepbook_margin` keeps calling that version's bodies through its own linkage table,
+/// so the legacy entries stop being reachable on chain when the admin calls
+/// `disable_version` on the version that still carries them — see `margin_constants`.
 module deepbook_margin::margin_manager_upgraded;
 
 use deepbook::{order_info::OrderInfo, pool::Pool};
@@ -23,7 +37,18 @@ use pyth_upgraded::price_info::PriceInfoObject as PriceInfoObjectUpgraded;
 use std::type_name;
 use sui::{clock::Clock, coin::Coin};
 
-/// Twin: `margin_manager::add_conditional_order`. Edit both.
+/// Add a conditional order (take-profit / stop-loss). Specifies the condition
+/// under which it triggers and the pending order to place when it does.
+///
+/// Lifetime: the conditional order itself is never clamped — it rests in the
+/// queue until it triggers or is cancelled. A *market* pending order
+/// (`tpsl::new_pending_market_order`) has no expiry, so it is the "until
+/// cancelled" stop: it waits indefinitely and, when triggered, fires and
+/// deleverages via `execute_conditional_orders_v3` (so it can protect even in
+/// the danger band). A *limit* pending order is intentionally transient — when
+/// it triggers, the resting order it places is clamped to `max_order_ttl_ms`
+/// (default 3 days) by `clamp_expire_timestamp`, the same stale-price guard as
+/// any margin limit order. For a permanent stop, use a market pending order.
 public fun add_conditional_order<BaseAsset, QuoteAsset>(
     self: &mut MarginManager<BaseAsset, QuoteAsset>,
     pool: &Pool<BaseAsset, QuoteAsset>,
@@ -49,7 +74,13 @@ public fun add_conditional_order<BaseAsset, QuoteAsset>(
     )
 }
 
-/// Twin: `margin_manager::execute_conditional_orders_v2`. Edit both.
+/// Execute conditional orders and return the order infos.
+/// This is a permissionless function that can be called by anyone.
+///
+/// v2 adds `base_margin_pool` + `quote_margin_pool` parameters and enforces
+/// a post-fill `risk_ratio >= min_borrow_risk_ratio` invariant inside the
+/// inner loop. If any single triggered fill would breach that floor, the
+/// entire txn aborts — no partial-state landing.
 public fun execute_conditional_orders_v2<BaseAsset, QuoteAsset>(
     self: &mut MarginManager<BaseAsset, QuoteAsset>,
     pool: &mut Pool<BaseAsset, QuoteAsset>,
@@ -75,7 +106,17 @@ public fun execute_conditional_orders_v2<BaseAsset, QuoteAsset>(
     )
 }
 
-/// Twin: `margin_manager::execute_conditional_orders_v3`. Edit both.
+/// Execute conditional orders, deleveraging on each market-type fill.
+/// Permissionless, like `execute_conditional_orders_v2`, with the same trigger
+/// and cancellation handling — but takes the margin pools as `&mut` and repays
+/// the loan with the market proceeds before gating on the net (post-repay)
+/// `risk_ratio` being at least the pre-fill ratio.
+///
+/// This is what lets a stop-loss fire in the `liquidation..min_borrow` danger
+/// band: a swap alone only lowers the oracle-valued ratio (so the v2 borrow-floor
+/// gate rejects it), while repaying actually improves it. If a single triggered
+/// fill would worsen net solvency the whole txn aborts — no partial-state
+/// landing.
 public fun execute_conditional_orders_v3<BaseAsset, QuoteAsset>(
     self: &mut MarginManager<BaseAsset, QuoteAsset>,
     pool: &mut Pool<BaseAsset, QuoteAsset>,
@@ -101,7 +142,7 @@ public fun execute_conditional_orders_v3<BaseAsset, QuoteAsset>(
     )
 }
 
-/// Twin: `margin_manager::deposit`. Edit both.
+/// Deposit a coin into the margin manager. The coin must be of the same type as either the base, quote, or DEEP.
 public fun deposit<BaseAsset, QuoteAsset, DepositAsset>(
     self: &mut MarginManager<BaseAsset, QuoteAsset>,
     registry: &MarginRegistry,
@@ -132,7 +173,8 @@ public fun deposit<BaseAsset, QuoteAsset, DepositAsset>(
     )
 }
 
-/// Twin: `margin_manager::withdraw`. Edit both.
+/// Withdraw a specified amount of an asset from the margin manager. The asset must be of the same type as either the base, quote, or DEEP.
+/// The withdrawal is subject to the risk ratio limit.
 public fun withdraw<BaseAsset, QuoteAsset, WithdrawAsset>(
     self: &mut MarginManager<BaseAsset, QuoteAsset>,
     registry: &MarginRegistry,
@@ -181,7 +223,7 @@ public fun withdraw<BaseAsset, QuoteAsset, WithdrawAsset>(
     )
 }
 
-/// Twin: `margin_manager::borrow_base`. Edit both.
+/// Borrow the base asset using the margin manager.
 public fun borrow_base<BaseAsset, QuoteAsset>(
     self: &mut MarginManager<BaseAsset, QuoteAsset>,
     registry: &MarginRegistry,
@@ -205,7 +247,7 @@ public fun borrow_base<BaseAsset, QuoteAsset>(
     )
 }
 
-/// Twin: `margin_manager::borrow_quote`. Edit both.
+/// Borrow the quote asset using the margin manager.
 public fun borrow_quote<BaseAsset, QuoteAsset>(
     self: &mut MarginManager<BaseAsset, QuoteAsset>,
     registry: &MarginRegistry,
@@ -229,7 +271,7 @@ public fun borrow_quote<BaseAsset, QuoteAsset>(
     )
 }
 
-/// Twin: `margin_manager::liquidate`. Edit both.
+/// Liquidates an unhealthy margin manager, returning the seized assets and any unspent repay.
 public fun liquidate<BaseAsset, QuoteAsset, DebtAsset>(
     self: &mut MarginManager<BaseAsset, QuoteAsset>,
     registry: &MarginRegistry,
@@ -253,7 +295,7 @@ public fun liquidate<BaseAsset, QuoteAsset, DebtAsset>(
     )
 }
 
-/// Twin: `margin_manager::risk_ratio`. Edit both.
+/// Returns the risk ratio of the margin manager given the corresponding margin pools.
 public fun risk_ratio<BaseAsset, QuoteAsset>(
     self: &MarginManager<BaseAsset, QuoteAsset>,
     registry: &MarginRegistry,
@@ -280,7 +322,8 @@ public fun risk_ratio<BaseAsset, QuoteAsset>(
     )
 }
 
-/// Twin: `margin_manager::risk_ratio_unsafe`. Edit both.
+/// Returns the risk ratio without validating staleness, EWMA divergence or confidence - only the feed id is checked.
+/// Use for read-only queries where stale prices are acceptable.
 public fun risk_ratio_unsafe<BaseAsset, QuoteAsset>(
     self: &MarginManager<BaseAsset, QuoteAsset>,
     registry: &MarginRegistry,
@@ -307,7 +350,11 @@ public fun risk_ratio_unsafe<BaseAsset, QuoteAsset>(
     )
 }
 
-/// Twin: `margin_manager::manager_state`. Edit both.
+/// Returns comprehensive state information for a margin manager.
+/// Returns (manager_id, deepbook_pool_id, risk_ratio, base_asset, quote_asset,
+///          base_debt, quote_debt, base_pyth_price, base_pyth_decimals,
+///          quote_pyth_price, quote_pyth_decimals, current_price,
+///          lowest_trigger_above_price, highest_trigger_below_price)
 public fun manager_state<BaseAsset, QuoteAsset>(
     self: &MarginManager<BaseAsset, QuoteAsset>,
     registry: &MarginRegistry,
@@ -329,7 +376,9 @@ public fun manager_state<BaseAsset, QuoteAsset>(
     )
 }
 
-/// Twin: `margin_manager::manager_states`. Edit both.
+/// Returns comprehensive state information for multiple margin managers.
+/// Same as manager_state but takes a vector and returns vectors of all values.
+/// All managers must be of the same type.
 public fun manager_states<BaseAsset, QuoteAsset>(
     margin_managers: &vector<MarginManager<BaseAsset, QuoteAsset>>,
     registry: &MarginRegistry,

--- a/packages/deepbook_margin/sources/pool_proxy.move
+++ b/packages/deepbook_margin/sources/pool_proxy.move
@@ -37,31 +37,24 @@ const EDeprecatedUseV2: u64 = 8;
 /// A reduce-only limit order cannot be placed while the manager is already below the
 /// liquidation floor — its resting fill is ungated and could self-match under 1.0.
 const EReduceOnlyBelowLiquidation: u64 = 9;
+/// A retired legacy-Pyth entry was called. Use the `pool_proxy_upgraded` twin,
+/// which takes an upgraded-Core `PriceInfoObject`.
+const EDeprecatedUseUpgradedPyth: u64 = 10;
 
 // === Public Functions - Price Protection ===
-/// Updates the current price for a pool using safe oracle price calculation.
-/// Anyone can call this to update the price oracle used for order validation.
-/// Updates the current price for a pool using safe oracle price calculation.
-/// Anyone can call this to update the price oracle used for order validation.
-/// Twin: `pool_proxy_upgraded::update_current_price`. Edit both.
+/// RETIRED. Use `pool_proxy_upgraded::update_current_price`.
+///
+/// Legacy-Pyth entry. See the module-level note in `margin_manager_upgraded` for
+/// why the whole legacy family aborts and what has to happen on chain for it to
+/// stop being reachable.
 public fun update_current_price<BaseAsset, QuoteAsset>(
-    registry: &mut MarginRegistry,
-    pool: &Pool<BaseAsset, QuoteAsset>,
-    base_price_info_object: &PriceInfoObject,
-    quote_price_info_object: &PriceInfoObject,
-    clock: &Clock,
+    _registry: &mut MarginRegistry,
+    _pool: &Pool<BaseAsset, QuoteAsset>,
+    _base_price_info_object: &PriceInfoObject,
+    _quote_price_info_object: &PriceInfoObject,
+    _clock: &Clock,
 ) {
-    // Safe reads enforce staleness, feed id, and EWMA. Price conversion enforces confidence.
-    let base_reading = oracle::read_price<BaseAsset>(base_price_info_object, registry, clock);
-    let quote_reading = oracle::read_price<QuoteAsset>(quote_price_info_object, registry, clock);
-
-    update_current_price_core<BaseAsset, QuoteAsset>(
-        registry,
-        pool,
-        base_reading,
-        quote_reading,
-        clock,
-    )
+    abort EDeprecatedUseUpgradedPyth
 }
 
 public(package) fun update_current_price_core<BaseAsset, QuoteAsset>(
@@ -1180,358 +1173,169 @@ fun repay_debt_then_assert_monotonic<BaseAsset, QuoteAsset>(
     };
 }
 
-// === Legacy Pyth entrypoints ===
-// Frozen signatures. Bodies delegate to the shared cores above.
+// === Legacy Pyth entrypoints (RETIRED) ===
+// Frozen signatures, aborting bodies. The live twins are in `pool_proxy_upgraded`
+// and delegate to the shared cores above.
 
-/// Places a limit order in the pool.
-/// Twin: `pool_proxy_upgraded::place_limit_order_v2`. Edit both.
+/// RETIRED. Use `pool_proxy_upgraded::place_limit_order_v2`.
+///
+/// Legacy-Pyth entry.
 public fun place_limit_order_v2<BaseAsset, QuoteAsset>(
-    registry: &MarginRegistry,
-    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
-    pool: &mut Pool<BaseAsset, QuoteAsset>,
-    base_margin_pool: &MarginPool<BaseAsset>,
-    quote_margin_pool: &MarginPool<QuoteAsset>,
-    base_oracle: &PriceInfoObject,
-    quote_oracle: &PriceInfoObject,
-    client_order_id: u64,
-    order_type: u8,
-    self_matching_option: u8,
-    price: u64,
-    quantity: u64,
-    is_bid: bool,
-    pay_with_deep: bool,
-    expire_timestamp: u64,
-    clock: &Clock,
-    ctx: &TxContext,
+    _registry: &MarginRegistry,
+    _margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    _pool: &mut Pool<BaseAsset, QuoteAsset>,
+    _base_margin_pool: &MarginPool<BaseAsset>,
+    _quote_margin_pool: &MarginPool<QuoteAsset>,
+    _base_oracle: &PriceInfoObject,
+    _quote_oracle: &PriceInfoObject,
+    _client_order_id: u64,
+    _order_type: u8,
+    _self_matching_option: u8,
+    _price: u64,
+    _quantity: u64,
+    _is_bid: bool,
+    _pay_with_deep: bool,
+    _expire_timestamp: u64,
+    _clock: &Clock,
+    _ctx: &TxContext,
 ): OrderInfo {
-    // A debt-free manager needs no price: every consumer below is debt-gated, so
-    // reading eagerly would let a stale feed block an order that used to succeed.
-    let (base_reading, quote_reading) = if (margin_manager.has_debt()) {
-        (
-            option::some(oracle::read_price<BaseAsset>(base_oracle, registry, clock)),
-            option::some(oracle::read_price<QuoteAsset>(quote_oracle, registry, clock)),
-        )
-    } else {
-        (option::none(), option::none())
-    };
-
-    place_limit_order_v2_core<BaseAsset, QuoteAsset>(
-        registry,
-        margin_manager,
-        pool,
-        base_margin_pool,
-        quote_margin_pool,
-        base_reading,
-        quote_reading,
-        client_order_id,
-        order_type,
-        self_matching_option,
-        price,
-        quantity,
-        is_bid,
-        pay_with_deep,
-        expire_timestamp,
-        clock,
-        ctx,
-    )
+    abort EDeprecatedUseUpgradedPyth
 }
 
-/// Places a market order in the pool.
-/// Twin: `pool_proxy_upgraded::place_market_order_v2`. Edit both.
+/// RETIRED. Use `pool_proxy_upgraded::place_market_order_v2`.
+///
+/// Legacy-Pyth entry.
 public fun place_market_order_v2<BaseAsset, QuoteAsset>(
-    registry: &MarginRegistry,
-    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
-    pool: &mut Pool<BaseAsset, QuoteAsset>,
-    base_margin_pool: &MarginPool<BaseAsset>,
-    quote_margin_pool: &MarginPool<QuoteAsset>,
-    base_oracle: &PriceInfoObject,
-    quote_oracle: &PriceInfoObject,
-    client_order_id: u64,
-    self_matching_option: u8,
-    quantity: u64,
-    is_bid: bool,
-    pay_with_deep: bool,
-    clock: &Clock,
-    ctx: &TxContext,
+    _registry: &MarginRegistry,
+    _margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    _pool: &mut Pool<BaseAsset, QuoteAsset>,
+    _base_margin_pool: &MarginPool<BaseAsset>,
+    _quote_margin_pool: &MarginPool<QuoteAsset>,
+    _base_oracle: &PriceInfoObject,
+    _quote_oracle: &PriceInfoObject,
+    _client_order_id: u64,
+    _self_matching_option: u8,
+    _quantity: u64,
+    _is_bid: bool,
+    _pay_with_deep: bool,
+    _clock: &Clock,
+    _ctx: &TxContext,
 ): OrderInfo {
-    // A debt-free manager needs no price: every consumer below is debt-gated, so
-    // reading eagerly would let a stale feed block an order that used to succeed.
-    let (base_reading, quote_reading) = if (margin_manager.has_debt()) {
-        (
-            option::some(oracle::read_price<BaseAsset>(base_oracle, registry, clock)),
-            option::some(oracle::read_price<QuoteAsset>(quote_oracle, registry, clock)),
-        )
-    } else {
-        (option::none(), option::none())
-    };
-
-    place_market_order_v2_core<BaseAsset, QuoteAsset>(
-        registry,
-        margin_manager,
-        pool,
-        base_margin_pool,
-        quote_margin_pool,
-        base_reading,
-        quote_reading,
-        client_order_id,
-        self_matching_option,
-        quantity,
-        is_bid,
-        pay_with_deep,
-        clock,
-        ctx,
-    )
+    abort EDeprecatedUseUpgradedPyth
 }
 
-/// Places a reduce-only order in the pool. Used when margin trading is disabled.
-/// Twin: `pool_proxy_upgraded::place_reduce_only_limit_order_v2`. Edit both.
+/// RETIRED. Use `pool_proxy_upgraded::place_reduce_only_limit_order_v2`.
+///
+/// Legacy-Pyth entry.
 public fun place_reduce_only_limit_order_v2<BaseAsset, QuoteAsset>(
-    registry: &MarginRegistry,
-    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
-    pool: &mut Pool<BaseAsset, QuoteAsset>,
-    base_margin_pool: &MarginPool<BaseAsset>,
-    quote_margin_pool: &MarginPool<QuoteAsset>,
-    base_oracle: &PriceInfoObject,
-    quote_oracle: &PriceInfoObject,
-    client_order_id: u64,
-    order_type: u8,
-    self_matching_option: u8,
-    price: u64,
-    quantity: u64,
-    is_bid: bool,
-    pay_with_deep: bool,
-    expire_timestamp: u64,
-    clock: &Clock,
-    ctx: &TxContext,
+    _registry: &MarginRegistry,
+    _margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    _pool: &mut Pool<BaseAsset, QuoteAsset>,
+    _base_margin_pool: &MarginPool<BaseAsset>,
+    _quote_margin_pool: &MarginPool<QuoteAsset>,
+    _base_oracle: &PriceInfoObject,
+    _quote_oracle: &PriceInfoObject,
+    _client_order_id: u64,
+    _order_type: u8,
+    _self_matching_option: u8,
+    _price: u64,
+    _quantity: u64,
+    _is_bid: bool,
+    _pay_with_deep: bool,
+    _expire_timestamp: u64,
+    _clock: &Clock,
+    _ctx: &TxContext,
 ): OrderInfo {
-    place_reduce_only_limit_order_v2_core<BaseAsset, QuoteAsset>(
-        registry,
-        margin_manager,
-        pool,
-        base_margin_pool,
-        quote_margin_pool,
-        oracle::read_price<BaseAsset>(base_oracle, registry, clock),
-        oracle::read_price<QuoteAsset>(quote_oracle, registry, clock),
-        client_order_id,
-        order_type,
-        self_matching_option,
-        price,
-        quantity,
-        is_bid,
-        pay_with_deep,
-        expire_timestamp,
-        clock,
-        ctx,
-    )
+    abort EDeprecatedUseUpgradedPyth
 }
 
-/// Places a reduce-only market order in the pool. Used when margin trading is
-/// disabled.
+/// RETIRED. Use `pool_proxy_upgraded::place_reduce_only_market_order_v2`.
 ///
-/// Superseded by `place_reduce_only_market_order_and_repay_loan`. A market
-/// (taker) fill always pays the spread, which lowers the oracle-valued
-/// `risk_ratio` while the debt is unchanged, so the swap-only monotonic check
-/// here rejects essentially every taker fill. The `_and_repay` variant
-/// deleverages with the proceeds so the net-state ratio actually improves. Kept
-/// callable for existing integrators; its reduce-only *direction* guard matches
-/// the other entries — a bid needs base (short-side) debt, the ask needs quote
-/// (long-side) debt and sells up to gross base held — with no size cap.
-/// Twin: `pool_proxy_upgraded::place_reduce_only_market_order_v2`. Edit both.
+/// Legacy-Pyth entry.
 public fun place_reduce_only_market_order_v2<BaseAsset, QuoteAsset>(
-    registry: &MarginRegistry,
-    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
-    pool: &mut Pool<BaseAsset, QuoteAsset>,
-    base_margin_pool: &MarginPool<BaseAsset>,
-    quote_margin_pool: &MarginPool<QuoteAsset>,
-    base_oracle: &PriceInfoObject,
-    quote_oracle: &PriceInfoObject,
-    client_order_id: u64,
-    self_matching_option: u8,
-    quantity: u64,
-    is_bid: bool,
-    pay_with_deep: bool,
-    clock: &Clock,
-    ctx: &TxContext,
+    _registry: &MarginRegistry,
+    _margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    _pool: &mut Pool<BaseAsset, QuoteAsset>,
+    _base_margin_pool: &MarginPool<BaseAsset>,
+    _quote_margin_pool: &MarginPool<QuoteAsset>,
+    _base_oracle: &PriceInfoObject,
+    _quote_oracle: &PriceInfoObject,
+    _client_order_id: u64,
+    _self_matching_option: u8,
+    _quantity: u64,
+    _is_bid: bool,
+    _pay_with_deep: bool,
+    _clock: &Clock,
+    _ctx: &TxContext,
 ): OrderInfo {
-    place_reduce_only_market_order_v2_core<BaseAsset, QuoteAsset>(
-        registry,
-        margin_manager,
-        pool,
-        base_margin_pool,
-        quote_margin_pool,
-        oracle::read_price<BaseAsset>(base_oracle, registry, clock),
-        oracle::read_price<QuoteAsset>(quote_oracle, registry, clock),
-        client_order_id,
-        self_matching_option,
-        quantity,
-        is_bid,
-        pay_with_deep,
-        clock,
-        ctx,
-    )
+    abort EDeprecatedUseUpgradedPyth
 }
 
-/// Atomically winds down a leveraged position: places a reduce-only market
-/// order, repays the loan with the proceeds, then requires the net (post-repay)
-/// risk ratio to be at least the pre-trade ratio.
+/// RETIRED. Use `pool_proxy_upgraded::place_reduce_only_market_order_and_repay_loan`.
 ///
-/// The post-repay check is the point. A market close pays the spread, which
-/// alone lowers the oracle-valued ratio (debt is unchanged until repay) and
-/// would abort the plain reduce-only path. Repaying first deleverages and
-/// absorbs the slippage (still bounded by the `assert_price` band), and lets a
-/// manager in the `liquidation..min_borrow` band climb out — it cannot reach
-/// the borrow floor in a single swap.
-/// Twin: `pool_proxy_upgraded::place_reduce_only_market_order_and_repay_loan`. Edit both.
+/// Legacy-Pyth entry.
 public fun place_reduce_only_market_order_and_repay_loan<BaseAsset, QuoteAsset>(
-    registry: &MarginRegistry,
-    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
-    pool: &mut Pool<BaseAsset, QuoteAsset>,
-    base_margin_pool: &mut MarginPool<BaseAsset>,
-    quote_margin_pool: &mut MarginPool<QuoteAsset>,
-    base_oracle: &PriceInfoObject,
-    quote_oracle: &PriceInfoObject,
-    client_order_id: u64,
-    self_matching_option: u8,
-    quantity: u64,
-    is_bid: bool,
-    pay_with_deep: bool,
-    clock: &Clock,
-    ctx: &mut TxContext,
+    _registry: &MarginRegistry,
+    _margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    _pool: &mut Pool<BaseAsset, QuoteAsset>,
+    _base_margin_pool: &mut MarginPool<BaseAsset>,
+    _quote_margin_pool: &mut MarginPool<QuoteAsset>,
+    _base_oracle: &PriceInfoObject,
+    _quote_oracle: &PriceInfoObject,
+    _client_order_id: u64,
+    _self_matching_option: u8,
+    _quantity: u64,
+    _is_bid: bool,
+    _pay_with_deep: bool,
+    _clock: &Clock,
+    _ctx: &mut TxContext,
 ): OrderInfo {
-    place_reduce_only_market_order_and_repay_loan_core<BaseAsset, QuoteAsset>(
-        registry,
-        margin_manager,
-        pool,
-        base_margin_pool,
-        quote_margin_pool,
-        oracle::read_price<BaseAsset>(base_oracle, registry, clock),
-        oracle::read_price<QuoteAsset>(quote_oracle, registry, clock),
-        client_order_id,
-        self_matching_option,
-        quantity,
-        is_bid,
-        pay_with_deep,
-        clock,
-        ctx,
-    )
+    abort EDeprecatedUseUpgradedPyth
 }
 
-/// Reduce-only **limit** order that atomically repays the loan with the taker
-/// fills. It is the limit/maker behaviour of `place_reduce_only_limit_order_v2`
-/// plus the repay-then-net-monotonic gate of
-/// `place_reduce_only_market_order_and_repay_loan`: the portion that crosses the
-/// book fills immediately and settles, the rest rests as a maker, then the
-/// settled (taker) proceeds repay the debt before the monotonic check on the net
-/// (post-repay) state.
+/// RETIRED. Use `pool_proxy_upgraded::place_reduce_only_limit_order_and_repay_loan`.
 ///
-/// This is the danger-band tool for a *price-bounded* reduce: a crossing
-/// reduce-only limit pays the spread on its taker fills, which alone would abort
-/// `place_reduce_only_limit_order_v2`'s swap-only monotonic check; repaying first
-/// deleverages so the net ratio holds. The resting remainder only locks balance
-/// (counted in assets), so it doesn't move the ratio. Unfilled-and-resting
-/// behaves exactly like `place_reduce_only_limit_order_v2` (nothing to repay).
-/// Twin: `pool_proxy_upgraded::place_reduce_only_limit_order_and_repay_loan`. Edit both.
+/// Legacy-Pyth entry.
 public fun place_reduce_only_limit_order_and_repay_loan<BaseAsset, QuoteAsset>(
-    registry: &MarginRegistry,
-    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
-    pool: &mut Pool<BaseAsset, QuoteAsset>,
-    base_margin_pool: &mut MarginPool<BaseAsset>,
-    quote_margin_pool: &mut MarginPool<QuoteAsset>,
-    base_oracle: &PriceInfoObject,
-    quote_oracle: &PriceInfoObject,
-    client_order_id: u64,
-    order_type: u8,
-    self_matching_option: u8,
-    price: u64,
-    quantity: u64,
-    is_bid: bool,
-    pay_with_deep: bool,
-    expire_timestamp: u64,
-    clock: &Clock,
-    ctx: &mut TxContext,
+    _registry: &MarginRegistry,
+    _margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    _pool: &mut Pool<BaseAsset, QuoteAsset>,
+    _base_margin_pool: &mut MarginPool<BaseAsset>,
+    _quote_margin_pool: &mut MarginPool<QuoteAsset>,
+    _base_oracle: &PriceInfoObject,
+    _quote_oracle: &PriceInfoObject,
+    _client_order_id: u64,
+    _order_type: u8,
+    _self_matching_option: u8,
+    _price: u64,
+    _quantity: u64,
+    _is_bid: bool,
+    _pay_with_deep: bool,
+    _expire_timestamp: u64,
+    _clock: &Clock,
+    _ctx: &mut TxContext,
 ): OrderInfo {
-    place_reduce_only_limit_order_and_repay_loan_core<BaseAsset, QuoteAsset>(
-        registry,
-        margin_manager,
-        pool,
-        base_margin_pool,
-        quote_margin_pool,
-        oracle::read_price<BaseAsset>(base_oracle, registry, clock),
-        oracle::read_price<QuoteAsset>(quote_oracle, registry, clock),
-        client_order_id,
-        order_type,
-        self_matching_option,
-        price,
-        quantity,
-        is_bid,
-        pay_with_deep,
-        expire_timestamp,
-        clock,
-        ctx,
-    )
+    abort EDeprecatedUseUpgradedPyth
 }
 
-/// Atomically places a market order and repays the loan with the proceeds,
-/// gating on a **monotonic** net-state check: if any debt remains after the
-/// repay, the post-repay `risk_ratio` must be at least the pre-trade ratio
-/// (improve-or-hold). A full close drives debt to 0 (`risk_ratio` MAX), which
-/// always passes.
+/// RETIRED. Use `pool_proxy_upgraded::place_market_order_and_repay_loan`.
 ///
-/// This is the everyday close / deleverage tool. The monotonic gate — rather than
-/// the `min_open` opening floor used by `place_market_order_v2` — lets a position
-/// in the `liquidation..min_borrow` danger band wind down *partially*: a small
-/// close that lifts the ratio from, say, 1.12 to 1.15 is allowed even though 1.15
-/// is still below `min_open`, which the opening floor would reject.
-///
-/// Not reduce-only and uncapped, but the monotonic check makes a quantity cap
-/// unnecessary: a market (taker) fill settles immediately, so any genuinely
-/// exposure-*increasing* trade lowers the ratio and aborts here, while any
-/// deleveraging trade is allowed at any size — an overshoot past the debt is fine
-/// (surplus is the manager's own holding) and `assert_price` still bounds
-/// slippage. Requires margin trading enabled; in reduce-only mode use
-/// `place_reduce_only_market_order_and_repay_loan`.
-/// Twin: `pool_proxy_upgraded::place_market_order_and_repay_loan`. Edit both.
+/// Legacy-Pyth entry.
 public fun place_market_order_and_repay_loan<BaseAsset, QuoteAsset>(
-    registry: &MarginRegistry,
-    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
-    pool: &mut Pool<BaseAsset, QuoteAsset>,
-    base_margin_pool: &mut MarginPool<BaseAsset>,
-    quote_margin_pool: &mut MarginPool<QuoteAsset>,
-    base_oracle: &PriceInfoObject,
-    quote_oracle: &PriceInfoObject,
-    client_order_id: u64,
-    self_matching_option: u8,
-    quantity: u64,
-    is_bid: bool,
-    pay_with_deep: bool,
-    clock: &Clock,
-    ctx: &mut TxContext,
+    _registry: &MarginRegistry,
+    _margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    _pool: &mut Pool<BaseAsset, QuoteAsset>,
+    _base_margin_pool: &mut MarginPool<BaseAsset>,
+    _quote_margin_pool: &mut MarginPool<QuoteAsset>,
+    _base_oracle: &PriceInfoObject,
+    _quote_oracle: &PriceInfoObject,
+    _client_order_id: u64,
+    _self_matching_option: u8,
+    _quantity: u64,
+    _is_bid: bool,
+    _pay_with_deep: bool,
+    _clock: &Clock,
+    _ctx: &mut TxContext,
 ): OrderInfo {
-    // A debt-free manager needs no price: every consumer below is debt-gated, so
-    // reading eagerly would let a stale feed block an order that used to succeed.
-    let (base_reading, quote_reading) = if (margin_manager.has_debt()) {
-        (
-            option::some(oracle::read_price<BaseAsset>(base_oracle, registry, clock)),
-            option::some(oracle::read_price<QuoteAsset>(quote_oracle, registry, clock)),
-        )
-    } else {
-        (option::none(), option::none())
-    };
-
-    place_market_order_and_repay_loan_core<BaseAsset, QuoteAsset>(
-        registry,
-        margin_manager,
-        pool,
-        base_margin_pool,
-        quote_margin_pool,
-        base_reading,
-        quote_reading,
-        client_order_id,
-        self_matching_option,
-        quantity,
-        is_bid,
-        pay_with_deep,
-        clock,
-        ctx,
-    )
+    abort EDeprecatedUseUpgradedPyth
 }

--- a/packages/deepbook_margin/sources/pool_proxy_upgraded.move
+++ b/packages/deepbook_margin/sources/pool_proxy_upgraded.move
@@ -50,7 +50,7 @@ public fun update_current_price<BaseAsset, QuoteAsset>(
     )
 }
 
-/// Twin: `pool_proxy::place_limit_order_v2`. Edit both.
+/// Places a limit order in the pool.
 public fun place_limit_order_v2<BaseAsset, QuoteAsset>(
     registry: &MarginRegistry,
     margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
@@ -102,7 +102,7 @@ public fun place_limit_order_v2<BaseAsset, QuoteAsset>(
     )
 }
 
-/// Twin: `pool_proxy::place_market_order_v2`. Edit both.
+/// Places a market order in the pool.
 public fun place_market_order_v2<BaseAsset, QuoteAsset>(
     registry: &MarginRegistry,
     margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
@@ -148,7 +148,7 @@ public fun place_market_order_v2<BaseAsset, QuoteAsset>(
     )
 }
 
-/// Twin: `pool_proxy::place_reduce_only_limit_order_v2`. Edit both.
+/// Places a reduce-only order in the pool. Used when margin trading is disabled.
 public fun place_reduce_only_limit_order_v2<BaseAsset, QuoteAsset>(
     registry: &MarginRegistry,
     margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
@@ -189,7 +189,17 @@ public fun place_reduce_only_limit_order_v2<BaseAsset, QuoteAsset>(
     )
 }
 
-/// Twin: `pool_proxy::place_reduce_only_market_order_v2`. Edit both.
+/// Places a reduce-only market order in the pool. Used when margin trading is
+/// disabled.
+///
+/// Superseded by `place_reduce_only_market_order_and_repay_loan`. A market
+/// (taker) fill always pays the spread, which lowers the oracle-valued
+/// `risk_ratio` while the debt is unchanged, so the swap-only monotonic check
+/// here rejects essentially every taker fill. The `_and_repay` variant
+/// deleverages with the proceeds so the net-state ratio actually improves. Kept
+/// callable for existing integrators; its reduce-only *direction* guard matches
+/// the other entries — a bid needs base (short-side) debt, the ask needs quote
+/// (long-side) debt and sells up to gross base held — with no size cap.
 public fun place_reduce_only_market_order_v2<BaseAsset, QuoteAsset>(
     registry: &MarginRegistry,
     margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
@@ -224,7 +234,16 @@ public fun place_reduce_only_market_order_v2<BaseAsset, QuoteAsset>(
     )
 }
 
-/// Twin: `pool_proxy::place_reduce_only_market_order_and_repay_loan`. Edit both.
+/// Atomically winds down a leveraged position: places a reduce-only market
+/// order, repays the loan with the proceeds, then requires the net (post-repay)
+/// risk ratio to be at least the pre-trade ratio.
+///
+/// The post-repay check is the point. A market close pays the spread, which
+/// alone lowers the oracle-valued ratio (debt is unchanged until repay) and
+/// would abort the plain reduce-only path. Repaying first deleverages and
+/// absorbs the slippage (still bounded by the `assert_price` band), and lets a
+/// manager in the `liquidation..min_borrow` band climb out — it cannot reach
+/// the borrow floor in a single swap.
 public fun place_reduce_only_market_order_and_repay_loan<BaseAsset, QuoteAsset>(
     registry: &MarginRegistry,
     margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
@@ -259,7 +278,20 @@ public fun place_reduce_only_market_order_and_repay_loan<BaseAsset, QuoteAsset>(
     )
 }
 
-/// Twin: `pool_proxy::place_reduce_only_limit_order_and_repay_loan`. Edit both.
+/// Reduce-only **limit** order that atomically repays the loan with the taker
+/// fills. It is the limit/maker behaviour of `place_reduce_only_limit_order_v2`
+/// plus the repay-then-net-monotonic gate of
+/// `place_reduce_only_market_order_and_repay_loan`: the portion that crosses the
+/// book fills immediately and settles, the rest rests as a maker, then the
+/// settled (taker) proceeds repay the debt before the monotonic check on the net
+/// (post-repay) state.
+///
+/// This is the danger-band tool for a *price-bounded* reduce: a crossing
+/// reduce-only limit pays the spread on its taker fills, which alone would abort
+/// `place_reduce_only_limit_order_v2`'s swap-only monotonic check; repaying first
+/// deleverages so the net ratio holds. The resting remainder only locks balance
+/// (counted in assets), so it doesn't move the ratio. Unfilled-and-resting
+/// behaves exactly like `place_reduce_only_limit_order_v2` (nothing to repay).
 public fun place_reduce_only_limit_order_and_repay_loan<BaseAsset, QuoteAsset>(
     registry: &MarginRegistry,
     margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
@@ -300,7 +332,25 @@ public fun place_reduce_only_limit_order_and_repay_loan<BaseAsset, QuoteAsset>(
     )
 }
 
-/// Twin: `pool_proxy::place_market_order_and_repay_loan`. Edit both.
+/// Atomically places a market order and repays the loan with the proceeds,
+/// gating on a **monotonic** net-state check: if any debt remains after the
+/// repay, the post-repay `risk_ratio` must be at least the pre-trade ratio
+/// (improve-or-hold). A full close drives debt to 0 (`risk_ratio` MAX), which
+/// always passes.
+///
+/// This is the everyday close / deleverage tool. The monotonic gate — rather than
+/// the `min_open` opening floor used by `place_market_order_v2` — lets a position
+/// in the `liquidation..min_borrow` danger band wind down *partially*: a small
+/// close that lifts the ratio from, say, 1.12 to 1.15 is allowed even though 1.15
+/// is still below `min_open`, which the opening floor would reject.
+///
+/// Not reduce-only and uncapped, but the monotonic check makes a quantity cap
+/// unnecessary: a market (taker) fill settles immediately, so any genuinely
+/// exposure-*increasing* trade lowers the ratio and aborts here, while any
+/// deleveraging trade is allowed at any size — an overshoot past the debt is fine
+/// (surplus is the manager's own holding) and `assert_price` still bounds
+/// slippage. Requires margin trading enabled; in reduce-only mode use
+/// `place_reduce_only_market_order_and_repay_loan`.
 public fun place_market_order_and_repay_loan<BaseAsset, QuoteAsset>(
     registry: &MarginRegistry,
     margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,

--- a/packages/deepbook_margin/sources/pool_proxy_upgraded.move
+++ b/packages/deepbook_margin/sources/pool_proxy_upgraded.move
@@ -1,13 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Pyth's upgraded Core entrypoints for `pool_proxy`.
+/// The oracle-taking entrypoints for `pool_proxy`.
 ///
-/// Pyth Core is being replaced by a separately published package, so its
-/// `PriceInfoObject` is a distinct Move type from the legacy one and the frozen
-/// signatures in `pool_proxy` can never accept it. The upgraded surface therefore lives
-/// here, under the same function names. Each entry reads the upgraded feed and delegates
-/// to the shared core in `pool_proxy`, so both feeds run identical logic.
+/// Pyth replaced Core with a separately published package, so its `PriceInfoObject` is a
+/// distinct Move type from the legacy one and the frozen signatures in `pool_proxy` can
+/// never accept it. The oracle surface therefore lives here, under the same function
+/// names; each entry reads the upgraded feed and delegates to the shared core in
+/// `pool_proxy`. The legacy-Pyth twins in `pool_proxy` are retired and abort
+/// `EDeprecatedUseUpgradedPyth`; the module-level note in `margin_manager_upgraded`
+/// records why, and what has to happen on chain for them to stop being reachable.
 module deepbook_margin::pool_proxy_upgraded;
 
 use deepbook::{order_info::OrderInfo, pool::Pool};
@@ -21,7 +23,8 @@ use deepbook_margin::{
 use pyth_upgraded::price_info::PriceInfoObject as PriceInfoObjectUpgraded;
 use sui::clock::Clock;
 
-/// Twin: `pool_proxy::update_current_price`. Edit both.
+/// Updates the current price for a pool using safe oracle price calculation.
+/// Anyone can call this to update the price oracle used for order validation.
 public fun update_current_price<BaseAsset, QuoteAsset>(
     registry: &mut MarginRegistry,
     pool: &Pool<BaseAsset, QuoteAsset>,

--- a/packages/deepbook_margin/tests/dual_feed_window_tests.move
+++ b/packages/deepbook_margin/tests/dual_feed_window_tests.move
@@ -1,34 +1,35 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Behaviour of the window in which BOTH Pyth feeds are live and authoritative.
+/// The window in which BOTH Pyth feeds were live and authoritative, and its closure.
 ///
-/// Between this upgrade and Pyth's Core cutover, `read_price` and `read_price_upgraded`
-/// each enforce the same feed id, staleness window and EWMA bound, and carry the
-/// confidence interval for `price_config` to check at pricing time - but they do so
-/// independently, with no cross-feed comparison. `PythReading` erases
-/// which feed produced it and both entrypoint families share one `_core`, so a caller
-/// chooses per call. These tests pin what that does and does not permit.
+/// `read_price` and `read_price_upgraded` each enforced the same feed id, staleness
+/// window and EWMA bound, and each carried the confidence interval for `price_config` to
+/// check at pricing time — but they did so independently, with no cross-feed comparison.
+/// `PythReading` erases which feed produced it and both entrypoint families shared one
+/// `_core`, so a caller chose per call. Prices could not be forged, but the divergence
+/// was *selectable*: an attacker chose which signed update landed on which object and
+/// when, so they picked a moment inside the window rather than merely finding one. The
+/// bound was each feed's own staleness allowance — one leg fresh while the other sat
+/// `max_age_secs` old, so the two prices could sit a full window apart.
 ///
-/// Prices cannot be forged, but the divergence is still *selectable*: an attacker
-/// chooses which signed update lands on which object and when, so they pick a moment
-/// inside the window rather than merely finding one. The bound is each feed's own
-/// staleness allowance — one leg may be fresh while the other is `max_age_secs` old,
-/// so the two prices can sit a full window apart. This suite runs the test config's
-/// 60s; live mainnet is configured at 70s.
+/// The exposed set was wider than liquidation. Liquidating on the lower feed needs the
+/// manager in the danger band, and calling `margin_manager::liquidate` directly needs the
+/// caller to post a repay coin — though `margin_liquidation`'s vault entries are
+/// permissionless and fund the repay themselves, so the capital half of that never really
+/// bound. Firing a conditional order needed neither: `execute_conditional_orders_v2`/`v3`
+/// are permissionless, take no capital, and act on a manager that is merely healthy.
 ///
-/// The exposed set is wider than liquidation. Liquidating on the lower feed needs the
-/// manager in the danger band, and calling `margin_manager::liquidate` directly needs
-/// the caller to post a repay coin — though `margin_liquidation`'s vault entries are
-/// permissionless and fund the repay themselves, so the capital half of that has never
-/// really bound. Firing a conditional order needs neither: `execute_conditional_orders_v2`/`v3`
-/// are permissionless, take no capital, and act on a manager that is healthy — in or
-/// out of the danger band — see
-/// `dual_feed_window_fires_a_stop_on_the_lower_feed_alone`.
+/// The window did not self-close at Pyth's cutover: legacy objects for most configured
+/// currencies stayed fresh past it, refreshed by third parties DeepBook does not control.
+/// It is closed here instead, by retiring the legacy readers and the entrypoints that
+/// called them. These tests are the scenario-level record of that: each one replays a
+/// path that used to succeed and pins where it now stops. The surface inventory — one
+/// abort test per retired entry — is `legacy_pyth_entrypoints_disabled_tests`.
 ///
-/// If a mitigation lands (an admin switch making exactly one reader family
-/// authoritative, say) `dual_feed_window_permits_liquidating_on_the_lower_feed` is the
-/// test that should start failing - update it deliberately, do not delete it.
+/// These tests are load-bearing in one direction: if any of them starts passing *through*
+/// the legacy entry rather than through its abort, a second authoritative reader has been
+/// reintroduced. Update them deliberately, do not delete them.
 #[test_only]
 module deepbook_margin::dual_feed_window_tests;
 
@@ -38,13 +39,14 @@ use deepbook_margin::{
     margin_manager_upgraded,
     margin_pool::MarginPool,
     margin_registry::{MarginRegistry, MarginAdminCap, MaintainerCap},
+    pool_proxy_upgraded,
     test_constants::{Self, USDC, BTC, btc_multiplier},
     test_helpers::{
         cleanup_margin_test,
         mint_coin,
         build_btc_price_info_object,
-        build_demo_usdc_price_info_object,
         build_btc_price_info_object_upgraded,
+        build_demo_usdc_price_info_object,
         build_demo_usdc_price_info_object_upgraded,
         build_stale_btc_price_info_object_upgraded,
         setup_btc_usd_deepbook_margin,
@@ -89,10 +91,11 @@ fun open_1btc_40k_usdc(): (test::Scenario, Clock, MarginAdminCap, MaintainerCap,
     let pool = scenario.take_shared<Pool<BTC, USDC>>();
     let registry = scenario.take_shared<MarginRegistry>();
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<BTC, USDC, BTC>(
+    margin_manager_upgraded::deposit<BTC, USDC, BTC>(
+        &mut mm,
         &registry,
         &btc_price,
         &usdc_price,
@@ -100,7 +103,8 @@ fun open_1btc_40k_usdc(): (test::Scenario, Clock, MarginAdminCap, MaintainerCap,
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_quote<BTC, USDC>(
+    margin_manager_upgraded::borrow_quote<BTC, USDC>(
+        &mut mm,
         &registry,
         &mut usdc_pool,
         &btc_price,
@@ -120,14 +124,63 @@ fun open_1btc_40k_usdc(): (test::Scenario, Clock, MarginAdminCap, MaintainerCap,
     (scenario, clock, admin_cap, maintainer_cap, btc_pool_id, usdc_pool_id, registry_id)
 }
 
-/// EXPLOIT ATTEMPT — dual-feed liquidation.
-/// The same manager is priced through two live feeds in the same block: the
-/// legacy Core feed puts BTC at $4100 (risk 1.1025, NOT liquidatable) while the
-/// Pyth's upgraded Core feed puts BTC at $3900 (risk 1.0975, liquidatable). If the upgraded feed
-/// alone suffices to liquidate a manager the Core feed calls healthy, the
-/// liquidation goes through and the liquidator walks away with collateral.
+/// CLOSED — dual-feed liquidation.
+///
+/// The exploit: price one manager through two live feeds in the same block. The legacy
+/// feed puts BTC at $4100 (risk 1.1025, NOT liquidatable) while the upgraded feed puts it
+/// at $3900 (risk 1.0975, liquidatable), and the upgraded feed alone sufficed to liquidate
+/// a manager the legacy feed called healthy. The liquidator walked away with collateral.
+///
+/// Both halves are gone. The legacy risk query — the "is it healthy on the other feed?"
+/// leg an attacker used to select the moment — aborts before it can price anything, so
+/// the divergence is not observable through the protocol, let alone actionable. The
+/// second half (that `margin_manager::liquidate` itself aborts) is
+/// `legacy_pyth_entrypoints_disabled_tests::legacy_liquidate_aborts`.
+#[test, expected_failure(abort_code = margin_manager::EDeprecatedUseUpgradedPyth)]
+fun dual_feed_window_no_longer_prices_a_manager_on_the_legacy_feed() {
+    let (
+        mut scenario,
+        clock,
+        _admin_cap,
+        _maintainer_cap,
+        btc_pool_id,
+        usdc_pool_id,
+        _registry_id,
+    ) = open_1btc_40k_usdc();
+
+    scenario.next_tx(test_constants::liquidator());
+    let mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let registry = scenario.take_shared<MarginRegistry>();
+    let btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
+    let usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+
+    // The legacy leg of the exploit: BTC at $4100, fresh and correctly configured, so
+    // the only thing that can stop this read is the retirement itself.
+    let legacy_btc = build_btc_price_info_object(&mut scenario, 4100, &clock);
+    let legacy_usdc = build_demo_usdc_price_info_object(&mut scenario, &clock);
+
+    let _ = margin_manager::risk_ratio<BTC, USDC>(
+        &mm,
+        &registry,
+        &legacy_btc,
+        &legacy_usdc,
+        &pool,
+        &btc_pool,
+        &usdc_pool,
+        &clock,
+    );
+
+    abort 999
+}
+
+/// The upgraded path still liquidates a genuinely unhealthy manager.
+///
+/// Closing the window must not close liquidation: the same $3900 mark that the exploit
+/// used as its *lower* leg is, on its own, a real liquidation. Without this the abort
+/// tests above would pass just as well against a package where liquidation was broken.
 #[test]
-fun dual_feed_window_permits_liquidating_on_the_lower_feed() {
+fun upgraded_feed_alone_still_liquidates_an_unhealthy_manager() {
     let (
         mut scenario,
         clock,
@@ -145,47 +198,38 @@ fun dual_feed_window_permits_liquidating_on_the_lower_feed() {
     let btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
 
-    // Core feed: BTC $4100. Legacy risk query must call it healthy.
-    let core_btc = build_btc_price_info_object(&mut scenario, 4100, &clock);
-    let core_usdc = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let core_risk = mm.risk_ratio<BTC, USDC>(
+    let btc = build_btc_price_info_object_upgraded(&mut scenario, 3900, &clock);
+    let usdc = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+
+    // 1 BTC at $3900 against 40k USDC of debt is below the pool's liquidation floor.
+    let risk = margin_manager_upgraded::risk_ratio<BTC, USDC>(
+        &mm,
         &registry,
-        &core_btc,
-        &core_usdc,
+        &btc,
+        &usdc,
         &pool,
         &btc_pool,
         &usdc_pool,
         &clock,
     );
-    let liq_threshold = registry.liquidation_risk_ratio(pool.id());
-    assert!(core_risk >= liq_threshold, 100); // Core: NOT liquidatable
-    assert!(!registry.can_liquidate(pool.id(), core_risk), 101);
+    assert!(registry.can_liquidate(pool.id(), risk), 100);
 
-    // Upgraded feed: BTC $3900. Liquidate through the upgraded entrypoint in the same block.
-    let upgraded_btc = build_btc_price_info_object_upgraded(&mut scenario, 3900, &clock);
-    let upgraded_usdc = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
     let repay = mint_coin<USDC>(100_000_000_000, scenario.ctx());
-
     let (base_coin, quote_coin, remaining) = margin_manager_upgraded::liquidate<BTC, USDC, USDC>(
         &mut mm,
         &registry,
-        &upgraded_btc,
-        &upgraded_usdc,
+        &btc,
+        &usdc,
         &mut usdc_pool,
         &mut pool,
         repay,
         &clock,
         scenario.ctx(),
     );
-
-    // Liquidator profited: received collateral back from a Core-healthy manager.
-    let extracted = base_coin.value();
-    let quote_back = quote_coin.value();
-    assert!(extracted > 0 || quote_back > 0, 102);
+    assert!(base_coin.value() > 0 || quote_coin.value() > 0, 101);
 
     destroy_3!(base_coin, quote_coin, remaining);
-    destroy_2!(core_btc, core_usdc);
-    destroy_2!(upgraded_btc, upgraded_usdc);
+    destroy_2!(btc, usdc);
     return_shared(btc_pool);
     return_shared(usdc_pool);
     return_shared(pool);
@@ -195,9 +239,10 @@ fun dual_feed_window_permits_liquidating_on_the_lower_feed() {
 
 /// GUARD — a debt-carrying position cannot be evaluated on a stale upgraded feed.
 /// Liquidation through the upgraded entrypoint with a stale BTC feed must abort in the
-/// upgraded reader's staleness check (get_price_no_older_than).
+/// upgraded reader's staleness check (get_price_no_older_than). With the legacy family
+/// retired this is the only staleness window left, so it is the whole guard.
 #[test, expected_failure(abort_code = pyth_upgraded::pyth::E_STALE_PRICE_UPDATE)]
-fun dual_feed_window_still_enforces_staleness_on_each_feed() {
+fun upgraded_feed_still_enforces_staleness() {
     let (
         mut scenario,
         clock,
@@ -239,21 +284,25 @@ fun dual_feed_window_still_enforces_staleness_on_each_feed() {
     cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
 }
 
-/// The window's exposed set is wider than liquidation.
+/// CLOSED — the widest leg: a permissionless stop fired on the lower feed alone.
 ///
-/// Liquidating on the lower feed needs the manager in the danger band. Firing a
-/// conditional order does not need even that: the v2 executor is permissionless, takes
-/// no capital, and acts on a manager that is merely healthy. The
-/// trigger is evaluated against whichever feed the caller supplies, and nothing on
-/// chain compares the two — so a stop the true price never reached can be realised by
-/// an arbitrary third party.
-#[test]
-fun dual_feed_window_fires_a_stop_on_the_lower_feed_alone() {
+/// Liquidating on the lower feed at least needed the manager in the danger band. Firing a
+/// conditional order needed nothing: the v2 executor is permissionless, takes no capital,
+/// and acts on a manager that is merely healthy. A caller ran the executor with the feed
+/// that suited them and realised a stop the true price never reached — an arbitrary third
+/// party closing someone else's position at a price of their choosing.
+///
+/// The stop is placed and confirmed queued through the live path, then the legacy
+/// executor is called on it exactly as the exploit did. It aborts, and the ordering
+/// matters: the assertions before the call prove the order was genuinely there to fire,
+/// so the abort is the retirement and not an empty queue.
+#[test, expected_failure(abort_code = margin_manager::EDeprecatedUseUpgradedPyth)]
+fun dual_feed_window_no_longer_fires_a_stop_on_the_legacy_feed() {
     let (
         mut scenario,
         clock,
-        admin_cap,
-        maintainer_cap,
+        _admin_cap,
+        _maintainer_cap,
         btc_pool_id,
         usdc_pool_id,
         _registry_id,
@@ -264,10 +313,10 @@ fun dual_feed_window_fires_a_stop_on_the_lower_feed_alone() {
     let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
     let pool = scenario.take_shared<Pool<BTC, USDC>>();
     let registry = scenario.take_shared<MarginRegistry>();
-    let btc_50k = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_50k = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
-    margin_manager::add_conditional_order<BTC, USDC>(
+    margin_manager_upgraded::add_conditional_order<BTC, USDC>(
         &mut mm,
         &pool,
         &btc_50k,
@@ -289,11 +338,86 @@ fun dual_feed_window_fires_a_stop_on_the_lower_feed_alone() {
         scenario.ctx(),
     );
     assert!(mm.conditional_order_ids().length() == 1);
+    destroy_2!(btc_50k, usdc);
     return_shared(registry);
     return_shared(pool);
     return_shared(mm);
 
-    // An arbitrary caller — not the owner — runs the executor twice in the same block.
+    // An arbitrary caller — not the owner — brings a legacy feed at $44k, below the stop.
+    scenario.next_tx(test_constants::liquidator());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let registry = scenario.take_shared<MarginRegistry>();
+    let btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
+    let usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+
+    let legacy_44k = build_btc_price_info_object(&mut scenario, 44000, &clock);
+    let legacy_usdc = build_demo_usdc_price_info_object(&mut scenario, &clock);
+
+    let _: vector<OrderInfo> = margin_manager::execute_conditional_orders_v2<BTC, USDC>(
+        &mut mm,
+        &mut pool,
+        &btc_pool,
+        &usdc_pool,
+        &legacy_44k,
+        &legacy_usdc,
+        &registry,
+        10,
+        &clock,
+        scenario.ctx(),
+    );
+
+    abort 999
+}
+
+/// The upgraded executor still fires that same stop, so the abort above is the legacy
+/// entry and not a queue that stopped working.
+#[test]
+fun upgraded_executor_still_fires_a_triggered_stop() {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        btc_pool_id,
+        usdc_pool_id,
+        _registry_id,
+    ) = open_1btc_40k_usdc();
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let registry = scenario.take_shared<MarginRegistry>();
+    let btc_50k = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+
+    margin_manager_upgraded::add_conditional_order<BTC, USDC>(
+        &mut mm,
+        &pool,
+        &btc_50k,
+        &usdc,
+        &registry,
+        1,
+        tpsl::new_condition(true, 450_000_000_000),
+        tpsl::new_pending_limit_order(
+            1,
+            constants::no_restriction(),
+            constants::self_matching_allowed(),
+            440_000_000_000,
+            btc_multiplier() / 10,
+            false,
+            false,
+            constants::max_u64(),
+        ),
+        &clock,
+        scenario.ctx(),
+    );
+    assert!(mm.conditional_order_ids().length() == 1);
+    destroy_2!(btc_50k, usdc);
+    return_shared(registry);
+    return_shared(pool);
+    return_shared(mm);
+
     scenario.next_tx(test_constants::liquidator());
     let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
     let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
@@ -301,36 +425,19 @@ fun dual_feed_window_fires_a_stop_on_the_lower_feed_alone() {
     let btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
     let usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
 
-    // Legacy feed at $48k is above the stop: the order must stay queued.
-    let legacy_48k = build_btc_price_info_object(&mut scenario, 48000, &clock);
-    let legacy_usdc = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let legacy_filled: vector<OrderInfo> = margin_manager::execute_conditional_orders_v2<BTC, USDC>(
-        &mut mm,
-        &mut pool,
-        &btc_pool,
-        &usdc_pool,
-        &legacy_48k,
-        &legacy_usdc,
-        &registry,
-        10,
-        &clock,
-        scenario.ctx(),
-    );
-    assert!(legacy_filled.is_empty());
-    assert!(mm.conditional_order_ids().length() == 1);
-
-    // Upgraded feed at $44k, same block, same manager. Re-anchoring the order-validation
-    // band is itself permissionless, so the same caller does it with the same feed.
-    let upgraded_44k = build_btc_price_info_object_upgraded(&mut scenario, 44000, &clock);
-    let upgraded_usdc = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
-    deepbook_margin::pool_proxy_upgraded::update_current_price<BTC, USDC>(
+    // Re-anchoring the order-validation band is permissionless, so the same caller does
+    // it — with the same feed the executor then reads.
+    let btc_44k = build_btc_price_info_object_upgraded(&mut scenario, 44000, &clock);
+    let usdc = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    pool_proxy_upgraded::update_current_price<BTC, USDC>(
         &mut registry,
         &pool,
-        &upgraded_44k,
-        &upgraded_usdc,
+        &btc_44k,
+        &usdc,
         &clock,
     );
-    let upgraded_filled: vector<OrderInfo> = margin_manager_upgraded::execute_conditional_orders_v2<
+
+    let filled: vector<OrderInfo> = margin_manager_upgraded::execute_conditional_orders_v2<
         BTC,
         USDC,
     >(
@@ -338,21 +445,18 @@ fun dual_feed_window_fires_a_stop_on_the_lower_feed_alone() {
         &mut pool,
         &btc_pool,
         &usdc_pool,
-        &upgraded_44k,
-        &upgraded_usdc,
+        &btc_44k,
+        &usdc,
         &registry,
         10,
         &clock,
         scenario.ctx(),
     );
-    assert!(upgraded_filled.length() == 1);
+    assert!(filled.length() == 1);
     assert!(mm.conditional_order_ids().is_empty());
 
-    std::unit_test::destroy(legacy_filled);
-    std::unit_test::destroy(upgraded_filled);
-    destroy_2!(legacy_48k, legacy_usdc);
-    destroy_2!(upgraded_44k, upgraded_usdc);
-    destroy_2!(btc_50k, usdc);
+    std::unit_test::destroy(filled);
+    destroy_2!(btc_44k, usdc);
     return_shared(btc_pool);
     return_shared(usdc_pool);
     return_shared(pool);

--- a/packages/deepbook_margin/tests/helper/oracle_tests.move
+++ b/packages/deepbook_margin/tests/helper/oracle_tests.move
@@ -8,7 +8,6 @@ use deepbook_margin::{
     margin_registry::{Self, MarginRegistry},
     oracle::{
         Self,
-        read_price,
         read_price_upgraded,
         read_price_upgraded_unsafe,
         calculate_price,
@@ -20,7 +19,6 @@ use deepbook_margin::{
     },
     test_constants::{Self, SUI, USDC},
     test_helpers::{
-        build_pyth_price_info_object,
         build_pyth_upgraded_price_info_object,
         build_pyth_upgraded_price_info_with_ewma,
         create_test_pyth_config,
@@ -257,7 +255,7 @@ fun test_calculate_usd_price_invalid_confidence_too_high() {
     // Price = $100 (10000000000 with 8 decimals: 100 * 10^8)
     // Max allowed conf = 1000 * 10000000000 / 10_000 = 1_000_000_000
     // We set conf = 1_500_000_000 which is > 10% (15%)
-    let price_info = build_pyth_price_info_object(
+    let price_info = build_pyth_upgraded_price_info_object(
         &mut scenario,
         test_constants::usdc_price_feed_id(),
         10000000000, // $100 price (100 * 10^8)
@@ -268,7 +266,7 @@ fun test_calculate_usd_price_invalid_confidence_too_high() {
 
     // This should fail with EInvalidPythPriceConf
     calculate_usd_price<USDC>(
-        read_price<USDC>(&price_info, &registry, &clock),
+        read_price_upgraded<USDC>(&price_info, &registry, &clock),
         &registry,
         1000000, // 1 USDC (6 decimals)
     );
@@ -301,7 +299,7 @@ fun test_calculate_usd_price_valid_confidence_at_limit() {
     // Price = $100 (10000000000 with 8 decimals: 100 * 10^8)
     // Max allowed conf = 1000 * 10000000000 / 10_000 = 1_000_000_000
     // We set conf = 1_000_000_000 which is exactly at 10%
-    let price_info = build_pyth_price_info_object(
+    let price_info = build_pyth_upgraded_price_info_object(
         &mut scenario,
         test_constants::usdc_price_feed_id(),
         10000000000, // $100 price (100 * 10^8)
@@ -312,7 +310,7 @@ fun test_calculate_usd_price_valid_confidence_at_limit() {
 
     // This should succeed
     let usd_price = calculate_usd_price<USDC>(
-        read_price<USDC>(&price_info, &registry, &clock),
+        read_price_upgraded<USDC>(&price_info, &registry, &clock),
         &registry,
         1000000, // 1 USDC (6 decimals)
     );
@@ -348,7 +346,7 @@ fun test_calculate_target_amount_invalid_confidence() {
     // Price = $50 (5000000000 with 8 decimals: 50 * 10^8)
     // Max allowed conf = 1000 * 5000000000 / 10_000 = 500_000_000
     // We set conf = 750_000_000 which is 15% (exceeds 10% threshold)
-    let price_info = build_pyth_price_info_object(
+    let price_info = build_pyth_upgraded_price_info_object(
         &mut scenario,
         test_constants::usdc_price_feed_id(),
         5000000000, // $50 price (50 * 10^8)
@@ -359,7 +357,7 @@ fun test_calculate_target_amount_invalid_confidence() {
 
     // This should fail with EInvalidPythPriceConf
     calculate_target_amount<USDC>(
-        read_price<USDC>(&price_info, &registry, &clock),
+        read_price_upgraded<USDC>(&price_info, &registry, &clock),
         &registry,
         100_000_000_000, // $100 USD (9 decimals)
     );
@@ -369,38 +367,6 @@ fun test_calculate_target_amount_invalid_confidence() {
     test_scenario::return_shared(registry);
     test_scenario::return_shared(clock);
     scenario.end();
-}
-
-/// Helper to build a price info object with separate pyth price and EWMA price
-fun build_pyth_price_info_with_ewma(
-    scenario: &mut Scenario,
-    id: vector<u8>,
-    price_value: u64,
-    ewma_price_value: u64,
-    conf_value: u64,
-    exp_value: u64,
-    timestamp: u64,
-): PriceInfoObject {
-    let price_id = price_identifier::from_byte_vec(id);
-    let price = price::new(
-        i64::new(price_value, false), // positive price
-        conf_value,
-        i64::new(exp_value, true), // negative exponent
-        timestamp,
-    );
-    let ewma_price = price::new(
-        i64::new(ewma_price_value, false), // positive EWMA price
-        conf_value,
-        i64::new(exp_value, true), // negative exponent
-        timestamp,
-    );
-    let price_feed = price_feed::new(price_id, price, ewma_price);
-    let price_info = price_info::new_price_info(
-        timestamp - 2, // attestation_time
-        timestamp - 1, // arrival_time
-        price_feed,
-    );
-    price_info::new_price_info_object_for_test(price_info, scenario.ctx())
 }
 
 #[test, expected_failure(abort_code = ::deepbook_margin::oracle::EInvalidPythPrice)]
@@ -423,7 +389,7 @@ fun test_ewma_price_difference_too_high() {
     // Create price info where pyth price is 20% higher than EWMA (exceeds 15% threshold)
     // EWMA price = $100 (10000000000 with 8 decimals)
     // Pyth price = $120 (12000000000 with 8 decimals) - 20% higher
-    let price_info = build_pyth_price_info_with_ewma(
+    let price_info = build_pyth_upgraded_price_info_with_ewma(
         &mut scenario,
         test_constants::usdc_price_feed_id(),
         12000000000, // $120 pyth price
@@ -435,7 +401,7 @@ fun test_ewma_price_difference_too_high() {
 
     // This should fail with EInvalidPythPrice
     calculate_usd_price<USDC>(
-        read_price<USDC>(&price_info, &registry, &clock),
+        read_price_upgraded<USDC>(&price_info, &registry, &clock),
         &registry,
         1000000, // 1 USDC (6 decimals)
     );
@@ -467,7 +433,7 @@ fun test_ewma_price_difference_too_low() {
     // Create price info where pyth price is 20% lower than EWMA (exceeds 15% threshold)
     // EWMA price = $100 (10000000000 with 8 decimals)
     // Pyth price = $80 (8000000000 with 8 decimals) - 20% lower
-    let price_info = build_pyth_price_info_with_ewma(
+    let price_info = build_pyth_upgraded_price_info_with_ewma(
         &mut scenario,
         test_constants::usdc_price_feed_id(),
         8000000000, // $80 pyth price
@@ -479,7 +445,7 @@ fun test_ewma_price_difference_too_low() {
 
     // This should fail with EInvalidPythPrice
     calculate_usd_price<USDC>(
-        read_price<USDC>(&price_info, &registry, &clock),
+        read_price_upgraded<USDC>(&price_info, &registry, &clock),
         &registry,
         1000000, // 1 USDC (6 decimals)
     );
@@ -511,7 +477,7 @@ fun test_ewma_price_difference_at_upper_limit() {
     // Create price info where pyth price is exactly 15% higher than EWMA
     // EWMA price = $100 (10000000000 with 8 decimals)
     // Pyth price = $115 (11500000000 with 8 decimals) - exactly 15% higher
-    let price_info = build_pyth_price_info_with_ewma(
+    let price_info = build_pyth_upgraded_price_info_with_ewma(
         &mut scenario,
         test_constants::usdc_price_feed_id(),
         11500000000, // $115 pyth price
@@ -523,7 +489,7 @@ fun test_ewma_price_difference_at_upper_limit() {
 
     // This should succeed
     let usd_price = calculate_usd_price<USDC>(
-        read_price<USDC>(&price_info, &registry, &clock),
+        read_price_upgraded<USDC>(&price_info, &registry, &clock),
         &registry,
         1000000, // 1 USDC (6 decimals)
     );
@@ -558,7 +524,7 @@ fun test_ewma_price_difference_at_lower_limit() {
     // Create price info where pyth price is exactly 15% lower than EWMA
     // EWMA price = $100 (10000000000 with 8 decimals)
     // Pyth price = $85 (8500000000 with 8 decimals) - exactly 15% lower
-    let price_info = build_pyth_price_info_with_ewma(
+    let price_info = build_pyth_upgraded_price_info_with_ewma(
         &mut scenario,
         test_constants::usdc_price_feed_id(),
         8500000000, // $85 pyth price
@@ -570,7 +536,7 @@ fun test_ewma_price_difference_at_lower_limit() {
 
     // This should succeed
     let usd_price = calculate_usd_price<USDC>(
-        read_price<USDC>(&price_info, &registry, &clock),
+        read_price_upgraded<USDC>(&price_info, &registry, &clock),
         &registry,
         1000000, // 1 USDC (6 decimals)
     );
@@ -607,7 +573,7 @@ fun test_confidence_check_with_high_price_no_overflow() {
     // With u64, max_conf_bps * pyth_price = 1000 * 100000000000000 = 10^17 (safe)
     // Max allowed conf = 1000 * 100000000000000 / 10_000 = 10_000_000_000_000
     // We set conf = 5_000_000_000_000 which is 5% (within 10% threshold)
-    let price_info = build_pyth_price_info_object(
+    let price_info = build_pyth_upgraded_price_info_object(
         &mut scenario,
         test_constants::usdc_price_feed_id(),
         100000000000000, // $1M price (1M * 10^8)
@@ -618,7 +584,7 @@ fun test_confidence_check_with_high_price_no_overflow() {
 
     // This should succeed with u128 casting preventing overflow
     let usd_price = calculate_usd_price<USDC>(
-        read_price<USDC>(&price_info, &registry, &clock),
+        read_price_upgraded<USDC>(&price_info, &registry, &clock),
         &registry,
         1000000, // 1 USDC (6 decimals)
     );
@@ -655,7 +621,7 @@ fun test_ewma_check_with_high_price_no_overflow() {
     // With u64: ewma_price * (10_000 + 1500) = 100000000000000 * 11500
     // = 1.15 * 10^18 which exceeds u64 max (~1.8 * 10^19) but is close
     // Pyth price = $1,100,000 (110000000000000) - 10% higher (within 15%)
-    let price_info = build_pyth_price_info_with_ewma(
+    let price_info = build_pyth_upgraded_price_info_with_ewma(
         &mut scenario,
         test_constants::usdc_price_feed_id(),
         110000000000000, // $1.1M pyth price
@@ -667,7 +633,7 @@ fun test_ewma_check_with_high_price_no_overflow() {
 
     // This should succeed with u128 casting preventing overflow
     let usd_price = calculate_usd_price<USDC>(
-        read_price<USDC>(&price_info, &registry, &clock),
+        read_price_upgraded<USDC>(&price_info, &registry, &clock),
         &registry,
         1000000, // 1 USDC (6 decimals)
     );
@@ -682,12 +648,13 @@ fun test_ewma_check_with_high_price_no_overflow() {
     scenario.end();
 }
 
-// === Pyth's upgraded Core reader parity ===
-// Pyth's upgraded Core is a separate published package, so its feed is a distinct Move type.
-// These pin that `read_price_upgraded` enforces exactly the policy `read_price` does.
+// === The upgraded-Core reader's policy ===
+// `read_price_upgraded` is the only validated reader left: the legacy-Core readers were
+// removed with the entrypoints that called them. These pin the policy it enforces —
+// staleness, feed id, EWMA divergence — and where the confidence bound is applied.
 
 #[test]
-fun test_read_price_upgraded_matches_legacy_reader() {
+fun test_read_price_upgraded_prices_a_fresh_feed() {
     let mut scenario = test_scenario::begin(test_constants::admin());
 
     scenario.next_tx(test_constants::admin());
@@ -702,39 +669,25 @@ fun test_read_price_upgraded_matches_legacy_reader() {
     let pyth_config = create_test_pyth_config(); // max_conf_bps = 1000 (10%)
     registry.add_config(&admin_cap, pyth_config);
 
-    // Same feed id, price, conf, exponent and timestamp through both packages. The
-    // two readers must produce an identical `PythReading`, or the upgraded entrypoints
-    // price differently from the legacy ones they shadow.
-    let legacy_info = build_pyth_price_info_object(
+    let price_info = build_pyth_upgraded_price_info_object(
         &mut scenario,
         test_constants::usdc_price_feed_id(),
-        10000000000, // $100
+        10000000000, // $100, 8 decimals
         1000000, // well inside the confidence bound
         8,
         clock.timestamp_ms() / 1000,
     );
-    let upgraded_info = build_pyth_upgraded_price_info_object(
-        &mut scenario,
-        test_constants::usdc_price_feed_id(),
-        10000000000,
-        1000000,
-        8,
-        clock.timestamp_ms() / 1000,
-    );
 
-    let legacy_reading = read_price<USDC>(&legacy_info, &registry, &clock);
-    let upgraded_reading = read_price_upgraded<USDC>(&upgraded_info, &registry, &clock);
-    assert!(upgraded_reading.price() == legacy_reading.price());
-    assert!(upgraded_reading.decimals() == legacy_reading.decimals());
+    let reading = read_price_upgraded<USDC>(&price_info, &registry, &clock);
+    assert!(reading.price() == 10000000000);
+    assert!(reading.decimals() == 8);
 
-    let legacy_usd = calculate_usd_price<USDC>(legacy_reading, &registry, 1000000);
-    let upgraded_usd = calculate_usd_price<USDC>(upgraded_reading, &registry, 1000000); // 1 USDC
-    assert!(upgraded_usd == legacy_usd);
-    assert!(upgraded_usd == 100_000_000_000);
+    // 1 USDC (6 decimals) at $100, expressed with 9 USD decimals: 100 * 10^9.
+    let usd = calculate_usd_price<USDC>(reading, &registry, 1000000);
+    assert!(usd == 100_000_000_000);
 
     destroy(admin_cap);
-    destroy(legacy_info);
-    destroy(upgraded_info);
+    destroy(price_info);
     test_scenario::return_shared(registry);
     test_scenario::return_shared(clock);
     scenario.end();
@@ -1030,7 +983,7 @@ fun test_reading_consumed_as_the_wrong_asset_aborts() {
 
     // A completely valid SUI reading: right feed id, fresh, tight confidence, EWMA in
     // band. Nothing about it is malformed - it is simply not a USDC price.
-    let price_info = build_pyth_price_info_object(
+    let price_info = build_pyth_upgraded_price_info_object(
         &mut scenario,
         test_constants::sui_price_feed_id(),
         10000000000,
@@ -1038,7 +991,7 @@ fun test_reading_consumed_as_the_wrong_asset_aborts() {
         8,
         clock.timestamp_ms() / 1000,
     );
-    let sui_reading = read_price<SUI>(&price_info, &registry, &clock);
+    let sui_reading = read_price_upgraded<SUI>(&price_info, &registry, &clock);
 
     let _ = calculate_usd_price<USDC>(sui_reading, &registry, 1000000);
 
@@ -1066,7 +1019,7 @@ fun test_reading_consumed_as_its_own_asset_prices_normally() {
     let clock = scenario.take_shared<Clock>();
     registry.add_config(&admin_cap, create_test_pyth_config());
 
-    let price_info = build_pyth_price_info_object(
+    let price_info = build_pyth_upgraded_price_info_object(
         &mut scenario,
         test_constants::sui_price_feed_id(),
         10000000000, // $100
@@ -1074,7 +1027,7 @@ fun test_reading_consumed_as_its_own_asset_prices_normally() {
         8,
         clock.timestamp_ms() / 1000,
     );
-    let sui_reading = read_price<SUI>(&price_info, &registry, &clock);
+    let sui_reading = read_price_upgraded<SUI>(&price_info, &registry, &clock);
 
     // SUI carries 9 decimals in the test config, so 1 SUI is 1_000_000_000.
     let usd = calculate_usd_price<SUI>(sui_reading, &registry, 1_000_000_000);
@@ -1108,7 +1061,7 @@ fun test_calculate_price_rejects_a_ratio_past_the_max_price_ceiling() {
     let clock = scenario.take_shared<Clock>();
     registry.add_config(&admin_cap, create_test_pyth_config());
 
-    let usdc_price_info = build_pyth_price_info_object(
+    let usdc_price_info = build_pyth_upgraded_price_info_object(
         &mut scenario,
         test_constants::usdc_price_feed_id(),
         100000000, // $1.00
@@ -1118,7 +1071,7 @@ fun test_calculate_price_rejects_a_ratio_past_the_max_price_ceiling() {
     );
     // SUI at the smallest representable price, 1e-8. Confidence must be 0 to stay
     // inside the 10% bound at this magnitude.
-    let sui_price_info = build_pyth_price_info_object(
+    let sui_price_info = build_pyth_upgraded_price_info_object(
         &mut scenario,
         test_constants::sui_price_feed_id(),
         1,
@@ -1127,8 +1080,8 @@ fun test_calculate_price_rejects_a_ratio_past_the_max_price_ceiling() {
         clock.timestamp_ms() / 1000,
     );
 
-    let usdc_reading = read_price<USDC>(&usdc_price_info, &registry, &clock);
-    let sui_reading = read_price<SUI>(&sui_price_info, &registry, &clock);
+    let usdc_reading = read_price_upgraded<USDC>(&usdc_price_info, &registry, &clock);
+    let sui_reading = read_price_upgraded<SUI>(&sui_price_info, &registry, &clock);
 
     let _ = calculate_price<USDC, SUI>(&registry, usdc_reading, sui_reading);
 

--- a/packages/deepbook_margin/tests/helper/test_helpers.move
+++ b/packages/deepbook_margin/tests/helper/test_helpers.move
@@ -7,6 +7,7 @@ module deepbook_margin::test_helpers;
 use deepbook::{constants, math, pool::{Self, Pool}, registry::{Self, Registry}};
 use deepbook_margin::{
     margin_manager::MarginApp,
+    margin_manager_upgraded,
     margin_pool::{Self, MarginPool},
     margin_registry::{
         Self,
@@ -17,7 +18,7 @@ use deepbook_margin::{
         MarginPoolCap,
     },
     oracle::{Self, PythConfig},
-    pool_proxy,
+    pool_proxy_upgraded,
     protocol_config::{Self, ProtocolConfig},
     test_constants::{Self, USDC, USDT, BTC, SUI}
 };
@@ -312,11 +313,11 @@ public fun initialize_pool_price<BaseAsset, QuoteAsset>(
     let pool = scenario.take_shared_by_id<Pool<BaseAsset, QuoteAsset>>(pool_id);
 
     // Build price info objects for base and quote
-    let base_price = build_price_info_for_type<BaseAsset>(scenario, clock);
-    let quote_price = build_price_info_for_type<QuoteAsset>(scenario, clock);
+    let base_price = build_price_info_for_type_upgraded<BaseAsset>(scenario, clock);
+    let quote_price = build_price_info_for_type_upgraded<QuoteAsset>(scenario, clock);
 
     // Update the current price in the registry
-    pool_proxy::update_current_price<BaseAsset, QuoteAsset>(
+    pool_proxy_upgraded::update_current_price<BaseAsset, QuoteAsset>(
         margin_registry,
         &pool,
         &base_price,
@@ -1329,9 +1330,9 @@ public fun place_limit_order_v2_for_test<BaseAsset, QuoteAsset>(
     expire_timestamp: u64,
     clock: &Clock,
 ): deepbook::order_info::OrderInfo {
-    let base_oracle = build_price_info_for_type<BaseAsset>(scenario, clock);
-    let quote_oracle = build_price_info_for_type<QuoteAsset>(scenario, clock);
-    let order_info = pool_proxy::place_limit_order_v2<BaseAsset, QuoteAsset>(
+    let base_oracle = build_price_info_for_type_upgraded<BaseAsset>(scenario, clock);
+    let quote_oracle = build_price_info_for_type_upgraded<QuoteAsset>(scenario, clock);
+    let order_info = pool_proxy_upgraded::place_limit_order_v2<BaseAsset, QuoteAsset>(
         registry,
         mm,
         pool,
@@ -1369,9 +1370,9 @@ public fun place_market_order_v2_for_test<BaseAsset, QuoteAsset>(
     pay_with_deep: bool,
     clock: &Clock,
 ): deepbook::order_info::OrderInfo {
-    let base_oracle = build_price_info_for_type<BaseAsset>(scenario, clock);
-    let quote_oracle = build_price_info_for_type<QuoteAsset>(scenario, clock);
-    let order_info = pool_proxy::place_market_order_v2<BaseAsset, QuoteAsset>(
+    let base_oracle = build_price_info_for_type_upgraded<BaseAsset>(scenario, clock);
+    let quote_oracle = build_price_info_for_type_upgraded<QuoteAsset>(scenario, clock);
+    let order_info = pool_proxy_upgraded::place_market_order_v2<BaseAsset, QuoteAsset>(
         registry,
         mm,
         pool,
@@ -1409,9 +1410,9 @@ public fun place_reduce_only_limit_order_v2_for_test<BaseAsset, QuoteAsset>(
     expire_timestamp: u64,
     clock: &Clock,
 ): deepbook::order_info::OrderInfo {
-    let base_oracle = build_price_info_for_type<BaseAsset>(scenario, clock);
-    let quote_oracle = build_price_info_for_type<QuoteAsset>(scenario, clock);
-    let order_info = pool_proxy::place_reduce_only_limit_order_v2<BaseAsset, QuoteAsset>(
+    let base_oracle = build_price_info_for_type_upgraded<BaseAsset>(scenario, clock);
+    let quote_oracle = build_price_info_for_type_upgraded<QuoteAsset>(scenario, clock);
+    let order_info = pool_proxy_upgraded::place_reduce_only_limit_order_v2<BaseAsset, QuoteAsset>(
         registry,
         mm,
         pool,
@@ -1449,9 +1450,9 @@ public fun place_reduce_only_market_order_v2_for_test<BaseAsset, QuoteAsset>(
     pay_with_deep: bool,
     clock: &Clock,
 ): deepbook::order_info::OrderInfo {
-    let base_oracle = build_price_info_for_type<BaseAsset>(scenario, clock);
-    let quote_oracle = build_price_info_for_type<QuoteAsset>(scenario, clock);
-    let order_info = pool_proxy::place_reduce_only_market_order_v2<BaseAsset, QuoteAsset>(
+    let base_oracle = build_price_info_for_type_upgraded<BaseAsset>(scenario, clock);
+    let quote_oracle = build_price_info_for_type_upgraded<QuoteAsset>(scenario, clock);
+    let order_info = pool_proxy_upgraded::place_reduce_only_market_order_v2<BaseAsset, QuoteAsset>(
         registry,
         mm,
         pool,
@@ -1489,9 +1490,9 @@ public fun place_reduce_only_market_order_and_repay_loan_for_test<BaseAsset, Quo
     pay_with_deep: bool,
     clock: &Clock,
 ): deepbook::order_info::OrderInfo {
-    let base_oracle = build_price_info_for_type<BaseAsset>(scenario, clock);
-    let quote_oracle = build_price_info_for_type<QuoteAsset>(scenario, clock);
-    let order_info = pool_proxy::place_reduce_only_market_order_and_repay_loan<
+    let base_oracle = build_price_info_for_type_upgraded<BaseAsset>(scenario, clock);
+    let quote_oracle = build_price_info_for_type_upgraded<QuoteAsset>(scenario, clock);
+    let order_info = pool_proxy_upgraded::place_reduce_only_market_order_and_repay_loan<
         BaseAsset,
         QuoteAsset,
     >(
@@ -1529,9 +1530,9 @@ public fun place_market_order_and_repay_loan_for_test<BaseAsset, QuoteAsset>(
     pay_with_deep: bool,
     clock: &Clock,
 ): deepbook::order_info::OrderInfo {
-    let base_oracle = build_price_info_for_type<BaseAsset>(scenario, clock);
-    let quote_oracle = build_price_info_for_type<QuoteAsset>(scenario, clock);
-    let order_info = pool_proxy::place_market_order_and_repay_loan<BaseAsset, QuoteAsset>(
+    let base_oracle = build_price_info_for_type_upgraded<BaseAsset>(scenario, clock);
+    let quote_oracle = build_price_info_for_type_upgraded<QuoteAsset>(scenario, clock);
+    let order_info = pool_proxy_upgraded::place_market_order_and_repay_loan<BaseAsset, QuoteAsset>(
         registry,
         mm,
         pool,
@@ -1569,9 +1570,9 @@ public fun place_reduce_only_limit_order_and_repay_loan_for_test<BaseAsset, Quot
     expire_timestamp: u64,
     clock: &Clock,
 ): deepbook::order_info::OrderInfo {
-    let base_oracle = build_price_info_for_type<BaseAsset>(scenario, clock);
-    let quote_oracle = build_price_info_for_type<QuoteAsset>(scenario, clock);
-    let order_info = pool_proxy::place_reduce_only_limit_order_and_repay_loan<
+    let base_oracle = build_price_info_for_type_upgraded<BaseAsset>(scenario, clock);
+    let quote_oracle = build_price_info_for_type_upgraded<QuoteAsset>(scenario, clock);
+    let order_info = pool_proxy_upgraded::place_reduce_only_limit_order_and_repay_loan<
         BaseAsset,
         QuoteAsset,
     >(
@@ -1604,13 +1605,14 @@ public fun execute_conditional_orders_v2_for_test<BaseAsset, QuoteAsset>(
     quote_margin_pool: &MarginPool<QuoteAsset>,
     mm: &mut deepbook_margin::margin_manager::MarginManager<BaseAsset, QuoteAsset>,
     pool: &mut Pool<BaseAsset, QuoteAsset>,
-    base_price_info_object: &PriceInfoObject,
-    quote_price_info_object: &PriceInfoObject,
+    base_price_info_object: &PriceInfoObjectUpgraded,
+    quote_price_info_object: &PriceInfoObjectUpgraded,
     registry: &MarginRegistry,
     max_orders_to_execute: u64,
     clock: &Clock,
 ): vector<deepbook::order_info::OrderInfo> {
-    mm.execute_conditional_orders_v2<BaseAsset, QuoteAsset>(
+    margin_manager_upgraded::execute_conditional_orders_v2<BaseAsset, QuoteAsset>(
+        mm,
         pool,
         base_margin_pool,
         quote_margin_pool,
@@ -1629,13 +1631,14 @@ public fun execute_conditional_orders_v3_for_test<BaseAsset, QuoteAsset>(
     quote_margin_pool: &mut MarginPool<QuoteAsset>,
     mm: &mut deepbook_margin::margin_manager::MarginManager<BaseAsset, QuoteAsset>,
     pool: &mut Pool<BaseAsset, QuoteAsset>,
-    base_price_info_object: &PriceInfoObject,
-    quote_price_info_object: &PriceInfoObject,
+    base_price_info_object: &PriceInfoObjectUpgraded,
+    quote_price_info_object: &PriceInfoObjectUpgraded,
     registry: &MarginRegistry,
     max_orders_to_execute: u64,
     clock: &Clock,
 ): vector<deepbook::order_info::OrderInfo> {
-    mm.execute_conditional_orders_v3<BaseAsset, QuoteAsset>(
+    margin_manager_upgraded::execute_conditional_orders_v3<BaseAsset, QuoteAsset>(
+        mm,
         pool,
         base_margin_pool,
         quote_margin_pool,
@@ -1803,6 +1806,83 @@ public fun build_stale_usdt_price_info_object_upgraded(
         test_constants::pyth_decimals(),
         (clock.timestamp_ms() / 1000) - stale_seconds,
     )
+}
+
+/// Build a SUI price info object at a given price
+public fun build_sui_price_info_object_upgraded(
+    scenario: &mut Scenario,
+    price_usd: u64,
+    clock: &Clock,
+): PriceInfoObjectUpgraded {
+    build_pyth_upgraded_price_info_object(
+        scenario,
+        test_constants::sui_price_feed_id(),
+        price_usd * test_constants::pyth_multiplier(),
+        100000,
+        test_constants::pyth_decimals(),
+        clock.timestamp_ms() / 1000,
+    )
+}
+
+/// Build a DEEP price info object at $0.10
+public fun build_deep_price_info_object_upgraded(
+    scenario: &mut Scenario,
+    clock: &Clock,
+): PriceInfoObjectUpgraded {
+    build_pyth_upgraded_price_info_object(
+        scenario,
+        test_constants::deep_price_feed_id(),
+        10_000_000, // $0.10 in 8 decimals (0.10 * 10^8)
+        100000,
+        test_constants::pyth_decimals(),
+        clock.timestamp_ms() / 1000,
+    )
+}
+
+public fun build_demo_usdc_price_info_object_with_price_upgraded(
+    scenario: &mut Scenario,
+    price: u64,
+    clock: &Clock,
+): PriceInfoObjectUpgraded {
+    build_pyth_upgraded_price_info_object(
+        scenario,
+        test_constants::usdc_price_feed_id(),
+        price,
+        50000,
+        test_constants::pyth_decimals(),
+        clock.timestamp_ms() / 1000,
+    )
+}
+
+/// Build a price info object based on the asset type
+public fun build_price_info_for_type_upgraded<Asset>(
+    scenario: &mut Scenario,
+    clock: &Clock,
+): PriceInfoObjectUpgraded {
+    let type_name = std::type_name::with_defining_ids<Asset>();
+    let type_string = type_name.into_string().into_bytes();
+
+    // Match on common test asset types
+    let usdc = b"USDC";
+    let usdt = b"USDT";
+    let btc = b"BTC";
+    let sui = b"SUI";
+    let deep = b"DEEP";
+
+    if (contains_substring(&type_string, &usdc)) {
+        build_demo_usdc_price_info_object_upgraded(scenario, clock)
+    } else if (contains_substring(&type_string, &usdt)) {
+        build_demo_usdt_price_info_object_upgraded(scenario, clock)
+    } else if (contains_substring(&type_string, &btc)) {
+        build_btc_price_info_object_upgraded(scenario, 50000, clock) // $50,000
+    } else if (contains_substring(&type_string, &sui)) {
+        build_sui_price_info_object_upgraded(scenario, 1, clock) // $1
+    } else if (contains_substring(&type_string, &deep)) {
+        build_deep_price_info_object_upgraded(scenario, clock) // $0.10
+    } else {
+        // Default to $1 price for unknown assets
+        build_demo_usdc_price_info_object_upgraded(scenario, clock)
+    }
 }
 
 /// Fresh BTC feed carrying an arbitrarily wide confidence interval. The confidence

--- a/packages/deepbook_margin/tests/legacy_pyth_entrypoints_disabled_tests.move
+++ b/packages/deepbook_margin/tests/legacy_pyth_entrypoints_disabled_tests.move
@@ -1,0 +1,784 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Every legacy-Pyth entrypoint aborts.
+///
+/// The two entrypoint families used to be equally authoritative: `margin_manager` and
+/// `pool_proxy` priced off legacy Pyth Core, `margin_manager_upgraded` and
+/// `pool_proxy_upgraded` off the upgraded Core, `PythReading` erased which feed produced
+/// a price, and both families shared one `_core`. A caller chose per call. The legacy
+/// bodies are now `abort EDeprecatedUseUpgradedPyth`.
+///
+/// One test per retired entry, calling it with a well-formed legacy `PriceInfoObject`.
+/// The point of passing a *good* feed is that nothing else can be blamed for the abort:
+/// these do not fail on staleness, on a feed id, or on any argument — they fail because
+/// the entry no longer prices anything. A test here going green through the entry rather
+/// than through the abort means a legacy reader has been wired back in.
+///
+/// Scenario-level coverage of what the window used to permit lives in
+/// `dual_feed_window_tests`; this file is the surface inventory. When a new
+/// oracle-taking entry is added to `margin_manager_upgraded` or `pool_proxy_upgraded`,
+/// it has no legacy twin and belongs in neither.
+#[test_only]
+module deepbook_margin::legacy_pyth_entrypoints_disabled_tests;
+
+use deepbook::{constants, pool::Pool, registry::Registry};
+use deepbook_margin::{
+    margin_manager::{Self, MarginManager},
+    margin_pool::MarginPool,
+    margin_registry::{MarginRegistry, MarginAdminCap, MaintainerCap},
+    pool_proxy,
+    test_constants::{Self, USDC, USDT},
+    test_helpers::{
+        setup_pool_proxy_test_env,
+        build_demo_usdc_price_info_object,
+        build_demo_usdt_price_info_object,
+        mint_coin,
+    },
+    tpsl
+};
+use pyth::price_info::PriceInfoObject;
+use sui::{clock::Clock, test_scenario::{Self as test, return_shared}};
+
+/// A registered USDC/USDT margin manager plus the ids needed to re-take the shared
+/// objects each entry wants. No debt and no orders: every retired body aborts on its
+/// first instruction, so manager state cannot change the outcome.
+fun env(): (test::Scenario, Clock, MarginAdminCap, MaintainerCap, ID, ID, ID) {
+    let (
+        mut scenario,
+        clock,
+        admin_cap,
+        maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+        registry_id,
+    ) = setup_pool_proxy_test_env<USDC, USDT>();
+
+    scenario.next_tx(test_constants::user1());
+    let pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let deepbook_registry = scenario.take_shared_by_id<Registry>(registry_id);
+    margin_manager::new<USDC, USDT>(
+        &pool,
+        &deepbook_registry,
+        &mut registry,
+        &clock,
+        scenario.ctx(),
+    );
+    return_shared(deepbook_registry);
+    return_shared(registry);
+    return_shared(pool);
+
+    (scenario, clock, admin_cap, maintainer_cap, base_pool_id, quote_pool_id, pool_id)
+}
+
+/// Fresh, correctly-configured legacy feeds for the two assets.
+fun legacy_feeds(scenario: &mut test::Scenario, clock: &Clock): (PriceInfoObject, PriceInfoObject) {
+    let base = build_demo_usdc_price_info_object(scenario, clock);
+    let quote = build_demo_usdt_price_info_object(scenario, clock);
+
+    (base, quote)
+}
+
+// === margin_manager ===
+
+#[test, expected_failure(abort_code = margin_manager::EDeprecatedUseUpgradedPyth)]
+fun legacy_add_conditional_order_aborts() {
+    let (mut scenario, clock, _admin_cap, _maintainer_cap, _b, _q, pool_id) = env();
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let registry = scenario.take_shared<MarginRegistry>();
+    let (base, quote) = legacy_feeds(&mut scenario, &clock);
+
+    margin_manager::add_conditional_order<USDC, USDT>(
+        &mut mm,
+        &pool,
+        &base,
+        &quote,
+        &registry,
+        1,
+        tpsl::new_condition(true, 900_000),
+        tpsl::new_pending_market_order(
+            1,
+            constants::self_matching_allowed(),
+            1_000_000,
+            false,
+            false,
+        ),
+        &clock,
+        scenario.ctx(),
+    );
+
+    abort 999
+}
+
+#[test, expected_failure(abort_code = margin_manager::EDeprecatedUseUpgradedPyth)]
+fun legacy_execute_conditional_orders_v2_aborts() {
+    let (
+        mut scenario,
+        clock,
+        _admin_cap,
+        _maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+    ) = env();
+
+    scenario.next_tx(test_constants::liquidator());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let registry = scenario.take_shared<MarginRegistry>();
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let (base, quote) = legacy_feeds(&mut scenario, &clock);
+
+    let _ = margin_manager::execute_conditional_orders_v2<USDC, USDT>(
+        &mut mm,
+        &mut pool,
+        &base_pool,
+        &quote_pool,
+        &base,
+        &quote,
+        &registry,
+        10,
+        &clock,
+        scenario.ctx(),
+    );
+
+    abort 999
+}
+
+#[test, expected_failure(abort_code = margin_manager::EDeprecatedUseUpgradedPyth)]
+fun legacy_execute_conditional_orders_v3_aborts() {
+    let (
+        mut scenario,
+        clock,
+        _admin_cap,
+        _maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+    ) = env();
+
+    scenario.next_tx(test_constants::liquidator());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let registry = scenario.take_shared<MarginRegistry>();
+    let mut base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let mut quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let (base, quote) = legacy_feeds(&mut scenario, &clock);
+
+    let _ = margin_manager::execute_conditional_orders_v3<USDC, USDT>(
+        &mut mm,
+        &mut pool,
+        &mut base_pool,
+        &mut quote_pool,
+        &base,
+        &quote,
+        &registry,
+        10,
+        &clock,
+        scenario.ctx(),
+    );
+
+    abort 999
+}
+
+#[test, expected_failure(abort_code = margin_manager::EDeprecatedUseUpgradedPyth)]
+fun legacy_deposit_aborts() {
+    let (mut scenario, clock, _admin_cap, _maintainer_cap, _b, _q, _pool_id) = env();
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let registry = scenario.take_shared<MarginRegistry>();
+    let (base, quote) = legacy_feeds(&mut scenario, &clock);
+
+    margin_manager::deposit<USDC, USDT, USDC>(
+        &mut mm,
+        &registry,
+        &base,
+        &quote,
+        mint_coin<USDC>(1_000 * test_constants::usdc_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+
+    abort 999
+}
+
+#[test, expected_failure(abort_code = margin_manager::EDeprecatedUseUpgradedPyth)]
+fun legacy_withdraw_aborts() {
+    let (
+        mut scenario,
+        clock,
+        _admin_cap,
+        _maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+    ) = env();
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let registry = scenario.take_shared<MarginRegistry>();
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let (base, quote) = legacy_feeds(&mut scenario, &clock);
+
+    let coin = margin_manager::withdraw<USDC, USDT, USDC>(
+        &mut mm,
+        &registry,
+        &base_pool,
+        &quote_pool,
+        &base,
+        &quote,
+        &pool,
+        1,
+        &clock,
+        scenario.ctx(),
+    );
+    std::unit_test::destroy(coin);
+
+    abort 999
+}
+
+#[test, expected_failure(abort_code = margin_manager::EDeprecatedUseUpgradedPyth)]
+fun legacy_borrow_base_aborts() {
+    let (mut scenario, clock, _admin_cap, _maintainer_cap, base_pool_id, _q, pool_id) = env();
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let registry = scenario.take_shared<MarginRegistry>();
+    let mut base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let (base, quote) = legacy_feeds(&mut scenario, &clock);
+
+    margin_manager::borrow_base<USDC, USDT>(
+        &mut mm,
+        &registry,
+        &mut base_pool,
+        &base,
+        &quote,
+        &pool,
+        1_000 * test_constants::usdc_multiplier(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    abort 999
+}
+
+#[test, expected_failure(abort_code = margin_manager::EDeprecatedUseUpgradedPyth)]
+fun legacy_borrow_quote_aborts() {
+    let (mut scenario, clock, _admin_cap, _maintainer_cap, _b, quote_pool_id, pool_id) = env();
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let registry = scenario.take_shared<MarginRegistry>();
+    let mut quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let (base, quote) = legacy_feeds(&mut scenario, &clock);
+
+    margin_manager::borrow_quote<USDC, USDT>(
+        &mut mm,
+        &registry,
+        &mut quote_pool,
+        &base,
+        &quote,
+        &pool,
+        1_000 * test_constants::usdt_multiplier(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    abort 999
+}
+
+#[test, expected_failure(abort_code = margin_manager::EDeprecatedUseUpgradedPyth)]
+fun legacy_liquidate_aborts() {
+    let (mut scenario, clock, _admin_cap, _maintainer_cap, _b, quote_pool_id, pool_id) = env();
+
+    scenario.next_tx(test_constants::liquidator());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let registry = scenario.take_shared<MarginRegistry>();
+    let mut quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let (base, quote) = legacy_feeds(&mut scenario, &clock);
+
+    let (base_coin, quote_coin, remaining) = margin_manager::liquidate<USDC, USDT, USDT>(
+        &mut mm,
+        &registry,
+        &base,
+        &quote,
+        &mut quote_pool,
+        &mut pool,
+        mint_coin<USDT>(1_000 * test_constants::usdt_multiplier(), scenario.ctx()),
+        &clock,
+        scenario.ctx(),
+    );
+    std::unit_test::destroy(base_coin);
+    std::unit_test::destroy(quote_coin);
+    std::unit_test::destroy(remaining);
+
+    abort 999
+}
+
+/// Read-only, but retired with the rest: an off-chain liquidator reading a ratio off
+/// one feed while acting on the other is the same divergence, one step removed.
+#[test, expected_failure(abort_code = margin_manager::EDeprecatedUseUpgradedPyth)]
+fun legacy_risk_ratio_aborts() {
+    let (
+        mut scenario,
+        clock,
+        _admin_cap,
+        _maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+    ) = env();
+
+    scenario.next_tx(test_constants::user1());
+    let mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let registry = scenario.take_shared<MarginRegistry>();
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let (base, quote) = legacy_feeds(&mut scenario, &clock);
+
+    let _ = margin_manager::risk_ratio<USDC, USDT>(
+        &mm,
+        &registry,
+        &base,
+        &quote,
+        &pool,
+        &base_pool,
+        &quote_pool,
+        &clock,
+    );
+
+    abort 999
+}
+
+/// The debt-free short-circuit used to return `max_risk_ratio()` before touching a
+/// feed. It is gone: a retired entry aborts for every manager, debt or not.
+#[test, expected_failure(abort_code = margin_manager::EDeprecatedUseUpgradedPyth)]
+fun legacy_risk_ratio_unsafe_aborts() {
+    let (
+        mut scenario,
+        clock,
+        _admin_cap,
+        _maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+    ) = env();
+
+    scenario.next_tx(test_constants::user1());
+    let mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let registry = scenario.take_shared<MarginRegistry>();
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let (base, quote) = legacy_feeds(&mut scenario, &clock);
+
+    let _ = margin_manager::risk_ratio_unsafe<USDC, USDT>(
+        &mm,
+        &registry,
+        &base,
+        &quote,
+        &pool,
+        &base_pool,
+        &quote_pool,
+        &clock,
+    );
+
+    abort 999
+}
+
+#[test, expected_failure(abort_code = margin_manager::EDeprecatedUseUpgradedPyth)]
+fun legacy_manager_state_aborts() {
+    let (
+        mut scenario,
+        clock,
+        _admin_cap,
+        _maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+    ) = env();
+
+    scenario.next_tx(test_constants::user1());
+    let mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let registry = scenario.take_shared<MarginRegistry>();
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let (base, quote) = legacy_feeds(&mut scenario, &clock);
+
+    margin_manager::manager_state<USDC, USDT>(
+        &mm,
+        &registry,
+        &base,
+        &quote,
+        &pool,
+        &base_pool,
+        &quote_pool,
+        &clock,
+    );
+
+    abort 999
+}
+
+/// The batch read is the one the off-chain liquidator actually calls, over tens of
+/// thousands of managers. An empty vector still aborts — nothing is read per manager.
+#[test, expected_failure(abort_code = margin_manager::EDeprecatedUseUpgradedPyth)]
+fun legacy_manager_states_aborts() {
+    let (
+        mut scenario,
+        clock,
+        _admin_cap,
+        _maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+    ) = env();
+
+    scenario.next_tx(test_constants::user1());
+    let pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let registry = scenario.take_shared<MarginRegistry>();
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let (base, quote) = legacy_feeds(&mut scenario, &clock);
+    let managers: vector<MarginManager<USDC, USDT>> = vector[];
+
+    margin_manager::manager_states<USDC, USDT>(
+        &managers,
+        &registry,
+        &base,
+        &quote,
+        &pool,
+        &base_pool,
+        &quote_pool,
+        &clock,
+    );
+
+    abort 999
+}
+
+// === pool_proxy ===
+
+/// The price the order-validation band is anchored to. Permissionless, so this was the
+/// entry that let a caller re-anchor the band to the feed that suited them before
+/// firing anything else.
+#[test, expected_failure(abort_code = pool_proxy::EDeprecatedUseUpgradedPyth)]
+fun legacy_update_current_price_aborts() {
+    let (mut scenario, clock, _admin_cap, _maintainer_cap, _b, _q, pool_id) = env();
+
+    scenario.next_tx(test_constants::liquidator());
+    let pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let mut registry = scenario.take_shared<MarginRegistry>();
+    let (base, quote) = legacy_feeds(&mut scenario, &clock);
+
+    pool_proxy::update_current_price<USDC, USDT>(
+        &mut registry,
+        &pool,
+        &base,
+        &quote,
+        &clock,
+    );
+
+    abort 999
+}
+
+#[test, expected_failure(abort_code = pool_proxy::EDeprecatedUseUpgradedPyth)]
+fun legacy_place_limit_order_v2_aborts() {
+    let (
+        mut scenario,
+        clock,
+        _admin_cap,
+        _maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+    ) = env();
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let registry = scenario.take_shared<MarginRegistry>();
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let (base, quote) = legacy_feeds(&mut scenario, &clock);
+
+    let _ = pool_proxy::place_limit_order_v2<USDC, USDT>(
+        &registry,
+        &mut mm,
+        &mut pool,
+        &base_pool,
+        &quote_pool,
+        &base,
+        &quote,
+        1,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        1_000_000,
+        1_000_000,
+        true,
+        false,
+        constants::max_u64(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    abort 999
+}
+
+#[test, expected_failure(abort_code = pool_proxy::EDeprecatedUseUpgradedPyth)]
+fun legacy_place_market_order_v2_aborts() {
+    let (
+        mut scenario,
+        clock,
+        _admin_cap,
+        _maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+    ) = env();
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let registry = scenario.take_shared<MarginRegistry>();
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let (base, quote) = legacy_feeds(&mut scenario, &clock);
+
+    let _ = pool_proxy::place_market_order_v2<USDC, USDT>(
+        &registry,
+        &mut mm,
+        &mut pool,
+        &base_pool,
+        &quote_pool,
+        &base,
+        &quote,
+        1,
+        constants::self_matching_allowed(),
+        1_000_000,
+        true,
+        false,
+        &clock,
+        scenario.ctx(),
+    );
+
+    abort 999
+}
+
+#[test, expected_failure(abort_code = pool_proxy::EDeprecatedUseUpgradedPyth)]
+fun legacy_place_reduce_only_limit_order_v2_aborts() {
+    let (
+        mut scenario,
+        clock,
+        _admin_cap,
+        _maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+    ) = env();
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let registry = scenario.take_shared<MarginRegistry>();
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let (base, quote) = legacy_feeds(&mut scenario, &clock);
+
+    let _ = pool_proxy::place_reduce_only_limit_order_v2<USDC, USDT>(
+        &registry,
+        &mut mm,
+        &mut pool,
+        &base_pool,
+        &quote_pool,
+        &base,
+        &quote,
+        1,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        1_000_000,
+        1_000_000,
+        true,
+        false,
+        constants::max_u64(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    abort 999
+}
+
+#[test, expected_failure(abort_code = pool_proxy::EDeprecatedUseUpgradedPyth)]
+fun legacy_place_reduce_only_market_order_v2_aborts() {
+    let (
+        mut scenario,
+        clock,
+        _admin_cap,
+        _maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+    ) = env();
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let registry = scenario.take_shared<MarginRegistry>();
+    let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let (base, quote) = legacy_feeds(&mut scenario, &clock);
+
+    let _ = pool_proxy::place_reduce_only_market_order_v2<USDC, USDT>(
+        &registry,
+        &mut mm,
+        &mut pool,
+        &base_pool,
+        &quote_pool,
+        &base,
+        &quote,
+        1,
+        constants::self_matching_allowed(),
+        1_000_000,
+        true,
+        false,
+        &clock,
+        scenario.ctx(),
+    );
+
+    abort 999
+}
+
+#[test, expected_failure(abort_code = pool_proxy::EDeprecatedUseUpgradedPyth)]
+fun legacy_place_reduce_only_market_order_and_repay_loan_aborts() {
+    let (
+        mut scenario,
+        clock,
+        _admin_cap,
+        _maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+    ) = env();
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let registry = scenario.take_shared<MarginRegistry>();
+    let mut base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let mut quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let (base, quote) = legacy_feeds(&mut scenario, &clock);
+
+    let _ = pool_proxy::place_reduce_only_market_order_and_repay_loan<USDC, USDT>(
+        &registry,
+        &mut mm,
+        &mut pool,
+        &mut base_pool,
+        &mut quote_pool,
+        &base,
+        &quote,
+        1,
+        constants::self_matching_allowed(),
+        1_000_000,
+        true,
+        false,
+        &clock,
+        scenario.ctx(),
+    );
+
+    abort 999
+}
+
+#[test, expected_failure(abort_code = pool_proxy::EDeprecatedUseUpgradedPyth)]
+fun legacy_place_reduce_only_limit_order_and_repay_loan_aborts() {
+    let (
+        mut scenario,
+        clock,
+        _admin_cap,
+        _maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+    ) = env();
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let registry = scenario.take_shared<MarginRegistry>();
+    let mut base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let mut quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let (base, quote) = legacy_feeds(&mut scenario, &clock);
+
+    let _ = pool_proxy::place_reduce_only_limit_order_and_repay_loan<USDC, USDT>(
+        &registry,
+        &mut mm,
+        &mut pool,
+        &mut base_pool,
+        &mut quote_pool,
+        &base,
+        &quote,
+        1,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        1_000_000,
+        1_000_000,
+        true,
+        false,
+        constants::max_u64(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    abort 999
+}
+
+#[test, expected_failure(abort_code = pool_proxy::EDeprecatedUseUpgradedPyth)]
+fun legacy_place_market_order_and_repay_loan_aborts() {
+    let (
+        mut scenario,
+        clock,
+        _admin_cap,
+        _maintainer_cap,
+        base_pool_id,
+        quote_pool_id,
+        pool_id,
+    ) = env();
+
+    scenario.next_tx(test_constants::user1());
+    let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
+    let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
+    let registry = scenario.take_shared<MarginRegistry>();
+    let mut base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
+    let mut quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
+    let (base, quote) = legacy_feeds(&mut scenario, &clock);
+
+    let _ = pool_proxy::place_market_order_and_repay_loan<USDC, USDT>(
+        &registry,
+        &mut mm,
+        &mut pool,
+        &mut base_pool,
+        &mut quote_pool,
+        &base,
+        &quote,
+        1,
+        constants::self_matching_allowed(),
+        1_000_000,
+        true,
+        false,
+        &clock,
+        scenario.ctx(),
+    );
+
+    abort 999
+}

--- a/packages/deepbook_margin/tests/margin_manager_borrow_share_tests.move
+++ b/packages/deepbook_margin/tests/margin_manager_borrow_share_tests.move
@@ -7,6 +7,7 @@ module deepbook_margin::margin_manager_borrow_share_tests;
 use deepbook::{pool::Pool, registry::Registry};
 use deepbook_margin::{
     margin_manager::{Self, MarginManager},
+    margin_manager_upgraded,
     margin_pool::MarginPool,
     margin_registry::MarginRegistry,
     test_constants::{Self, USDC, BTC, btc_multiplier},
@@ -14,8 +15,8 @@ use deepbook_margin::{
         setup_btc_usd_deepbook_margin,
         cleanup_margin_test,
         mint_coin,
-        build_demo_usdc_price_info_object,
-        build_btc_price_info_object,
+        build_demo_usdc_price_info_object_upgraded,
+        build_btc_price_info_object_upgraded,
         destroy_2,
         return_shared_2,
         return_shared_3,
@@ -70,14 +71,15 @@ fun test_multiple_borrows_accumulate_shares_base() {
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
     let registry = scenario.take_shared<MarginRegistry>();
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
     // Deposit significant USDC as collateral
     let deposit_coin = mint_coin<USDC>(
         5_000_000 * test_constants::usdc_multiplier(),
         scenario.ctx(),
     );
-    mm.deposit<BTC, USDC, USDC>(
+    margin_manager_upgraded::deposit<BTC, USDC, USDC>(
+        &mut mm,
         &registry,
         &btc_price,
         &usdc_price,
@@ -95,10 +97,11 @@ fun test_multiple_borrows_accumulate_shares_base() {
     let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
     let usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
     let pool = scenario.take_shared<Pool<BTC, USDC>>();
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.borrow_base<BTC, USDC>(
+    margin_manager_upgraded::borrow_base<BTC, USDC>(
+        &mut mm,
         &registry,
         &mut btc_pool,
         &btc_price,
@@ -114,7 +117,8 @@ fun test_multiple_borrows_accumulate_shares_base() {
     assert!(borrowed_base_shares_after_first == 10 * btc_multiplier());
 
     // Second borrow: 15 BTC more
-    mm.borrow_base<BTC, USDC>(
+    margin_manager_upgraded::borrow_base<BTC, USDC>(
+        &mut mm,
         &registry,
         &mut btc_pool,
         &btc_price,
@@ -181,11 +185,12 @@ fun test_multiple_borrows_accumulate_shares_quote() {
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
     let registry = scenario.take_shared<MarginRegistry>();
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
     // Deposit significant BTC as collateral
     let deposit_coin = mint_coin<BTC>(10 * btc_multiplier(), scenario.ctx());
-    mm.deposit<BTC, USDC, BTC>(
+    margin_manager_upgraded::deposit<BTC, USDC, BTC>(
+        &mut mm,
         &registry,
         &btc_price,
         &usdc_price,
@@ -203,10 +208,11 @@ fun test_multiple_borrows_accumulate_shares_quote() {
     let btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
     let pool = scenario.take_shared<Pool<BTC, USDC>>();
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.borrow_quote<BTC, USDC>(
+    margin_manager_upgraded::borrow_quote<BTC, USDC>(
+        &mut mm,
         &registry,
         &mut usdc_pool,
         &btc_price,
@@ -222,7 +228,8 @@ fun test_multiple_borrows_accumulate_shares_quote() {
     assert!(borrowed_quote_shares_after_first == 10 * test_constants::usdc_multiplier());
 
     // Second borrow: 15 USDC more
-    mm.borrow_quote<BTC, USDC>(
+    margin_manager_upgraded::borrow_quote<BTC, USDC>(
+        &mut mm,
         &registry,
         &mut usdc_pool,
         &btc_price,
@@ -289,13 +296,14 @@ fun test_user_shares_isolated_from_other_users_base() {
     scenario.next_tx(test_constants::user1());
     let mut mm1 = scenario.take_shared<MarginManager<BTC, USDC>>();
     let registry = scenario.take_shared<MarginRegistry>();
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
     let deposit_coin = mint_coin<USDC>(
         5_000_000 * test_constants::usdc_multiplier(),
         scenario.ctx(),
     );
-    mm1.deposit<BTC, USDC, USDC>(
+    margin_manager_upgraded::deposit<BTC, USDC, USDC>(
+        &mut mm1,
         &registry,
         &btc_price,
         &usdc_price,
@@ -313,10 +321,11 @@ fun test_user_shares_isolated_from_other_users_base() {
     let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
     let usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
     let pool = scenario.take_shared<Pool<BTC, USDC>>();
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm1.borrow_base<BTC, USDC>(
+    margin_manager_upgraded::borrow_base<BTC, USDC>(
+        &mut mm1,
         &registry,
         &mut btc_pool,
         &btc_price,
@@ -355,13 +364,14 @@ fun test_user_shares_isolated_from_other_users_base() {
     scenario.next_tx(test_constants::user2());
     let mut mm2 = scenario.take_shared<MarginManager<BTC, USDC>>();
     let registry = scenario.take_shared<MarginRegistry>();
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
     let deposit_coin = mint_coin<USDC>(
         5_000_000 * test_constants::usdc_multiplier(),
         scenario.ctx(),
     );
-    mm2.deposit<BTC, USDC, USDC>(
+    margin_manager_upgraded::deposit<BTC, USDC, USDC>(
+        &mut mm2,
         &registry,
         &btc_price,
         &usdc_price,
@@ -379,10 +389,11 @@ fun test_user_shares_isolated_from_other_users_base() {
     let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
     let usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
     let pool = scenario.take_shared<Pool<BTC, USDC>>();
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm2.borrow_base<BTC, USDC>(
+    margin_manager_upgraded::borrow_base<BTC, USDC>(
+        &mut mm2,
         &registry,
         &mut btc_pool,
         &btc_price,
@@ -456,10 +467,11 @@ fun test_user_shares_isolated_from_other_users_quote() {
     scenario.next_tx(test_constants::user1());
     let mut mm1 = scenario.take_shared<MarginManager<BTC, USDC>>();
     let registry = scenario.take_shared<MarginRegistry>();
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
     let deposit_coin = mint_coin<BTC>(10 * btc_multiplier(), scenario.ctx());
-    mm1.deposit<BTC, USDC, BTC>(
+    margin_manager_upgraded::deposit<BTC, USDC, BTC>(
+        &mut mm1,
         &registry,
         &btc_price,
         &usdc_price,
@@ -477,10 +489,11 @@ fun test_user_shares_isolated_from_other_users_quote() {
     let btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
     let pool = scenario.take_shared<Pool<BTC, USDC>>();
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm1.borrow_quote<BTC, USDC>(
+    margin_manager_upgraded::borrow_quote<BTC, USDC>(
+        &mut mm1,
         &registry,
         &mut usdc_pool,
         &btc_price,
@@ -519,10 +532,11 @@ fun test_user_shares_isolated_from_other_users_quote() {
     scenario.next_tx(test_constants::user2());
     let mut mm2 = scenario.take_shared<MarginManager<BTC, USDC>>();
     let registry = scenario.take_shared<MarginRegistry>();
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
     let deposit_coin = mint_coin<BTC>(10 * btc_multiplier(), scenario.ctx());
-    mm2.deposit<BTC, USDC, BTC>(
+    margin_manager_upgraded::deposit<BTC, USDC, BTC>(
+        &mut mm2,
         &registry,
         &btc_price,
         &usdc_price,
@@ -540,10 +554,11 @@ fun test_user_shares_isolated_from_other_users_quote() {
     let btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
     let pool = scenario.take_shared<Pool<BTC, USDC>>();
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm2.borrow_quote<BTC, USDC>(
+    margin_manager_upgraded::borrow_quote<BTC, USDC>(
+        &mut mm2,
         &registry,
         &mut usdc_pool,
         &btc_price,

--- a/packages/deepbook_margin/tests/margin_manager_math_tests.move
+++ b/packages/deepbook_margin/tests/margin_manager_math_tests.move
@@ -7,15 +7,16 @@ module deepbook_margin::margin_manager_math_tests;
 use deepbook::{pool::Pool, registry::Registry};
 use deepbook_margin::{
     margin_manager::{Self, MarginManager},
+    margin_manager_upgraded,
     margin_pool::MarginPool,
     margin_registry::MarginRegistry,
     test_constants::{Self, USDC, BTC, SUI, btc_multiplier, sui_multiplier, usdc_multiplier},
     test_helpers::{
         cleanup_margin_test,
         mint_coin,
-        build_demo_usdc_price_info_object,
-        build_btc_price_info_object,
-        build_sui_price_info_object,
+        build_demo_usdc_price_info_object_upgraded,
+        build_btc_price_info_object_upgraded,
+        build_sui_price_info_object_upgraded,
         setup_btc_usd_deepbook_margin,
         setup_btc_sui_deepbook_margin,
         destroy_3,
@@ -87,8 +88,8 @@ fun test_liquidation(error_code: u64) {
         registry_id,
     ) = setup_btc_usd_deepbook_margin();
 
-    let btc_price = build_btc_price_info_object(&mut scenario, 50, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
     scenario.next_tx(test_constants::user1());
     let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
@@ -109,7 +110,8 @@ fun test_liquidation(error_code: u64) {
     let btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
 
     // Deposit 1 BTC worth $50
-    mm.deposit<BTC, USDC, BTC>(
+    margin_manager_upgraded::deposit<BTC, USDC, BTC>(
+        &mut mm,
         &registry,
         &btc_price,
         &usdc_price,
@@ -119,7 +121,8 @@ fun test_liquidation(error_code: u64) {
     );
 
     // Borrow $200 USDC. Risk ratio = (50 + 200) / 200 = 1.25
-    mm.borrow_quote<BTC, USDC>(
+    margin_manager_upgraded::borrow_quote<BTC, USDC>(
+        &mut mm,
         &registry,
         &mut usdc_pool,
         &btc_price,
@@ -131,7 +134,7 @@ fun test_liquidation(error_code: u64) {
     );
 
     assert!(
-        mm.risk_ratio(&registry, &btc_price, &usdc_price, &pool, &btc_pool,&usdc_pool, &clock) == 1_250_000_000,
+        margin_manager_upgraded::risk_ratio(&mm, &registry, &btc_price, &usdc_price, &pool, &btc_pool,&usdc_pool, &clock) == 1_250_000_000,
         0,
     );
 
@@ -141,13 +144,18 @@ fun test_liquidation(error_code: u64) {
     if (error_code == ECannotLiquidate) {
         // At BTC price 40, Risk ratio = (40 + 200) / 200 = 1.2, still cannot liquidate
         let repay_coin = mint_coin<USDC>(500 * test_constants::usdc_multiplier(), scenario.ctx());
-        let btc_price_40 = build_btc_price_info_object(&mut scenario, 40, &clock);
+        let btc_price_40 = build_btc_price_info_object_upgraded(&mut scenario, 40, &clock);
         assert!(
-            mm.risk_ratio(&registry, &btc_price_40, &usdc_price, &pool, &btc_pool, &usdc_pool, &clock) == 1_200_000_000,
+            margin_manager_upgraded::risk_ratio(&mm, &registry, &btc_price_40, &usdc_price, &pool, &btc_pool, &usdc_pool, &clock) == 1_200_000_000,
             0,
         );
 
-        let (_base_coin, _quote_coin, _remaining_repay_coin) = mm.liquidate<BTC, USDC, USDC>(
+        let (_base_coin, _quote_coin, _remaining_repay_coin) = margin_manager_upgraded::liquidate<
+            BTC,
+            USDC,
+            USDC,
+        >(
+            &mut mm,
             &registry,
             &btc_price_40,
             &usdc_price,
@@ -162,9 +170,9 @@ fun test_liquidation(error_code: u64) {
 
     // At BTC price 10, Risk ratio = (18 + 200) / 200 = 218 / 200 = 1.09 < 1.1, can liquidate
     let repay_coin = mint_coin<USDC>(500 * test_constants::usdc_multiplier(), scenario.ctx());
-    let btc_price_18 = build_btc_price_info_object(&mut scenario, 18, &clock);
+    let btc_price_18 = build_btc_price_info_object_upgraded(&mut scenario, 18, &clock);
     assert!(
-        mm.risk_ratio(&registry, &btc_price_18, &usdc_price, &pool, &btc_pool, &usdc_pool, &clock) == 1_090_000_000,
+        margin_manager_upgraded::risk_ratio(&mm, &registry, &btc_price_18, &usdc_price, &pool, &btc_pool, &usdc_pool, &clock) == 1_090_000_000,
         0,
     );
 
@@ -174,7 +182,12 @@ fun test_liquidation(error_code: u64) {
     // Remaining_repay_coin = 500 - 164.8 = 335.2 USDC
     // The liquidator should receive 160 * 1.05 = 168 USDC. The net profit is 168 - 164.8 = 3.2 USDC
     // 3.2 USDC / 160 USDC = 2% reward
-    let (base_coin, quote_coin, remaining_repay_coin) = mm.liquidate<BTC, USDC, USDC>(
+    let (base_coin, quote_coin, remaining_repay_coin) = margin_manager_upgraded::liquidate<
+        BTC,
+        USDC,
+        USDC,
+    >(
+        &mut mm,
         &registry,
         &btc_price_18,
         &usdc_price,
@@ -224,11 +237,12 @@ fun test_liquidation_quote_debt(error_code: u64) {
     let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
     let btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
-    let btc_price = build_btc_price_info_object(&mut scenario, 500, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 500, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit 1 BTC worth $500
-    mm.deposit<BTC, USDC, BTC>(
+    margin_manager_upgraded::deposit<BTC, USDC, BTC>(
+        &mut mm,
         &registry,
         &btc_price,
         &usdc_price,
@@ -238,7 +252,8 @@ fun test_liquidation_quote_debt(error_code: u64) {
     );
 
     // Borrow $200 USDC. Risk ratio = (500 + 200) / 200 = 3.5
-    mm.borrow_quote<BTC, USDC>(
+    margin_manager_upgraded::borrow_quote<BTC, USDC>(
+        &mut mm,
         &registry,
         &mut usdc_pool,
         &btc_price,
@@ -250,12 +265,13 @@ fun test_liquidation_quote_debt(error_code: u64) {
     );
 
     assert!(
-        mm.risk_ratio(&registry, &btc_price, &usdc_price, &pool, &btc_pool, &usdc_pool, &clock) == 3_500_000_000,
+        margin_manager_upgraded::risk_ratio(&mm, &registry, &btc_price, &usdc_price, &pool, &btc_pool, &usdc_pool, &clock) == 3_500_000_000,
         0,
     );
 
     // Now we withdraw 100 USDC. This should be allowed since risk ratio >= 2;
-    let withdraw_usdc = mm.withdraw<BTC, USDC, USDC>(
+    let withdraw_usdc = margin_manager_upgraded::withdraw<BTC, USDC, USDC>(
+        &mut mm,
         &registry,
         &btc_pool,
         &usdc_pool,
@@ -270,13 +286,14 @@ fun test_liquidation_quote_debt(error_code: u64) {
 
     // Risk ratio is now (500 + 100) / 200 = 3.0
     assert!(
-        mm.risk_ratio(&registry, &btc_price, &usdc_price, &pool, &btc_pool, &usdc_pool, &clock) == 3_000_000_000,
+        margin_manager_upgraded::risk_ratio(&mm, &registry, &btc_price, &usdc_price, &pool, &btc_pool, &usdc_pool, &clock) == 3_000_000_000,
         0,
     );
 
     if (error_code == ECannotWithdraw) {
         // At BTC price 500, we try to withdraw half BTC. (250 + 100) / 200 = 1.75 < 2.0, cannot withdraw
-        let withdraw_usdc_2 = mm.withdraw<BTC, USDC, BTC>(
+        let withdraw_usdc_2 = margin_manager_upgraded::withdraw<BTC, USDC, BTC>(
+            &mut mm,
             &registry,
             &btc_pool,
             &usdc_pool,
@@ -296,9 +313,9 @@ fun test_liquidation_quote_debt(error_code: u64) {
 
     // At BTC price 115, Risk ratio = (115 + 100) / 200 = 1.075 < 1.1, can liquidate
     let repay_coin = mint_coin<USDC>(500 * test_constants::usdc_multiplier(), scenario.ctx());
-    let btc_price_115 = build_btc_price_info_object(&mut scenario, 115, &clock);
+    let btc_price_115 = build_btc_price_info_object_upgraded(&mut scenario, 115, &clock);
     assert!(
-        mm.risk_ratio(&registry, &btc_price_115, &usdc_price, &pool, &btc_pool, &usdc_pool, &clock) == 1_075_000_000,
+        margin_manager_upgraded::risk_ratio(&mm, &registry, &btc_price_115, &usdc_price, &pool, &btc_pool, &usdc_pool, &clock) == 1_075_000_000,
         0,
     );
 
@@ -310,7 +327,12 @@ fun test_liquidation_quote_debt(error_code: u64) {
     // 3.5 USDC / 175 USDC = 2% reward
     // Since there's only 100 USDC in the manager, quote_coin will be 100 USDC
     // The remaining 83.75 USDC will be taken as base_coin (in BTC). 83.75 / 115 = 0.728260869565217391 BTC
-    let (base_coin, quote_coin, remaining_repay_coin) = mm.liquidate<BTC, USDC, USDC>(
+    let (base_coin, quote_coin, remaining_repay_coin) = margin_manager_upgraded::liquidate<
+        BTC,
+        USDC,
+        USDC,
+    >(
+        &mut mm,
         &registry,
         &btc_price_115,
         &usdc_price,
@@ -361,11 +383,12 @@ fun test_liquidation_quote_debt_partial() {
     let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
     let btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
-    let btc_price = build_btc_price_info_object(&mut scenario, 500, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 500, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit 1 BTC worth $500
-    mm.deposit<BTC, USDC, BTC>(
+    margin_manager_upgraded::deposit<BTC, USDC, BTC>(
+        &mut mm,
         &registry,
         &btc_price,
         &usdc_price,
@@ -375,7 +398,8 @@ fun test_liquidation_quote_debt_partial() {
     );
 
     // Borrow $200 USDC. Risk ratio = (500 + 200) / 200 = 3.5
-    mm.borrow_quote<BTC, USDC>(
+    margin_manager_upgraded::borrow_quote<BTC, USDC>(
+        &mut mm,
         &registry,
         &mut usdc_pool,
         &btc_price,
@@ -387,12 +411,13 @@ fun test_liquidation_quote_debt_partial() {
     );
 
     assert!(
-        mm.risk_ratio(&registry, &btc_price, &usdc_price, &pool, &btc_pool, &usdc_pool, &clock) == 3_500_000_000,
+        margin_manager_upgraded::risk_ratio(&mm, &registry, &btc_price, &usdc_price, &pool, &btc_pool, &usdc_pool, &clock) == 3_500_000_000,
         0,
     );
 
     // Now we withdraw 100 USDC. This should be allowed since risk ratio >= 2;
-    let withdraw_usdc = mm.withdraw<BTC, USDC, USDC>(
+    let withdraw_usdc = margin_manager_upgraded::withdraw<BTC, USDC, USDC>(
+        &mut mm,
         &registry,
         &btc_pool,
         &usdc_pool,
@@ -407,7 +432,7 @@ fun test_liquidation_quote_debt_partial() {
 
     // Risk ratio is now (500 + 100) / 200 = 3.0
     assert!(
-        mm.risk_ratio(&registry, &btc_price, &usdc_price, &pool, &btc_pool, &usdc_pool, &clock) == 3_000_000_000,
+        margin_manager_upgraded::risk_ratio(&mm, &registry, &btc_price, &usdc_price, &pool, &btc_pool, &usdc_pool, &clock) == 3_000_000_000,
         0,
     );
 
@@ -416,9 +441,9 @@ fun test_liquidation_quote_debt_partial() {
 
     // At BTC price 115, Risk ratio = (115 + 100) / 200 = 1.075 < 1.1, can liquidate
     let repay_coin = mint_coin<USDC>(90_125_000, scenario.ctx());
-    let btc_price_115 = build_btc_price_info_object(&mut scenario, 115, &clock);
+    let btc_price_115 = build_btc_price_info_object_upgraded(&mut scenario, 115, &clock);
     assert!(
-        mm.risk_ratio(&registry, &btc_price_115, &usdc_price, &pool, &btc_pool, &usdc_pool, &clock) == 1_075_000_000,
+        margin_manager_upgraded::risk_ratio(&mm, &registry, &btc_price_115, &usdc_price, &pool, &btc_pool, &usdc_pool, &clock) == 1_075_000_000,
         0,
     );
 
@@ -429,7 +454,12 @@ fun test_liquidation_quote_debt_partial() {
     // The liquidator should receive 87.5 * 1.05 = 91.875 USDC. The net profit is 91.875 - 90.125 = 1.75 USDC
     // 1.75 USDC / 87.5 USDC = 2% reward
     // Since there's 100 USDC in the manager, only USDC will be paid out
-    let (base_coin, quote_coin, remaining_repay_coin) = mm.liquidate<BTC, USDC, USDC>(
+    let (base_coin, quote_coin, remaining_repay_coin) = margin_manager_upgraded::liquidate<
+        BTC,
+        USDC,
+        USDC,
+    >(
+        &mut mm,
         &registry,
         &btc_price_115,
         &usdc_price,
@@ -447,7 +477,12 @@ fun test_liquidation_quote_debt_partial() {
 
     // Since risk ratio still < 1.1, can liquidate again
     let repay_coin = mint_coin<USDC>(90_125_000, scenario.ctx());
-    let (base_coin, quote_coin, remaining_repay_coin) = mm.liquidate<BTC, USDC, USDC>(
+    let (base_coin, quote_coin, remaining_repay_coin) = margin_manager_upgraded::liquidate<
+        BTC,
+        USDC,
+        USDC,
+    >(
+        &mut mm,
         &registry,
         &btc_price_115,
         &usdc_price,
@@ -481,8 +516,8 @@ fun test_liquidation_base_debt_default() {
         registry_id,
     ) = setup_btc_usd_deepbook_margin();
 
-    let btc_price = build_btc_price_info_object(&mut scenario, 500, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 500, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
     scenario.next_tx(test_constants::user1());
     let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
@@ -503,7 +538,8 @@ fun test_liquidation_base_debt_default() {
     let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
 
     // Deposit 500 USDC
-    mm.deposit<BTC, USDC, USDC>(
+    margin_manager_upgraded::deposit<BTC, USDC, USDC>(
+        &mut mm,
         &registry,
         &btc_price,
         &usdc_price,
@@ -513,7 +549,8 @@ fun test_liquidation_base_debt_default() {
     );
 
     // Borrow $200 BTC (0.4 BTC). Risk ratio = (500 + 200) / 200 = 3.5
-    mm.borrow_base<BTC, USDC>(
+    margin_manager_upgraded::borrow_base<BTC, USDC>(
+        &mut mm,
         &registry,
         &mut btc_pool,
         &btc_price,
@@ -525,12 +562,13 @@ fun test_liquidation_base_debt_default() {
     );
 
     assert!(
-        mm.risk_ratio(&registry, &btc_price, &usdc_price, &pool, &btc_pool, &usdc_pool, &clock) == 3_500_000_000,
+        margin_manager_upgraded::risk_ratio(&mm, &registry, &btc_price, &usdc_price, &pool, &btc_pool, &usdc_pool, &clock) == 3_500_000_000,
         0,
     );
 
     // Now we withdraw 0.2 BTC. This should be allowed since risk ratio >= 2;
-    let withdraw_btc = mm.withdraw<BTC, USDC, BTC>(
+    let withdraw_btc = margin_manager_upgraded::withdraw<BTC, USDC, BTC>(
+        &mut mm,
         &registry,
         &btc_pool,
         &usdc_pool,
@@ -545,7 +583,7 @@ fun test_liquidation_base_debt_default() {
 
     // Risk ratio is now (500 + 100) / 200 = 3.0
     assert!(
-        mm.risk_ratio(&registry, &btc_price, &usdc_price, &pool, &btc_pool, &usdc_pool, &clock) == 3_000_000_000,
+        margin_manager_upgraded::risk_ratio(&mm, &registry, &btc_price, &usdc_price, &pool, &btc_pool, &usdc_pool, &clock) == 3_000_000_000,
         0,
     );
 
@@ -555,7 +593,7 @@ fun test_liquidation_base_debt_default() {
     // We now have 0.2 BTC ($100) and 500 USDC ($500), with a debt of 0.4 BTC ($200)
     // At BTC price 3000, Risk ratio = (600 + 500) / 1200 = 0.916666666666666666 < 1.1, can liquidate
     let repay_coin = mint_coin<BTC>(1 * btc_multiplier(), scenario.ctx());
-    let btc_price_3000 = build_btc_price_info_object(&mut scenario, 3000, &clock);
+    let btc_price_3000 = build_btc_price_info_object_upgraded(&mut scenario, 3000, &clock);
 
     // 0.3597 BTC will be used to liquidate. 0.3492 BTC for repayment of loan, 0.0105 BTC for pool liquidation fee.
     // Since 0.3492 BTC is used for repayment, the liquidator should receive 0.3492 * 0.02 = 0.006984 as a reward.
@@ -564,7 +602,12 @@ fun test_liquidation_base_debt_default() {
     // The liquidator should receive 0.3492 * 1.05 = 0.36666 BTC = 1100 USD. The net profit is 0.36666 - 0.3597 = 0.00696 BTC
     // 0.00696 BTC / 0.3492 BTC = 2% reward
     // The 0.2 BTC will be used first. 1100 - 0.2 * 3000 = 500 USD. Then the remaining 500 USD will be taken as USDC.
-    let (base_coin, quote_coin, remaining_repay_coin) = mm.liquidate<BTC, USDC, BTC>(
+    let (base_coin, quote_coin, remaining_repay_coin) = margin_manager_upgraded::liquidate<
+        BTC,
+        USDC,
+        BTC,
+    >(
+        &mut mm,
         &registry,
         &btc_price_3000,
         &usdc_price,
@@ -602,8 +645,8 @@ fun test_liquidation_base_debt() {
         registry_id,
     ) = setup_btc_usd_deepbook_margin();
 
-    let btc_price = build_btc_price_info_object(&mut scenario, 500, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 500, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
     scenario.next_tx(test_constants::user1());
     let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
@@ -624,7 +667,8 @@ fun test_liquidation_base_debt() {
     let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
 
     // Deposit 500 USDC
-    mm.deposit<BTC, USDC, USDC>(
+    margin_manager_upgraded::deposit<BTC, USDC, USDC>(
+        &mut mm,
         &registry,
         &btc_price,
         &usdc_price,
@@ -634,7 +678,8 @@ fun test_liquidation_base_debt() {
     );
 
     // Borrow $200 BTC (0.4 BTC). Risk ratio = (500 + 200) / 200 = 3.5
-    mm.borrow_base<BTC, USDC>(
+    margin_manager_upgraded::borrow_base<BTC, USDC>(
+        &mut mm,
         &registry,
         &mut btc_pool,
         &btc_price,
@@ -646,12 +691,13 @@ fun test_liquidation_base_debt() {
     );
 
     assert!(
-        mm.risk_ratio(&registry, &btc_price, &usdc_price, &pool, &btc_pool, &usdc_pool, &clock) == 3_500_000_000,
+        margin_manager_upgraded::risk_ratio(&mm, &registry, &btc_price, &usdc_price, &pool, &btc_pool, &usdc_pool, &clock) == 3_500_000_000,
         0,
     );
 
     // Now we withdraw 0.2 BTC. This should be allowed since risk ratio >= 2;
-    let withdraw_btc = mm.withdraw<BTC, USDC, BTC>(
+    let withdraw_btc = margin_manager_upgraded::withdraw<BTC, USDC, BTC>(
+        &mut mm,
         &registry,
         &btc_pool,
         &usdc_pool,
@@ -666,7 +712,7 @@ fun test_liquidation_base_debt() {
 
     // Risk ratio is now (500 + 100) / 200 = 3.0
     assert!(
-        mm.risk_ratio(&registry, &btc_price, &usdc_price, &pool, &btc_pool, &usdc_pool, &clock) == 3_000_000_000,
+        margin_manager_upgraded::risk_ratio(&mm, &registry, &btc_price, &usdc_price, &pool, &btc_pool, &usdc_pool, &clock) == 3_000_000_000,
         0,
     );
 
@@ -676,10 +722,10 @@ fun test_liquidation_base_debt() {
     // We now have 0.2 BTC ($440) and 500 USDC ($500), with a debt of 0.4 BTC ($880)
     // At BTC price 2200, Risk ratio = (440 + 500) / 880 = 1.0681818 < 1.1, can liquidate
     let repay_coin = mint_coin<BTC>(1 * btc_multiplier(), scenario.ctx());
-    let btc_price_2200 = build_btc_price_info_object(&mut scenario, 2200, &clock);
+    let btc_price_2200 = build_btc_price_info_object_upgraded(&mut scenario, 2200, &clock);
 
     assert!(
-        mm.risk_ratio(&registry, &btc_price_2200, &usdc_price, &pool, &btc_pool, &usdc_pool, &clock) == 1_068_181_825,
+        margin_manager_upgraded::risk_ratio(&mm, &registry, &btc_price_2200, &usdc_price, &pool, &btc_pool, &usdc_pool, &clock) == 1_068_181_825,
         0,
     );
 
@@ -689,7 +735,12 @@ fun test_liquidation_base_debt() {
     // Remaining_repay_coin = 1 - 0.37454 = 0.62546 BTC
     // The liquidator should receive 0.3636 * 1.05 = 0.38178 BTC = 840 USD.
     // The 0.2 BTC will be used first (0.2 BTC = 440 USD). Then the remaining 400 USD will be taken as USDC.
-    let (base_coin, quote_coin, remaining_repay_coin) = mm.liquidate<BTC, USDC, BTC>(
+    let (base_coin, quote_coin, remaining_repay_coin) = margin_manager_upgraded::liquidate<
+        BTC,
+        USDC,
+        BTC,
+    >(
+        &mut mm,
         &registry,
         &btc_price_2200,
         &usdc_price,
@@ -726,8 +777,8 @@ fun test_btc_sui_liquidation(error_code: u64) {
     ) = setup_btc_sui_deepbook_margin();
 
     // BTC at $50,000, SUI at $20
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let sui_price = build_sui_price_info_object(&mut scenario, 20, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let sui_price = build_sui_price_info_object_upgraded(&mut scenario, 20, &clock);
 
     scenario.next_tx(test_constants::user1());
     let mut pool = scenario.take_shared<Pool<BTC, SUI>>();
@@ -742,7 +793,8 @@ fun test_btc_sui_liquidation(error_code: u64) {
     let mut sui_pool = scenario.take_shared_by_id<MarginPool<SUI>>(sui_pool_id);
 
     // Deposit 0.1 BTC worth $5,000
-    mm.deposit<BTC, SUI, BTC>(
+    margin_manager_upgraded::deposit<BTC, SUI, BTC>(
+        &mut mm,
         &registry,
         &btc_price,
         &sui_price,
@@ -752,7 +804,8 @@ fun test_btc_sui_liquidation(error_code: u64) {
     );
 
     // Borrow 200 SUI worth $4,000. Risk ratio = (5000 + 4000) / 4000 = 2.25
-    mm.borrow_quote<BTC, SUI>(
+    margin_manager_upgraded::borrow_quote<BTC, SUI>(
+        &mut mm,
         &registry,
         &mut sui_pool,
         &btc_price,
@@ -764,7 +817,8 @@ fun test_btc_sui_liquidation(error_code: u64) {
     );
 
     // Calculate expected risk ratio: (5000 + 4000) / 4000 = 2.25
-    let actual_risk_ratio = mm.risk_ratio(
+    let actual_risk_ratio = margin_manager_upgraded::risk_ratio(
+        &mm,
         &registry,
         &btc_price,
         &sui_price,
@@ -784,7 +838,8 @@ fun test_btc_sui_liquidation(error_code: u64) {
         // Risk ratio = (5000 + 4000) / 4000 = 2.25, still cannot liquidate
         let repay_coin = mint_coin<SUI>(3000 * sui_multiplier(), scenario.ctx());
 
-        let safe_risk_ratio = mm.risk_ratio(
+        let safe_risk_ratio = margin_manager_upgraded::risk_ratio(
+            &mm,
             &registry,
             &btc_price,
             &sui_price,
@@ -795,7 +850,12 @@ fun test_btc_sui_liquidation(error_code: u64) {
         );
         assert!(safe_risk_ratio > test_constants::liquidation_risk_ratio());
 
-        let (_base_coin, _quote_coin, _remaining_repay_coin) = mm.liquidate<BTC, SUI, SUI>(
+        let (_base_coin, _quote_coin, _remaining_repay_coin) = margin_manager_upgraded::liquidate<
+            BTC,
+            SUI,
+            SUI,
+        >(
+            &mut mm,
             &registry,
             &btc_price,
             &sui_price,
@@ -811,11 +871,12 @@ fun test_btc_sui_liquidation(error_code: u64) {
     // Create a liquidatable scenario: BTC drops to $15,000, SUI rises to $100
     // BTC value: 0.1 * $15,000 = $1500, SUI borrowed value: 200 * $100 = $20,000
     // Risk ratio = (1500 + 20000) / 20000 = 1.075 < 1.1, can liquidate
-    let btc_price_crash = build_btc_price_info_object(&mut scenario, 15000, &clock);
-    let sui_price_spike = build_sui_price_info_object(&mut scenario, 100, &clock);
+    let btc_price_crash = build_btc_price_info_object_upgraded(&mut scenario, 15000, &clock);
+    let sui_price_spike = build_sui_price_info_object_upgraded(&mut scenario, 100, &clock);
     let repay_coin = mint_coin<SUI>(3000 * sui_multiplier(), scenario.ctx());
 
-    let liquidation_risk_ratio = mm.risk_ratio(
+    let liquidation_risk_ratio = margin_manager_upgraded::risk_ratio(
+        &mm,
         &registry,
         &btc_price_crash,
         &sui_price_spike,
@@ -832,7 +893,12 @@ fun test_btc_sui_liquidation(error_code: u64) {
     // Remaining_repay_coin = 3000 - 180.25 = 2819.75 SUI
     // The liquidator should receive 175 * 1.05 = 183.75 SUI = 183.75 * 100 = 18375 USD.
     // Since there's enough SUI, no BTC is paid out
-    let (base_coin, quote_coin, remaining_repay_coin) = mm.liquidate<BTC, SUI, SUI>(
+    let (base_coin, quote_coin, remaining_repay_coin) = margin_manager_upgraded::liquidate<
+        BTC,
+        SUI,
+        SUI,
+    >(
+        &mut mm,
         &registry,
         &btc_price_crash,
         &sui_price_spike,
@@ -883,8 +949,8 @@ fun test_liquidate_base_debt_partial_payout_capped() {
         registry_id,
     ) = setup_btc_usd_deepbook_margin();
 
-    let btc_price = build_btc_price_info_object(&mut scenario, 500, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 500, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
     scenario.next_tx(test_constants::user1());
     let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
@@ -906,7 +972,8 @@ fun test_liquidate_base_debt_partial_payout_capped() {
 
     // Deposit 60 USDC, borrow 0.4 BTC ($200 at BTC=$500): risk ratio = 260 / 200 = 1.30.
     // The borrowed BTC is never withdrawn, so the manager holds the full 0.4 BTC.
-    mm.deposit<BTC, USDC, USDC>(
+    margin_manager_upgraded::deposit<BTC, USDC, USDC>(
+        &mut mm,
         &registry,
         &btc_price,
         &usdc_price,
@@ -914,7 +981,8 @@ fun test_liquidate_base_debt_partial_payout_capped() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_base<BTC, USDC>(
+    margin_manager_upgraded::borrow_base<BTC, USDC>(
+        &mut mm,
         &registry,
         &mut btc_pool,
         &btc_price,
@@ -930,13 +998,18 @@ fun test_liquidate_base_debt_partial_payout_capped() {
     // risk ratio = 1.0681818 < 1.10 -> liquidatable, and assets still exceed
     // debt * 1.05, so the proportional (partial) branch runs.
     scenario.next_tx(test_constants::liquidator());
-    let btc_price_2200 = build_btc_price_info_object(&mut scenario, 2200, &clock);
+    let btc_price_2200 = build_btc_price_info_object_upgraded(&mut scenario, 2200, &clock);
 
     // The liquidator brings only 0.01 BTC. After the 3% pool cut that funds
     // repay_amount = 0.00970873 BTC, so the payout is 0.00970873 * 1.05 BTC — about a
     // fortieth of the 0.4 BTC the manager holds, which is what leaves the cap slack.
     let repay_coin = mint_coin<BTC>(1_000_000, scenario.ctx()); // 0.01 BTC
-    let (base_coin, quote_coin, remaining_repay_coin) = mm.liquidate<BTC, USDC, BTC>(
+    let (base_coin, quote_coin, remaining_repay_coin) = margin_manager_upgraded::liquidate<
+        BTC,
+        USDC,
+        BTC,
+    >(
+        &mut mm,
         &registry,
         &btc_price_2200,
         &usdc_price,
@@ -982,8 +1055,8 @@ fun test_liquidate_dust_repay_burning_no_shares() {
         registry_id,
     ) = setup_btc_sui_deepbook_margin();
 
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let sui_price = build_sui_price_info_object(&mut scenario, 20, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let sui_price = build_sui_price_info_object_upgraded(&mut scenario, 20, &clock);
 
     scenario.next_tx(test_constants::user1());
     let mut pool = scenario.take_shared<Pool<BTC, SUI>>();
@@ -999,7 +1072,8 @@ fun test_liquidate_dust_repay_burning_no_shares() {
 
     // Deposit 1 BTC ($50,000), borrow 2000 SUI ($40,000 at SUI=$20):
     // risk ratio = (50000 + 40000) / 40000 = 2.25.
-    mm.deposit<BTC, SUI, BTC>(
+    margin_manager_upgraded::deposit<BTC, SUI, BTC>(
+        &mut mm,
         &registry,
         &btc_price,
         &sui_price,
@@ -1007,7 +1081,8 @@ fun test_liquidate_dust_repay_burning_no_shares() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_quote<BTC, SUI>(
+    margin_manager_upgraded::borrow_quote<BTC, SUI>(
+        &mut mm,
         &registry,
         &mut sui_pool,
         &btc_price,
@@ -1021,13 +1096,18 @@ fun test_liquidate_dust_repay_burning_no_shares() {
     // BTC to $15,000 and SUI to $100: assets = 15,000 + 200,000 = $215,000,
     // debt = $200,000, risk ratio = 1.075 < 1.10 -> liquidatable.
     scenario.next_tx(test_constants::liquidator());
-    let btc_price_crash = build_btc_price_info_object(&mut scenario, 15000, &clock);
-    let sui_price_spike = build_sui_price_info_object(&mut scenario, 100, &clock);
+    let btc_price_crash = build_btc_price_info_object_upgraded(&mut scenario, 15000, &clock);
+    let sui_price_spike = build_sui_price_info_object_upgraded(&mut scenario, 100, &clock);
 
     // Exactly `min_liquidation_repay` — the smallest coin the entry accepts. Against a
     // 2e12-raw-unit debt, `div(repay_amount, debt)` floors to 0 and so does repay_shares.
     let repay_coin = mint_coin<SUI>(1000, scenario.ctx());
-    let (base_coin, quote_coin, remaining_repay_coin) = mm.liquidate<BTC, SUI, SUI>(
+    let (base_coin, quote_coin, remaining_repay_coin) = margin_manager_upgraded::liquidate<
+        BTC,
+        SUI,
+        SUI,
+    >(
+        &mut mm,
         &registry,
         &btc_price_crash,
         &sui_price_spike,

--- a/packages/deepbook_margin/tests/margin_manager_tests.move
+++ b/packages/deepbook_margin/tests/margin_manager_tests.move
@@ -8,6 +8,7 @@ use deepbook::{balance_manager, constants, pool::Pool, registry::Registry};
 use deepbook_margin::{
     margin_constants,
     margin_manager::{Self, MarginManager},
+    margin_manager_upgraded,
     margin_pool::{Self, MarginPool},
     margin_registry::{Self, MarginRegistry},
     test_constants::{Self, USDC, USDT, BTC, INVALID_ASSET, btc_multiplier},
@@ -20,11 +21,11 @@ use deepbook_margin::{
         default_protocol_config,
         cleanup_margin_test,
         mint_coin,
-        build_demo_usdc_price_info_object,
-        build_demo_usdt_price_info_object,
-        build_btc_price_info_object,
-        build_stale_btc_price_info_object,
-        build_stale_usdc_price_info_object,
+        build_demo_usdc_price_info_object_upgraded,
+        build_demo_usdt_price_info_object_upgraded,
+        build_btc_price_info_object_upgraded,
+        build_stale_btc_price_info_object_upgraded,
+        build_stale_usdc_price_info_object_upgraded,
         setup_btc_usd_deepbook_margin,
         setup_usdc_usdt_deepbook_margin,
         setup_pool_proxy_test_env,
@@ -116,8 +117,8 @@ fun test_deepbook_margin_with_oracle() {
     return_shared(deepbook_registry);
 
     scenario.next_tx(test_constants::admin());
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // Test borrowing with oracle prices
     scenario.next_tx(test_constants::user1());
@@ -126,7 +127,8 @@ fun test_deepbook_margin_with_oracle() {
 
     // User1 deposits 10k USDT as collateral
     let deposit_coin = mint_coin<USDT>(10_000_000_000, scenario.ctx()); // 10k USDT with 6 decimals
-    mm.deposit<USDT, USDC, USDT>(
+    margin_manager_upgraded::deposit<USDT, USDC, USDT>(
+        &mut mm,
         &registry,
         &usdt_price,
         &usdc_price,
@@ -136,7 +138,8 @@ fun test_deepbook_margin_with_oracle() {
     );
 
     // Borrow 5k USDC against the collateral (50% borrow ratio)
-    mm.borrow_quote<USDT, USDC>(
+    margin_manager_upgraded::borrow_quote<USDT, USDC>(
+        &mut mm,
         &registry,
         &mut usdc_pool,
         &usdt_price,
@@ -165,12 +168,12 @@ fun test_btc_usd_deepbook_margin() {
         registry_id,
     ) = setup_btc_usd_deepbook_margin();
 
-    let btc_price = build_btc_price_info_object(
+    let btc_price = build_btc_price_info_object_upgraded(
         &mut scenario,
         60000,
         &clock,
     );
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
     scenario.next_tx(test_constants::user1());
     let pool = scenario.take_shared<Pool<BTC, USDC>>();
@@ -190,9 +193,18 @@ fun test_btc_usd_deepbook_margin() {
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
 
     let deposit = mint_coin<BTC>(btc_multiplier() / 2, scenario.ctx()); // 0.5 BTC
-    mm.deposit<BTC, USDC, BTC>(&registry, &btc_price, &usdc_price, deposit, &clock, scenario.ctx());
+    margin_manager_upgraded::deposit<BTC, USDC, BTC>(
+        &mut mm,
+        &registry,
+        &btc_price,
+        &usdc_price,
+        deposit,
+        &clock,
+        scenario.ctx(),
+    );
 
-    mm.borrow_quote<BTC, USDC>(
+    margin_manager_upgraded::borrow_quote<BTC, USDC>(
+        &mut mm,
         &registry,
         &mut usdc_pool,
         &btc_price,
@@ -224,12 +236,12 @@ fun test_usd_deposit_btc_borrow() {
     ) = setup_btc_usd_deepbook_margin();
 
     // Set initial prices
-    let btc_price = build_btc_price_info_object(
+    let btc_price = build_btc_price_info_object_upgraded(
         &mut scenario,
         100000,
         &clock,
     );
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
     scenario.next_tx(test_constants::user1());
     let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
@@ -249,7 +261,8 @@ fun test_usd_deposit_btc_borrow() {
     let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
 
     // Deposit 100000 USD
-    mm.deposit<BTC, USDC, USDC>(
+    margin_manager_upgraded::deposit<BTC, USDC, USDC>(
+        &mut mm,
         &registry,
         &btc_price,
         &usdc_price,
@@ -258,7 +271,8 @@ fun test_usd_deposit_btc_borrow() {
         scenario.ctx(),
     );
 
-    mm.borrow_base<BTC, USDC>(
+    margin_manager_upgraded::borrow_base<BTC, USDC>(
+        &mut mm,
         &registry,
         &mut btc_pool,
         &btc_price,
@@ -270,7 +284,7 @@ fun test_usd_deposit_btc_borrow() {
     );
 
     advance_time(&mut clock, 1);
-    let btc_increased = build_btc_price_info_object(
+    let btc_increased = build_btc_price_info_object_upgraded(
         &mut scenario,
         1_000_000,
         &clock,
@@ -278,7 +292,8 @@ fun test_usd_deposit_btc_borrow() {
 
     let debt_coin = mint_coin<BTC>(10 * test_constants::btc_multiplier(), scenario.ctx());
     scenario.next_tx(test_constants::admin());
-    let (base_coin, quote_coin, debt_coin) = mm.liquidate<BTC, USDC, BTC>(
+    let (base_coin, quote_coin, debt_coin) = margin_manager_upgraded::liquidate<BTC, USDC, BTC>(
+        &mut mm,
         &registry,
         &btc_increased,
         &usdc_price,
@@ -405,10 +420,11 @@ fun test_deposit_with_base_quote_deep_assets() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -417,7 +433,8 @@ fun test_deposit_with_base_quote_deep_assets() {
         scenario.ctx(),
     );
 
-    mm.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -426,7 +443,8 @@ fun test_deposit_with_base_quote_deep_assets() {
         scenario.ctx(),
     );
 
-    mm.deposit<USDC, USDT, DEEP>(
+    margin_manager_upgraded::deposit<USDC, USDT, DEEP>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -474,10 +492,11 @@ fun test_deposit_with_invalid_asset_fails() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, INVALID_ASSET>(
+    margin_manager_upgraded::deposit<USDC, USDT, INVALID_ASSET>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -520,10 +539,11 @@ fun test_withdrawal_ok_when_risk_ratio_above_limit() {
     let mut mm = scenario.take_shared<MarginManager<USDT, USDC>>();
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
     let usdt_pool = scenario.take_shared_by_id<MarginPool<USDT>>(usdt_pool_id);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDT, USDC, USDT>(
+    margin_manager_upgraded::deposit<USDT, USDC, USDT>(
+        &mut mm,
         &registry,
         &usdt_price,
         &usdc_price,
@@ -531,7 +551,8 @@ fun test_withdrawal_ok_when_risk_ratio_above_limit() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_quote<USDT, USDC>(
+    margin_manager_upgraded::borrow_quote<USDT, USDC>(
+        &mut mm,
         &registry,
         &mut usdc_pool,
         &usdt_price,
@@ -544,7 +565,8 @@ fun test_withdrawal_ok_when_risk_ratio_above_limit() {
 
     // Now test withdrawal with existing loan (risk ratio should still be high)
     let withdraw_amount = 100 * test_constants::usdt_multiplier();
-    let withdrawn_coin = mm.withdraw<USDT, USDC, USDT>(
+    let withdrawn_coin = margin_manager_upgraded::withdraw<USDT, USDC, USDT>(
+        &mut mm,
         &registry,
         &usdt_pool,
         &usdc_pool,
@@ -595,10 +617,11 @@ fun test_withdrawal_fails_when_risk_ratio_goes_below_limit() {
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
     let usdt_pool = scenario.take_shared_by_id<MarginPool<USDT>>(usdt_pool_id);
 
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
     let usdt_deposit = mint_coin<USDT>(10_000 * test_constants::usdt_multiplier(), scenario.ctx());
-    mm.deposit<USDT, USDC, USDT>(
+    margin_manager_upgraded::deposit<USDT, USDC, USDT>(
+        &mut mm,
         &registry,
         &usdt_price,
         &usdc_price,
@@ -606,7 +629,8 @@ fun test_withdrawal_fails_when_risk_ratio_goes_below_limit() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_quote<USDT, USDC>(
+    margin_manager_upgraded::borrow_quote<USDT, USDC>(
+        &mut mm,
         &registry,
         &mut usdc_pool,
         &usdt_price,
@@ -618,7 +642,8 @@ fun test_withdrawal_fails_when_risk_ratio_goes_below_limit() {
     );
 
     let withdraw_amount = 9000 * test_constants::usdt_multiplier();
-    let withdraw_coin = mm.withdraw<USDT, USDC, USDT>(
+    let withdraw_coin = margin_manager_upgraded::withdraw<USDT, USDC, USDT>(
+        &mut mm,
         &registry,
         &usdt_pool,
         &usdc_pool,
@@ -665,10 +690,11 @@ fun test_borrow_fails_from_both_pools() {
     let mut mm = scenario.take_shared<MarginManager<USDT, USDC>>();
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
     let mut usdt_pool = scenario.take_shared_by_id<MarginPool<USDT>>(usdt_pool_id);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDT, USDC, USDT>(
+    margin_manager_upgraded::deposit<USDT, USDC, USDT>(
+        &mut mm,
         &registry,
         &usdt_price,
         &usdc_price,
@@ -677,7 +703,8 @@ fun test_borrow_fails_from_both_pools() {
         scenario.ctx(),
     );
 
-    mm.borrow_quote<USDT, USDC>(
+    margin_manager_upgraded::borrow_quote<USDT, USDC>(
+        &mut mm,
         &registry,
         &mut usdc_pool,
         &usdt_price,
@@ -688,7 +715,8 @@ fun test_borrow_fails_from_both_pools() {
         scenario.ctx(),
     );
 
-    mm.borrow_base<USDT, USDC>(
+    margin_manager_upgraded::borrow_base<USDT, USDC>(
+        &mut mm,
         &registry,
         &mut usdt_pool,
         &usdt_price,
@@ -731,10 +759,11 @@ fun test_borrow_fails_with_zero_amount() {
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDT, USDC>>();
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDT, USDC, USDT>(
+    margin_manager_upgraded::deposit<USDT, USDC, USDT>(
+        &mut mm,
         &registry,
         &usdt_price,
         &usdc_price,
@@ -742,7 +771,8 @@ fun test_borrow_fails_with_zero_amount() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_quote<USDT, USDC>(
+    margin_manager_upgraded::borrow_quote<USDT, USDC>(
+        &mut mm,
         &registry,
         &mut usdc_pool,
         &usdt_price,
@@ -787,9 +817,10 @@ fun test_borrow_fails_when_risk_ratio_below_150() {
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
 
     // Deposit small collateral
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
-    mm.deposit<USDT, USDC, USDT>(
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
+    margin_manager_upgraded::deposit<USDT, USDC, USDT>(
+        &mut mm,
         &registry,
         &usdt_price,
         &usdc_price,
@@ -801,7 +832,8 @@ fun test_borrow_fails_when_risk_ratio_below_150() {
     // Try to borrow amount that would push risk ratio below 1.5
     // With $1000 collateral, borrowing $5000 would give ratio of 0.2 which is way below 1.5
     let borrow_amount = 5000 * test_constants::usdc_multiplier();
-    mm.borrow_quote<USDT, USDC>(
+    margin_manager_upgraded::borrow_quote<USDT, USDC>(
+        &mut mm,
         &registry,
         &mut usdc_pool,
         &usdt_price,
@@ -847,9 +879,10 @@ fun test_repay_fails_wrong_pool() {
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
     let mut usdt_pool = scenario.take_shared_by_id<MarginPool<USDT>>(usdt_pool_id);
 
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
-    mm.deposit<USDT, USDC, USDT>(
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
+    margin_manager_upgraded::deposit<USDT, USDC, USDT>(
+        &mut mm,
         &registry,
         &usdt_price,
         &usdc_price,
@@ -858,7 +891,8 @@ fun test_repay_fails_wrong_pool() {
         scenario.ctx(),
     );
     let borrow_amount = 2000 * test_constants::usdc_multiplier();
-    mm.borrow_quote<USDT, USDC>(
+    margin_manager_upgraded::borrow_quote<USDT, USDC>(
+        &mut mm,
         &registry,
         &mut usdc_pool,
         &usdt_price,
@@ -871,7 +905,8 @@ fun test_repay_fails_wrong_pool() {
 
     // Try to repay to wrong pool (USDT pool instead of USDC pool)
     let repay_coin = mint_coin<USDT>(1000 * test_constants::usdt_multiplier(), scenario.ctx());
-    mm.deposit<USDT, USDC, USDT>(
+    margin_manager_upgraded::deposit<USDT, USDC, USDT>(
+        &mut mm,
         &registry,
         &usdt_price,
         &usdc_price,
@@ -971,9 +1006,10 @@ fun test_repay_full_with_none() {
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
 
     // Deposit and borrow
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
-    mm.deposit<USDT, USDC, USDT>(
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
+    margin_manager_upgraded::deposit<USDT, USDC, USDT>(
+        &mut mm,
         &registry,
         &usdt_price,
         &usdc_price,
@@ -982,7 +1018,8 @@ fun test_repay_full_with_none() {
         scenario.ctx(),
     );
     let borrow_amount = 2000 * test_constants::usdc_multiplier();
-    mm.borrow_quote<USDT, USDC>(
+    margin_manager_upgraded::borrow_quote<USDT, USDC>(
+        &mut mm,
         &registry,
         &mut usdc_pool,
         &usdt_price,
@@ -997,7 +1034,8 @@ fun test_repay_full_with_none() {
     let repay_coin = mint_coin<USDC>(3000 * test_constants::usdc_multiplier(), scenario.ctx()); // More than enough
 
     // Deposit the repay coin margin manager's balance manager
-    mm.deposit<USDT, USDC, USDC>(
+    margin_manager_upgraded::deposit<USDT, USDC, USDC>(
+        &mut mm,
         &registry,
         &usdt_price,
         &usdc_price,
@@ -1049,10 +1087,11 @@ fun test_repay_exact_amount_no_rounding_errors() {
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDT, USDC>>();
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDT, USDC, USDT>(
+    margin_manager_upgraded::deposit<USDT, USDC, USDT>(
+        &mut mm,
         &registry,
         &usdt_price,
         &usdc_price,
@@ -1070,7 +1109,8 @@ fun test_repay_exact_amount_no_rounding_errors() {
 
     test_amounts.do!(|borrow_amount| {
         // Borrow
-        mm.borrow_quote<USDT, USDC>(
+        margin_manager_upgraded::borrow_quote<USDT, USDC>(
+            &mut mm,
             &registry,
             &mut usdc_pool,
             &usdt_price,
@@ -1087,7 +1127,8 @@ fun test_repay_exact_amount_no_rounding_errors() {
 
         // Deposit enough for repayment
         let repay_coin = mint_coin<USDC>(exact_amount + 1000, scenario.ctx()); // Add buffer
-        mm.deposit<USDT, USDC, USDC>(
+        margin_manager_upgraded::deposit<USDT, USDC, USDC>(
+            &mut mm,
             &registry,
             &usdt_price,
             &usdc_price,
@@ -1119,7 +1160,8 @@ fun test_repay_exact_amount_no_rounding_errors() {
                 &clock,
             );
             if (remaining_amount > 0) {
-                mm.deposit<USDT, USDC, USDC>(
+                margin_manager_upgraded::deposit<USDT, USDC, USDC>(
+                    &mut mm,
                     &registry,
                     &usdt_price,
                     &usdc_price,
@@ -1172,11 +1214,12 @@ fun test_liquidation_reward_calculations() {
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit 1 BTC worth $50k
-    mm.deposit<BTC, USDC, BTC>(
+    margin_manager_upgraded::deposit<BTC, USDC, BTC>(
+        &mut mm,
         &registry,
         &btc_price,
         &usdc_price,
@@ -1186,7 +1229,8 @@ fun test_liquidation_reward_calculations() {
     );
 
     // Borrow $45k
-    mm.borrow_quote<BTC, USDC>(
+    margin_manager_upgraded::borrow_quote<BTC, USDC>(
+        &mut mm,
         &registry,
         &mut usdc_pool,
         &btc_price,
@@ -1200,13 +1244,18 @@ fun test_liquidation_reward_calculations() {
     // Price drops severely to trigger liquidation
     // At $10k BTC price: ($10k BTC + $45k USDC) / $45k debt = $55k / $45k = 122% (still above 110%)
     // At $2k BTC price: ($2k BTC + $45k USDC) / $45k debt = $47k / $45k = 104.4% (below 110% - triggers liquidation!)
-    let btc_price_dropped = build_btc_price_info_object(&mut scenario, 2000, &clock);
+    let btc_price_dropped = build_btc_price_info_object_upgraded(&mut scenario, 2000, &clock);
 
     // Perform liquidation and check rewards
     scenario.next_tx(test_constants::liquidator());
     let debt_coin = mint_coin<USDC>(50_000_000_000, scenario.ctx());
 
-    let (base_coin, quote_coin, remaining_debt) = mm.liquidate<BTC, USDC, USDC>(
+    let (base_coin, quote_coin, remaining_debt) = margin_manager_upgraded::liquidate<
+        BTC,
+        USDC,
+        USDC,
+    >(
+        &mut mm,
         &registry,
         &btc_price_dropped,
         &usdc_price,
@@ -1348,11 +1397,12 @@ fun test_risk_ratio_with_multiple_assets() {
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
     let mut usdt_pool = scenario.take_shared_by_id<MarginPool<USDT>>(usdt_pool_id);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit multiple asset types
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -1360,7 +1410,8 @@ fun test_risk_ratio_with_multiple_assets() {
         &clock,
         scenario.ctx(),
     );
-    mm.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -1368,7 +1419,8 @@ fun test_risk_ratio_with_multiple_assets() {
         &clock,
         scenario.ctx(),
     );
-    mm.deposit<USDC, USDT, DEEP>(
+    margin_manager_upgraded::deposit<USDC, USDT, DEEP>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -1378,7 +1430,8 @@ fun test_risk_ratio_with_multiple_assets() {
     );
 
     // Borrow to create debt
-    mm.borrow_quote<USDC, USDT>(
+    margin_manager_upgraded::borrow_quote<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut usdt_pool,
         &usdc_price,
@@ -1429,11 +1482,12 @@ fun test_risk_ratio_with_oracle_price_changes() {
     let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
     let btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit 1 BTC worth $50k
-    mm.deposit<BTC, USDC, BTC>(
+    margin_manager_upgraded::deposit<BTC, USDC, BTC>(
+        &mut mm,
         &registry,
         &btc_price,
         &usdc_price,
@@ -1443,7 +1497,8 @@ fun test_risk_ratio_with_oracle_price_changes() {
     );
 
     // Borrow $20k (40% LTV initially)
-    mm.borrow_quote<BTC, USDC>(
+    margin_manager_upgraded::borrow_quote<BTC, USDC>(
+        &mut mm,
         &registry,
         &mut usdc_pool,
         &btc_price,
@@ -1458,10 +1513,11 @@ fun test_risk_ratio_with_oracle_price_changes() {
 
     // BTC price increases to $60k
     advance_time(&mut clock, 1000);
-    let btc_price_increased = build_btc_price_info_object(&mut scenario, 60000, &clock);
+    let btc_price_increased = build_btc_price_info_object_upgraded(&mut scenario, 60000, &clock);
 
     // Try withdrawing - should succeed as risk ratio improved to $60k / $20k = 3.0 (300%)
-    let withdrawn = mm.withdraw<BTC, USDC, BTC>(
+    let withdrawn = margin_manager_upgraded::withdraw<BTC, USDC, BTC>(
+        &mut mm,
         &registry,
         &btc_pool,
         &usdc_pool,
@@ -1477,7 +1533,7 @@ fun test_risk_ratio_with_oracle_price_changes() {
 
     // BTC price drops to $35k
     advance_time(&mut clock, 1000);
-    let btc_price_dropped = build_btc_price_info_object(&mut scenario, 35000, &clock);
+    let btc_price_dropped = build_btc_price_info_object_upgraded(&mut scenario, 35000, &clock);
 
     // Risk ratio now: 0.9 BTC * $35k / $20k = $31.5k / $20k = 1.575 (157.5%)
     // Still above liquidation threshold (120%) but close
@@ -1554,11 +1610,12 @@ fun test_max_leverage_enforcement() {
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
     let mut usdt_pool = scenario.take_shared_by_id<MarginPool<USDT>>(usdt_pool_id);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit small collateral
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -1570,7 +1627,8 @@ fun test_max_leverage_enforcement() {
     // Try to borrow beyond max leverage (would require > 10x leverage)
     let excessive_borrow = 10_000 * test_constants::usdt_multiplier();
     // This should fail due to exceeding max leverage
-    mm.borrow_quote<USDC, USDT>(
+    margin_manager_upgraded::borrow_quote<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut usdt_pool,
         &usdc_price,
@@ -1647,10 +1705,11 @@ fun test_min_position_size_requirement() {
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
     let mut usdt_pool = scenario.take_shared_by_id<MarginPool<USDT>>(usdt_pool_id);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -1661,7 +1720,8 @@ fun test_min_position_size_requirement() {
 
     // Try to borrow below minimum position size (default min_borrow is 10 * PRECISION_DECIMAL_9)
     let tiny_borrow = 1; // 1 mist, way below minimum
-    mm.borrow_quote<USDC, USDT>(
+    margin_manager_upgraded::borrow_quote<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut usdt_pool,
         &usdc_price,
@@ -1753,11 +1813,12 @@ fun test_repayment_rounding() {
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
     let mut usdt_pool = scenario.take_shared_by_id<MarginPool<USDT>>(usdt_pool_id);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // Setup position with debt
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -1766,7 +1827,8 @@ fun test_repayment_rounding() {
         scenario.ctx(),
     );
 
-    mm.borrow_quote<USDC, USDT>(
+    margin_manager_upgraded::borrow_quote<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut usdt_pool,
         &usdc_price,
@@ -1784,11 +1846,12 @@ fun test_repayment_rounding() {
     // Recreate price objects after time advance (they become stale)
     // Create new ones in a new transaction to avoid stale price errors
     scenario.next_tx(test_constants::user1());
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // Partial repayment
-    mm.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -1808,7 +1871,8 @@ fun test_repayment_rounding() {
     assert!(repaid_amount == 2_000 * test_constants::usdt_multiplier());
 
     // Full repayment
-    mm.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -1911,11 +1975,12 @@ fun test_asset_rebalancing_between_pools() {
     // Get margin pools for withdraw API
     let usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
     let usdt_pool = scenario.take_shared_by_id<MarginPool<USDT>>(usdt_pool_id);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit assets in both base and quote
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -1923,7 +1988,8 @@ fun test_asset_rebalancing_between_pools() {
         &clock,
         scenario.ctx(),
     );
-    mm.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -1933,7 +1999,8 @@ fun test_asset_rebalancing_between_pools() {
     );
 
     // Withdraw from one type (using new API)
-    let usdc_withdrawn = mm.withdraw<USDC, USDT, USDC>(
+    let usdc_withdrawn = margin_manager_upgraded::withdraw<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_pool,
         &usdt_pool,
@@ -1949,7 +2016,8 @@ fun test_asset_rebalancing_between_pools() {
     assert!(usdc_withdrawn.value() == 5_000 * test_constants::usdc_multiplier());
 
     // Deposit back different asset
-    mm.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -1995,11 +2063,12 @@ fun test_risk_ratio_returns_max_when_no_loan_but_has_assets() {
     let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
     let btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
     let usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit 1 BTC worth $50k (but don't borrow anything)
-    mm.deposit<BTC, USDC, BTC>(
+    margin_manager_upgraded::deposit<BTC, USDC, BTC>(
+        &mut mm,
         &registry,
         &btc_price,
         &usdc_price,
@@ -2011,7 +2080,8 @@ fun test_risk_ratio_returns_max_when_no_loan_but_has_assets() {
     assert!(mm.borrowed_base_shares() == 0);
     assert!(mm.borrowed_quote_shares() == 0);
 
-    let risk_ratio = mm.risk_ratio<BTC, USDC>(
+    let risk_ratio = margin_manager_upgraded::risk_ratio<BTC, USDC>(
+        &mm,
         &registry,
         &btc_price,
         &usdc_price,
@@ -2042,8 +2112,8 @@ fun test_risk_ratio_returns_max_when_completely_empty() {
         registry_id,
     ) = setup_btc_usd_deepbook_margin();
 
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
     scenario.next_tx(test_constants::user1());
     let pool = scenario.take_shared<Pool<BTC, USDC>>();
@@ -2070,7 +2140,8 @@ fun test_risk_ratio_returns_max_when_completely_empty() {
     assert!(base_assets == 0);
     assert!(quote_assets == 0);
 
-    let risk_ratio = mm.risk_ratio<BTC, USDC>(
+    let risk_ratio = margin_manager_upgraded::risk_ratio<BTC, USDC>(
+        &mm,
         &registry,
         &btc_price,
         &usdc_price,
@@ -2176,11 +2247,12 @@ fun test_borrow_at_exact_min_risk_ratio_no_rounding_issues() {
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDT, USDC>>();
     let registry = scenario.take_shared<MarginRegistry>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     let deposit_coin = mint_coin<USDC>(1 * test_constants::usdc_multiplier(), scenario.ctx());
-    mm.deposit<USDT, USDC, USDC>(
+    margin_manager_upgraded::deposit<USDT, USDC, USDC>(
+        &mut mm,
         &registry,
         &usdt_price,
         &usdc_price,
@@ -2198,10 +2270,11 @@ fun test_borrow_at_exact_min_risk_ratio_no_rounding_issues() {
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
     let registry = scenario.take_shared<MarginRegistry>();
     let pool = scenario.take_shared<Pool<USDT, USDC>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.borrow_quote<USDT, USDC>(
+    margin_manager_upgraded::borrow_quote<USDT, USDC>(
+        &mut mm,
         &registry,
         &mut usdc_pool,
         &usdt_price,
@@ -2214,7 +2287,8 @@ fun test_borrow_at_exact_min_risk_ratio_no_rounding_issues() {
 
     // Verify risk ratio is exactly at the minimum (1.25 with 9 decimals = 1_250_000_000)
     let base_pool = scenario.take_shared_by_id<MarginPool<USDT>>(usdt_pool_id);
-    let risk_ratio = mm.risk_ratio(
+    let risk_ratio = margin_manager_upgraded::risk_ratio(
+        &mm,
         &registry,
         &usdt_price,
         &usdc_price,
@@ -2321,11 +2395,12 @@ fun test_borrow_at_exact_min_risk_ratio_with_custom_price() {
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDT, USDC>>();
     let registry = scenario.take_shared<MarginRegistry>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     let deposit_coin = mint_coin<USDC>(1 * test_constants::usdc_multiplier(), scenario.ctx());
-    mm.deposit<USDT, USDC, USDC>(
+    margin_manager_upgraded::deposit<USDT, USDC, USDC>(
+        &mut mm,
         &registry,
         &usdt_price,
         &usdc_price,
@@ -2343,14 +2418,15 @@ fun test_borrow_at_exact_min_risk_ratio_with_custom_price() {
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
     let registry = scenario.take_shared<MarginRegistry>();
     let pool = scenario.take_shared<Pool<USDT, USDC>>();
-    let usdc_price = test_helpers::build_demo_usdc_price_info_object_with_price(
+    let usdc_price = test_helpers::build_demo_usdc_price_info_object_with_price_upgraded(
         &mut scenario,
         99984495, // $0.99984495 with 8 decimals
         &clock,
     );
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.borrow_quote<USDT, USDC>(
+    margin_manager_upgraded::borrow_quote<USDT, USDC>(
+        &mut mm,
         &registry,
         &mut usdc_pool,
         &usdt_price,
@@ -2363,7 +2439,8 @@ fun test_borrow_at_exact_min_risk_ratio_with_custom_price() {
 
     // Verify risk ratio
     let base_pool = scenario.take_shared_by_id<MarginPool<USDT>>(usdt_pool_id);
-    let risk_ratio = mm.risk_ratio(
+    let risk_ratio = margin_manager_upgraded::risk_ratio(
+        &mm,
         &registry,
         &usdt_price,
         &usdc_price,
@@ -2414,11 +2491,12 @@ fun test_liquidate_fails_with_too_low_repay_amount() {
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit 1 BTC worth $50k
-    mm.deposit<BTC, USDC, BTC>(
+    margin_manager_upgraded::deposit<BTC, USDC, BTC>(
+        &mut mm,
         &registry,
         &btc_price,
         &usdc_price,
@@ -2428,7 +2506,8 @@ fun test_liquidate_fails_with_too_low_repay_amount() {
     );
 
     // Borrow $40k USDC (risk ratio = 50k/40k = 1.25)
-    mm.borrow_quote<BTC, USDC>(
+    margin_manager_upgraded::borrow_quote<BTC, USDC>(
+        &mut mm,
         &registry,
         &mut usdc_pool,
         &btc_price,
@@ -2450,15 +2529,20 @@ fun test_liquidate_fails_with_too_low_repay_amount() {
     destroy(btc_price);
     destroy(usdc_price);
     scenario.next_tx(test_constants::admin());
-    let btc_price_dropped = build_btc_price_info_object(&mut scenario, 3000, &clock);
-    let usdc_price_fresh = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price_dropped = build_btc_price_info_object_upgraded(&mut scenario, 3000, &clock);
+    let usdc_price_fresh = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
     // Try to liquidate with an extremely small repay amount (1 unit)
     // This should fail with ERepayAmountTooLow
     scenario.next_tx(test_constants::liquidator());
     let debt_coin = mint_coin<USDC>(1, scenario.ctx()); // Just 1 unit - way too low
 
-    let (base_coin, quote_coin, remaining_debt) = mm.liquidate<BTC, USDC, USDC>(
+    let (base_coin, quote_coin, remaining_debt) = margin_manager_upgraded::liquidate<
+        BTC,
+        USDC,
+        USDC,
+    >(
+        &mut mm,
         &registry,
         &btc_price_dropped,
         &usdc_price_fresh,
@@ -2608,13 +2692,14 @@ fun test_borrow_base_fails_when_pool_disabled() {
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
     let registry = scenario.take_shared<MarginRegistry>();
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
     let deposit_coin = mint_coin<USDC>(
         5_000_000 * test_constants::usdc_multiplier(),
         scenario.ctx(),
     );
-    mm.deposit<BTC, USDC, USDC>(
+    margin_manager_upgraded::deposit<BTC, USDC, USDC>(
+        &mut mm,
         &registry,
         &btc_price,
         &usdc_price,
@@ -2638,10 +2723,11 @@ fun test_borrow_base_fails_when_pool_disabled() {
     let registry = scenario.take_shared<MarginRegistry>();
     let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
     let pool = scenario.take_shared<Pool<BTC, USDC>>();
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.borrow_base<BTC, USDC>(
+    margin_manager_upgraded::borrow_base<BTC, USDC>(
+        &mut mm,
         &registry,
         &mut btc_pool,
         &btc_price,
@@ -2702,13 +2788,14 @@ fun test_borrow_quote_fails_when_pool_disabled() {
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
     let registry = scenario.take_shared<MarginRegistry>();
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
     let deposit_coin = mint_coin<BTC>(
         10 * btc_multiplier(),
         scenario.ctx(),
     );
-    mm.deposit<BTC, USDC, BTC>(
+    margin_manager_upgraded::deposit<BTC, USDC, BTC>(
+        &mut mm,
         &registry,
         &btc_price,
         &usdc_price,
@@ -2732,10 +2819,11 @@ fun test_borrow_quote_fails_when_pool_disabled() {
     let registry = scenario.take_shared<MarginRegistry>();
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
     let pool = scenario.take_shared<Pool<BTC, USDC>>();
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.borrow_quote<BTC, USDC>(
+    margin_manager_upgraded::borrow_quote<BTC, USDC>(
+        &mut mm,
         &registry,
         &mut usdc_pool,
         &btc_price,
@@ -2797,9 +2885,10 @@ fun test_unregister_margin_manager_fails_with_outstanding_base_debt() {
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
     let registry = scenario.take_shared<MarginRegistry>();
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    mm.deposit<BTC, USDC, USDC>(
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    margin_manager_upgraded::deposit<BTC, USDC, USDC>(
+        &mut mm,
         &registry,
         &btc_price,
         &usdc_price,
@@ -2816,10 +2905,11 @@ fun test_unregister_margin_manager_fails_with_outstanding_base_debt() {
     let registry = scenario.take_shared<MarginRegistry>();
     let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
     let pool = scenario.take_shared<Pool<BTC, USDC>>();
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.borrow_base<BTC, USDC>(
+    margin_manager_upgraded::borrow_base<BTC, USDC>(
+        &mut mm,
         &registry,
         &mut btc_pool,
         &btc_price,
@@ -2898,9 +2988,10 @@ fun test_unregister_margin_manager_fails_with_outstanding_quote_debt() {
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
     let registry = scenario.take_shared<MarginRegistry>();
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    mm.deposit<BTC, USDC, BTC>(
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    margin_manager_upgraded::deposit<BTC, USDC, BTC>(
+        &mut mm,
         &registry,
         &btc_price,
         &usdc_price,
@@ -2917,10 +3008,11 @@ fun test_unregister_margin_manager_fails_with_outstanding_quote_debt() {
     let registry = scenario.take_shared<MarginRegistry>();
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
     let pool = scenario.take_shared<Pool<BTC, USDC>>();
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.borrow_quote<BTC, USDC>(
+    margin_manager_upgraded::borrow_quote<BTC, USDC>(
+        &mut mm,
         &registry,
         &mut usdc_pool,
         &btc_price,
@@ -2985,11 +3077,12 @@ fun liquidation_with_unsettled_maker_fills() {
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit 1 BTC worth $50k
-    mm.deposit<BTC, USDC, BTC>(
+    margin_manager_upgraded::deposit<BTC, USDC, BTC>(
+        &mut mm,
         &registry,
         &btc_price,
         &usdc_price,
@@ -2999,7 +3092,8 @@ fun liquidation_with_unsettled_maker_fills() {
     );
 
     // Borrow $40k USDC
-    mm.borrow_quote<BTC, USDC>(
+    margin_manager_upgraded::borrow_quote<BTC, USDC>(
+        &mut mm,
         &registry,
         &mut usdc_pool,
         &btc_price,
@@ -3018,8 +3112,8 @@ fun liquidation_with_unsettled_maker_fills() {
     let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
     let registry = scenario.take_shared<MarginRegistry>();
     let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
     // Place a bid for 0.1 BTC at a price that will sit in the book as maker
     // Price must be within 5% of oracle price. For BTC at $50,000 and USDC at $1:
@@ -3090,14 +3184,19 @@ fun liquidation_with_unsettled_maker_fills() {
     let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
 
-    let btc_price_dropped = build_btc_price_info_object(&mut scenario, 2000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price_dropped = build_btc_price_info_object_upgraded(&mut scenario, 2000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
     // Step 5: Liquidator liquidates - should succeed because withdraw_settled_amounts
     // is called first, depositing the BTC from filled maker order to balance_manager
     let debt_coin = mint_coin<USDC>(50_000_000_000, scenario.ctx());
 
-    let (base_coin, quote_coin, remaining_debt) = mm.liquidate<BTC, USDC, USDC>(
+    let (base_coin, quote_coin, remaining_debt) = margin_manager_upgraded::liquidate<
+        BTC,
+        USDC,
+        USDC,
+    >(
+        &mut mm,
         &registry,
         &btc_price_dropped,
         &usdc_price,
@@ -3154,11 +3253,12 @@ fun manager_state_works_with_stale_oracles() {
     let registry = scenario.take_shared<MarginRegistry>();
     let pool = scenario.take_shared<Pool<BTC, USDC>>();
 
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
     let deposit_coin = mint_coin<USDC>(100_000_000_000, scenario.ctx()); // 100k USDC
-    mm.deposit<BTC, USDC, USDC>(
+    margin_manager_upgraded::deposit<BTC, USDC, USDC>(
+        &mut mm,
         &registry,
         &btc_price,
         &usdc_price,
@@ -3176,8 +3276,13 @@ fun manager_state_works_with_stale_oracles() {
 
     // Create stale price info objects (120 seconds old relative to current clock)
     scenario.next_tx(test_constants::user1());
-    let stale_btc_price = build_stale_btc_price_info_object(&mut scenario, 50000, &clock, 120);
-    let stale_usdc_price = build_stale_usdc_price_info_object(&mut scenario, &clock, 120);
+    let stale_btc_price = build_stale_btc_price_info_object_upgraded(
+        &mut scenario,
+        50000,
+        120,
+        &clock,
+    );
+    let stale_usdc_price = build_stale_usdc_price_info_object_upgraded(&mut scenario, 120, &clock);
 
     let mm = scenario.take_shared<MarginManager<BTC, USDC>>();
     let registry = scenario.take_shared<MarginRegistry>();
@@ -3201,7 +3306,8 @@ fun manager_state_works_with_stale_oracles() {
         current_price,
         _lowest_trigger_above_price,
         _highest_trigger_below_price,
-    ) = mm.manager_state<BTC, USDC>(
+    ) = margin_manager_upgraded::manager_state<BTC, USDC>(
+        &mm,
         &registry,
         &stale_btc_price,
         &stale_usdc_price,
@@ -3268,13 +3374,14 @@ fun manager_state_returns_accurate_values_with_stale_oracles() {
     let pool = scenario.take_shared<Pool<BTC, USDC>>();
     let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
 
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit 100k USDC
     let usdc_deposit = 100_000_000_000u64; // 100k USDC (6 decimals)
     let deposit_coin = mint_coin<USDC>(usdc_deposit, scenario.ctx());
-    mm.deposit<BTC, USDC, USDC>(
+    margin_manager_upgraded::deposit<BTC, USDC, USDC>(
+        &mut mm,
         &registry,
         &btc_price,
         &usdc_price,
@@ -3285,7 +3392,8 @@ fun manager_state_returns_accurate_values_with_stale_oracles() {
 
     // Borrow 0.5 BTC (worth $25k at $50k/BTC, ~25% of collateral)
     let btc_borrow = 50_000_000u64; // 0.5 BTC (8 decimals)
-    mm.borrow_base<BTC, USDC>(
+    margin_manager_upgraded::borrow_base<BTC, USDC>(
+        &mut mm,
         &registry,
         &mut btc_pool,
         &btc_price,
@@ -3305,13 +3413,13 @@ fun manager_state_returns_accurate_values_with_stale_oracles() {
     // Create stale price info objects
     scenario.next_tx(test_constants::user1());
     let btc_price_usd = 50000u64;
-    let stale_btc_price = build_stale_btc_price_info_object(
+    let stale_btc_price = build_stale_btc_price_info_object_upgraded(
         &mut scenario,
         btc_price_usd,
-        &clock,
         120,
+        &clock,
     );
-    let stale_usdc_price = build_stale_usdc_price_info_object(&mut scenario, &clock, 120);
+    let stale_usdc_price = build_stale_usdc_price_info_object_upgraded(&mut scenario, 120, &clock);
 
     let mm = scenario.take_shared<MarginManager<BTC, USDC>>();
     let registry = scenario.take_shared<MarginRegistry>();
@@ -3334,7 +3442,8 @@ fun manager_state_returns_accurate_values_with_stale_oracles() {
         current_price,
         _lowest_trigger_above_price,
         _highest_trigger_below_price,
-    ) = mm.manager_state<BTC, USDC>(
+    ) = margin_manager_upgraded::manager_state<BTC, USDC>(
+        &mm,
         &registry,
         &stale_btc_price,
         &stale_usdc_price,
@@ -3385,7 +3494,7 @@ fun manager_state_returns_accurate_values_with_stale_oracles() {
     cleanup_margin_test(registry, admin_cap, maintainer_cap, clock, scenario);
 }
 
-#[test, expected_failure(abort_code = pyth::pyth::E_STALE_PRICE_UPDATE)]
+#[test, expected_failure(abort_code = pyth_upgraded::pyth::E_STALE_PRICE_UPDATE)]
 /// Tests that borrow_base fails when oracle prices are stale.
 /// This confirms that state-changing functions still use validated price checks.
 fun borrow_base_fails_with_stale_oracles() {
@@ -3422,11 +3531,12 @@ fun borrow_base_fails_with_stale_oracles() {
     let registry = scenario.take_shared<MarginRegistry>();
     let pool = scenario.take_shared<Pool<BTC, USDC>>();
 
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
     let deposit_coin = mint_coin<USDC>(100_000_000_000, scenario.ctx()); // 100k USDC
-    mm.deposit<BTC, USDC, USDC>(
+    margin_manager_upgraded::deposit<BTC, USDC, USDC>(
+        &mut mm,
         &registry,
         &btc_price,
         &usdc_price,
@@ -3443,8 +3553,13 @@ fun borrow_base_fails_with_stale_oracles() {
 
     // Try to borrow with stale prices - should fail
     scenario.next_tx(test_constants::user1());
-    let stale_btc_price = build_stale_btc_price_info_object(&mut scenario, 50000, &clock, 120);
-    let stale_usdc_price = build_stale_usdc_price_info_object(&mut scenario, &clock, 120);
+    let stale_btc_price = build_stale_btc_price_info_object_upgraded(
+        &mut scenario,
+        50000,
+        120,
+        &clock,
+    );
+    let stale_usdc_price = build_stale_usdc_price_info_object_upgraded(&mut scenario, 120, &clock);
 
     let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
     let registry = scenario.take_shared<MarginRegistry>();
@@ -3452,7 +3567,8 @@ fun borrow_base_fails_with_stale_oracles() {
     let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
 
     // This should fail with E_STALE_PRICE_UPDATE
-    mm.borrow_base<BTC, USDC>(
+    margin_manager_upgraded::borrow_base<BTC, USDC>(
+        &mut mm,
         &registry,
         &mut btc_pool,
         &stale_btc_price,
@@ -3496,9 +3612,10 @@ fun get_account_order_details_returns_open_orders() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
-    mm.deposit<USDC, USDT, USDC>(
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -3570,9 +3687,10 @@ fun account_open_orders_returns_order_ids() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
-    mm.deposit<USDC, USDT, USDC>(
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -3664,9 +3782,10 @@ fun locked_balance_reflects_open_orders() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
-    mm.deposit<USDC, USDT, USDC>(
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -3746,8 +3865,8 @@ fun execute_conditional_orders_v1_aborts() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = test_helpers::build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let usdt_price = test_helpers::build_demo_usdt_price_info_object(&mut scenario, &clock);
 
     let _ = mm.execute_conditional_orders<USDC, USDT>(
         &mut pool,
@@ -3800,13 +3919,14 @@ fun execute_conditional_orders_v2_post_loop_check_aborts() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // 100 USDT collateral + 100 DEEP (for fees) + borrow 400 USDC
     // Post-borrow: 100 USDT + 400 USDC = 500 USDC-equiv, debt 400 USDC,
     // risk_ratio = 1.25 (exactly at borrow floor).
-    mm.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -3814,7 +3934,8 @@ fun execute_conditional_orders_v2_post_loop_check_aborts() {
         &clock,
         scenario.ctx(),
     );
-    mm.deposit<USDC, USDT, DEEP>(
+    margin_manager_upgraded::deposit<USDC, USDT, DEEP>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -3822,7 +3943,8 @@ fun execute_conditional_orders_v2_post_loop_check_aborts() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_base<USDC, USDT>(
+    margin_manager_upgraded::borrow_base<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut base_pool,
         &usdc_price,
@@ -3848,7 +3970,8 @@ fun execute_conditional_orders_v2_post_loop_check_aborts() {
         true, // pay_with_deep (fees from DEEP balance, not the trade)
         constants::max_u64(),
     );
-    mm.add_conditional_order<USDC, USDT>(
+    margin_manager_upgraded::add_conditional_order<USDC, USDT>(
+        &mut mm,
         &pool,
         &usdc_price,
         &usdt_price,
@@ -3867,12 +3990,12 @@ fun execute_conditional_orders_v2_post_loop_check_aborts() {
     // selling becomes more valuable), so the trade loss isn't compensated by
     // a cross-asset reval. Post-fill assets_in_debt_unit drops below the
     // pre-trade value, dragging risk_ratio under 1.25.
-    let usdc_price_high = test_helpers::build_demo_usdc_price_info_object_with_price(
+    let usdc_price_high = test_helpers::build_demo_usdc_price_info_object_with_price_upgraded(
         &mut scenario,
         101 * test_constants::pyth_multiplier() / 100, // $1.01
         &clock,
     );
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     let order_infos = test_helpers::execute_conditional_orders_v2_for_test<USDC, USDT>(
         &mut scenario,
@@ -3911,8 +4034,8 @@ fun test_liquidate_one_sided_base_collateral_base_debt() {
         registry_id,
     ) = setup_btc_usd_deepbook_margin();
 
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
     scenario.next_tx(test_constants::user1());
     let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
@@ -3935,7 +4058,8 @@ fun test_liquidate_one_sided_base_collateral_base_debt() {
     // balance manager (base key), so the manager holds 5 BTC total against 4 BTC of debt
     // (risk_ratio = 1.25, exactly min_borrow_risk_ratio). The USDC (quote) key is never
     // created on this manager.
-    mm.deposit<BTC, USDC, BTC>(
+    margin_manager_upgraded::deposit<BTC, USDC, BTC>(
+        &mut mm,
         &registry,
         &btc_price,
         &usdc_price,
@@ -3943,7 +4067,8 @@ fun test_liquidate_one_sided_base_collateral_base_debt() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_base<BTC, USDC>(
+    margin_manager_upgraded::borrow_base<BTC, USDC>(
+        &mut mm,
         &registry,
         &mut btc_pool,
         &btc_price,
@@ -3962,15 +4087,20 @@ fun test_liquidate_one_sided_base_collateral_base_debt() {
     destroy(btc_price);
     destroy(usdc_price);
     scenario.next_tx(test_constants::admin());
-    let btc_price_fresh = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price_fresh = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price_fresh = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price_fresh = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
     scenario.next_tx(test_constants::liquidator());
     let debt_coin = mint_coin<BTC>(10 * btc_multiplier(), scenario.ctx());
 
     // Liquidate must not abort despite the missing USDC key — the in-function
     // `withdraw_without_owner_check(0, USDC)` should pass through (zero amount, key absent).
-    let (base_coin, quote_coin, remaining_debt) = mm.liquidate<BTC, USDC, BTC>(
+    let (base_coin, quote_coin, remaining_debt) = margin_manager_upgraded::liquidate<
+        BTC,
+        USDC,
+        BTC,
+    >(
+        &mut mm,
         &registry,
         &btc_price_fresh,
         &usdc_price_fresh,
@@ -4026,12 +4156,13 @@ fun test_liquidate_slightly_solvent_clears_all_shares() {
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit 1 BTC ($50k), borrow 40k USDC. Post-borrow: manager holds 1 BTC + 40k USDC,
     // debt = 40k USDC, risk_ratio = 90k / 40k = 2.25 (well above min_borrow_risk_ratio).
-    mm.deposit<BTC, USDC, BTC>(
+    margin_manager_upgraded::deposit<BTC, USDC, BTC>(
+        &mut mm,
         &registry,
         &btc_price,
         &usdc_price,
@@ -4039,7 +4170,8 @@ fun test_liquidate_slightly_solvent_clears_all_shares() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_quote<BTC, USDC>(
+    margin_manager_upgraded::borrow_quote<BTC, USDC>(
+        &mut mm,
         &registry,
         &mut usdc_pool,
         &btc_price,
@@ -4057,13 +4189,18 @@ fun test_liquidate_slightly_solvent_clears_all_shares() {
     destroy(btc_price);
     destroy(usdc_price);
     scenario.next_tx(test_constants::admin());
-    let btc_price_dropped = build_btc_price_info_object(&mut scenario, 1500, &clock);
-    let usdc_price_fresh = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price_dropped = build_btc_price_info_object_upgraded(&mut scenario, 1500, &clock);
+    let usdc_price_fresh = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
     scenario.next_tx(test_constants::liquidator());
     // Generous repay coin — caps at max_repay (~39.52k USDC) inside the contract.
     let debt_coin = mint_coin<USDC>(100_000_000_000, scenario.ctx()); // 100k USDC
-    let (base_coin, quote_coin, remaining_debt) = mm.liquidate<BTC, USDC, USDC>(
+    let (base_coin, quote_coin, remaining_debt) = margin_manager_upgraded::liquidate<
+        BTC,
+        USDC,
+        USDC,
+    >(
+        &mut mm,
         &registry,
         &btc_price_dropped,
         &usdc_price_fresh,
@@ -4128,10 +4265,11 @@ fun test_liquidate_partial_keeps_proportional_shares() {
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<BTC, USDC, BTC>(
+    margin_manager_upgraded::deposit<BTC, USDC, BTC>(
+        &mut mm,
         &registry,
         &btc_price,
         &usdc_price,
@@ -4139,7 +4277,8 @@ fun test_liquidate_partial_keeps_proportional_shares() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_quote<BTC, USDC>(
+    margin_manager_upgraded::borrow_quote<BTC, USDC>(
+        &mut mm,
         &registry,
         &mut usdc_pool,
         &btc_price,
@@ -4159,12 +4298,17 @@ fun test_liquidate_partial_keeps_proportional_shares() {
     destroy(btc_price);
     destroy(usdc_price);
     scenario.next_tx(test_constants::admin());
-    let btc_price_dropped = build_btc_price_info_object(&mut scenario, 3200, &clock);
-    let usdc_price_fresh = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price_dropped = build_btc_price_info_object_upgraded(&mut scenario, 3200, &clock);
+    let usdc_price_fresh = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
     scenario.next_tx(test_constants::liquidator());
     let debt_coin = mint_coin<USDC>(100_000_000_000, scenario.ctx()); // 100k USDC
-    let (base_coin, quote_coin, remaining_debt) = mm.liquidate<BTC, USDC, USDC>(
+    let (base_coin, quote_coin, remaining_debt) = margin_manager_upgraded::liquidate<
+        BTC,
+        USDC,
+        USDC,
+    >(
+        &mut mm,
         &registry,
         &btc_price_dropped,
         &usdc_price_fresh,
@@ -4230,10 +4374,11 @@ fun test_liquidate_partial_in_slightly_solvent_range_keeps_residual() {
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<BTC, USDC, BTC>(
+    margin_manager_upgraded::deposit<BTC, USDC, BTC>(
+        &mut mm,
         &registry,
         &btc_price,
         &usdc_price,
@@ -4241,7 +4386,8 @@ fun test_liquidate_partial_in_slightly_solvent_range_keeps_residual() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_quote<BTC, USDC>(
+    margin_manager_upgraded::borrow_quote<BTC, USDC>(
+        &mut mm,
         &registry,
         &mut usdc_pool,
         &btc_price,
@@ -4257,15 +4403,20 @@ fun test_liquidate_partial_in_slightly_solvent_range_keeps_residual() {
     destroy(btc_price);
     destroy(usdc_price);
     scenario.next_tx(test_constants::admin());
-    let btc_price_dropped = build_btc_price_info_object(&mut scenario, 1500, &clock);
-    let usdc_price_fresh = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price_dropped = build_btc_price_info_object_upgraded(&mut scenario, 1500, &clock);
+    let usdc_price_fresh = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
     scenario.next_tx(test_constants::liquidator());
     // Only 10k USDC: input/1.03 ≈ 9,708.74 USDC = repay_amount, which is far below
     // max_repay (≈ 39,523.81). The IF branch requires `repay_amount == max_repay`, so
     // we must hit the proportional ELSE branch.
     let debt_coin = mint_coin<USDC>(10_000_000_000, scenario.ctx());
-    let (base_coin, quote_coin, remaining_debt) = mm.liquidate<BTC, USDC, USDC>(
+    let (base_coin, quote_coin, remaining_debt) = margin_manager_upgraded::liquidate<
+        BTC,
+        USDC,
+        USDC,
+    >(
+        &mut mm,
         &registry,
         &btc_price_dropped,
         &usdc_price_fresh,
@@ -4330,10 +4481,11 @@ fun test_liquidate_records_pool_default_when_repay_below_debt() {
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<BTC, USDC, BTC>(
+    margin_manager_upgraded::deposit<BTC, USDC, BTC>(
+        &mut mm,
         &registry,
         &btc_price,
         &usdc_price,
@@ -4341,7 +4493,8 @@ fun test_liquidate_records_pool_default_when_repay_below_debt() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_quote<BTC, USDC>(
+    margin_manager_upgraded::borrow_quote<BTC, USDC>(
+        &mut mm,
         &registry,
         &mut usdc_pool,
         &btc_price,
@@ -4358,8 +4511,8 @@ fun test_liquidate_records_pool_default_when_repay_below_debt() {
     destroy(btc_price);
     destroy(usdc_price);
     scenario.next_tx(test_constants::admin());
-    let btc_price_dropped = build_btc_price_info_object(&mut scenario, 400, &clock);
-    let usdc_price_fresh = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price_dropped = build_btc_price_info_object_upgraded(&mut scenario, 400, &clock);
+    let usdc_price_fresh = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
     // Snapshot pool supply right before the liquidation. The clock has not advanced
     // between borrow and now, so `update` inside `decrease_borrow_shares` accrues no
@@ -4369,7 +4522,12 @@ fun test_liquidate_records_pool_default_when_repay_below_debt() {
 
     scenario.next_tx(test_constants::liquidator());
     let debt_coin = mint_coin<USDC>(100_000_000_000, scenario.ctx()); // 100k USDC
-    let (base_coin, quote_coin, remaining_debt) = mm.liquidate<BTC, USDC, USDC>(
+    let (base_coin, quote_coin, remaining_debt) = margin_manager_upgraded::liquidate<
+        BTC,
+        USDC,
+        USDC,
+    >(
+        &mut mm,
         &registry,
         &btc_price_dropped,
         &usdc_price_fresh,
@@ -4435,10 +4593,11 @@ fun test_liquidate_near_risk_ratio_one_records_large_default() {
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<BTC, USDC, BTC>(
+    margin_manager_upgraded::deposit<BTC, USDC, BTC>(
+        &mut mm,
         &registry,
         &btc_price,
         &usdc_price,
@@ -4446,7 +4605,8 @@ fun test_liquidate_near_risk_ratio_one_records_large_default() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_quote<BTC, USDC>(
+    margin_manager_upgraded::borrow_quote<BTC, USDC>(
+        &mut mm,
         &registry,
         &mut usdc_pool,
         &btc_price,
@@ -4464,14 +4624,19 @@ fun test_liquidate_near_risk_ratio_one_records_large_default() {
     destroy(btc_price);
     destroy(usdc_price);
     scenario.next_tx(test_constants::admin());
-    let btc_price_dropped = build_btc_price_info_object(&mut scenario, 50, &clock);
-    let usdc_price_fresh = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price_dropped = build_btc_price_info_object_upgraded(&mut scenario, 50, &clock);
+    let usdc_price_fresh = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
     let supply_before = usdc_pool.total_supply();
 
     scenario.next_tx(test_constants::liquidator());
     let debt_coin = mint_coin<USDC>(100_000_000_000, scenario.ctx()); // 100k USDC
-    let (base_coin, quote_coin, remaining_debt) = mm.liquidate<BTC, USDC, USDC>(
+    let (base_coin, quote_coin, remaining_debt) = margin_manager_upgraded::liquidate<
+        BTC,
+        USDC,
+        USDC,
+    >(
+        &mut mm,
         &registry,
         &btc_price_dropped,
         &usdc_price_fresh,
@@ -4539,10 +4704,11 @@ fun test_liquidate_just_outside_assets_exhausted_runs_proportional() {
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<BTC, USDC, BTC>(
+    margin_manager_upgraded::deposit<BTC, USDC, BTC>(
+        &mut mm,
         &registry,
         &btc_price,
         &usdc_price,
@@ -4550,7 +4716,8 @@ fun test_liquidate_just_outside_assets_exhausted_runs_proportional() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_quote<BTC, USDC>(
+    margin_manager_upgraded::borrow_quote<BTC, USDC>(
+        &mut mm,
         &registry,
         &mut usdc_pool,
         &btc_price,
@@ -4568,12 +4735,17 @@ fun test_liquidate_just_outside_assets_exhausted_runs_proportional() {
     destroy(btc_price);
     destroy(usdc_price);
     scenario.next_tx(test_constants::admin());
-    let btc_price_dropped = build_btc_price_info_object(&mut scenario, 2001, &clock);
-    let usdc_price_fresh = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price_dropped = build_btc_price_info_object_upgraded(&mut scenario, 2001, &clock);
+    let usdc_price_fresh = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
     scenario.next_tx(test_constants::liquidator());
     let debt_coin = mint_coin<USDC>(100_000_000_000, scenario.ctx());
-    let (base_coin, quote_coin, remaining_debt) = mm.liquidate<BTC, USDC, USDC>(
+    let (base_coin, quote_coin, remaining_debt) = margin_manager_upgraded::liquidate<
+        BTC,
+        USDC,
+        USDC,
+    >(
+        &mut mm,
         &registry,
         &btc_price_dropped,
         &usdc_price_fresh,
@@ -4629,10 +4801,11 @@ fun test_liquidate_repay_just_below_max_does_not_clear_all() {
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
-    let btc_price = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<BTC, USDC, BTC>(
+    margin_manager_upgraded::deposit<BTC, USDC, BTC>(
+        &mut mm,
         &registry,
         &btc_price,
         &usdc_price,
@@ -4640,7 +4813,8 @@ fun test_liquidate_repay_just_below_max_does_not_clear_all() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_quote<BTC, USDC>(
+    margin_manager_upgraded::borrow_quote<BTC, USDC>(
+        &mut mm,
         &registry,
         &mut usdc_pool,
         &btc_price,
@@ -4660,12 +4834,17 @@ fun test_liquidate_repay_just_below_max_does_not_clear_all() {
     destroy(btc_price);
     destroy(usdc_price);
     scenario.next_tx(test_constants::admin());
-    let btc_price_dropped = build_btc_price_info_object(&mut scenario, 1500, &clock);
-    let usdc_price_fresh = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price_dropped = build_btc_price_info_object_upgraded(&mut scenario, 1500, &clock);
+    let usdc_price_fresh = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
     scenario.next_tx(test_constants::liquidator());
     let debt_coin = mint_coin<USDC>(40_709_523_808, scenario.ctx());
-    let (base_coin, quote_coin, remaining_debt) = mm.liquidate<BTC, USDC, USDC>(
+    let (base_coin, quote_coin, remaining_debt) = margin_manager_upgraded::liquidate<
+        BTC,
+        USDC,
+        USDC,
+    >(
+        &mut mm,
         &registry,
         &btc_price_dropped,
         &usdc_price_fresh,
@@ -4706,8 +4885,8 @@ fun risk_ratio_unsafe_with_debt_prices_both_legs() {
         registry_id,
     ) = setup_btc_usd_deepbook_margin();
 
-    let btc_price = build_btc_price_info_object(&mut scenario, 100000, &clock);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc_price = build_btc_price_info_object_upgraded(&mut scenario, 100000, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
     scenario.next_tx(test_constants::user1());
     let pool = scenario.take_shared<Pool<BTC, USDC>>();
@@ -4727,7 +4906,7 @@ fun risk_ratio_unsafe_with_debt_prices_both_legs() {
     let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
     let usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
 
-    margin_manager::deposit<BTC, USDC, USDC>(
+    margin_manager_upgraded::deposit<BTC, USDC, USDC>(
         &mut mm,
         &registry,
         &btc_price,
@@ -4736,7 +4915,7 @@ fun risk_ratio_unsafe_with_debt_prices_both_legs() {
         &clock,
         scenario.ctx(),
     );
-    margin_manager::borrow_base<BTC, USDC>(
+    margin_manager_upgraded::borrow_base<BTC, USDC>(
         &mut mm,
         &registry,
         &mut btc_pool,
@@ -4750,7 +4929,7 @@ fun risk_ratio_unsafe_with_debt_prices_both_legs() {
 
     // $100k USDC plus the 0.5 BTC drawn at $100k is $150k of assets against $50k of
     // debt: exactly 3.0. Transposed, BTC would price at $1 and USDC at $100k.
-    let ratio = margin_manager::risk_ratio_unsafe<BTC, USDC>(
+    let ratio = margin_manager_upgraded::risk_ratio_unsafe<BTC, USDC>(
         &mm,
         &registry,
         &btc_price,
@@ -4802,10 +4981,11 @@ fun test_unregister_margin_manager_fails_with_leftover_collateral() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDT, USDC>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDT, USDC, USDT>(
+    margin_manager_upgraded::deposit<USDT, USDC, USDT>(
+        &mut mm,
         &registry,
         &usdt_price,
         &usdc_price,

--- a/packages/deepbook_margin/tests/margin_registry_tests.move
+++ b/packages/deepbook_margin/tests/margin_registry_tests.move
@@ -485,7 +485,7 @@ fun test_new_pool_config_with_leverage_too_high() {
     cleanup_test(registry, admin_cap, maintainer_cap, clock, scenario);
 }
 
-#[test, expected_failure(abort_code = pyth::pyth::E_STALE_PRICE_UPDATE)]
+#[test, expected_failure(abort_code = pyth_upgraded::pyth::E_STALE_PRICE_UPDATE)]
 fun test_oracle_max_age_exceeded() {
     let (
         mut scenario,
@@ -508,7 +508,7 @@ fun test_oracle_max_age_exceeded() {
     // Create a price info object with timestamp that's older than 60 seconds
     let old_timestamp_seconds = (current_time_ms / 1000) - 65; // 65 seconds ago
 
-    let old_price_info = test_helpers::build_pyth_price_info_object(
+    let old_price_info = test_helpers::build_pyth_upgraded_price_info_object(
         &mut scenario,
         test_constants::usdc_price_feed_id(),
         1 * test_constants::pyth_multiplier(), // $1.00 price
@@ -520,7 +520,7 @@ fun test_oracle_max_age_exceeded() {
     // This should fail with Pyth error because price is older than 60 seconds
     // Staleness is enforced by the reader now, so the read is the failing step.
     let _usd_value = oracle::calculate_usd_price<USDC>(
-        oracle::read_price<USDC>(&old_price_info, &registry, &clock),
+        oracle::read_price_upgraded<USDC>(&old_price_info, &registry, &clock),
         &registry,
         1000000, // 1 USDC (6 decimals)
     );
@@ -552,7 +552,7 @@ fun test_oracle_max_age_within_limit() {
     // Create a price info object with recent timestamp (30 seconds ago, within 60 second limit)
     let recent_timestamp_seconds = (current_time_ms / 1000) - 30; // 30 seconds ago
 
-    let recent_price_info = test_helpers::build_pyth_price_info_object(
+    let recent_price_info = test_helpers::build_pyth_upgraded_price_info_object(
         &mut scenario,
         test_constants::usdc_price_feed_id(),
         1 * test_constants::pyth_multiplier(), // $1.00 price
@@ -563,7 +563,7 @@ fun test_oracle_max_age_within_limit() {
 
     // This should succeed because price is within 60 second limit
     let usd_value = oracle::calculate_usd_price<USDC>(
-        oracle::read_price<USDC>(&recent_price_info, &registry, &clock),
+        oracle::read_price_upgraded<USDC>(&recent_price_info, &registry, &clock),
         &registry,
         1000000, // 1 USDC (6 decimals)
     );

--- a/packages/deepbook_margin/tests/pool_proxy_tests.move
+++ b/packages/deepbook_margin/tests/pool_proxy_tests.move
@@ -8,9 +8,11 @@ use deepbook::{constants, pool::Pool, registry::Registry};
 use deepbook_margin::{
     margin_constants,
     margin_manager::{Self, MarginManager},
+    margin_manager_upgraded,
     margin_pool::{Self, MarginPool},
     margin_registry::{Self, MarginRegistry},
     pool_proxy,
+    pool_proxy_upgraded,
     test_constants::{Self, USDC, USDT},
     test_helpers::{
         Self,
@@ -27,11 +29,11 @@ use deepbook_margin::{
         destroy_2,
         return_shared_2,
         return_shared_3,
-        build_demo_usdc_price_info_object,
-        build_stale_usdc_price_info_object,
-        build_stale_usdt_price_info_object,
-        build_demo_usdt_price_info_object,
-        build_demo_usdc_price_info_object_with_price,
+        build_demo_usdc_price_info_object_upgraded,
+        build_stale_usdc_price_info_object_upgraded,
+        build_stale_usdt_price_info_object_upgraded,
+        build_demo_usdt_price_info_object_upgraded,
+        build_demo_usdc_price_info_object_with_price_upgraded,
         setup_orderbook_liquidity_stablecoin,
         setup_orderbook_liquidity_at_prices,
         setup_orderbook_liquidity_out_of_bounds_stablecoin,
@@ -70,11 +72,12 @@ fun test_place_limit_order_ok() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit some collateral
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -235,10 +238,11 @@ fun test_place_limit_order_pool_not_enabled() {
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
     let mut non_margin_pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(non_margin_pool_id);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -306,10 +310,11 @@ fun test_place_market_order_ok() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -452,10 +457,11 @@ fun test_place_market_order_pool_not_enabled() {
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
     let mut non_margin_pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(non_margin_pool_id);
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -519,11 +525,12 @@ fun test_place_reduce_only_limit_order_ok() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit USDT as collateral
-    mm.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -533,7 +540,8 @@ fun test_place_reduce_only_limit_order_ok() {
     );
 
     // Borrow USDC to establish a base debt
-    mm.borrow_base<USDC, USDT>(
+    margin_manager_upgraded::borrow_base<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut base_pool,
         &usdc_price,
@@ -545,7 +553,8 @@ fun test_place_reduce_only_limit_order_ok() {
     );
 
     // Withdraw some USDC so we have debt but less assets (creating a net debt position)
-    let withdrawn_coin = mm.withdraw<USDC, USDT, USDC>(
+    let withdrawn_coin = margin_manager_upgraded::withdraw<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &base_pool,
         &quote_pool,
@@ -624,11 +633,12 @@ fun test_place_reduce_only_limit_order_ok_ask() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit USDC as collateral
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -638,7 +648,8 @@ fun test_place_reduce_only_limit_order_ok_ask() {
     );
 
     // Borrow USDT to establish a quote debt
-    mm.borrow_quote<USDC, USDT>(
+    margin_manager_upgraded::borrow_quote<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut quote_pool,
         &usdc_price,
@@ -650,7 +661,8 @@ fun test_place_reduce_only_limit_order_ok_ask() {
     );
 
     // Withdraw some USDT so we have debt but less assets (creating a net debt position)
-    let withdrawn_coin = mm.withdraw<USDC, USDT, USDT>(
+    let withdrawn_coin = margin_manager_upgraded::withdraw<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &base_pool,
         &quote_pool,
@@ -729,10 +741,11 @@ fun reduce_only_limit_ask_above_net_debt_ok() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -740,7 +753,8 @@ fun reduce_only_limit_ask_above_net_debt_ok() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_quote<USDC, USDT>(
+    margin_manager_upgraded::borrow_quote<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut quote_pool,
         &usdc_price,
@@ -750,7 +764,8 @@ fun reduce_only_limit_ask_above_net_debt_ok() {
         &clock,
         scenario.ctx(),
     );
-    let withdrawn_coin = mm.withdraw<USDC, USDT, USDT>(
+    let withdrawn_coin = margin_manager_upgraded::withdraw<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &base_pool,
         &quote_pool,
@@ -938,11 +953,12 @@ fun test_place_reduce_only_limit_order_not_reduce_only() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit some USDT to use as collateral
-    mm.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -952,10 +968,11 @@ fun test_place_reduce_only_limit_order_not_reduce_only() {
     );
     destroy_2!(usdc_price, usdt_price);
 
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
     // Borrow some USDT to establish relationship with quote pool
-    mm.borrow_quote<USDC, USDT>(
+    margin_manager_upgraded::borrow_quote<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut quote_pool,
         &usdc_price,
@@ -1033,11 +1050,12 @@ fun test_place_reduce_only_limit_order_bid_requires_base_debt() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // USDC collateral + USDT (quote) debt -> a long, no base debt.
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -1045,7 +1063,8 @@ fun test_place_reduce_only_limit_order_bid_requires_base_debt() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_quote<USDC, USDT>(
+    margin_manager_upgraded::borrow_quote<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut quote_pool,
         &usdc_price,
@@ -1117,11 +1136,12 @@ fun test_place_reduce_only_limit_order_ask_requires_quote_debt() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // USDT collateral + USDC (base) debt -> a short, no quote debt.
-    mm.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -1129,7 +1149,8 @@ fun test_place_reduce_only_limit_order_ask_requires_quote_debt() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_base<USDC, USDT>(
+    margin_manager_upgraded::borrow_base<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut base_pool,
         &usdc_price,
@@ -1193,11 +1214,12 @@ fun test_place_reduce_only_limit_order_not_reduce_only_quantity_ask() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit some USDC to use as collateral
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -1206,7 +1228,8 @@ fun test_place_reduce_only_limit_order_not_reduce_only_quantity_ask() {
         scenario.ctx(),
     );
     // Borrow some USDT
-    mm.borrow_quote<USDC, USDT>(
+    margin_manager_upgraded::borrow_quote<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut quote_pool,
         &usdc_price,
@@ -1217,7 +1240,8 @@ fun test_place_reduce_only_limit_order_not_reduce_only_quantity_ask() {
         scenario.ctx(),
     );
 
-    let coin = mm.withdraw<USDC, USDT, USDT>(
+    let coin = margin_manager_upgraded::withdraw<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &base_pool,
         &quote_pool, // Pass quote_pool since we have USDT debt
@@ -1304,11 +1328,12 @@ fun test_place_reduce_only_market_order_ok() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit USDT as collateral
-    mm.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -1317,7 +1342,8 @@ fun test_place_reduce_only_market_order_ok() {
         scenario.ctx(),
     );
     // Borrow USDC to establish a base debt
-    mm.borrow_base<USDC, USDT>(
+    margin_manager_upgraded::borrow_base<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut base_pool,
         &usdc_price,
@@ -1329,7 +1355,8 @@ fun test_place_reduce_only_market_order_ok() {
     );
 
     // Withdraw some USDC so we have debt but less assets (creating a net debt position)
-    let withdrawn_coin = mm.withdraw<USDC, USDT, USDC>(
+    let withdrawn_coin = margin_manager_upgraded::withdraw<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &base_pool,
         &quote_pool,
@@ -1407,11 +1434,12 @@ fun test_place_reduce_only_market_order_ok_ask() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit USDC as collateral
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -1421,7 +1449,8 @@ fun test_place_reduce_only_market_order_ok_ask() {
     );
 
     // Borrow USDT to establish a quote debt
-    mm.borrow_quote<USDC, USDT>(
+    margin_manager_upgraded::borrow_quote<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut quote_pool,
         &usdc_price,
@@ -1433,7 +1462,8 @@ fun test_place_reduce_only_market_order_ok_ask() {
     );
 
     // Withdraw some USDT so we have debt but less assets (creating a net debt position)
-    let withdrawn_coin = mm.withdraw<USDC, USDT, USDT>(
+    let withdrawn_coin = margin_manager_upgraded::withdraw<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &base_pool,
         &quote_pool,
@@ -1512,10 +1542,11 @@ fun reduce_only_and_repay_bid_succeeds_where_swap_only_fails() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -1523,7 +1554,8 @@ fun reduce_only_and_repay_bid_succeeds_where_swap_only_fails() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_base<USDC, USDT>(
+    margin_manager_upgraded::borrow_base<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut base_pool,
         &usdc_price,
@@ -1533,7 +1565,8 @@ fun reduce_only_and_repay_bid_succeeds_where_swap_only_fails() {
         &clock,
         scenario.ctx(),
     );
-    let withdrawn = mm.withdraw<USDC, USDT, USDC>(
+    let withdrawn = margin_manager_upgraded::withdraw<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &base_pool,
         &quote_pool,
@@ -1547,7 +1580,8 @@ fun reduce_only_and_repay_bid_succeeds_where_swap_only_fails() {
     destroy(withdrawn);
 
     let shares_before = mm.borrowed_base_shares();
-    let rr_before = mm.risk_ratio(
+    let rr_before = margin_manager_upgraded::risk_ratio(
+        &mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -1576,7 +1610,8 @@ fun reduce_only_and_repay_bid_succeeds_where_swap_only_fails() {
     );
     destroy(order_info);
 
-    let rr_after = mm.risk_ratio(
+    let rr_after = margin_manager_upgraded::risk_ratio(
+        &mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -1634,10 +1669,11 @@ fun reduce_only_and_repay_ask_succeeds_where_swap_only_fails() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -1645,7 +1681,8 @@ fun reduce_only_and_repay_ask_succeeds_where_swap_only_fails() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_quote<USDC, USDT>(
+    margin_manager_upgraded::borrow_quote<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut quote_pool,
         &usdc_price,
@@ -1655,7 +1692,8 @@ fun reduce_only_and_repay_ask_succeeds_where_swap_only_fails() {
         &clock,
         scenario.ctx(),
     );
-    let withdrawn = mm.withdraw<USDC, USDT, USDT>(
+    let withdrawn = margin_manager_upgraded::withdraw<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &base_pool,
         &quote_pool,
@@ -1669,7 +1707,8 @@ fun reduce_only_and_repay_ask_succeeds_where_swap_only_fails() {
     destroy(withdrawn);
 
     let shares_before = mm.borrowed_quote_shares();
-    let rr_before = mm.risk_ratio(
+    let rr_before = margin_manager_upgraded::risk_ratio(
+        &mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -1698,7 +1737,8 @@ fun reduce_only_and_repay_ask_succeeds_where_swap_only_fails() {
     );
     destroy(order_info);
 
-    let rr_after = mm.risk_ratio(
+    let rr_after = margin_manager_upgraded::risk_ratio(
+        &mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -1769,10 +1809,11 @@ fun reduce_only_and_repay_closes_from_danger_zone() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -1780,7 +1821,8 @@ fun reduce_only_and_repay_closes_from_danger_zone() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_quote<USDC, USDT>(
+    margin_manager_upgraded::borrow_quote<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut quote_pool,
         &usdc_price,
@@ -1790,7 +1832,8 @@ fun reduce_only_and_repay_closes_from_danger_zone() {
         &clock,
         scenario.ctx(),
     );
-    let withdrawn = mm.withdraw<USDC, USDT, USDT>(
+    let withdrawn = margin_manager_upgraded::withdraw<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &base_pool,
         &quote_pool,
@@ -1805,12 +1848,12 @@ fun reduce_only_and_repay_closes_from_danger_zone() {
     destroy(usdc_price);
 
     // Drift USDC to $0.60 and refresh the stored price the band keys off of.
-    let usdc_drifted = build_demo_usdc_price_info_object_with_price(
+    let usdc_drifted = build_demo_usdc_price_info_object_with_price_upgraded(
         &mut scenario,
         60_000_000,
         &clock,
     );
-    pool_proxy::update_current_price<USDC, USDT>(
+    pool_proxy_upgraded::update_current_price<USDC, USDT>(
         &mut registry,
         &pool,
         &usdc_drifted,
@@ -1820,7 +1863,8 @@ fun reduce_only_and_repay_closes_from_danger_zone() {
 
     let pool_id_inner = pool.id();
     let shares_before = mm.borrowed_quote_shares();
-    let rr_before = mm.risk_ratio(
+    let rr_before = margin_manager_upgraded::risk_ratio(
+        &mm,
         &registry,
         &usdc_drifted,
         &usdt_price,
@@ -1834,7 +1878,7 @@ fun reduce_only_and_repay_closes_from_danger_zone() {
     assert!(rr_before < registry.min_borrow_risk_ratio(pool_id_inner));
     assert!(rr_before >= registry.liquidation_risk_ratio(pool_id_inner));
 
-    let order_info = pool_proxy::place_reduce_only_market_order_and_repay_loan<USDC, USDT>(
+    let order_info = pool_proxy_upgraded::place_reduce_only_market_order_and_repay_loan<USDC, USDT>(
         &registry,
         &mut mm,
         &mut pool,
@@ -1852,7 +1896,8 @@ fun reduce_only_and_repay_closes_from_danger_zone() {
     );
     destroy(order_info);
 
-    let rr_after = mm.risk_ratio(
+    let rr_after = margin_manager_upgraded::risk_ratio(
+        &mm,
         &registry,
         &usdc_drifted,
         &usdt_price,
@@ -1919,10 +1964,11 @@ fun place_market_order_and_repay_loan_partial_close_below_min_open_ok() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -1930,7 +1976,8 @@ fun place_market_order_and_repay_loan_partial_close_below_min_open_ok() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_quote<USDC, USDT>(
+    margin_manager_upgraded::borrow_quote<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut quote_pool,
         &usdc_price,
@@ -1940,7 +1987,8 @@ fun place_market_order_and_repay_loan_partial_close_below_min_open_ok() {
         &clock,
         scenario.ctx(),
     );
-    let withdrawn = mm.withdraw<USDC, USDT, USDT>(
+    let withdrawn = margin_manager_upgraded::withdraw<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &base_pool,
         &quote_pool,
@@ -1954,12 +2002,12 @@ fun place_market_order_and_repay_loan_partial_close_below_min_open_ok() {
     destroy(withdrawn);
     destroy(usdc_price);
 
-    let usdc_drifted = build_demo_usdc_price_info_object_with_price(
+    let usdc_drifted = build_demo_usdc_price_info_object_with_price_upgraded(
         &mut scenario,
         60_000_000,
         &clock,
     );
-    pool_proxy::update_current_price<USDC, USDT>(
+    pool_proxy_upgraded::update_current_price<USDC, USDT>(
         &mut registry,
         &pool,
         &usdc_drifted,
@@ -1979,7 +2027,8 @@ fun place_market_order_and_repay_loan_partial_close_below_min_open_ok() {
     );
 
     let shares_before = mm.borrowed_quote_shares();
-    let rr_before = mm.risk_ratio(
+    let rr_before = margin_manager_upgraded::risk_ratio(
+        &mm,
         &registry,
         &usdc_drifted,
         &usdt_price,
@@ -1991,7 +2040,7 @@ fun place_market_order_and_repay_loan_partial_close_below_min_open_ok() {
     assert!(rr_before < registry.min_open_risk_ratio(pool_id_inner));
     assert!(rr_before >= registry.liquidation_risk_ratio(pool_id_inner));
 
-    let order_info = pool_proxy::place_market_order_and_repay_loan<USDC, USDT>(
+    let order_info = pool_proxy_upgraded::place_market_order_and_repay_loan<USDC, USDT>(
         &registry,
         &mut mm,
         &mut pool,
@@ -2009,7 +2058,8 @@ fun place_market_order_and_repay_loan_partial_close_below_min_open_ok() {
     );
     destroy(order_info);
 
-    let rr_after = mm.risk_ratio(
+    let rr_after = margin_manager_upgraded::risk_ratio(
+        &mm,
         &registry,
         &usdc_drifted,
         &usdt_price,
@@ -2070,10 +2120,11 @@ fun reduce_only_and_repay_fully_closes_selling_above_net_debt() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -2081,7 +2132,8 @@ fun reduce_only_and_repay_fully_closes_selling_above_net_debt() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_quote<USDC, USDT>(
+    margin_manager_upgraded::borrow_quote<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut quote_pool,
         &usdc_price,
@@ -2091,7 +2143,8 @@ fun reduce_only_and_repay_fully_closes_selling_above_net_debt() {
         &clock,
         scenario.ctx(),
     );
-    let withdrawn = mm.withdraw<USDC, USDT, USDT>(
+    let withdrawn = margin_manager_upgraded::withdraw<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &base_pool,
         &quote_pool,
@@ -2176,10 +2229,11 @@ fun reduce_only_and_repay_bid_over_net_debt_fully_closes() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -2187,7 +2241,8 @@ fun reduce_only_and_repay_bid_over_net_debt_fully_closes() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_base<USDC, USDT>(
+    margin_manager_upgraded::borrow_base<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut base_pool,
         &usdc_price,
@@ -2197,7 +2252,8 @@ fun reduce_only_and_repay_bid_over_net_debt_fully_closes() {
         &clock,
         scenario.ctx(),
     );
-    let withdrawn = mm.withdraw<USDC, USDT, USDC>(
+    let withdrawn = margin_manager_upgraded::withdraw<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &base_pool,
         &quote_pool,
@@ -2281,12 +2337,13 @@ fun reduce_only_limit_resting_fill_at_band_edge_bounded_and_solvent() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // M1 short: deposit 3000 USDT, borrow 1000 USDC, withdraw it -> holds 3000
     // USDT, owes 1000 USDC (ratio 3.0).
-    mm.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -2294,7 +2351,8 @@ fun reduce_only_limit_resting_fill_at_band_edge_bounded_and_solvent() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_base<USDC, USDT>(
+    margin_manager_upgraded::borrow_base<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut base_pool,
         &usdc_price,
@@ -2304,7 +2362,8 @@ fun reduce_only_limit_resting_fill_at_band_edge_bounded_and_solvent() {
         &clock,
         scenario.ctx(),
     );
-    let withdrawn = mm.withdraw<USDC, USDT, USDC>(
+    let withdrawn = margin_manager_upgraded::withdraw<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &base_pool,
         &quote_pool,
@@ -2317,7 +2376,8 @@ fun reduce_only_limit_resting_fill_at_band_edge_bounded_and_solvent() {
     );
     destroy(withdrawn);
 
-    let rr_before = mm.risk_ratio(
+    let rr_before = margin_manager_upgraded::risk_ratio(
+        &mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -2385,9 +2445,10 @@ fun reduce_only_limit_resting_fill_at_band_edge_bounded_and_solvent() {
     );
     sui::transfer::public_transfer(m2, test_constants::user2());
 
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
-    let rr_after = mm.risk_ratio(
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
+    let rr_after = margin_manager_upgraded::risk_ratio(
+        &mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -2446,11 +2507,12 @@ fun resting_fill_from_danger_band_cannot_go_underwater() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // M1 short: 2200 USDT, owe 1000 USDC (ratio 2.2 at $1, so withdraw is allowed).
-    mm.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -2458,7 +2520,8 @@ fun resting_fill_from_danger_band_cannot_go_underwater() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_base<USDC, USDT>(
+    margin_manager_upgraded::borrow_base<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut base_pool,
         &usdc_price,
@@ -2468,7 +2531,8 @@ fun resting_fill_from_danger_band_cannot_go_underwater() {
         &clock,
         scenario.ctx(),
     );
-    let withdrawn = mm.withdraw<USDC, USDT, USDC>(
+    let withdrawn = margin_manager_upgraded::withdraw<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &base_pool,
         &quote_pool,
@@ -2483,12 +2547,12 @@ fun resting_fill_from_danger_band_cannot_go_underwater() {
     destroy(usdc_price);
 
     // Drift USDC up to $2.00 -> the short's ratio drops to 1.10 (at liquidation).
-    let usdc_drifted = build_demo_usdc_price_info_object_with_price(
+    let usdc_drifted = build_demo_usdc_price_info_object_with_price_upgraded(
         &mut scenario,
         200_000_000,
         &clock,
     );
-    pool_proxy::update_current_price<USDC, USDT>(
+    pool_proxy_upgraded::update_current_price<USDC, USDT>(
         &mut registry,
         &pool,
         &usdc_drifted,
@@ -2496,7 +2560,8 @@ fun resting_fill_from_danger_band_cannot_go_underwater() {
         &clock,
     );
 
-    let rr_before = mm.risk_ratio(
+    let rr_before = margin_manager_upgraded::risk_ratio(
+        &mm,
         &registry,
         &usdc_drifted,
         &usdt_price,
@@ -2564,13 +2629,14 @@ fun resting_fill_from_danger_band_cannot_go_underwater() {
     );
     sui::transfer::public_transfer(m2, test_constants::user2());
 
-    let usdc_drifted2 = build_demo_usdc_price_info_object_with_price(
+    let usdc_drifted2 = build_demo_usdc_price_info_object_with_price_upgraded(
         &mut scenario,
         200_000_000,
         &clock,
     );
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
-    let rr_after = mm.risk_ratio(
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
+    let rr_after = margin_manager_upgraded::risk_ratio(
+        &mm,
         &registry,
         &usdc_drifted2,
         &usdt_price,
@@ -2638,12 +2704,13 @@ fun reduce_only_limit_v2_ask_resting_fill_extraction_bounded_one_way() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // M1 long: deposit 3000 USDC, borrow 1000 USDT, withdraw it -> holds 3000 USDC,
     // owes 1000 USDT (ratio 3.0 at $1).
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -2651,7 +2718,8 @@ fun reduce_only_limit_v2_ask_resting_fill_extraction_bounded_one_way() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_quote<USDC, USDT>(
+    margin_manager_upgraded::borrow_quote<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut quote_pool,
         &usdc_price,
@@ -2661,7 +2729,8 @@ fun reduce_only_limit_v2_ask_resting_fill_extraction_bounded_one_way() {
         &clock,
         scenario.ctx(),
     );
-    let withdrawn = mm.withdraw<USDC, USDT, USDT>(
+    let withdrawn = margin_manager_upgraded::withdraw<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &base_pool,
         &quote_pool,
@@ -2674,7 +2743,8 @@ fun reduce_only_limit_v2_ask_resting_fill_extraction_bounded_one_way() {
     );
     destroy(withdrawn);
 
-    let rr_before = mm.risk_ratio(
+    let rr_before = margin_manager_upgraded::risk_ratio(
+        &mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -2740,9 +2810,10 @@ fun reduce_only_limit_v2_ask_resting_fill_extraction_bounded_one_way() {
     );
     sui::transfer::public_transfer(m2, test_constants::user2());
 
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
-    let rr_after = mm.risk_ratio(
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
+    let rr_after = margin_manager_upgraded::risk_ratio(
+        &mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -2803,11 +2874,12 @@ fun reduce_only_limit_below_liquidation_placement_aborts() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // M1 short: 2200 USDT collateral, owe 1000 USDC (ratio 2.2 at $1).
-    mm.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -2815,7 +2887,8 @@ fun reduce_only_limit_below_liquidation_placement_aborts() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_base<USDC, USDT>(
+    margin_manager_upgraded::borrow_base<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut base_pool,
         &usdc_price,
@@ -2825,7 +2898,8 @@ fun reduce_only_limit_below_liquidation_placement_aborts() {
         &clock,
         scenario.ctx(),
     );
-    let withdrawn = mm.withdraw<USDC, USDT, USDC>(
+    let withdrawn = margin_manager_upgraded::withdraw<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &base_pool,
         &quote_pool,
@@ -2840,12 +2914,12 @@ fun reduce_only_limit_below_liquidation_placement_aborts() {
     destroy(usdc_price);
 
     // Drift USDC to $2.15 -> ratio ~2200/2.15/1000 = 1.023, below liquidation (1.10).
-    let usdc_drifted = build_demo_usdc_price_info_object_with_price(
+    let usdc_drifted = build_demo_usdc_price_info_object_with_price_upgraded(
         &mut scenario,
         215_000_000,
         &clock,
     );
-    pool_proxy::update_current_price<USDC, USDT>(
+    pool_proxy_upgraded::update_current_price<USDC, USDT>(
         &mut registry,
         &pool,
         &usdc_drifted,
@@ -2853,7 +2927,8 @@ fun reduce_only_limit_below_liquidation_placement_aborts() {
         &clock,
     );
 
-    let rr_before = mm.risk_ratio(
+    let rr_before = margin_manager_upgraded::risk_ratio(
+        &mm,
         &registry,
         &usdc_drifted,
         &usdt_price,
@@ -2866,7 +2941,7 @@ fun reduce_only_limit_below_liquidation_placement_aborts() {
     assert!(rr_before < registry.liquidation_risk_ratio(pool.id()));
 
     // Placing a resting reduce-only bid within the +5% band now aborts at placement.
-    let order_info = pool_proxy::place_reduce_only_limit_order_and_repay_loan<USDC, USDT>(
+    let order_info = pool_proxy_upgraded::place_reduce_only_limit_order_and_repay_loan<USDC, USDT>(
         &registry,
         &mut mm,
         &mut pool,
@@ -2922,10 +2997,11 @@ fun reduce_only_limit_v2_below_liquidation_placement_aborts() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -2933,7 +3009,8 @@ fun reduce_only_limit_v2_below_liquidation_placement_aborts() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_base<USDC, USDT>(
+    margin_manager_upgraded::borrow_base<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut base_pool,
         &usdc_price,
@@ -2943,7 +3020,8 @@ fun reduce_only_limit_v2_below_liquidation_placement_aborts() {
         &clock,
         scenario.ctx(),
     );
-    let withdrawn = mm.withdraw<USDC, USDT, USDC>(
+    let withdrawn = margin_manager_upgraded::withdraw<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &base_pool,
         &quote_pool,
@@ -2958,12 +3036,12 @@ fun reduce_only_limit_v2_below_liquidation_placement_aborts() {
     destroy(usdc_price);
 
     // Drift USDC to $2.15 -> ratio ~1.023, below liquidation (1.10).
-    let usdc_drifted = build_demo_usdc_price_info_object_with_price(
+    let usdc_drifted = build_demo_usdc_price_info_object_with_price_upgraded(
         &mut scenario,
         215_000_000,
         &clock,
     );
-    pool_proxy::update_current_price<USDC, USDT>(
+    pool_proxy_upgraded::update_current_price<USDC, USDT>(
         &mut registry,
         &pool,
         &usdc_drifted,
@@ -2971,7 +3049,8 @@ fun reduce_only_limit_v2_below_liquidation_placement_aborts() {
         &clock,
     );
 
-    let rr_before = mm.risk_ratio(
+    let rr_before = margin_manager_upgraded::risk_ratio(
+        &mm,
         &registry,
         &usdc_drifted,
         &usdt_price,
@@ -2982,7 +3061,7 @@ fun reduce_only_limit_v2_below_liquidation_placement_aborts() {
     );
     assert!(rr_before < registry.liquidation_risk_ratio(pool.id()));
 
-    let order_info = pool_proxy::place_reduce_only_limit_order_v2<USDC, USDT>(
+    let order_info = pool_proxy_upgraded::place_reduce_only_limit_order_v2<USDC, USDT>(
         &registry,
         &mut mm,
         &mut pool,
@@ -3039,10 +3118,11 @@ fun market_and_repay_empty_book_aborts() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -3050,7 +3130,8 @@ fun market_and_repay_empty_book_aborts() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_base<USDC, USDT>(
+    margin_manager_upgraded::borrow_base<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut base_pool,
         &usdc_price,
@@ -3117,10 +3198,11 @@ fun resting_order_by_itself_is_ratio_neutral() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -3128,7 +3210,8 @@ fun resting_order_by_itself_is_ratio_neutral() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_base<USDC, USDT>(
+    margin_manager_upgraded::borrow_base<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut base_pool,
         &usdc_price,
@@ -3140,7 +3223,8 @@ fun resting_order_by_itself_is_ratio_neutral() {
     );
     // Withdraw the borrowed USDC so M1 is a real short (no idle USDC for the
     // and-repay to sweep; the placement is then a pure resting order).
-    let withdrawn = mm.withdraw<USDC, USDT, USDC>(
+    let withdrawn = margin_manager_upgraded::withdraw<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &base_pool,
         &quote_pool,
@@ -3153,7 +3237,8 @@ fun resting_order_by_itself_is_ratio_neutral() {
     );
     destroy(withdrawn);
 
-    let rr_before = mm.risk_ratio(
+    let rr_before = margin_manager_upgraded::risk_ratio(
+        &mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -3186,7 +3271,8 @@ fun resting_order_by_itself_is_ratio_neutral() {
     );
     destroy(order_info);
 
-    let rr_after = mm.risk_ratio(
+    let rr_after = margin_manager_upgraded::risk_ratio(
+        &mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -3342,11 +3428,12 @@ fun test_place_reduce_only_market_order_not_reduce_only() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit some USDT to use as collateral
-    mm.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -3356,10 +3443,11 @@ fun test_place_reduce_only_market_order_not_reduce_only() {
     );
     destroy_2!(usdc_price, usdt_price);
 
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
     // Borrow some USDT to establish relationship with quote pool
-    mm.borrow_quote<USDC, USDT>(
+    margin_manager_upgraded::borrow_quote<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut quote_pool,
         &usdc_price,
@@ -3433,11 +3521,12 @@ fun test_place_reduce_only_market_order_bid_requires_base_debt() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // USDC collateral + USDT (quote) debt -> a long, no base debt.
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -3445,7 +3534,8 @@ fun test_place_reduce_only_market_order_bid_requires_base_debt() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_quote<USDC, USDT>(
+    margin_manager_upgraded::borrow_quote<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut quote_pool,
         &usdc_price,
@@ -3508,10 +3598,11 @@ fun test_place_reduce_only_market_order_not_reduce_only_quantity_ask() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -3520,7 +3611,8 @@ fun test_place_reduce_only_market_order_not_reduce_only_quantity_ask() {
         scenario.ctx(),
     );
 
-    mm.borrow_quote<USDC, USDT>(
+    margin_manager_upgraded::borrow_quote<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut quote_pool,
         &usdc_price,
@@ -3531,7 +3623,8 @@ fun test_place_reduce_only_market_order_not_reduce_only_quantity_ask() {
         scenario.ctx(),
     );
 
-    let coin = mm.withdraw<USDC, USDT, USDT>(
+    let coin = margin_manager_upgraded::withdraw<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &base_pool,
         &quote_pool,
@@ -3595,11 +3688,12 @@ fun test_stake_ok() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit DEEP tokens
-    mm.deposit<USDC, USDT, DEEP>(
+    margin_manager_upgraded::deposit<USDC, USDT, DEEP>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -3692,10 +3786,11 @@ fun test_modify_order_ok() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -3777,10 +3872,11 @@ fun test_cancel_order_ok() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -3860,10 +3956,11 @@ fun test_cancel_orders_ok() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -3964,10 +4061,11 @@ fun test_cancel_all_orders_ok() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -4097,11 +4195,12 @@ fun test_submit_proposal_ok() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit DEEP tokens
-    mm.deposit<USDC, USDT, DEEP>(
+    margin_manager_upgraded::deposit<USDC, USDT, DEEP>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -4172,11 +4271,12 @@ fun test_vote_ok() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit DEEP tokens
-    mm.deposit<USDC, USDT, DEEP>(
+    margin_manager_upgraded::deposit<USDC, USDT, DEEP>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -4302,11 +4402,12 @@ fun test_withdraw_settled_amounts_permissionless_ok() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit USDC
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -4362,11 +4463,12 @@ fun test_withdraw_settled_amounts_permissionless_ok() {
 
     scenario.next_tx(test_constants::user2());
     let mut mm2 = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit USDT for user2
-    mm2.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm2,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -4536,11 +4638,12 @@ fun test_limit_order_price_too_high() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit collateral
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -4610,11 +4713,12 @@ fun test_limit_order_price_too_low() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit collateral
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -4685,11 +4789,12 @@ fun test_limit_order_price_at_upper_bound_ok() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit collateral
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -4762,11 +4867,12 @@ fun test_limit_order_price_at_lower_bound_ok() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit collateral
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -5587,10 +5693,11 @@ fun test_tolerance_decrease_rejects_order_e2e() {
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
     let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
     let registry = scenario.take_shared<MarginRegistry>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -5697,10 +5804,11 @@ fun test_max_price_age_decrease_rejects_order_e2e() {
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
     let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
     let registry = scenario.take_shared<MarginRegistry>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -5774,10 +5882,11 @@ fun test_limit_order_price_just_above_upper_bound_fails() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -5846,10 +5955,11 @@ fun test_limit_order_price_just_below_lower_bound_fails() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -5918,11 +6028,12 @@ fun test_bid_order_allowed_at_any_price_below_oracle() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit USDT collateral for buying USDC
-    mm.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -5996,11 +6107,12 @@ fun test_ask_order_allowed_at_any_price_above_oracle() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit USDC collateral for selling
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -6078,11 +6190,12 @@ fun test_market_buy_order_above_oracle_within_bounds() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit USDT to buy USDC
-    mm.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -6154,11 +6267,12 @@ fun test_market_sell_order_below_oracle_within_bounds() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit USDC to sell
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -6229,11 +6343,12 @@ fun test_market_buy_order_exceeds_upper_bound() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit USDT to buy USDC
-    mm.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -6301,11 +6416,12 @@ fun test_market_sell_order_below_lower_bound() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit USDC to sell
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -6371,10 +6487,11 @@ fun test_market_buy_order_no_liquidity() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -6440,10 +6557,11 @@ fun test_market_sell_order_no_liquidity() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -6557,10 +6675,11 @@ fun test_limit_order_price_not_initialized() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -6627,10 +6746,11 @@ fun test_limit_order_price_stale() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -6708,13 +6828,14 @@ fun test_market_sell_min_size_input_fee_ok() {
     let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
     let registry = scenario.take_shared<MarginRegistry>();
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit enough USDC to sell min_size (no DEEP deposited - will use input fee).
     // When using input fee, fee is deducted from the sell amount, so we need slightly more.
     // Deposit min_size + 10% to cover the taker fee.
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -6791,13 +6912,14 @@ fun test_market_buy_min_size_input_fee_ok() {
     let mut pool = scenario.take_shared_by_id<Pool<USDC, USDT>>(pool_id);
     let registry = scenario.take_shared<MarginRegistry>();
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit quote (USDT) to buy base (USDC) - no DEEP deposited (will use input fee)
     // Need enough quote to cover min_size base + fees
     // At $1.01 price, min_size base costs ~10100 quote + fees
-    mm.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -7075,14 +7197,15 @@ fun place_limit_order_v2_borrow_at_floor_then_adverse_fill_ok() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // Deposit 100 USDT collateral + DEEP for fees, borrow 400 USDC.
     // Post-borrow: 100 USDT + 400 USDC = 500 USDC-equiv, debt 400 USDC,
     // risk_ratio = 500/400 = 1.25 (exactly at borrow floor). DEEP isn't summed
     // by `calculate_assets`, so it doesn't affect risk_ratio.
-    mm.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -7090,7 +7213,8 @@ fun place_limit_order_v2_borrow_at_floor_then_adverse_fill_ok() {
         &clock,
         scenario.ctx(),
     );
-    mm.deposit<USDC, USDT, DEEP>(
+    margin_manager_upgraded::deposit<USDC, USDT, DEEP>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -7098,7 +7222,8 @@ fun place_limit_order_v2_borrow_at_floor_then_adverse_fill_ok() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_base<USDC, USDT>(
+    margin_manager_upgraded::borrow_base<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut base_pool,
         &usdc_price,
@@ -7135,9 +7260,10 @@ fun place_limit_order_v2_borrow_at_floor_then_adverse_fill_ok() {
 
     // Post-trade risk_ratio = 499/400 = 1.2475: below the 1.25 borrow floor,
     // above the 1.175 open floor, so the opening order is accepted.
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
-    let rr = mm.risk_ratio(
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
+    let rr = margin_manager_upgraded::risk_ratio(
+        &mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -7199,10 +7325,11 @@ fun place_limit_order_v2_adverse_fill_aborts_with_strict_open_floor() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -7210,7 +7337,8 @@ fun place_limit_order_v2_adverse_fill_aborts_with_strict_open_floor() {
         &clock,
         scenario.ctx(),
     );
-    mm.deposit<USDC, USDT, DEEP>(
+    margin_manager_upgraded::deposit<USDC, USDT, DEEP>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -7218,7 +7346,8 @@ fun place_limit_order_v2_adverse_fill_aborts_with_strict_open_floor() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_base<USDC, USDT>(
+    margin_manager_upgraded::borrow_base<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut base_pool,
         &usdc_price,
@@ -7787,9 +7916,10 @@ fun place_limit_order_clamps_expire_timestamp() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
-    mm.deposit<USDC, USDT, USDC>(
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -7863,9 +7993,10 @@ fun place_limit_order_v2_no_debt_at_oracle_price_ok() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
-    mm.deposit<USDC, USDT, USDC>(
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -7940,10 +8071,11 @@ fun place_market_order_v2_with_free_borrowed_funds_in_band_ok() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -7951,7 +8083,8 @@ fun place_market_order_v2_with_free_borrowed_funds_in_band_ok() {
         &clock,
         scenario.ctx(),
     );
-    mm.deposit<USDC, USDT, DEEP>(
+    margin_manager_upgraded::deposit<USDC, USDT, DEEP>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -7960,7 +8093,8 @@ fun place_market_order_v2_with_free_borrowed_funds_in_band_ok() {
         scenario.ctx(),
     );
     // Borrow 400 USDT: ratio = (100 + 400) / 400 = 1.25 at $1.
-    mm.borrow_quote<USDC, USDT>(
+    margin_manager_upgraded::borrow_quote<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut quote_pool,
         &usdc_price,
@@ -7990,9 +8124,10 @@ fun place_market_order_v2_with_free_borrowed_funds_in_band_ok() {
     destroy(order_info);
 
     // Post-trade risk_ratio = (200 + 299) / 400 = 1.2475: in the band, accepted.
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
-    let rr = mm.risk_ratio(
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
+    let rr = margin_manager_upgraded::risk_ratio(
+        &mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -8048,10 +8183,11 @@ fun place_market_order_and_repay_loan_fully_closes_long() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -8059,7 +8195,8 @@ fun place_market_order_and_repay_loan_fully_closes_long() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_quote<USDC, USDT>(
+    margin_manager_upgraded::borrow_quote<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut quote_pool,
         &usdc_price,
@@ -8069,7 +8206,8 @@ fun place_market_order_and_repay_loan_fully_closes_long() {
         &clock,
         scenario.ctx(),
     );
-    let withdrawn = mm.withdraw<USDC, USDT, USDT>(
+    let withdrawn = margin_manager_upgraded::withdraw<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &base_pool,
         &quote_pool,
@@ -8143,10 +8281,11 @@ fun place_market_order_and_repay_loan_overbuys_short_past_debt() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -8154,7 +8293,8 @@ fun place_market_order_and_repay_loan_overbuys_short_past_debt() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_base<USDC, USDT>(
+    margin_manager_upgraded::borrow_base<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut base_pool,
         &usdc_price,
@@ -8166,7 +8306,8 @@ fun place_market_order_and_repay_loan_overbuys_short_past_debt() {
     );
     // Withdraw the borrowed USDC so the manager is a real short: owe 100 USDC,
     // hold 250 USDT (ratio 2.5, above min_withdraw 2.0).
-    let withdrawn = mm.withdraw<USDC, USDT, USDC>(
+    let withdrawn = margin_manager_upgraded::withdraw<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &base_pool,
         &quote_pool,
@@ -8250,12 +8391,13 @@ fun place_market_order_and_repay_loan_worsening_aborts() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // M1 long: 1100 USDC collateral + 1000 USDT (quote) debt, holding the borrowed
     // USDT (ratio ~2.1).
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -8263,7 +8405,8 @@ fun place_market_order_and_repay_loan_worsening_aborts() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_quote<USDC, USDT>(
+    margin_manager_upgraded::borrow_quote<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut quote_pool,
         &usdc_price,
@@ -8330,10 +8473,11 @@ fun place_market_order_and_repay_loan_aborts_when_pool_disabled() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -8341,7 +8485,8 @@ fun place_market_order_and_repay_loan_aborts_when_pool_disabled() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_base<USDC, USDT>(
+    margin_manager_upgraded::borrow_base<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut base_pool,
         &usdc_price,
@@ -8409,10 +8554,11 @@ fun reduce_only_bid_covers_sub_min_size_net_debt() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -8420,7 +8566,8 @@ fun reduce_only_bid_covers_sub_min_size_net_debt() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_base<USDC, USDT>(
+    margin_manager_upgraded::borrow_base<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut base_pool,
         &usdc_price,
@@ -8431,7 +8578,8 @@ fun reduce_only_bid_covers_sub_min_size_net_debt() {
         scenario.ctx(),
     );
     // Withdraw only half a min_size of the borrowed USDC, leaving net short 5000.
-    let withdrawn = mm.withdraw<USDC, USDT, USDC>(
+    let withdrawn = margin_manager_upgraded::withdraw<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &base_pool,
         &quote_pool,
@@ -8509,10 +8657,11 @@ fun reduce_only_and_repay_closes_non_lot_aligned_debt() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -8520,7 +8669,8 @@ fun reduce_only_and_repay_closes_non_lot_aligned_debt() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_base<USDC, USDT>(
+    margin_manager_upgraded::borrow_base<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut base_pool,
         &usdc_price,
@@ -8532,7 +8682,8 @@ fun reduce_only_and_repay_closes_non_lot_aligned_debt() {
     );
     // Withdraw all but 500 raw, leaving net short = 30_000_000 - 500 = 29_999_500
     // (not a multiple of lot_size 1000).
-    let withdrawn = mm.withdraw<USDC, USDT, USDC>(
+    let withdrawn = margin_manager_upgraded::withdraw<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &base_pool,
         &quote_pool,
@@ -8613,10 +8764,11 @@ fun reduce_only_limit_and_repay_partial_taker_fill_repays() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -8624,7 +8776,8 @@ fun reduce_only_limit_and_repay_partial_taker_fill_repays() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_quote<USDC, USDT>(
+    margin_manager_upgraded::borrow_quote<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut quote_pool,
         &usdc_price,
@@ -8634,7 +8787,8 @@ fun reduce_only_limit_and_repay_partial_taker_fill_repays() {
         &clock,
         scenario.ctx(),
     );
-    let withdrawn = mm.withdraw<USDC, USDT, USDT>(
+    let withdrawn = margin_manager_upgraded::withdraw<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &base_pool,
         &quote_pool,
@@ -8715,10 +8869,11 @@ fun reduce_only_limit_v2_taker_fill_aborts() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    mm.deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -8726,7 +8881,8 @@ fun reduce_only_limit_v2_taker_fill_aborts() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_quote<USDC, USDT>(
+    margin_manager_upgraded::borrow_quote<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut quote_pool,
         &usdc_price,
@@ -8736,7 +8892,8 @@ fun reduce_only_limit_v2_taker_fill_aborts() {
         &clock,
         scenario.ctx(),
     );
-    let withdrawn = mm.withdraw<USDC, USDT, USDT>(
+    let withdrawn = margin_manager_upgraded::withdraw<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &base_pool,
         &quote_pool,
@@ -8805,10 +8962,10 @@ fun place_limit_order_v2_no_debt_tolerates_stale_feed() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    margin_manager::deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
         &mut mm,
         &registry,
         &usdc_price,
@@ -8821,9 +8978,9 @@ fun place_limit_order_v2_no_debt_tolerates_stale_feed() {
     let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
     let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
 
-    let stale_usdc = build_stale_usdc_price_info_object(&mut scenario, &clock, 600);
-    let stale_usdt = build_stale_usdt_price_info_object(&mut scenario, &clock, 600);
-    let order_info = pool_proxy::place_limit_order_v2<USDC, USDT>(
+    let stale_usdc = build_stale_usdc_price_info_object_upgraded(&mut scenario, 600, &clock);
+    let stale_usdt = build_stale_usdt_price_info_object_upgraded(&mut scenario, 600, &clock);
+    let order_info = pool_proxy_upgraded::place_limit_order_v2<USDC, USDT>(
         &registry,
         &mut mm,
         &mut pool,
@@ -8885,10 +9042,10 @@ fun place_market_order_v2_no_debt_tolerates_stale_feed() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
-    margin_manager::deposit<USDC, USDT, USDC>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDC>(
         &mut mm,
         &registry,
         &usdc_price,
@@ -8901,9 +9058,9 @@ fun place_market_order_v2_no_debt_tolerates_stale_feed() {
     let base_pool = scenario.take_shared_by_id<MarginPool<USDC>>(base_pool_id);
     let quote_pool = scenario.take_shared_by_id<MarginPool<USDT>>(quote_pool_id);
 
-    let stale_usdc = build_stale_usdc_price_info_object(&mut scenario, &clock, 600);
-    let stale_usdt = build_stale_usdt_price_info_object(&mut scenario, &clock, 600);
-    let order_info = pool_proxy::place_market_order_v2<USDC, USDT>(
+    let stale_usdc = build_stale_usdc_price_info_object_upgraded(&mut scenario, 600, &clock);
+    let stale_usdt = build_stale_usdt_price_info_object_upgraded(&mut scenario, 600, &clock);
+    let order_info = pool_proxy_upgraded::place_market_order_v2<USDC, USDT>(
         &registry,
         &mut mm,
         &mut pool,
@@ -8970,12 +9127,13 @@ fun reduce_only_market_buy_outside_the_oracle_band_aborts() {
 
     scenario.next_tx(test_constants::user1());
     let mut mm = scenario.take_shared<MarginManager<USDC, USDT>>();
-    let usdc_price = build_demo_usdc_price_info_object(&mut scenario, &clock);
-    let usdt_price = build_demo_usdt_price_info_object(&mut scenario, &clock);
+    let usdc_price = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
+    let usdt_price = build_demo_usdt_price_info_object_upgraded(&mut scenario, &clock);
 
     // USDT collateral plus a USDC (base) loan gives the short-side debt a reduce-only
     // bid requires.
-    mm.deposit<USDC, USDT, USDT>(
+    margin_manager_upgraded::deposit<USDC, USDT, USDT>(
+        &mut mm,
         &registry,
         &usdc_price,
         &usdt_price,
@@ -8983,7 +9141,8 @@ fun reduce_only_market_buy_outside_the_oracle_band_aborts() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_base<USDC, USDT>(
+    margin_manager_upgraded::borrow_base<USDC, USDT>(
+        &mut mm,
         &registry,
         &mut base_pool,
         &usdc_price,

--- a/packages/deepbook_margin/tests/tpsl_tests.move
+++ b/packages/deepbook_margin/tests/tpsl_tests.move
@@ -7,9 +7,10 @@ module deepbook_margin::tpsl_tests;
 use deepbook::{constants, pool::Pool, registry::Registry};
 use deepbook_margin::{
     margin_manager::{Self, MarginManager},
+    margin_manager_upgraded,
     margin_pool::{Self, MarginPool},
     margin_registry::{MarginRegistry, MarginAdminCap, MaintainerCap},
-    pool_proxy,
+    pool_proxy_upgraded,
     test_constants::{Self, SUI, USDC},
     test_helpers::{
         Self,
@@ -23,7 +24,7 @@ use deepbook_margin::{
         setup_deep_price,
         cleanup_margin_test,
         mint_coin,
-        build_pyth_price_info_object,
+        build_pyth_upgraded_price_info_object,
         destroy_2,
         return_shared_2,
     },
@@ -324,8 +325,8 @@ fun build_sui_price_info_object_with_price(
     scenario: &mut test_scenario::Scenario,
     price_cents: u64,
     clock: &sui::clock::Clock,
-): pyth::price_info::PriceInfoObject {
-    build_pyth_price_info_object(
+): pyth_upgraded::price_info::PriceInfoObject {
+    build_pyth_upgraded_price_info_object(
         scenario,
         test_constants::sui_price_feed_id(),
         price_cents * test_constants::pyth_multiplier() / 100, // Convert cents to Pyth format
@@ -339,8 +340,8 @@ fun build_sui_price_info_object_with_price(
 fun build_usdc_price_info_object(
     scenario: &mut test_scenario::Scenario,
     clock: &sui::clock::Clock,
-): pyth::price_info::PriceInfoObject {
-    build_pyth_price_info_object(
+): pyth_upgraded::price_info::PriceInfoObject {
+    build_pyth_upgraded_price_info_object(
         scenario,
         test_constants::usdc_price_feed_id(),
         1 * test_constants::pyth_multiplier(), // $1.00
@@ -404,7 +405,8 @@ fun test_tpsl_trigger_below_executed() {
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock); // $1.00
 
     // Deposit collateral (SUI)
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price_high,
         &usdc_price,
@@ -433,7 +435,8 @@ fun test_tpsl_trigger_below_executed() {
         constants::max_u64(), // expire_timestamp
     );
 
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price_high,
         &usdc_price,
@@ -559,7 +562,8 @@ fun test_tpsl_trigger_above_executed() {
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock); // $1.00
 
     // Deposit collateral (SUI)
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price_low,
         &usdc_price,
@@ -588,7 +592,8 @@ fun test_tpsl_trigger_above_executed() {
         constants::max_u64(), // expire_timestamp
     );
 
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price_low,
         &usdc_price,
@@ -618,7 +623,7 @@ fun test_tpsl_trigger_above_executed() {
     let mut margin_registry = scenario.take_shared<MarginRegistry>();
 
     // Update the current price in the registry to match the new oracle price
-    pool_proxy::update_current_price<SUI, USDC>(
+    pool_proxy_upgraded::update_current_price<SUI, USDC>(
         &mut margin_registry,
         &pool,
         &sui_price_high,
@@ -712,7 +717,8 @@ fun test_tpsl_orders_sorted_correctly() {
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock); // $1.00
 
     // Deposit collateral (SUI)
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price,
         &usdc_price,
@@ -747,7 +753,8 @@ fun test_tpsl_orders_sorted_correctly() {
             constants::max_u64(),
         );
 
-        mm.add_conditional_order<SUI, USDC>(
+        margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+            &mut mm,
             &pool,
             &sui_price,
             &usdc_price,
@@ -787,7 +794,8 @@ fun test_tpsl_orders_sorted_correctly() {
             constants::max_u64(),
         );
 
-        mm.add_conditional_order<SUI, USDC>(
+        margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+            &mut mm,
             &pool,
             &sui_price,
             &usdc_price,
@@ -896,7 +904,8 @@ fun test_tpsl_orders_with_same_trigger_price_maintain_fifo_order() {
     let sui_price = build_sui_price_info_object_with_price(&mut scenario, 200, &clock); // $2.00
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock); // $1.00
 
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price,
         &usdc_price,
@@ -920,7 +929,8 @@ fun test_tpsl_orders_with_same_trigger_price_maintain_fifo_order() {
         false,
         constants::max_u64(),
     );
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price,
         &usdc_price,
@@ -943,7 +953,8 @@ fun test_tpsl_orders_with_same_trigger_price_maintain_fifo_order() {
         false,
         constants::max_u64(),
     );
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price,
         &usdc_price,
@@ -970,7 +981,8 @@ fun test_tpsl_orders_with_same_trigger_price_maintain_fifo_order() {
         false,
         constants::max_u64(),
     );
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price,
         &usdc_price,
@@ -993,7 +1005,8 @@ fun test_tpsl_orders_with_same_trigger_price_maintain_fifo_order() {
         false,
         constants::max_u64(),
     );
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price,
         &usdc_price,
@@ -1087,7 +1100,8 @@ fun test_tpsl_trigger_price_getters() {
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock); // $1.00
 
     // Deposit collateral (SUI)
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price,
         &usdc_price,
@@ -1123,7 +1137,8 @@ fun test_tpsl_trigger_price_getters() {
             constants::max_u64(),
         );
 
-        mm.add_conditional_order<SUI, USDC>(
+        margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+            &mut mm,
             &pool,
             &sui_price,
             &usdc_price,
@@ -1169,7 +1184,8 @@ fun test_tpsl_trigger_price_getters() {
             constants::max_u64(),
         );
 
-        mm.add_conditional_order<SUI, USDC>(
+        margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+            &mut mm,
             &pool,
             &sui_price,
             &usdc_price,
@@ -1253,7 +1269,8 @@ fun test_tpsl_trigger_below_market_order_executed() {
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock); // $1.00
 
     // Deposit collateral (SUI)
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price_high,
         &usdc_price,
@@ -1276,7 +1293,8 @@ fun test_tpsl_trigger_below_market_order_executed() {
         false, // pay_with_deep
     );
 
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price_high,
         &usdc_price,
@@ -1304,7 +1322,7 @@ fun test_tpsl_trigger_below_market_order_executed() {
     let mut margin_registry = scenario.take_shared<MarginRegistry>();
 
     // Update the current price in the registry to match the new oracle price
-    pool_proxy::update_current_price<SUI, USDC>(
+    pool_proxy_upgraded::update_current_price<SUI, USDC>(
         &mut margin_registry,
         &pool,
         &sui_price_low,
@@ -1427,7 +1445,8 @@ fun test_tpsl_trigger_above_market_order_executed() {
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock); // $1.00
 
     // Deposit collateral (SUI)
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price_low,
         &usdc_price,
@@ -1450,7 +1469,8 @@ fun test_tpsl_trigger_above_market_order_executed() {
         false, // pay_with_deep
     );
 
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price_low,
         &usdc_price,
@@ -1478,7 +1498,7 @@ fun test_tpsl_trigger_above_market_order_executed() {
     let mut margin_registry = scenario.take_shared<MarginRegistry>();
 
     // Update the current price in the registry to match the new oracle price
-    pool_proxy::update_current_price<SUI, USDC>(
+    pool_proxy_upgraded::update_current_price<SUI, USDC>(
         &mut margin_registry,
         &pool,
         &sui_price_high,
@@ -1587,7 +1607,8 @@ fun test_tpsl_cancel_conditional_order() {
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock); // $1.00
 
     // Deposit collateral
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price,
         &usdc_price,
@@ -1618,7 +1639,8 @@ fun test_tpsl_cancel_conditional_order() {
             constants::max_u64(),
         );
 
-        mm.add_conditional_order<SUI, USDC>(
+        margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+            &mut mm,
             &pool,
             &sui_price,
             &usdc_price,
@@ -1654,7 +1676,8 @@ fun test_tpsl_cancel_conditional_order() {
             constants::max_u64(),
         );
 
-        mm.add_conditional_order<SUI, USDC>(
+        margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+            &mut mm,
             &pool,
             &sui_price,
             &usdc_price,
@@ -1751,7 +1774,8 @@ fun test_tpsl_cancel_all_conditional_orders() {
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock); // $1.00
 
     // Deposit collateral
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price,
         &usdc_price,
@@ -1777,7 +1801,8 @@ fun test_tpsl_cancel_all_conditional_orders() {
             constants::max_u64(),
         );
 
-        mm.add_conditional_order<SUI, USDC>(
+        margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+            &mut mm,
             &pool,
             &sui_price,
             &usdc_price,
@@ -1808,7 +1833,8 @@ fun test_tpsl_cancel_all_conditional_orders() {
             constants::max_u64(),
         );
 
-        mm.add_conditional_order<SUI, USDC>(
+        margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+            &mut mm,
             &pool,
             &sui_price,
             &usdc_price,
@@ -1884,7 +1910,8 @@ fun test_error_invalid_condition() {
     let sui_price = build_sui_price_info_object_with_price(&mut scenario, 200, &clock); // $2.00
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock);
 
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price,
         &usdc_price,
@@ -1906,7 +1933,8 @@ fun test_error_invalid_condition() {
         constants::max_u64(),
     );
 
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price,
         &usdc_price,
@@ -1962,7 +1990,8 @@ fun test_error_invalid_condition_trigger_above() {
     let sui_price = build_sui_price_info_object_with_price(&mut scenario, 200, &clock); // $2.00
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock);
 
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price,
         &usdc_price,
@@ -1984,7 +2013,8 @@ fun test_error_invalid_condition_trigger_above() {
         constants::max_u64(),
     );
 
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price,
         &usdc_price,
@@ -2079,7 +2109,8 @@ fun test_error_max_conditional_orders_reached() {
     let sui_price = build_sui_price_info_object_with_price(&mut scenario, 200, &clock);
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock);
 
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price,
         &usdc_price,
@@ -2103,7 +2134,8 @@ fun test_error_max_conditional_orders_reached() {
             constants::max_u64(),
         );
 
-        mm.add_conditional_order<SUI, USDC>(
+        margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+            &mut mm,
             &pool,
             &sui_price,
             &usdc_price,
@@ -2179,7 +2211,8 @@ fun test_error_duplicate_conditional_order_identifier() {
     let sui_price = build_sui_price_info_object_with_price(&mut scenario, 200, &clock);
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock);
 
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price,
         &usdc_price,
@@ -2201,7 +2234,8 @@ fun test_error_duplicate_conditional_order_identifier() {
         constants::max_u64(),
     );
 
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price,
         &usdc_price,
@@ -2226,7 +2260,8 @@ fun test_error_duplicate_conditional_order_identifier() {
         constants::max_u64(),
     );
 
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price,
         &usdc_price,
@@ -2281,7 +2316,8 @@ fun test_error_invalid_order_params_quantity_too_small() {
     let sui_price = build_sui_price_info_object_with_price(&mut scenario, 200, &clock);
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock);
 
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price,
         &usdc_price,
@@ -2303,7 +2339,8 @@ fun test_error_invalid_order_params_quantity_too_small() {
         constants::max_u64(),
     );
 
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price,
         &usdc_price,
@@ -2358,7 +2395,8 @@ fun test_error_invalid_order_params_quantity_not_lot_size_multiple() {
     let sui_price = build_sui_price_info_object_with_price(&mut scenario, 200, &clock);
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock);
 
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price,
         &usdc_price,
@@ -2381,7 +2419,8 @@ fun test_error_invalid_order_params_quantity_not_lot_size_multiple() {
         constants::max_u64(),
     );
 
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price,
         &usdc_price,
@@ -2436,7 +2475,8 @@ fun test_error_invalid_order_params_price_not_tick_size_multiple() {
     let sui_price = build_sui_price_info_object_with_price(&mut scenario, 200, &clock);
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock);
 
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price,
         &usdc_price,
@@ -2458,7 +2498,8 @@ fun test_error_invalid_order_params_price_not_tick_size_multiple() {
         constants::max_u64(),
     );
 
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price,
         &usdc_price,
@@ -2513,7 +2554,8 @@ fun test_error_invalid_order_params_price_below_min() {
     let sui_price = build_sui_price_info_object_with_price(&mut scenario, 200, &clock);
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock);
 
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price,
         &usdc_price,
@@ -2535,7 +2577,8 @@ fun test_error_invalid_order_params_price_below_min() {
         constants::max_u64(),
     );
 
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price,
         &usdc_price,
@@ -2590,7 +2633,8 @@ fun test_error_invalid_order_params_expired_timestamp() {
     let sui_price = build_sui_price_info_object_with_price(&mut scenario, 200, &clock);
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock);
 
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price,
         &usdc_price,
@@ -2612,7 +2656,8 @@ fun test_error_invalid_order_params_expired_timestamp() {
         100, // Already expired
     );
 
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price,
         &usdc_price,
@@ -2667,7 +2712,8 @@ fun test_error_invalid_order_params_market_order_quantity_too_small() {
     let sui_price = build_sui_price_info_object_with_price(&mut scenario, 200, &clock);
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock);
 
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price,
         &usdc_price,
@@ -2686,7 +2732,8 @@ fun test_error_invalid_order_params_market_order_quantity_too_small() {
         false,
     );
 
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price,
         &usdc_price,
@@ -2747,7 +2794,8 @@ fun test_tpsl_insufficient_funds_second_order() {
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock); // $1.00
 
     // Deposit limited collateral: only 150 SUI
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price_high,
         &usdc_price,
@@ -2773,7 +2821,8 @@ fun test_tpsl_insufficient_funds_second_order() {
         constants::max_u64(),
     );
 
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price_high,
         &usdc_price,
@@ -2802,7 +2851,8 @@ fun test_tpsl_insufficient_funds_second_order() {
         constants::max_u64(),
     );
 
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price_high,
         &usdc_price,
@@ -2830,7 +2880,7 @@ fun test_tpsl_insufficient_funds_second_order() {
     let mut margin_registry = scenario.take_shared<MarginRegistry>();
 
     // Update the current price in the registry to match the new oracle price
-    pool_proxy::update_current_price<SUI, USDC>(
+    pool_proxy_upgraded::update_current_price<SUI, USDC>(
         &mut margin_registry,
         &pool,
         &sui_price_low,
@@ -2920,7 +2970,8 @@ fun test_tpsl_expired_order_during_execution() {
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock); // $1.00
 
     // Deposit collateral
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price_high,
         &usdc_price,
@@ -2946,7 +2997,8 @@ fun test_tpsl_expired_order_during_execution() {
         expire_timestamp,
     );
 
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price_high,
         &usdc_price,
@@ -3051,7 +3103,8 @@ fun test_tpsl_early_exit_optimization() {
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock);
 
     // Deposit collateral
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price_high,
         &usdc_price,
@@ -3084,7 +3137,8 @@ fun test_tpsl_early_exit_optimization() {
             constants::max_u64(),
         );
 
-        mm.add_conditional_order<SUI, USDC>(
+        margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+            &mut mm,
             &pool,
             &sui_price_high,
             &usdc_price,
@@ -3114,7 +3168,7 @@ fun test_tpsl_early_exit_optimization() {
     let mut margin_registry = scenario.take_shared<MarginRegistry>();
 
     // Update the current price in the registry to match the new oracle price
-    pool_proxy::update_current_price<SUI, USDC>(
+    pool_proxy_upgraded::update_current_price<SUI, USDC>(
         &mut margin_registry,
         &pool,
         &sui_price_mid,
@@ -3213,7 +3267,8 @@ fun test_tpsl_max_orders_to_execute_limit() {
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock);
 
     // Deposit collateral
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price_high,
         &usdc_price,
@@ -3246,7 +3301,8 @@ fun test_tpsl_max_orders_to_execute_limit() {
             constants::max_u64(),
         );
 
-        mm.add_conditional_order<SUI, USDC>(
+        margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+            &mut mm,
             &pool,
             &sui_price_high,
             &usdc_price,
@@ -3277,7 +3333,7 @@ fun test_tpsl_max_orders_to_execute_limit() {
     let mut margin_registry = scenario.take_shared<MarginRegistry>();
 
     // Update the current price in the registry to match the new oracle price
-    pool_proxy::update_current_price<SUI, USDC>(
+    pool_proxy_upgraded::update_current_price<SUI, USDC>(
         &mut margin_registry,
         &pool,
         &sui_price_low,
@@ -3508,7 +3564,7 @@ fun tpsl_cancel_maker_self_match_cannot_bypass_price_bounds() {
     let pool = scenario.take_shared<Pool<SUI, USDC>>();
     let sui_price = build_sui_price_info_object_with_price(&mut scenario, 200, &clock);
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock);
-    pool_proxy::update_current_price<SUI, USDC>(
+    pool_proxy_upgraded::update_current_price<SUI, USDC>(
         &mut margin_registry,
         &pool,
         &sui_price,
@@ -3539,7 +3595,8 @@ fun tpsl_cancel_maker_self_match_cannot_bypass_price_bounds() {
     let sui_price = build_sui_price_info_object_with_price(&mut scenario, 200, &clock);
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock);
 
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price,
         &usdc_price,
@@ -3547,7 +3604,8 @@ fun tpsl_cancel_maker_self_match_cannot_bypass_price_bounds() {
         &clock,
         scenario.ctx(),
     );
-    mm.deposit<SUI, USDC, USDC>(
+    margin_manager_upgraded::deposit<SUI, USDC, USDC>(
+        &mut mm,
         &margin_registry,
         &sui_price,
         &usdc_price,
@@ -3583,7 +3641,8 @@ fun tpsl_cancel_maker_self_match_cannot_bypass_price_bounds() {
         false, // market sell
         false,
     );
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price,
         &usdc_price,
@@ -3615,7 +3674,7 @@ fun tpsl_cancel_maker_self_match_cannot_bypass_price_bounds() {
 
     // Drop the registry price to a fresh $1.80 (aligned with the trigger): bounds
     // become $1.71-$1.89 so the manager's own $1.80 bid reads as in-bounds.
-    pool_proxy::update_current_price<SUI, USDC>(
+    pool_proxy_upgraded::update_current_price<SUI, USDC>(
         &mut margin_registry,
         &pool,
         &sui_price_trigger,
@@ -3680,7 +3739,8 @@ fun test_tpsl_limit_order_price_below_lower_bound_cancelled() {
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock);
 
     // Deposit collateral
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price,
         &usdc_price,
@@ -3706,7 +3766,8 @@ fun test_tpsl_limit_order_price_below_lower_bound_cancelled() {
         constants::max_u64(),
     );
 
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price,
         &usdc_price,
@@ -3733,7 +3794,7 @@ fun test_tpsl_limit_order_price_below_lower_bound_cancelled() {
     let mut margin_registry = scenario.take_shared<MarginRegistry>();
 
     // Update current price in registry
-    pool_proxy::update_current_price<SUI, USDC>(
+    pool_proxy_upgraded::update_current_price<SUI, USDC>(
         &mut margin_registry,
         &pool,
         &sui_price_trigger,
@@ -3811,7 +3872,8 @@ fun test_tpsl_limit_order_price_above_upper_bound_cancelled() {
     let sui_price = build_sui_price_info_object_with_price(&mut scenario, 200, &clock);
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock);
 
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price,
         &usdc_price,
@@ -3837,7 +3899,8 @@ fun test_tpsl_limit_order_price_above_upper_bound_cancelled() {
         constants::max_u64(),
     );
 
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price,
         &usdc_price,
@@ -3863,7 +3926,7 @@ fun test_tpsl_limit_order_price_above_upper_bound_cancelled() {
     let mut pool = scenario.take_shared<Pool<SUI, USDC>>();
     let mut margin_registry = scenario.take_shared<MarginRegistry>();
 
-    pool_proxy::update_current_price<SUI, USDC>(
+    pool_proxy_upgraded::update_current_price<SUI, USDC>(
         &mut margin_registry,
         &pool,
         &sui_price_trigger,
@@ -3940,7 +4003,8 @@ fun test_tpsl_market_sell_order_price_out_of_bounds_cancelled() {
     let sui_price = build_sui_price_info_object_with_price(&mut scenario, 200, &clock); // $2.00
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock);
 
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price,
         &usdc_price,
@@ -3962,7 +4026,8 @@ fun test_tpsl_market_sell_order_price_out_of_bounds_cancelled() {
         false,
     );
 
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price,
         &usdc_price,
@@ -3988,7 +4053,7 @@ fun test_tpsl_market_sell_order_price_out_of_bounds_cancelled() {
     let mut pool = scenario.take_shared<Pool<SUI, USDC>>();
     let mut margin_registry = scenario.take_shared<MarginRegistry>();
 
-    pool_proxy::update_current_price<SUI, USDC>(
+    pool_proxy_upgraded::update_current_price<SUI, USDC>(
         &mut margin_registry,
         &pool,
         &sui_price_trigger,
@@ -4066,7 +4131,8 @@ fun test_tpsl_market_buy_order_price_out_of_bounds_cancelled() {
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock);
 
     // Deposit USDC for buying
-    mm.deposit<SUI, USDC, USDC>(
+    margin_manager_upgraded::deposit<SUI, USDC, USDC>(
+        &mut mm,
         &margin_registry,
         &sui_price,
         &usdc_price,
@@ -4088,7 +4154,8 @@ fun test_tpsl_market_buy_order_price_out_of_bounds_cancelled() {
         false,
     );
 
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price,
         &usdc_price,
@@ -4114,7 +4181,7 @@ fun test_tpsl_market_buy_order_price_out_of_bounds_cancelled() {
     let mut pool = scenario.take_shared<Pool<SUI, USDC>>();
     let mut margin_registry = scenario.take_shared<MarginRegistry>();
 
-    pool_proxy::update_current_price<SUI, USDC>(
+    pool_proxy_upgraded::update_current_price<SUI, USDC>(
         &mut margin_registry,
         &pool,
         &sui_price_trigger,
@@ -4190,7 +4257,8 @@ fun test_tpsl_market_buy_order_no_liquidity_cancelled() {
     let sui_price = build_sui_price_info_object_with_price(&mut scenario, 200, &clock);
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock);
 
-    mm.deposit<SUI, USDC, USDC>(
+    margin_manager_upgraded::deposit<SUI, USDC, USDC>(
+        &mut mm,
         &margin_registry,
         &sui_price,
         &usdc_price,
@@ -4212,7 +4280,8 @@ fun test_tpsl_market_buy_order_no_liquidity_cancelled() {
         false,
     );
 
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price,
         &usdc_price,
@@ -4238,7 +4307,7 @@ fun test_tpsl_market_buy_order_no_liquidity_cancelled() {
     let mut pool = scenario.take_shared<Pool<SUI, USDC>>();
     let mut margin_registry = scenario.take_shared<MarginRegistry>();
 
-    pool_proxy::update_current_price<SUI, USDC>(
+    pool_proxy_upgraded::update_current_price<SUI, USDC>(
         &mut margin_registry,
         &pool,
         &sui_price_trigger,
@@ -4315,7 +4384,8 @@ fun test_tpsl_mixed_orders_some_cancelled_some_executed() {
     let sui_price = build_sui_price_info_object_with_price(&mut scenario, 200, &clock);
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock);
 
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price,
         &usdc_price,
@@ -4337,7 +4407,8 @@ fun test_tpsl_mixed_orders_some_cancelled_some_executed() {
         false,
         constants::max_u64(),
     );
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price,
         &usdc_price,
@@ -4361,7 +4432,8 @@ fun test_tpsl_mixed_orders_some_cancelled_some_executed() {
         false,
         constants::max_u64(),
     );
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price,
         &usdc_price,
@@ -4387,7 +4459,7 @@ fun test_tpsl_mixed_orders_some_cancelled_some_executed() {
     let mut pool = scenario.take_shared<Pool<SUI, USDC>>();
     let mut margin_registry = scenario.take_shared<MarginRegistry>();
 
-    pool_proxy::update_current_price<SUI, USDC>(
+    pool_proxy_upgraded::update_current_price<SUI, USDC>(
         &mut margin_registry,
         &pool,
         &sui_price_trigger,
@@ -4472,7 +4544,8 @@ fun execute_conditional_orders_v3_stop_loss_deleverages_in_danger_band() {
     let sui_price_high = build_sui_price_info_object_with_price(&mut scenario, 200, &clock); // $2.00
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock);
 
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price_high,
         &usdc_price,
@@ -4481,7 +4554,8 @@ fun execute_conditional_orders_v3_stop_loss_deleverages_in_danger_band() {
         scenario.ctx(),
     );
     // Borrow 8000 USDC: ratio = (1000*2 + 8000) / 8000 = 1.25 at SUI=$2.
-    mm.borrow_quote<SUI, USDC>(
+    margin_manager_upgraded::borrow_quote<SUI, USDC>(
+        &mut mm,
         &margin_registry,
         &mut usdc_pool,
         &sui_price_high,
@@ -4500,7 +4574,8 @@ fun execute_conditional_orders_v3_stop_loss_deleverages_in_danger_band() {
         false, // is_bid = false (sell)
         false, // pay_with_deep
     );
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price_high,
         &usdc_price,
@@ -4523,7 +4598,7 @@ fun execute_conditional_orders_v3_stop_loss_deleverages_in_danger_band() {
     let mut pool = scenario.take_shared<Pool<SUI, USDC>>();
     let mut margin_registry = scenario.take_shared<MarginRegistry>();
     let mut mm = scenario.take_shared<MarginManager<SUI, USDC>>();
-    pool_proxy::update_current_price<SUI, USDC>(
+    pool_proxy_upgraded::update_current_price<SUI, USDC>(
         &mut margin_registry,
         &pool,
         &sui_price_low,
@@ -4610,7 +4685,8 @@ fun execute_conditional_orders_v3_base_debt_stop_loss_deleverages_in_danger_band
 
     // Short: deposit 2500 USDC, borrow 1000 SUI, withdraw it -> holds 2500 USDC,
     // owes 1000 SUI (ratio 2.5 at SUI=$1, safe to withdraw).
-    mm.deposit<SUI, USDC, USDC>(
+    margin_manager_upgraded::deposit<SUI, USDC, USDC>(
+        &mut mm,
         &margin_registry,
         &sui_price_open,
         &usdc_price,
@@ -4618,7 +4694,8 @@ fun execute_conditional_orders_v3_base_debt_stop_loss_deleverages_in_danger_band
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_base<SUI, USDC>(
+    margin_manager_upgraded::borrow_base<SUI, USDC>(
+        &mut mm,
         &margin_registry,
         &mut sui_pool,
         &sui_price_open,
@@ -4628,7 +4705,8 @@ fun execute_conditional_orders_v3_base_debt_stop_loss_deleverages_in_danger_band
         &clock,
         scenario.ctx(),
     );
-    let withdrawn = mm.withdraw<SUI, USDC, SUI>(
+    let withdrawn = margin_manager_upgraded::withdraw<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_pool,
         &usdc_pool_ro,
@@ -4649,7 +4727,8 @@ fun execute_conditional_orders_v3_base_debt_stop_loss_deleverages_in_danger_band
         true, // is_bid = true (buy to cover the short)
         false, // pay_with_deep
     );
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price_open,
         &usdc_price,
@@ -4673,7 +4752,7 @@ fun execute_conditional_orders_v3_base_debt_stop_loss_deleverages_in_danger_band
     let mut pool = scenario.take_shared<Pool<SUI, USDC>>();
     let mut margin_registry = scenario.take_shared<MarginRegistry>();
     let mut mm = scenario.take_shared<MarginManager<SUI, USDC>>();
-    pool_proxy::update_current_price<SUI, USDC>(
+    pool_proxy_upgraded::update_current_price<SUI, USDC>(
         &mut margin_registry,
         &pool,
         &sui_price_high,
@@ -4753,7 +4832,8 @@ fun execute_conditional_orders_v2_stop_loss_aborts_in_danger_band() {
     let sui_price_high = build_sui_price_info_object_with_price(&mut scenario, 200, &clock);
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock);
 
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price_high,
         &usdc_price,
@@ -4761,7 +4841,8 @@ fun execute_conditional_orders_v2_stop_loss_aborts_in_danger_band() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_quote<SUI, USDC>(
+    margin_manager_upgraded::borrow_quote<SUI, USDC>(
+        &mut mm,
         &margin_registry,
         &mut usdc_pool,
         &sui_price_high,
@@ -4780,7 +4861,8 @@ fun execute_conditional_orders_v2_stop_loss_aborts_in_danger_band() {
         false,
         false,
     );
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price_high,
         &usdc_price,
@@ -4803,7 +4885,7 @@ fun execute_conditional_orders_v2_stop_loss_aborts_in_danger_band() {
     let mut pool = scenario.take_shared<Pool<SUI, USDC>>();
     let mut margin_registry = scenario.take_shared<MarginRegistry>();
     let mut mm = scenario.take_shared<MarginManager<SUI, USDC>>();
-    pool_proxy::update_current_price<SUI, USDC>(
+    pool_proxy_upgraded::update_current_price<SUI, USDC>(
         &mut margin_registry,
         &pool,
         &sui_price_low,
@@ -4871,7 +4953,8 @@ fun execute_conditional_orders_v3_limit_stop_loss_rests_in_danger_band() {
     let sui_price_high = build_sui_price_info_object_with_price(&mut scenario, 200, &clock);
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock);
 
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price_high,
         &usdc_price,
@@ -4879,7 +4962,8 @@ fun execute_conditional_orders_v3_limit_stop_loss_rests_in_danger_band() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_quote<SUI, USDC>(
+    margin_manager_upgraded::borrow_quote<SUI, USDC>(
+        &mut mm,
         &margin_registry,
         &mut usdc_pool,
         &sui_price_high,
@@ -4903,7 +4987,8 @@ fun execute_conditional_orders_v3_limit_stop_loss_rests_in_danger_band() {
         false, // pay_with_deep
         constants::max_u64(),
     );
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price_high,
         &usdc_price,
@@ -4926,7 +5011,7 @@ fun execute_conditional_orders_v3_limit_stop_loss_rests_in_danger_band() {
     let mut pool = scenario.take_shared<Pool<SUI, USDC>>();
     let mut margin_registry = scenario.take_shared<MarginRegistry>();
     let mut mm = scenario.take_shared<MarginManager<SUI, USDC>>();
-    pool_proxy::update_current_price<SUI, USDC>(
+    pool_proxy_upgraded::update_current_price<SUI, USDC>(
         &mut margin_registry,
         &pool,
         &sui_price_low,
@@ -5010,7 +5095,8 @@ fun execute_conditional_orders_v3_limit_below_liquidation_cancelled() {
     let sui_price_high = build_sui_price_info_object_with_price(&mut scenario, 200, &clock);
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock);
 
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price_high,
         &usdc_price,
@@ -5018,7 +5104,8 @@ fun execute_conditional_orders_v3_limit_below_liquidation_cancelled() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_quote<SUI, USDC>(
+    margin_manager_upgraded::borrow_quote<SUI, USDC>(
+        &mut mm,
         &margin_registry,
         &mut usdc_pool,
         &sui_price_high,
@@ -5040,7 +5127,8 @@ fun execute_conditional_orders_v3_limit_below_liquidation_cancelled() {
         false,
         constants::max_u64(),
     );
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price_high,
         &usdc_price,
@@ -5064,7 +5152,7 @@ fun execute_conditional_orders_v3_limit_below_liquidation_cancelled() {
     let mut pool = scenario.take_shared<Pool<SUI, USDC>>();
     let mut margin_registry = scenario.take_shared<MarginRegistry>();
     let mut mm = scenario.take_shared<MarginManager<SUI, USDC>>();
-    pool_proxy::update_current_price<SUI, USDC>(
+    pool_proxy_upgraded::update_current_price<SUI, USDC>(
         &mut margin_registry,
         &pool,
         &sui_price_low,
@@ -5076,7 +5164,8 @@ fun execute_conditional_orders_v3_limit_below_liquidation_cancelled() {
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
 
     // Sanity: the manager is genuinely below the liquidation floor.
-    let rr_before = mm.risk_ratio(
+    let rr_before = margin_manager_upgraded::risk_ratio(
+        &mm,
         &margin_registry,
         &sui_price_low,
         &usdc_price,
@@ -5158,7 +5247,8 @@ fun tpsl_trigger_below_does_not_fire_at_exactly_the_trigger_price() {
     let sui_price_high = build_sui_price_info_object_with_price(&mut scenario, 200, &clock); // $2.00
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock);
 
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price_high,
         &usdc_price,
@@ -5183,7 +5273,8 @@ fun tpsl_trigger_below_does_not_fire_at_exactly_the_trigger_price() {
             false,
             constants::max_u64(),
         );
-        mm.add_conditional_order<SUI, USDC>(
+        margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+            &mut mm,
             &pool,
             &sui_price_high,
             &usdc_price,
@@ -5210,7 +5301,7 @@ fun tpsl_trigger_below_does_not_fire_at_exactly_the_trigger_price() {
 
     let mut pool = scenario.take_shared<Pool<SUI, USDC>>();
     let mut margin_registry = scenario.take_shared<MarginRegistry>();
-    pool_proxy::update_current_price<SUI, USDC>(
+    pool_proxy_upgraded::update_current_price<SUI, USDC>(
         &mut margin_registry,
         &pool,
         &sui_price_at_trigger,
@@ -5292,7 +5383,8 @@ fun tpsl_trigger_above_does_not_fire_at_exactly_the_trigger_price() {
     let sui_price_low = build_sui_price_info_object_with_price(&mut scenario, 100, &clock); // $1.00
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock);
 
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price_low,
         &usdc_price,
@@ -5317,7 +5409,8 @@ fun tpsl_trigger_above_does_not_fire_at_exactly_the_trigger_price() {
             false,
             constants::max_u64(),
         );
-        mm.add_conditional_order<SUI, USDC>(
+        margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+            &mut mm,
             &pool,
             &sui_price_low,
             &usdc_price,
@@ -5344,7 +5437,7 @@ fun tpsl_trigger_above_does_not_fire_at_exactly_the_trigger_price() {
 
     let mut pool = scenario.take_shared<Pool<SUI, USDC>>();
     let mut margin_registry = scenario.take_shared<MarginRegistry>();
-    pool_proxy::update_current_price<SUI, USDC>(
+    pool_proxy_upgraded::update_current_price<SUI, USDC>(
         &mut margin_registry,
         &pool,
         &sui_price_at_trigger,
@@ -5427,7 +5520,8 @@ fun add_conditional_order_max_bound_counts_both_trigger_queues() {
     let sui_price = build_sui_price_info_object_with_price(&mut scenario, 200, &clock); // $2.00
     let usdc_price = build_usdc_price_info_object(&mut scenario, &clock);
 
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price,
         &usdc_price,
@@ -5457,7 +5551,8 @@ fun add_conditional_order_max_bound_counts_both_trigger_queues() {
             constants::max_u64(),
         );
 
-        mm.add_conditional_order<SUI, USDC>(
+        margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+            &mut mm,
             &pool,
             &sui_price,
             &usdc_price,
@@ -5521,7 +5616,8 @@ fun execute_conditional_orders_v3_crossing_limit_that_leaks_value_aborts() {
 
     // Same danger-band position as the v3 deleverage tests: ratio 1.25 at SUI=$2,
     // ~1.119 once SUI falls to $0.95.
-    mm.deposit<SUI, USDC, SUI>(
+    margin_manager_upgraded::deposit<SUI, USDC, SUI>(
+        &mut mm,
         &margin_registry,
         &sui_price_high,
         &usdc_price,
@@ -5529,7 +5625,8 @@ fun execute_conditional_orders_v3_crossing_limit_that_leaks_value_aborts() {
         &clock,
         scenario.ctx(),
     );
-    mm.borrow_quote<SUI, USDC>(
+    margin_manager_upgraded::borrow_quote<SUI, USDC>(
+        &mut mm,
         &margin_registry,
         &mut usdc_pool,
         &sui_price_high,
@@ -5554,7 +5651,8 @@ fun execute_conditional_orders_v3_crossing_limit_that_leaks_value_aborts() {
         false, // pay_with_deep
         constants::max_u64(),
     );
-    mm.add_conditional_order<SUI, USDC>(
+    margin_manager_upgraded::add_conditional_order<SUI, USDC>(
+        &mut mm,
         &pool,
         &sui_price_high,
         &usdc_price,
@@ -5577,7 +5675,7 @@ fun execute_conditional_orders_v3_crossing_limit_that_leaks_value_aborts() {
     let mut pool = scenario.take_shared<Pool<SUI, USDC>>();
     let mut margin_registry = scenario.take_shared<MarginRegistry>();
     let mut mm = scenario.take_shared<MarginManager<SUI, USDC>>();
-    pool_proxy::update_current_price<SUI, USDC>(
+    pool_proxy_upgraded::update_current_price<SUI, USDC>(
         &mut margin_registry,
         &pool,
         &sui_price_low,

--- a/packages/margin_liquidation/sources/liquidation_vault.move
+++ b/packages/margin_liquidation/sources/liquidation_vault.move
@@ -5,7 +5,7 @@ module margin_liquidation::liquidation_vault;
 
 use deepbook::pool::Pool;
 use deepbook_margin::{
-    margin_manager::{MarginManager, liquidate},
+    margin_manager::MarginManager,
     margin_manager_upgraded,
     margin_pool::MarginPool,
     margin_registry::MarginRegistry
@@ -31,6 +31,9 @@ use fun df::exists_ as UID.exists_;
 // === Errors ===
 const ENotEnoughBalanceInVault: u64 = 1;
 const ETraderNotAuthorized: u64 = 2;
+/// A retired legacy-Pyth entry was called. Use the `_upgraded` twin, which takes
+/// an upgraded-Core `PriceInfoObject`.
+const EDeprecatedUseUpgradedPyth: u64 = 3;
 
 public struct LIQUIDATION_VAULT has drop {}
 
@@ -174,104 +177,44 @@ public fun swap_quote_to_base<BaseAsset, QuoteAsset>(
 }
 
 // === Public Functions * LIQUIDATION * ===
-/// Twin: `liquidate_base_upgraded`. Edit both.
+/// RETIRED. Use `liquidate_base_upgraded`.
+///
+/// Legacy-Pyth entry. The vault entries are permissionless and fund their own
+/// repay, so this was the capital-free liquidation leg of the dual-feed window.
 public fun liquidate_base<BaseAsset, QuoteAsset>(
-    self: &mut LiquidationVault,
-    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
-    registry: &MarginRegistry,
-    base_oracle: &PriceInfoObject,
-    quote_oracle: &PriceInfoObject,
-    base_margin_pool: &mut MarginPool<BaseAsset>,
-    quote_margin_pool: &mut MarginPool<QuoteAsset>,
-    pool: &mut Pool<BaseAsset, QuoteAsset>,
-    repay_amount: Option<u64>,
-    clock: &Clock,
-    ctx: &mut TxContext,
+    _self: &mut LiquidationVault,
+    _margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    _registry: &MarginRegistry,
+    _base_oracle: &PriceInfoObject,
+    _quote_oracle: &PriceInfoObject,
+    _base_margin_pool: &mut MarginPool<BaseAsset>,
+    _quote_margin_pool: &mut MarginPool<QuoteAsset>,
+    _pool: &mut Pool<BaseAsset, QuoteAsset>,
+    _repay_amount: Option<u64>,
+    _clock: &Clock,
+    _ctx: &mut TxContext,
 ) {
-    let risk_ratio = margin_manager.risk_ratio(
-        registry,
-        base_oracle,
-        quote_oracle,
-        pool,
-        base_margin_pool,
-        quote_margin_pool,
-        clock,
-    );
-    if (!self.should_liquidate<BaseAsset>(registry, pool.id(), risk_ratio)) return;
-    let amount = repay_amount.destroy_with_default(self.balance<BaseAsset>());
-    let balance = self.withdraw_int<BaseAsset>(amount);
-    let (base_coin, quote_coin, base_repay_coin) = margin_manager.liquidate<
-        BaseAsset,
-        QuoteAsset,
-        BaseAsset,
-    >(
-        registry,
-        base_oracle,
-        quote_oracle,
-        base_margin_pool,
-        pool,
-        balance.into_coin(ctx),
-        clock,
-        ctx,
-    );
-    self.settle_base_liquidation(
-        margin_manager.id(),
-        base_margin_pool.id(),
-        amount,
-        base_coin,
-        quote_coin,
-        base_repay_coin,
-    );
+    abort EDeprecatedUseUpgradedPyth
 }
 
-/// Twin: `liquidate_quote_upgraded`. Edit both.
+/// RETIRED. Use `liquidate_quote_upgraded`.
+///
+/// Legacy-Pyth entry. The vault entries are permissionless and fund their own
+/// repay, so this was the capital-free liquidation leg of the dual-feed window.
 public fun liquidate_quote<BaseAsset, QuoteAsset>(
-    self: &mut LiquidationVault,
-    margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
-    registry: &MarginRegistry,
-    base_oracle: &PriceInfoObject,
-    quote_oracle: &PriceInfoObject,
-    base_margin_pool: &mut MarginPool<BaseAsset>,
-    quote_margin_pool: &mut MarginPool<QuoteAsset>,
-    pool: &mut Pool<BaseAsset, QuoteAsset>,
-    repay_amount: Option<u64>,
-    clock: &Clock,
-    ctx: &mut TxContext,
+    _self: &mut LiquidationVault,
+    _margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
+    _registry: &MarginRegistry,
+    _base_oracle: &PriceInfoObject,
+    _quote_oracle: &PriceInfoObject,
+    _base_margin_pool: &mut MarginPool<BaseAsset>,
+    _quote_margin_pool: &mut MarginPool<QuoteAsset>,
+    _pool: &mut Pool<BaseAsset, QuoteAsset>,
+    _repay_amount: Option<u64>,
+    _clock: &Clock,
+    _ctx: &mut TxContext,
 ) {
-    let risk_ratio = margin_manager.risk_ratio(
-        registry,
-        base_oracle,
-        quote_oracle,
-        pool,
-        base_margin_pool,
-        quote_margin_pool,
-        clock,
-    );
-    if (!self.should_liquidate<QuoteAsset>(registry, pool.id(), risk_ratio)) return;
-    let amount = repay_amount.destroy_with_default(self.balance<QuoteAsset>());
-    let balance = self.withdraw_int<QuoteAsset>(amount);
-    let (base_coin, quote_coin, quote_repay_coin) = margin_manager.liquidate<
-        BaseAsset,
-        QuoteAsset,
-        QuoteAsset,
-    >(
-        registry,
-        base_oracle,
-        quote_oracle,
-        quote_margin_pool,
-        pool,
-        balance.into_coin(ctx),
-        clock,
-        ctx,
-    );
-    self.settle_quote_liquidation(
-        margin_manager.id(),
-        quote_margin_pool.id(),
-        amount,
-        base_coin,
-        quote_coin,
-        quote_repay_coin,
-    );
+    abort EDeprecatedUseUpgradedPyth
 }
 
 public fun balance<T>(self: &LiquidationVault): u64 {
@@ -286,16 +229,11 @@ public fun balance<T>(self: &LiquidationVault): u64 {
     }
 }
 
-/// `liquidate_base` against Pyth's upgraded Core.
+/// Liquidates a base-debt margin manager from the vault's own balance.
 ///
-/// Pyth is replacing Core with a separately published package, so its `PriceInfoObject`
-/// is a distinct Move type and `liquidate_base`'s frozen signature can never accept it.
-/// Once Pyth stops publishing legacy Core the legacy entry aborts on staleness by
-/// itself, and this becomes the only way the vault can liquidate. The gate
-/// (`should_liquidate`) and the settlement (`settle_base_liquidation`) are shared with
-/// the legacy entry; the body between them is duplicated, because the two
-/// `PriceInfoObject` types cannot be unified.
-/// Twin: `liquidate_base`. Edit both.
+/// Pyth replaced Core with a separately published package, so its `PriceInfoObject` is a
+/// distinct Move type and `liquidate_base`'s frozen signature can never accept it. That
+/// entry is now retired, making this the only way the vault can liquidate a base debt.
 public fun liquidate_base_upgraded<BaseAsset, QuoteAsset>(
     self: &mut LiquidationVault,
     margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,
@@ -347,8 +285,8 @@ public fun liquidate_base_upgraded<BaseAsset, QuoteAsset>(
     );
 }
 
-/// `liquidate_quote` against Pyth's upgraded Core. See `liquidate_base_upgraded`.
-/// Twin: `liquidate_quote`. Edit both.
+/// Liquidates a quote-debt margin manager from the vault's own balance.
+/// See `liquidate_base_upgraded`.
 public fun liquidate_quote_upgraded<BaseAsset, QuoteAsset>(
     self: &mut LiquidationVault,
     margin_manager: &mut MarginManager<BaseAsset, QuoteAsset>,

--- a/packages/margin_liquidation/tests/liquidation_vault_oracle_tests.move
+++ b/packages/margin_liquidation/tests/liquidation_vault_oracle_tests.move
@@ -498,12 +498,6 @@ fun liquidate_base_upgraded_pays_out_and_returns_every_coin() {
     scenario.end();
 }
 
-/// The vault's swap entrypoints are gated by `assert_trader`, and nothing exercised
-/// that gate through them: the three tests named for it in `liquidation_vault_tests`
-/// call `assert_trader_for_testing` directly, so deleting the check from
-/// `swap_base_to_quote` left the whole suite green. That check is the only thing
-/// between an arbitrary caller and swapping the vault's entire inventory with
-/// `min_quote_out` of zero.
 /// The legacy pair is retired. These two aborts are what closed the vault's half of the
 /// dual-feed window: the entries are permissionless and fund their own repay, so unlike
 /// `margin_manager::liquidate` they never needed the caller to bring capital.
@@ -585,6 +579,12 @@ fun legacy_liquidate_base_aborts() {
     abort WRONG_ABORT_SENTINEL
 }
 
+/// The vault's swap entrypoints are gated by `assert_trader`, and nothing exercised
+/// that gate through them: the three tests named for it in `liquidation_vault_tests`
+/// call `assert_trader_for_testing` directly, so deleting the check from
+/// `swap_base_to_quote` left the whole suite green. That check is the only thing
+/// between an arbitrary caller and swapping the vault's entire inventory with
+/// `min_quote_out` of zero.
 #[test, expected_failure(abort_code = liquidation_vault::ETraderNotAuthorized)]
 fun swap_base_to_quote_rejects_an_unauthorised_caller() {
     let (mut scenario, clock, _btc_pool_id, _usdc_pool_id) = manager_with_base_debt();

--- a/packages/margin_liquidation/tests/liquidation_vault_oracle_tests.move
+++ b/packages/margin_liquidation/tests/liquidation_vault_oracle_tests.move
@@ -8,12 +8,17 @@
 /// neither the legacy pair nor the upgraded pair added for the Pyth cutover had any
 /// coverage of the two things that can silently go wrong: which oracle generation an
 /// entry reads, and whether the `can_liquidate` gate actually holds.
+///
+/// The legacy pair is now retired and covered by its aborts alone; everything that
+/// exercises a real liquidation runs against the upgraded pair, which is the only way
+/// the vault can liquidate.
 #[test_only]
 module margin_liquidation::liquidation_vault_oracle_tests;
 
 use deepbook::pool::Pool;
 use deepbook_margin::{
     margin_manager::{Self, MarginManager},
+    margin_manager_upgraded,
     margin_pool::MarginPool,
     margin_registry::MarginRegistry,
     test_constants::{Self, USDC, BTC, btc_multiplier},
@@ -23,7 +28,6 @@ use deepbook_margin::{
         build_demo_usdc_price_info_object,
         build_btc_price_info_object_upgraded,
         build_demo_usdc_price_info_object_upgraded,
-        build_stale_btc_price_info_object,
         build_stale_btc_price_info_object_upgraded,
         mint_coin,
     }
@@ -70,10 +74,10 @@ fun healthy_manager(): (test::Scenario, Clock, ID, ID, ID) {
     let pool = scenario.take_shared<Pool<BTC, USDC>>();
     let registry = scenario.take_shared<MarginRegistry>();
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
-    let btc = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
-    margin_manager::deposit<BTC, USDC, BTC>(
+    margin_manager_upgraded::deposit<BTC, USDC, BTC>(
         &mut mm,
         &registry,
         &btc,
@@ -82,7 +86,7 @@ fun healthy_manager(): (test::Scenario, Clock, ID, ID, ID) {
         &clock,
         scenario.ctx(),
     );
-    margin_manager::borrow_quote<BTC, USDC>(
+    margin_manager_upgraded::borrow_quote<BTC, USDC>(
         &mut mm,
         &registry,
         &mut usdc_pool,
@@ -213,56 +217,6 @@ fun liquidate_quote_upgraded_rejects_a_stale_feed() {
     scenario.end();
 }
 
-/// The legacy entry keeps the same two properties, so the pair cannot drift. This is
-/// the coverage `liquidate_quote` never had.
-#[test, expected_failure(abort_code = pyth::pyth::E_STALE_PRICE_UPDATE)]
-fun liquidate_quote_rejects_a_stale_feed() {
-    let (mut scenario, clock, btc_pool_id, usdc_pool_id, _r) = healthy_manager();
-
-    scenario.next_tx(test_constants::admin());
-    let mut vault = liquidation_vault::create_liquidation_vault_for_testing(scenario.ctx());
-    let cap = liquidation_vault::create_admin_cap_for_testing(scenario.ctx());
-    vault.deposit(
-        &cap,
-        mint_coin<USDC>(50_000 * test_constants::usdc_multiplier(), scenario.ctx()),
-    );
-
-    scenario.next_tx(test_constants::admin());
-    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
-    let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
-    let registry = scenario.take_shared<MarginRegistry>();
-    let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
-    let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
-
-    let stale_btc = build_stale_btc_price_info_object(&mut scenario, 50000, &clock, 600);
-    let usdc = build_demo_usdc_price_info_object(&mut scenario, &clock);
-
-    vault.liquidate_quote<BTC, USDC>(
-        &mut mm,
-        &registry,
-        &stale_btc,
-        &usdc,
-        &mut btc_pool,
-        &mut usdc_pool,
-        &mut pool,
-        option::none(),
-        &clock,
-        scenario.ctx(),
-    );
-
-    destroy(stale_btc);
-    destroy(usdc);
-    destroy(vault);
-    destroy(cap);
-    return_shared(btc_pool);
-    return_shared(usdc_pool);
-    return_shared(registry);
-    return_shared(pool);
-    return_shared(mm);
-    destroy(clock);
-    scenario.end();
-}
-
 /// The full settlement path, which nothing else in the package reaches.
 ///
 /// The two `*_rejects_a_stale_feed` tests abort inside `risk_ratio`, and the
@@ -363,65 +317,6 @@ fun liquidate_quote_upgraded_seizes_collateral_and_settles() {
     scenario.end();
 }
 
-/// The legacy entry on the same fixture at the same prices must settle to exactly the
-/// same numbers as its upgraded twin above. Asserting identical literals in both tests
-/// is what makes the twin invariant executable: `scripts/check_upgraded_parity.py`
-/// compares signatures, this compares outcomes. Change one body and one test breaks.
-#[test]
-fun liquidate_quote_settles_the_same_numbers_on_the_legacy_generation() {
-    let (mut scenario, clock, btc_pool_id, usdc_pool_id, _r) = healthy_manager();
-
-    scenario.next_tx(test_constants::admin());
-    let mut vault = liquidation_vault::create_liquidation_vault_for_testing(scenario.ctx());
-    let cap = liquidation_vault::create_admin_cap_for_testing(scenario.ctx());
-    vault.deposit(
-        &cap,
-        mint_coin<USDC>(50_000 * test_constants::usdc_multiplier(), scenario.ctx()),
-    );
-
-    scenario.next_tx(test_constants::admin());
-    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
-    let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
-    let registry = scenario.take_shared<MarginRegistry>();
-    let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
-    let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
-    let shares_before = mm.borrowed_quote_shares();
-
-    let btc = build_btc_price_info_object(&mut scenario, 3000, &clock);
-    let usdc = build_demo_usdc_price_info_object(&mut scenario, &clock);
-
-    vault.liquidate_quote<BTC, USDC>(
-        &mut mm,
-        &registry,
-        &btc,
-        &usdc,
-        &mut btc_pool,
-        &mut usdc_pool,
-        &mut pool,
-        option::none(),
-        &clock,
-        scenario.ctx(),
-    );
-
-    // Identical to `liquidate_quote_upgraded_seizes_collateral_and_settles`.
-    assert!(shares_before == 40_000_000_000);
-    assert!(mm.borrowed_quote_shares() == 5_000_000_000);
-    assert!(vault.balance<BTC>() == 0);
-    assert!(vault.balance<USDC>() == 50_700_000_000);
-
-    destroy(btc);
-    destroy(usdc);
-    destroy(vault);
-    destroy(cap);
-    return_shared(btc_pool);
-    return_shared(usdc_pool);
-    return_shared(registry);
-    return_shared(pool);
-    return_shared(mm);
-    destroy(clock);
-    scenario.end();
-}
-
 /// A base-debt manager: 50k USDC of collateral against a 0.8 BTC loan opened at $50k.
 fun manager_with_base_debt(): (test::Scenario, Clock, ID, ID) {
     let (
@@ -455,10 +350,10 @@ fun manager_with_base_debt(): (test::Scenario, Clock, ID, ID) {
     let pool = scenario.take_shared<Pool<BTC, USDC>>();
     let registry = scenario.take_shared<MarginRegistry>();
     let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
-    let btc = build_btc_price_info_object(&mut scenario, 50000, &clock);
-    let usdc = build_demo_usdc_price_info_object(&mut scenario, &clock);
+    let btc = build_btc_price_info_object_upgraded(&mut scenario, 50000, &clock);
+    let usdc = build_demo_usdc_price_info_object_upgraded(&mut scenario, &clock);
 
-    margin_manager::deposit<BTC, USDC, USDC>(
+    margin_manager_upgraded::deposit<BTC, USDC, USDC>(
         &mut mm,
         &registry,
         &btc,
@@ -467,7 +362,7 @@ fun manager_with_base_debt(): (test::Scenario, Clock, ID, ID) {
         &clock,
         scenario.ctx(),
     );
-    margin_manager::borrow_base<BTC, USDC>(
+    margin_manager_upgraded::borrow_base<BTC, USDC>(
         &mut mm,
         &registry,
         &mut btc_pool,
@@ -603,13 +498,60 @@ fun liquidate_base_upgraded_pays_out_and_returns_every_coin() {
     scenario.end();
 }
 
-/// The legacy base entry, same fixture and prices, must settle to the same numbers as
-/// its upgraded twin above — the base-side counterpart of
-/// `liquidate_quote_settles_the_same_numbers_on_the_legacy_generation`. It is also the
-/// only coverage of `liquidate_base`'s event, whose `margin_pool_id` would otherwise be
-/// free to report the quote pool.
-#[test]
-fun liquidate_base_settles_the_same_numbers_on_the_legacy_generation() {
+/// The vault's swap entrypoints are gated by `assert_trader`, and nothing exercised
+/// that gate through them: the three tests named for it in `liquidation_vault_tests`
+/// call `assert_trader_for_testing` directly, so deleting the check from
+/// `swap_base_to_quote` left the whole suite green. That check is the only thing
+/// between an arbitrary caller and swapping the vault's entire inventory with
+/// `min_quote_out` of zero.
+/// The legacy pair is retired. These two aborts are what closed the vault's half of the
+/// dual-feed window: the entries are permissionless and fund their own repay, so unlike
+/// `margin_manager::liquidate` they never needed the caller to bring capital.
+///
+/// Both are called on a fixture that is genuinely liquidatable at the price supplied —
+/// the same $3000 BTC that `liquidate_quote_upgraded_seizes_collateral_and_settles`
+/// settles on — so the abort is the retirement and not the `can_liquidate` gate
+/// declining to act.
+#[test, expected_failure(abort_code = liquidation_vault::EDeprecatedUseUpgradedPyth)]
+fun legacy_liquidate_quote_aborts() {
+    let (mut scenario, clock, btc_pool_id, usdc_pool_id, _r) = healthy_manager();
+
+    scenario.next_tx(test_constants::admin());
+    let mut vault = liquidation_vault::create_liquidation_vault_for_testing(scenario.ctx());
+    let cap = liquidation_vault::create_admin_cap_for_testing(scenario.ctx());
+    vault.deposit(
+        &cap,
+        mint_coin<USDC>(50_000 * test_constants::usdc_multiplier(), scenario.ctx()),
+    );
+
+    scenario.next_tx(test_constants::admin());
+    let mut mm = scenario.take_shared<MarginManager<BTC, USDC>>();
+    let mut pool = scenario.take_shared<Pool<BTC, USDC>>();
+    let registry = scenario.take_shared<MarginRegistry>();
+    let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
+    let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
+
+    let btc = build_btc_price_info_object(&mut scenario, 3000, &clock);
+    let usdc = build_demo_usdc_price_info_object(&mut scenario, &clock);
+
+    vault.liquidate_quote<BTC, USDC>(
+        &mut mm,
+        &registry,
+        &btc,
+        &usdc,
+        &mut btc_pool,
+        &mut usdc_pool,
+        &mut pool,
+        option::none(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    abort WRONG_ABORT_SENTINEL
+}
+
+#[test, expected_failure(abort_code = liquidation_vault::EDeprecatedUseUpgradedPyth)]
+fun legacy_liquidate_base_aborts() {
     let (mut scenario, clock, btc_pool_id, usdc_pool_id) = manager_with_base_debt();
 
     scenario.next_tx(test_constants::admin());
@@ -623,7 +565,6 @@ fun liquidate_base_settles_the_same_numbers_on_the_legacy_generation() {
     let registry = scenario.take_shared<MarginRegistry>();
     let mut btc_pool = scenario.take_shared_by_id<MarginPool<BTC>>(btc_pool_id);
     let mut usdc_pool = scenario.take_shared_by_id<MarginPool<USDC>>(usdc_pool_id);
-    let shares_before = mm.borrowed_base_shares();
 
     let btc = build_btc_price_info_object(&mut scenario, 700000, &clock);
     let usdc = build_demo_usdc_price_info_object(&mut scenario, &clock);
@@ -641,48 +582,9 @@ fun liquidate_base_settles_the_same_numbers_on_the_legacy_generation() {
         scenario.ctx(),
     );
 
-    // Identical to `liquidate_base_upgraded_pays_out_and_returns_every_coin`.
-    assert!(shares_before == 80_000_000);
-    assert!(mm.borrowed_base_shares() == 15_714_292);
-    assert!(vault.balance<BTC>() == 101_285_714);
-
-    let events = sui::event::events_by_type<LiquidationByVault>();
-    assert!(events.length() == 1);
-    let (
-        base_in,
-        quote_in,
-        base_out,
-        quote_out,
-        remaining,
-        base_liquidation,
-    ) = liquidation_vault::liquidation_event_fields(&events[0]);
-    assert!(base_liquidation);
-    assert!(quote_in == 0);
-    assert!(base_in == 100_000_000);
-    assert!(base_out == 67_499_994);
-    assert!(quote_out == 0);
-    assert!(remaining == 33_785_720);
-    assert!(liquidation_vault::liquidation_event_margin_pool_id(&events[0]) == btc_pool_id);
-
-    destroy(btc);
-    destroy(usdc);
-    destroy(vault);
-    destroy(cap);
-    return_shared(btc_pool);
-    return_shared(usdc_pool);
-    return_shared(registry);
-    return_shared(pool);
-    return_shared(mm);
-    destroy(clock);
-    scenario.end();
+    abort WRONG_ABORT_SENTINEL
 }
 
-/// The vault's swap entrypoints are gated by `assert_trader`, and nothing exercised
-/// that gate through them: the three tests named for it in `liquidation_vault_tests`
-/// call `assert_trader_for_testing` directly, so deleting the check from
-/// `swap_base_to_quote` left the whole suite green. That check is the only thing
-/// between an arbitrary caller and swapping the vault's entire inventory with
-/// `min_quote_out` of zero.
 #[test, expected_failure(abort_code = liquidation_vault::ETraderNotAuthorized)]
 fun swap_base_to_quote_rejects_an_unauthorised_caller() {
     let (mut scenario, clock, _btc_pool_id, _usdc_pool_id) = manager_with_base_debt();


### PR DESCRIPTION
## Summary

- Every `deepbook_margin` entrypoint that priced a position off legacy Pyth Core now aborts `EDeprecatedUseUpgradedPyth`: 12 in `margin_manager`, 8 in `pool_proxy`. Signatures are unchanged — Sui's `compatible` policy forbids removing them — and each retired entry names the `_upgraded` twin that replaces it.
- `margin_liquidation::liquidate_base` / `liquidate_quote` are retired the same way; `liquidate_base_upgraded` / `liquidate_quote_upgraded` are now the only way the vault can liquidate.
- `oracle::read_price` and `oracle::read_price_unsafe` are deleted. They were `public(package)` and had no callers left, so removing them means no code path in the package can read a legacy `PriceInfoObject` at all.
- `MARGIN_VERSION` goes 7 → 8.
- The behavioural test suites move onto the upgraded entrypoints with their coverage intact; `dual_feed_window_tests` is rewritten to pin the window closed; a new `legacy_pyth_entrypoints_disabled_tests` carries one abort test per retired entry.

## Why

Margin prices collateral through Pyth, and since the upgraded-Core migration it has carried two entrypoint families: one taking a legacy `PriceInfoObject`, one taking the upgraded type. Both were live and authoritative. Each reader enforced its own `max_age_secs` independently, with no cross-feed comparison, and `PythReading` erases which feed produced a price — so a caller chose per call between two marks that could sit a full staleness window apart, and the resulting loss lands on lender capital. The permissionless conditional-order executor is the widest leg: it needs no capital and no danger band.

This was expected to close on its own when Pyth stopped publishing legacy Core. It did not. Six days past the cutover, five of six registry-configured currencies were still fresh on **both** families in every sample taken over two minutes, kept alive by two third-party senders DeepBook does not control. Waiting is not a plan when the timeline belongs to someone else.

## Linear / Context

- DBU-756
- Completes the migration started in DBU-668 (#1170, #1171, #1211, #1218). Every first-party caller is on the upgraded family: `@mysten/deepbook-v3` 2.0.1, the price pusher, the liquidation stacks, and — under DBU-755, done — the TP/SL executor, which was the last one on legacy.

## Key decisions

- **Read-only entries are retired too** (`risk_ratio`, `risk_ratio_unsafe`, `manager_state`, `manager_states`). They cannot move funds, so retiring them is not required to close the exploit, and it does break any third-party `devInspect` caller still on legacy ids. Kept anyway: an off-chain liquidator reading a ratio off one feed while acting on the other is the same divergence one step removed, and leaving them live would mean keeping a legacy reader in the package for them to call.
- **The readers are deleted, not left unused.** Aborting the entrypoints is sufficient for the exploit; deleting `read_price`/`read_price_unsafe` is what makes a legacy read unrepresentable rather than merely unreachable. The cost is that `oracle_tests`' validation-policy tests move to `read_price_upgraded` — the assertions are unchanged, only the reader and the fixture type — and the legacy/upgraded reader-parity test is dropped, since there is no longer a second reader to compare against.
- **`margin_liquidation` is included** even though its two entries would abort transitively through `margin_manager::liquidate` anyway. They are permissionless and fund their own repay, which made them the one liquidation leg that never needed the caller to bring capital; an explicit abort names the reason instead of surfacing an opaque cross-package failure.
- **The version bump is the actual mechanism, not hygiene.** A package published against `deepbook_margin` v7 keeps calling v7's bodies through its own linkage table, so retiring the bodies in v8 does nothing for it. `disable_version(7)` is what takes the old entrypoints off chain.

## Scope / Descoped

- No registry or feed-id changes. Mainnet feed ids did not move across the upgraded-Core migration.
- Not multiple-oracle support (DBU-718). Single-oracle dependence is the structural issue this exposed and does not fix.
- The v1 `pool_proxy` stubs and `margin_manager::execute_conditional_orders` keep their existing `EDeprecatedUseV2`; that is a separate deprecation with its own abort code and its own test.
- On-chain retirement is a follow-up: this PR ships the code. Publishing v8, republishing `margin_liquidation` against it, moving the SDK's margin and liquidation package ids, and the `enable_version(8)` / `disable_version(7)` multisig calls are what make it take effect — see Risk / Rollout for the order.

## Test plan

- [x] `sui move test --gas-limit 100000000000 --path packages/deepbook_margin` — 477 tests pass (was 455; +22 net, and the whole behavioural suite now runs against the upgraded entrypoints).
- [x] `sui move test --gas-limit 100000000000 --path packages/margin_liquidation` — 25 tests pass.
- [x] CI's own loop over every package on the pinned toolchain (`testnet-v1.74.1`, per `SUI_VERSION` in `move_test.yml`) — all 12 packages green; a local `sui` 1.77.1 is not evidence CI is green.
- [x] `python3 .github/scripts/check_upgraded_parity.py` — passes, 20 `deepbook_margin` pairs and 2 `margin_liquidation` pairs found, so no retired signature drifted from its twin.
- [x] `legacy_pyth_entrypoints_disabled_tests` — one `expected_failure` per retired entry, each called with a **fresh, correctly-configured** legacy feed so nothing but the retirement can be blamed for the abort.
- [x] `dual_feed_window_tests` — the two exploit paths that previously succeeded (liquidate on the lower feed; fire a stop on the lower feed alone) now abort, each paired with a positive control (`upgraded_feed_alone_still_liquidates_an_unhealthy_manager`, `upgraded_executor_still_fires_a_triggered_stop`) so the aborts cannot pass against a package where liquidation or the executor is simply broken.
- [x] `pnpm format:move` via the repo-pinned formatter — clean.

## Risk / Rollout

- **Breaking by design for anyone still on the legacy entrypoints.** Every retired entry aborts with a named, greppable code rather than failing deep inside the oracle. Every first-party caller is already on the upgraded family (see Linear / Context).
- **The version gate retires whole packages, not functions.** `disable_version(7)` makes every entry of the v7 package abort `EPackageVersionDisabled` for anything that still resolves to the v7 package id — repay, cancels, referrals and getters included, not only the oracle-taking entries. The deployed mainnet `margin_liquidation` (v5) links `deepbook_margin` at v7 in its linkage table, so its `_upgraded` entries stop working at that same call unless it has been republished against v8 first; the SDK's margin and liquidation package ids and any integrator package are in the same position.
- **Rollout order:** publish v8 → `enable_version(8)` → republish `margin_liquidation` against v8 and repoint the SDK's margin and liquidation package ids → confirm the migrated services are healthy on v8 → `disable_version(7)`. Until that last call, v7 stays reachable and the window stays open for anything linked against it, so the deploy is not finished when the package is published. Until `margin_liquidation` is republished, its legacy vault entries on chain still run v7's live bodies rather than the aborts in this PR.
- **Rollback:** re-enabling v7 restores the old behaviour for callers on the v7 id, since the version gate is what governs reachability — and re-opens the window with it. There is no state migration and no object-layout change.
