### PR TITLE
predict: make PLP flush valuation resumable (DBU-754)

### DIFF
--- a/packages/predict/sources/config/protocol_config.move
+++ b/packages/predict/sources/config/protocol_config.move
@@ -5,7 +5,7 @@
 ///
 /// This shared object owns the admin-tunable config structs, the trading pause
 /// gate, the protocol-wide emergency freeze, and the transaction-local full-pool
-/// valuation lock. Flow modules decide which gates apply before they mutate
+/// snapshot lock. Flow modules decide which gates apply before they mutate
 /// expiry, oracle, pool, or account state.
 module deepbook_predict::protocol_config;
 
@@ -21,8 +21,8 @@ use deepbook_predict::{
 use sui::clock::Clock;
 
 const ETradingPaused: u64 = 0;
-const EValuationInProgress: u64 = 1;
-const EValuationNotInProgress: u64 = 2;
+const ESnapshotInProgress: u64 = 1;
+const ESnapshotNotInProgress: u64 = 2;
 const EPackageVersionDisabled: u64 = 3;
 const EVersionWatermarkNotAdvanced: u64 = 4;
 const EProtocolFrozen: u64 = 5;
@@ -73,9 +73,9 @@ public struct ProtocolConfig has key {
     /// Account-package custody withdrawals and builder-fee claims are ungated and
     /// stay available (already-earned funds).
     frozen: bool,
-    /// Transaction-local lock held while a full-pool valuation is assembled, so no
-    /// NAV-changing op can interleave between per-market value steps in the PTB.
-    valuation_in_progress: bool,
+    /// Transaction-local lock held while a full-pool snapshot is assembled, so no
+    /// NAV-changing operation can interleave between its per-market preparation steps.
+    snapshot_in_progress: bool,
 }
 
 // === Public Functions ===
@@ -223,7 +223,7 @@ public fun set_template_max_entry_probability(
 
 /// Select which source the live forward is built from: `true` carries the Block
 /// Scholes basis on a fresh Pyth spot, `false` uses the Block Scholes forward
-/// directly. Locked during valuation so one flush marks every market on one formula.
+/// directly. Locked during snapshotting so one flush marks every market on one formula.
 public fun set_use_pyth_spot_for_forward(
     config: &mut ProtocolConfig,
     _admin_cap: &AdminCap,
@@ -231,7 +231,7 @@ public fun set_use_pyth_spot_for_forward(
     clock: &Clock,
 ) {
     config.assert_version();
-    config.assert_not_valuation_in_progress();
+    config.assert_not_snapshot_in_progress();
     config.pricing_config.set_use_pyth_spot_for_forward(enabled);
     config_events::emit_pricing_config_updated(&config.pricing_config, clock.timestamp_ms());
 }
@@ -244,7 +244,7 @@ public fun set_pyth_spot_freshness_ms(
     clock: &Clock,
 ) {
     config.assert_version();
-    config.assert_not_valuation_in_progress();
+    config.assert_not_snapshot_in_progress();
     config.pricing_config.set_pyth_spot_freshness_ms(value);
     config_events::emit_pricing_config_updated(&config.pricing_config, clock.timestamp_ms());
 }
@@ -257,7 +257,7 @@ public fun set_block_scholes_price_freshness_ms(
     clock: &Clock,
 ) {
     config.assert_version();
-    config.assert_not_valuation_in_progress();
+    config.assert_not_snapshot_in_progress();
     config.pricing_config.set_block_scholes_price_freshness_ms(value);
     config_events::emit_pricing_config_updated(&config.pricing_config, clock.timestamp_ms());
 }
@@ -270,7 +270,7 @@ public fun set_block_scholes_svi_freshness_ms(
     clock: &Clock,
 ) {
     config.assert_version();
-    config.assert_not_valuation_in_progress();
+    config.assert_not_snapshot_in_progress();
     config.pricing_config.set_block_scholes_svi_freshness_ms(value);
     config_events::emit_pricing_config_updated(&config.pricing_config, clock.timestamp_ms());
 }
@@ -285,9 +285,6 @@ public fun set_lp_request_limit_flush_attempts(
     attempts: u64,
 ) {
     config.assert_version();
-    // The flush reads this value mid-PTB; refuse to move it under a valuation in
-    // flight, as the other setters a flush reads from do.
-    config.assert_not_valuation_in_progress();
     config_constants::assert_lp_request_limit_flush_attempts(attempts);
     config.lp_request_limit_flush_attempts = attempts;
 }
@@ -303,8 +300,6 @@ public fun set_max_lp_pool_value(
     max_pool_value: u64,
 ) {
     config.assert_version();
-    // The flush reads this mid-PTB, like the attempt count.
-    config.assert_not_valuation_in_progress();
     config_constants::assert_max_lp_pool_value(max_pool_value);
     config.max_lp_pool_value = max_pool_value;
 }
@@ -369,7 +364,7 @@ public fun set_protocol_reserve_profit_share(
     protocol_reserve_profit_share: u64,
 ) {
     config.assert_version();
-    config.assert_not_valuation_in_progress();
+    config.assert_not_snapshot_in_progress();
     config_constants::assert_protocol_reserve_profit_share(protocol_reserve_profit_share);
     config.protocol_reserve_profit_share = protocol_reserve_profit_share;
 }
@@ -383,8 +378,7 @@ public fun set_referral_fee_rate(config: &mut ProtocolConfig, _admin_cap: &Admin
 }
 
 /// Set the fee charged on executed PLP supply fills. Admin-gated and validated
-/// against its config-constants envelope. Locked during valuation so the rate a
-/// flush froze into its mark cannot change midway through that flush.
+/// against its config-constants envelope.
 public fun set_plp_supply_fee_rate(
     config: &mut ProtocolConfig,
     _admin_cap: &AdminCap,
@@ -392,7 +386,6 @@ public fun set_plp_supply_fee_rate(
     clock: &Clock,
 ) {
     config.assert_version();
-    config.assert_not_valuation_in_progress();
     config_constants::assert_plp_supply_fee_rate(rate);
     config.plp_supply_fee_rate = rate;
     config_events::emit_plp_fee_rates_updated(
@@ -402,8 +395,8 @@ public fun set_plp_supply_fee_rate(
     );
 }
 
-/// Set the fee charged on executed PLP withdraw fills. Same gating as the supply
-/// leg; the two are independent so the exit charge can move without taxing entry.
+/// Set the fee charged on executed PLP withdraw fills. The two legs are independent
+/// so the exit charge can move without taxing entry.
 public fun set_plp_withdraw_fee_rate(
     config: &mut ProtocolConfig,
     _admin_cap: &AdminCap,
@@ -411,7 +404,6 @@ public fun set_plp_withdraw_fee_rate(
     clock: &Clock,
 ) {
     config.assert_version();
-    config.assert_not_valuation_in_progress();
     config_constants::assert_plp_withdraw_fee_rate(rate);
     config.plp_withdraw_fee_rate = rate;
     config_events::emit_plp_fee_rates_updated(
@@ -479,14 +471,14 @@ public(package) fun assert_trading_allowed(config: &ProtocolConfig) {
     config.assert_not_trading_paused();
 }
 
-/// Abort unless a valuation lock is currently active.
-public(package) fun assert_valuation_in_progress(config: &ProtocolConfig) {
-    assert!(config.valuation_in_progress, EValuationNotInProgress);
+/// Abort unless a snapshot lock is currently active.
+public(package) fun assert_snapshot_in_progress(config: &ProtocolConfig) {
+    assert!(config.snapshot_in_progress, ESnapshotNotInProgress);
 }
 
-/// Abort unless no valuation lock is currently active.
-public(package) fun assert_not_valuation_in_progress(config: &ProtocolConfig) {
-    assert!(!config.valuation_in_progress, EValuationInProgress);
+/// Abort unless no snapshot lock is currently active.
+public(package) fun assert_not_snapshot_in_progress(config: &ProtocolConfig) {
+    assert!(!config.snapshot_in_progress, ESnapshotInProgress);
 }
 
 /// Create and share the protocol-wide configuration object.
@@ -509,16 +501,16 @@ public(package) fun freeze_protocol(config: &mut ProtocolConfig) {
     config.set_frozen_internal(true);
 }
 
-/// Begin a transaction-local full-pool valuation lock.
-public(package) fun begin_valuation(config: &mut ProtocolConfig) {
-    config.assert_not_valuation_in_progress();
-    config.valuation_in_progress = true;
+/// Begin a transaction-local full-pool snapshot lock.
+public(package) fun begin_snapshot(config: &mut ProtocolConfig) {
+    config.assert_not_snapshot_in_progress();
+    config.snapshot_in_progress = true;
 }
 
-/// End a transaction-local full-pool valuation lock.
-public(package) fun end_valuation(config: &mut ProtocolConfig) {
-    config.assert_valuation_in_progress();
-    config.valuation_in_progress = false;
+/// End a transaction-local full-pool snapshot lock.
+public(package) fun end_snapshot(config: &mut ProtocolConfig) {
+    config.assert_snapshot_in_progress();
+    config.snapshot_in_progress = false;
 }
 
 fun set_trading_paused_internal(config: &mut ProtocolConfig, paused: bool) {
@@ -551,6 +543,6 @@ fun new(ctx: &mut TxContext): ProtocolConfig {
         version_watermark: constants::current_version!(),
         trading_paused: false,
         frozen: false,
-        valuation_in_progress: false,
+        snapshot_in_progress: false,
     }
 }

--- a/packages/predict/sources/events/vault_events.move
+++ b/packages/predict/sources/events/vault_events.move
@@ -155,8 +155,10 @@ public struct WithdrawFilled has copy, drop, store {
 public struct FlushExecuted has copy, drop, store {
     pool_vault_id: ID,
     epoch: u64,
+    /// Pool snapshot generation that produced this mark.
+    snapshot_seq: u64,
     /// LP-attributable pool NAV every fill was priced at: idle plus
-    /// `active_market_nav`, excluding unrealized and pending protocol profit.
+    /// snapshotted market cash, less marked liability and protocol-owned profit.
     pool_value: u64,
     /// PLP supply in the frozen pre-drain mark used to price every fill.
     total_supply: u64,
@@ -165,12 +167,6 @@ public struct FlushExecuted has copy, drop, store {
     supply_fee_rate: u64,
     /// Withdraw-leg fee rate in FLOAT_SCALING, frozen alongside it.
     withdraw_fee_rate: u64,
-    /// Sum of the marked NAV contributed by each active market; settled markets add zero.
-    active_market_nav: u64,
-    /// Number of active markets valued for this flush.
-    market_count: u64,
-    /// Idle DUSDC held by the pool at valuation time, before the drain.
-    idle_balance_before: u64,
     supplies_filled: u64,
     withdrawals_filled: u64,
     requests_processed: u64,
@@ -408,13 +404,11 @@ public(package) fun emit_withdraw_filled(
 public(package) fun emit_flush_executed(
     pool_vault_id: ID,
     epoch: u64,
+    snapshot_seq: u64,
     pool_value: u64,
     total_supply: u64,
     supply_fee_rate: u64,
     withdraw_fee_rate: u64,
-    active_market_nav: u64,
-    market_count: u64,
-    idle_balance_before: u64,
     supplies_filled: u64,
     withdrawals_filled: u64,
     requests_processed: u64,
@@ -424,13 +418,11 @@ public(package) fun emit_flush_executed(
     event::emit(FlushExecuted {
         pool_vault_id,
         epoch,
+        snapshot_seq,
         pool_value,
         total_supply,
         supply_fee_rate,
         withdraw_fee_rate,
-        active_market_nav,
-        market_count,
-        idle_balance_before,
         supplies_filled,
         withdrawals_filled,
         requests_processed,

--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -691,10 +691,11 @@ public(package) fun set_snapshot_pricer(
     market.strike_exposure.set_snapshot_pricer(pricer, snapshot_seq);
 }
 
-/// Return the marked liability from this market's frozen pricer and position view.
-/// Frozen cash accounting remains the pool valuation's responsibility.
-public(package) fun snapshot_marked_liability(market: &ExpiryMarket): u64 {
-    market.strike_exposure.snapshot_marked_liability()
+/// Return the marked liability from this market's frozen pricer and position view,
+/// consuming the snapshot. Frozen cash accounting remains the pool valuation's
+/// responsibility.
+public(package) fun consume_snapshot_marked_liability(market: &mut ExpiryMarket): u64 {
+    market.strike_exposure.consume_snapshot_marked_liability()
 }
 
 /// Return cash available to PLP NAV after excluding the inventory-impact escrow.

--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -588,7 +588,7 @@ public fun set_reference_tick(
     clock: &Clock,
 ): u64 {
     config.assert_version();
-    config.assert_not_valuation_in_progress();
+    config.assert_not_snapshot_in_progress();
 
     let source_timestamp_ms = market.strike_exposure.reference_tick_source_timestamp_ms();
     let spot = pricing::load_exact_spot(
@@ -680,6 +680,27 @@ public fun try_settle(
 }
 
 // === Public-Package Functions ===
+
+/// Freeze this market's bound pricer in its payout tree, starting a lazy position snapshot.
+public(package) fun set_snapshot_pricer(
+    market: &mut ExpiryMarket,
+    pricer: Pricer,
+    snapshot_seq: u64,
+) {
+    market.assert_pricer_bound(&pricer);
+    market.strike_exposure.set_snapshot_pricer(pricer, snapshot_seq);
+}
+
+/// Return the marked liability from this market's frozen pricer and position view.
+/// Frozen cash accounting remains the pool valuation's responsibility.
+public(package) fun snapshot_marked_liability(market: &ExpiryMarket): u64 {
+    market.strike_exposure.snapshot_marked_liability()
+}
+
+/// Return cash available to PLP NAV after excluding the inventory-impact escrow.
+public(package) fun free_cash(market: &ExpiryMarket): u64 {
+    market.cash.free_cash()
+}
 
 /// Force `mint_paused = true` through the registry's `PauseCap` path. This cannot
 /// unpause and does not apply the package-version gate.
@@ -779,13 +800,13 @@ fun assert_live_mint_allowed(market: &ExpiryMarket, config: &ProtocolConfig, pri
 
 fun assert_live_flow_allowed(market: &ExpiryMarket, config: &ProtocolConfig, pricer: &Pricer) {
     config.assert_version();
-    config.assert_not_valuation_in_progress();
+    config.assert_not_snapshot_in_progress();
     market.assert_pricer_bound(pricer);
 }
 
 fun assert_settled_flow_allowed(market: &ExpiryMarket, config: &ProtocolConfig) {
     config.assert_version();
-    config.assert_not_valuation_in_progress();
+    config.assert_not_snapshot_in_progress();
     assert!(market.is_settled(), EMarketNotSettled);
 }
 

--- a/packages/predict/sources/plp/lp_book.move
+++ b/packages/predict/sources/plp/lp_book.move
@@ -45,6 +45,9 @@ public struct RequestEntry has copy, drop, store {
     recipient: address,
     amount: u64,
     min_output: u64,
+    /// Pool snapshot generation current when this request entered the queue. A
+    /// valuation may process it only after the pool advances to a later generation.
+    request_seq: u64,
     /// Frozen marks this request has already missed. Only ever non-zero when the
     /// protocol allows more than one attempt (`ProtocolConfig`), since at one
     /// attempt a miss refunds immediately.
@@ -146,9 +149,12 @@ public(package) fun request_supply<LP>(
     account_id: ID,
     recipient: address,
     min_plp_out: u64,
+    request_seq: u64,
 ): u64 {
     assert!(payment.value() >= constants::min_supply_request!(), EBelowMinSupplyRequest);
-    book.supply_queue.enqueue(account_id, recipient, payment.into_balance(), min_plp_out)
+    book
+        .supply_queue
+        .enqueue(account_id, recipient, payment.into_balance(), min_plp_out, request_seq)
 }
 
 public(package) fun request_withdraw<LP>(
@@ -157,9 +163,12 @@ public(package) fun request_withdraw<LP>(
     account_id: ID,
     recipient: address,
     min_dusdc_out: u64,
+    request_seq: u64,
 ): u64 {
     assert!(lp.value() >= constants::min_withdraw_request!(), EBelowMinWithdrawRequest);
-    book.withdraw_queue.enqueue(account_id, recipient, lp.into_balance(), min_dusdc_out)
+    book
+        .withdraw_queue
+        .enqueue(account_id, recipient, lp.into_balance(), min_dusdc_out, request_seq)
 }
 
 public(package) fun cancel_supply_request<LP>(
@@ -242,6 +251,8 @@ public(package) fun requests_processed(summary: &DrainSummary): u64 {
 ///
 /// Supplies run first on purpose: their fresh idle cash funds same-flush withdrawals.
 /// User-cancelled requests are removed at cancel time and never spend flush capacity.
+/// Each queue stops at its first request that does not precede `snapshot_seq`,
+/// leaving that request and every later one for the next mark.
 /// Every fill is charged its leg's frozen fee rate on the DUSDC it actually fills —
 /// the slice, not the whole request, when the fill is partial. The two legs carry
 /// independent rates and the supply leg ships at zero. Refunded and still-queued
@@ -252,6 +263,7 @@ public(package) fun drain<LP>(
     mark: FlushMark,
     fees: FeeRates,
     pool_vault_id: ID,
+    snapshot_seq: u64,
     supply_budget: Option<u64>,
     withdraw_budget: Option<u64>,
     max_limit_misses: u64,
@@ -264,6 +276,7 @@ public(package) fun drain<LP>(
         &mark,
         &fees,
         pool_vault_id,
+        snapshot_seq,
         &supply_budget,
         max_limit_misses,
         max_pool_value,
@@ -274,6 +287,7 @@ public(package) fun drain<LP>(
         &mark,
         &fees,
         pool_vault_id,
+        snapshot_seq,
         &withdraw_budget,
         max_limit_misses,
         ctx,
@@ -292,6 +306,7 @@ fun drain_supply_queue<LP>(
     mark: &FlushMark,
     fees: &FeeRates,
     pool_vault_id: ID,
+    snapshot_seq: u64,
     budget: &Option<u64>,
     max_limit_misses: u64,
     max_pool_value: u64,
@@ -306,6 +321,7 @@ fun drain_supply_queue<LP>(
 
     while (under_budget(budget, processed) && !book.supply_queue.is_empty()) {
         let request = book.supply_queue.front_request();
+        if (request.request_seq >= snapshot_seq) break;
         let quote = mark.quote_supply_shares(fees, request.amount);
         if (quote.is_none()) {
             processed = processed + 1;
@@ -428,6 +444,7 @@ fun drain_withdraw_queue<LP>(
     mark: &FlushMark,
     fees: &FeeRates,
     pool_vault_id: ID,
+    snapshot_seq: u64,
     budget: &Option<u64>,
     max_limit_misses: u64,
     ctx: &mut TxContext,
@@ -437,6 +454,7 @@ fun drain_withdraw_queue<LP>(
 
     while (under_budget(budget, processed) && !book.withdraw_queue.is_empty()) {
         let request = book.withdraw_queue.front_request();
+        if (request.request_seq >= snapshot_seq) break;
         let quote = mark.quote_withdraw_dusdc(fees, request.amount);
         if (quote.is_none()) {
             quote.destroy_none();
@@ -648,6 +666,7 @@ fun enqueue<T>(
     recipient: address,
     escrow: Balance<T>,
     min_output: u64,
+    request_seq: u64,
 ): u64 {
     let index = queue.next_index;
     queue.next_index = index + 1;
@@ -663,6 +682,7 @@ fun enqueue<T>(
             recipient,
             amount,
             min_output,
+            request_seq,
             missed_flushes: 0,
         });
     queue.escrow.join(escrow);

--- a/packages/predict/sources/plp/plp.move
+++ b/packages/predict/sources/plp/plp.move
@@ -86,10 +86,8 @@ public struct PoolSnapshot {
 
 /// Frozen pool-price function awaiting zero or more per-market liability walks.
 public struct PoolValuation has store {
-    assets_before_liability: u64,
-    profit_before_liability: u64,
-    protocol_profit_share: u64,
-    aggregate_liability: u64,
+    assets_remaining: u64,
+    profit_remaining: u64,
     pending_markets: vector<ID>,
 }
 
@@ -259,7 +257,7 @@ public fun snapshot_expiry(
 
 /// Consume the atomic snapshot builder after every market has frozen its cash and
 /// pricer. All pool and queue inputs are reduced to the constants needed to finish
-/// pricing from aggregate liability, then the snapshot lock is released.
+/// pricing as each market liability arrives, then the snapshot lock is released.
 public fun finish_pool_snapshot(
     snapshot: PoolSnapshot,
     vault: &mut PoolVault,
@@ -278,19 +276,17 @@ public fun finish_pool_snapshot(
     assert!(unprepared_markets.is_empty(), EMissingExpiryValuation);
     unprepared_markets.destroy_empty();
 
-    let assets_before_liability = (
+    let assets_remaining = (
         vault.expiry_accounting.idle_balance() + aggregate_market_cash,
     ).saturating_sub(vault.expiry_accounting.pending_protocol_profit());
-    let profit_before_liability = (
+    let profit_remaining = (
         vault.expiry_accounting.profit_basis_credits() + aggregate_market_cash,
     ).saturating_sub(vault.expiry_accounting.profit_basis_debits());
     vault
         .valuation
         .fill(PoolValuation {
-            assets_before_liability,
-            profit_before_liability,
-            protocol_profit_share: config.protocol_reserve_profit_share(),
-            aggregate_liability: 0,
+            assets_remaining,
+            profit_remaining,
             pending_markets,
         });
     config.end_snapshot();
@@ -305,8 +301,9 @@ public fun value_expiry(vault: &mut PoolVault, market: &mut ExpiryMarket, config
     let index = valuation.pending_markets.find_index!(|id| *id == market.id());
     if (index.is_none()) return;
     let index = index.destroy_some();
-    valuation.aggregate_liability =
-        valuation.aggregate_liability + market.consume_snapshot_marked_liability();
+    let liability = market.consume_snapshot_marked_liability();
+    valuation.assets_remaining = valuation.assets_remaining.saturating_sub(liability);
+    valuation.profit_remaining = valuation.profit_remaining.saturating_sub(liability);
     valuation.pending_markets.swap_remove(index);
 }
 
@@ -345,22 +342,18 @@ public fun finish_flush(
     if (vault.valuation.is_none()) return option::none();
     let valuation = vault.valuation.extract();
     let PoolValuation {
-        assets_before_liability,
-        profit_before_liability,
-        protocol_profit_share,
-        aggregate_liability,
+        assets_remaining,
+        profit_remaining,
         pending_markets,
     } = valuation;
     assert!(pending_markets.is_empty(), EMissingExpiryValuation);
     pending_markets.destroy_empty();
 
     let protocol_exclusion = math::mul_down(
-        profit_before_liability.saturating_sub(aggregate_liability),
-        protocol_profit_share,
+        profit_remaining,
+        config.protocol_reserve_profit_share(),
     );
-    let pool_value = assets_before_liability
-        .saturating_sub(aggregate_liability)
-        .saturating_sub(protocol_exclusion);
+    let pool_value = assets_remaining.saturating_sub(protocol_exclusion);
     // Only this drain can mint or burn PLP while a valuation is stored, so supply
     // is unchanged from the snapshot and needs only one pre-drain sample.
     let total_supply = vault.lp.total_supply();

--- a/packages/predict/sources/plp/plp.move
+++ b/packages/predict/sources/plp/plp.move
@@ -296,9 +296,9 @@ public fun finish_pool_snapshot(
     config.end_snapshot();
 }
 
-/// Add one pending market's frozen liability to the pool aggregate. Calls without
-/// a current valuation, markets outside it, and repeated calls are no-ops.
-public fun value_expiry(vault: &mut PoolVault, market: &ExpiryMarket, config: &ProtocolConfig) {
+/// Consume one pending market's frozen liability into the pool aggregate. Calls
+/// without a current valuation, markets outside it, and repeated calls are no-ops.
+public fun value_expiry(vault: &mut PoolVault, market: &mut ExpiryMarket, config: &ProtocolConfig) {
     config.assert_version();
     if (vault.valuation.is_none()) return;
     let valuation = vault.valuation.borrow_mut();
@@ -306,7 +306,7 @@ public fun value_expiry(vault: &mut PoolVault, market: &ExpiryMarket, config: &P
     if (index.is_none()) return;
     let index = index.destroy_some();
     valuation.aggregate_liability =
-        valuation.aggregate_liability + market.snapshot_marked_liability();
+        valuation.aggregate_liability + market.consume_snapshot_marked_liability();
     valuation.pending_markets.swap_remove(index);
 }
 

--- a/packages/predict/sources/plp/plp.move
+++ b/packages/predict/sources/plp/plp.move
@@ -6,7 +6,8 @@
 /// PoolVault owns the PLP treasury cap, idle
 /// DUSDC, the protocol reserve, sponsor-funded fee incentives, per-expiry cash
 /// accounting, and the queued LP supply/withdraw requests. It coordinates the
-/// full-pool NAV valuation (a hot-potato aggregation over every active market) and
+/// full-pool NAV valuation (an atomic snapshot followed by resumable per-market
+/// liability walks) and
 /// the unified per-market cash flow (initial funding, live rebalance/sweep, and
 /// settled-market sweep with terminal profit materialization). LPs queue
 /// supply/withdraw requests routed through a loaded Account; each flush
@@ -40,15 +41,15 @@ use sui::{
     coin_registry::{Self, MetadataCap}
 };
 
-const EExpiryMarketNotActive: u64 = 0;
-const EExpiryMarketAlreadyValued: u64 = 1;
-const EWrongPoolVault: u64 = 2;
-const EMissingExpiryValuation: u64 = 3;
-const ENotBootstrapped: u64 = 4;
-const EAlreadyBootstrapped: u64 = 5;
-const EBelowMinBootstrapLiquidity: u64 = 6;
-const EBelowMinFeeIncentiveSponsorship: u64 = 7;
-const EMaxLiveExpiryMarketsExceeded: u64 = 8;
+const EWrongPoolVault: u64 = 0;
+const EMissingExpiryValuation: u64 = 1;
+const ENotBootstrapped: u64 = 2;
+const EAlreadyBootstrapped: u64 = 3;
+const EBelowMinBootstrapLiquidity: u64 = 4;
+const EBelowMinFeeIncentiveSponsorship: u64 = 5;
+const EMaxLiveExpiryMarketsExceeded: u64 = 6;
+const EPoolValuationAlreadyStored: u64 = 7;
+const EPoolValuationInProgress: u64 = 8;
 
 /// One-time witness type for Predict LP token registration.
 public struct PLP has drop {}
@@ -65,23 +66,31 @@ public struct PoolVault has key {
     lp: LpBook<PLP>,
     /// Idle DUSDC custody, registered expiries, and per-expiry cash-flow rows.
     expiry_accounting: Ledger,
+    /// Canonical flush generation. Snapshot start increments it atomically;
+    /// requests record the current value and only earlier generations may drain.
+    snapshot_seq: u64,
+    /// Durable valuation prepared by one atomic snapshot transaction and filled
+    /// by resumable per-market liability walks.
+    valuation: Option<PoolValuation>,
 }
 
-/// Transaction-local full-pool NAV valuation hot potato.
-///
-/// `start_pool_valuation` snapshots the active expiry set; each `value_expiry`
-/// runs the per-market cash flush then folds that market's NAV into `total_nav`
-/// exactly once (a swept settled market contributes 0); `finish_flush` proves every
-/// snapshotted market was valued, returns the LP-attributable pool NAV, and drains
-/// the LP queues against it. Has no abilities, so it must be consumed by the finisher.
-public struct PoolValuation {
+/// Transaction-local snapshot builder. Its lack of abilities requires every
+/// market's pricer and cash state to be prepared atomically before the inner
+/// valuation can be stored in `PoolVault`.
+public struct PoolSnapshot {
     pool_vault_id: ID,
-    /// Active expiry markets snapshotted at start; every one must be valued.
-    expected_expiry_markets: vector<ID>,
-    /// Markets valued so far this flow; folded against `expected` at finish.
-    valued_expiry_markets: vector<ID>,
-    /// Running Σ of each valued market's NAV (settled markets contribute 0).
-    total_nav: u64,
+    unprepared_markets: vector<ID>,
+    pending_markets: vector<ID>,
+    aggregate_market_cash: u64,
+}
+
+/// Frozen pool-price function awaiting zero or more per-market liability walks.
+public struct PoolValuation has store {
+    assets_before_liability: u64,
+    profit_before_liability: u64,
+    protocol_profit_share: u64,
+    aggregate_liability: u64,
+    pending_markets: vector<ID>,
 }
 
 // === Package Initializer ===
@@ -119,6 +128,8 @@ fun create_and_share_vault(treasury_cap: TreasuryCap<PLP>, ctx: &mut TxContext):
         fee_incentive_reserve: balance::zero(),
         lp: lp_book::new(treasury_cap, ctx),
         expiry_accounting: pool_accounting::new(ctx),
+        snapshot_seq: 0,
+        valuation: option::none(),
     };
     let vault_id = vault.id();
     transfer::share_object(vault);
@@ -187,30 +198,29 @@ public fun pending_protocol_profit(vault: &PoolVault): u64 {
     vault.expiry_accounting.pending_protocol_profit()
 }
 
-/// Begin a full-pool valuation using a registry-issued lifecycle proof. The proof
-/// grants control over when current oracle state is frozen for queued LP fills.
-/// Starting engages the transaction-local valuation lock and snapshots every
-/// active expiry that must be included before the queues can drain.
+/// Begin the atomic snapshot stage using a registry-issued lifecycle proof. The
+/// returned hot potato fixes the active market set and increments the vault's
+/// canonical snapshot sequence. Every market must be prepared before its valuation
+/// can become durable.
 public fun start_pool_valuation(
     config: &mut ProtocolConfig,
-    vault: &PoolVault,
+    vault: &mut PoolVault,
     lifecycle_proof: MarketLifecycleProof,
-): PoolValuation {
+): PoolSnapshot {
     config.assert_version();
     lifecycle_proof.destroy_proof();
     start_pool_valuation_internal(config, vault)
 }
 
-/// Run the per-market cash flow for one snapshotted market, then fold its NAV into
-/// the running total. The market must be in the snapshot and not already valued.
-/// A settled market is swept
-/// (deactivated, cash returned, profit materialized) and contributes 0; a live
-/// market is rebalanced to target and valued on its current cash.
+/// Prepare one market inside the atomic snapshot transaction. A stale market that
+/// is no longer in the active set is skipped. A settled market is swept out of the
+/// set; a live market contributes its cash to the aggregate and stores its bound
+/// pricer in the payout tree, leaving only the expensive liability walk unfilled.
 ///
 /// Settlement is a separate PTB step through `expiry_market::try_settle`. An
 /// expired unsettled market cannot produce the live pricer required here.
-public fun value_expiry(
-    valuation: &mut PoolValuation,
+public fun snapshot_expiry(
+    snapshot: &mut PoolSnapshot,
     vault: &mut PoolVault,
     market: &mut ExpiryMarket,
     config: &ProtocolConfig,
@@ -222,13 +232,15 @@ public fun value_expiry(
     ctx: &TxContext,
 ) {
     config.assert_version();
-    config.assert_valuation_in_progress();
+    config.assert_snapshot_in_progress();
     let expiry_market_id = market.id();
-    valuation.assert_expiry_ready_to_value(expiry_market_id);
+    snapshot.assert_pool_vault(vault);
+    let index = snapshot.unprepared_markets.find_index!(|id| *id == expiry_market_id);
+    if (index.is_none()) return;
+    let index = index.destroy_some();
     vault.expiry_accounting.assert_registered_expiry(expiry_market_id);
-    let nav = if (vault.sweep_or_rebalance_expiry(market, config, clock)) {
-        0
-    } else {
+    let settled = vault.sweep_or_rebalance_expiry(market, config, clock);
+    if (!settled) {
         let pricer = market.load_live_pricer(
             config,
             propbook_registry,
@@ -238,18 +250,71 @@ public fun value_expiry(
             clock,
             ctx,
         );
-        market.current_nav(&pricer)
+        market.set_snapshot_pricer(pricer, vault.snapshot_seq);
+        snapshot.aggregate_market_cash = snapshot.aggregate_market_cash + market.free_cash();
+        snapshot.pending_markets.push_back(expiry_market_id);
     };
-    valuation.valued_expiry_markets.push_back(expiry_market_id);
-    valuation.total_nav = valuation.total_nav + nav;
+    snapshot.unprepared_markets.swap_remove(index);
 }
 
-/// Finish a full-pool valuation and run the LP flush: prove every snapshotted market
-/// was valued exactly once, price the pool NAV, then drain the supply/withdraw queues
-/// at that frozen mark (mint PLP for supplies, burn PLP and pay DUSDC for
-/// withdrawals), release the valuation lock, consume the potato, and return the
-/// LP-attributable pool-wide DUSDC NAV (idle + Σ active NAV, net of the
-/// pending-protocol-profit exclusion priced from the aggregate profit basis).
+/// Consume the atomic snapshot builder after every market has frozen its cash and
+/// pricer. All pool and queue inputs are reduced to the constants needed to finish
+/// pricing from aggregate liability, then the snapshot lock is released.
+public fun finish_pool_snapshot(
+    snapshot: PoolSnapshot,
+    vault: &mut PoolVault,
+    config: &mut ProtocolConfig,
+) {
+    config.assert_version();
+    config.assert_snapshot_in_progress();
+    snapshot.assert_pool_vault(vault);
+    assert!(vault.valuation.is_none(), EPoolValuationAlreadyStored);
+    let PoolSnapshot {
+        unprepared_markets,
+        pending_markets,
+        aggregate_market_cash,
+        ..,
+    } = snapshot;
+    assert!(unprepared_markets.is_empty(), EMissingExpiryValuation);
+    unprepared_markets.destroy_empty();
+
+    let assets_before_liability = (
+        vault.expiry_accounting.idle_balance() + aggregate_market_cash,
+    ).saturating_sub(vault.expiry_accounting.pending_protocol_profit());
+    let profit_before_liability = (
+        vault.expiry_accounting.profit_basis_credits() + aggregate_market_cash,
+    ).saturating_sub(vault.expiry_accounting.profit_basis_debits());
+    vault
+        .valuation
+        .fill(PoolValuation {
+            assets_before_liability,
+            profit_before_liability,
+            protocol_profit_share: config.protocol_reserve_profit_share(),
+            aggregate_liability: 0,
+            pending_markets,
+        });
+    config.end_snapshot();
+}
+
+/// Add one pending market's frozen liability to the pool aggregate. Calls without
+/// a current valuation, markets outside it, and repeated calls are no-ops.
+public fun value_expiry(vault: &mut PoolVault, market: &ExpiryMarket, config: &ProtocolConfig) {
+    config.assert_version();
+    if (vault.valuation.is_none()) return;
+    let valuation = vault.valuation.borrow_mut();
+    let index = valuation.pending_markets.find_index!(|id| *id == market.id());
+    if (index.is_none()) return;
+    let index = index.destroy_some();
+    valuation.aggregate_liability =
+        valuation.aggregate_liability + market.snapshot_marked_liability();
+    valuation.pending_markets.swap_remove(index);
+}
+
+/// Finish the stored full-pool valuation: prove every snapshotted liability is
+/// filled, price the pool NAV, drain the supply/withdraw queues at that frozen
+/// mark, clear the durable valuation, and return the LP-attributable pool-wide
+/// DUSDC NAV. Returns `none` when no valuation remains to finalize. Only requests
+/// from generations strictly older than the snapshot are eligible.
 ///
 /// `supply_budget` and `withdraw_budget` bound how many requests each queue may
 /// process this flush (`None` = unbounded). Fills — whole or partial — and
@@ -270,54 +335,52 @@ public fun value_expiry(
 /// same transaction, an operator should bound both budgets in production rather than
 /// rely on queue length staying small — see RP-12.
 public fun finish_flush(
-    valuation: PoolValuation,
     vault: &mut PoolVault,
-    config: &mut ProtocolConfig,
+    config: &ProtocolConfig,
     supply_budget: Option<u64>,
     withdraw_budget: Option<u64>,
     ctx: &mut TxContext,
-): u64 {
+): Option<u64> {
     config.assert_version();
-    config.assert_valuation_in_progress();
-    valuation.assert_pool_vault(vault);
-    assert_all_expected_valued(
-        &valuation.expected_expiry_markets,
-        &valuation.valued_expiry_markets,
-    );
-    let PoolValuation { total_nav, valued_expiry_markets, .. } = valuation;
+    if (vault.valuation.is_none()) return option::none();
+    let valuation = vault.valuation.extract();
+    let PoolValuation {
+        assets_before_liability,
+        profit_before_liability,
+        protocol_profit_share,
+        aggregate_liability,
+        pending_markets,
+    } = valuation;
+    assert!(pending_markets.is_empty(), EMissingExpiryValuation);
+    pending_markets.destroy_empty();
 
-    let idle_balance_before = vault.expiry_accounting.idle_balance();
-    let pool_nav = lp_pool_value(
-        vault,
-        config.protocol_reserve_profit_share(),
-        total_nav,
+    let protocol_exclusion = math::mul_down(
+        profit_before_liability.saturating_sub(aggregate_liability),
+        protocol_profit_share,
     );
+    let pool_value = assets_before_liability
+        .saturating_sub(aggregate_liability)
+        .saturating_sub(protocol_exclusion);
+    // Only this drain can mint or burn PLP while a valuation is stored, so supply
+    // is unchanged from the snapshot and needs only one pre-drain sample.
     let total_supply = vault.lp.total_supply();
-    let market_count = valued_expiry_markets.length();
-
-    // Snapshot the share price once (frozen pair), drain both queues against it, then
-    // release the valuation lock at the very end. The flush IS the full-pool
-    // valuation, so the single FlushExecuted event carries the priced mark and its
-    // idle + active-NAV breakdown.
     let vault_id = vault.id();
-    let mark = lp_book::new_flush_mark(pool_nav, total_supply);
-    let fees = lp_book::new_fee_rates(
+    let snapshot_seq = vault.snapshot_seq;
+    let mark = lp_book::new_flush_mark(pool_value, total_supply);
+    let fee_rates = lp_book::new_fee_rates(
         config.plp_supply_fee_rate(),
         config.plp_withdraw_fee_rate(),
     );
-    // The frozen `FeeRates` is the only source for these: the config reads are inlined
-    // above so no local survives that the event could report instead of what the drain
-    // was handed, and each read is named per leg so a transposition cannot compile into
-    // a silently-swapped event.
-    let frozen_supply_fee_rate = fees.supply_fee_rate();
-    let frozen_withdraw_fee_rate = fees.withdraw_fee_rate();
+    let supply_fee_rate = fee_rates.supply_fee_rate();
+    let withdraw_fee_rate = fee_rates.withdraw_fee_rate();
     let drain_summary = vault
         .lp
         .drain(
             &mut vault.expiry_accounting,
             mark,
-            fees,
+            fee_rates,
             vault_id,
+            snapshot_seq,
             supply_budget,
             withdraw_budget,
             config.lp_request_limit_flush_attempts(),
@@ -325,24 +388,21 @@ public fun finish_flush(
             ctx,
         );
     let total_supply_after = vault.lp.total_supply();
-    config.end_valuation();
     vault_events::emit_flush_executed(
         vault_id,
         ctx.epoch(),
-        pool_nav,
+        snapshot_seq,
+        pool_value,
         total_supply,
-        frozen_supply_fee_rate,
-        frozen_withdraw_fee_rate,
-        total_nav,
-        market_count,
-        idle_balance_before,
+        supply_fee_rate,
+        withdraw_fee_rate,
         drain_summary.supplies_filled(),
         drain_summary.withdrawals_filled(),
         drain_summary.requests_processed(),
         vault.expiry_accounting.idle_balance(),
         total_supply_after,
     );
-    pool_nav
+    option::some(pool_value)
 }
 
 /// Move cash between pool idle liquidity and one expiry market.
@@ -355,8 +415,8 @@ public fun finish_flush(
 /// An expired unsettled market is a no-op until that transition succeeds.
 /// Mint asserts backing but never pulls pool cash, so this is what makes a market
 /// mintable. The market must already be registered to this vault
-/// (`registry::create_and_share_expiry_market`). Blocked while a full-pool valuation is in
-/// progress.
+/// (`registry::create_and_share_expiry_market`). Blocked only while the atomic
+/// snapshot is being assembled.
 public fun rebalance_expiry_cash(
     vault: &mut PoolVault,
     market: &mut ExpiryMarket,
@@ -364,7 +424,7 @@ public fun rebalance_expiry_cash(
     clock: &Clock,
 ) {
     config.assert_version();
-    config.assert_not_valuation_in_progress();
+    config.assert_not_snapshot_in_progress();
     let expiry_market_id = market.id();
     vault.expiry_accounting.assert_registered_expiry(expiry_market_id);
     vault.sweep_or_rebalance_expiry(market, config, clock);
@@ -380,7 +440,7 @@ public fun sponsor_fee_incentives(
     ctx: &mut TxContext,
 ) {
     config.assert_version();
-    config.assert_not_valuation_in_progress();
+    config.assert_not_snapshot_in_progress();
     let amount = payment.value();
     assert!(
         amount >= constants::min_fee_incentive_sponsorship!(),
@@ -441,7 +501,7 @@ public fun request_supply(
     ctx: &mut TxContext,
 ): u64 {
     config.assert_version();
-    config.assert_not_valuation_in_progress();
+    config.assert_not_snapshot_in_progress();
     assert!(vault.lp.total_supply() > 0, ENotBootstrapped);
     wrapper.settle<DUSDC>(root, clock);
     let account = wrapper.load_account_mut(auth);
@@ -449,7 +509,8 @@ public fun request_supply(
     let vault_id = vault.id();
     let account_id = account.account_id();
     let recipient = account.receive_address();
-    let index = vault.lp.request_supply(payment, account_id, recipient, min_plp_out);
+    let request_seq = vault.snapshot_seq;
+    let index = vault.lp.request_supply(payment, account_id, recipient, min_plp_out, request_seq);
     vault_events::emit_supply_requested(
         vault_id,
         account_id,
@@ -486,7 +547,7 @@ public fun request_withdraw(
     ctx: &mut TxContext,
 ): u64 {
     config.assert_version();
-    config.assert_not_valuation_in_progress();
+    config.assert_not_snapshot_in_progress();
     assert!(vault.lp.total_supply() > 0, ENotBootstrapped);
     wrapper.settle<PLP>(root, clock);
     let account = wrapper.load_account_mut(auth);
@@ -494,7 +555,8 @@ public fun request_withdraw(
     let vault_id = vault.id();
     let account_id = account.account_id();
     let recipient = account.receive_address();
-    let index = vault.lp.request_withdraw(lp, account_id, recipient, min_dusdc_out);
+    let request_seq = vault.snapshot_seq;
+    let index = vault.lp.request_withdraw(lp, account_id, recipient, min_dusdc_out, request_seq);
     vault_events::emit_withdraw_requested(
         vault_id,
         account_id,
@@ -509,6 +571,7 @@ public fun request_withdraw(
 
 /// Cancel a still-pending supply request, refunding its escrowed DUSDC straight into
 /// the requesting account. `account` must be the request's recorded recipient.
+/// Cancellation is blocked while a frozen valuation is readable on-chain.
 public fun cancel_supply_request(
     vault: &mut PoolVault,
     wrapper: &mut AccountWrapper,
@@ -520,7 +583,8 @@ public fun cancel_supply_request(
     ctx: &mut TxContext,
 ) {
     config.assert_version();
-    config.assert_not_valuation_in_progress();
+    config.assert_not_snapshot_in_progress();
+    vault.assert_no_pending_valuation();
     let vault_id = vault.id();
     wrapper.settle<DUSDC>(root, clock);
     let account = wrapper.load_account_mut(auth);
@@ -541,6 +605,7 @@ public fun cancel_supply_request(
 
 /// Cancel a still-pending withdraw request, refunding its escrowed PLP straight into
 /// the requesting account. `account` must be the request's recorded recipient.
+/// Cancellation is blocked while a frozen valuation is readable on-chain.
 public fun cancel_withdraw_request(
     vault: &mut PoolVault,
     wrapper: &mut AccountWrapper,
@@ -552,7 +617,8 @@ public fun cancel_withdraw_request(
     ctx: &mut TxContext,
 ) {
     config.assert_version();
-    config.assert_not_valuation_in_progress();
+    config.assert_not_snapshot_in_progress();
+    vault.assert_no_pending_valuation();
     let vault_id = vault.id();
     wrapper.settle<PLP>(root, clock);
     let account = wrapper.load_account_mut(auth);
@@ -598,38 +664,8 @@ public(package) fun register_expiry(
 
 // === Private Functions ===
 
-/// LP-attributable DUSDC pool value used to price PLP supply/withdraw.
-///
-/// `gross = idle_balance + active_expiry_value`. NAV prices the protocol's
-/// not-yet-materialized profit share before terminal materialization and excludes
-/// it from LP value: `exclusion = share * max(0, (credits + active) - debits)`
-/// (live cash returns update credits, but reserve custody waits for terminal
-/// profit). A cut already materialized but not yet physically moved (idle was
-/// deployed elsewhere) has left that debit-basis exclusion, so the carried
-/// `pending_protocol_profit` is subtracted separately to keep it out of LP value
-/// until it is drained into the reserve.
-fun lp_pool_value(
-    vault: &PoolVault,
-    protocol_reserve_profit_share: u64,
-    active_expiry_value: u64,
-): u64 {
-    let idle_balance = vault.expiry_accounting.idle_balance();
-    let profit_basis_credits = vault.expiry_accounting.profit_basis_credits();
-    let profit_basis_debits = vault.expiry_accounting.profit_basis_debits();
-    let pending_protocol_profit = vault.expiry_accounting.pending_protocol_profit();
-    let gross_pool_value = idle_balance + active_expiry_value;
-    let aggregate_credits = profit_basis_credits + active_expiry_value;
-    let exclusion = math::mul_down(
-        aggregate_credits.saturating_sub(profit_basis_debits),
-        protocol_reserve_profit_share,
-    );
-    // The realized `credits - debits` term is sticky: it does not shrink when LPs
-    // withdraw idle cash, so when an active mark they withdrew against later
-    // collapses, the held-out total (`exclusion + pending_protocol_profit`) can
-    // exceed gross. LP value can never be negative, so floor it at 0 to keep the
-    // subtraction from underflow-aborting. A 0/dust pool NAV makes non-executable
-    // LP queue heads refund inside `lp_book::drain`, rather than aborting the flush.
-    gross_pool_value.saturating_sub(exclusion + pending_protocol_profit)
+fun assert_no_pending_valuation(vault: &PoolVault) {
+    assert!(vault.valuation.is_none(), EPoolValuationInProgress);
 }
 
 /// Sweep a settled market, rebalance a live market, or leave an expired unsettled
@@ -827,39 +863,26 @@ fun materialize_expiry_profit(
     );
 }
 
-/// Engage the valuation lock and snapshot the active expiry set after requiring a
-/// bootstrapped pool with nonzero PLP supply.
-fun start_pool_valuation_internal(config: &mut ProtocolConfig, vault: &PoolVault): PoolValuation {
+/// Engage the snapshot lock and collect the active expiries the transaction must
+/// prepare before it can persist the aggregate valuation.
+fun start_pool_valuation_internal(
+    config: &mut ProtocolConfig,
+    vault: &mut PoolVault,
+): PoolSnapshot {
     assert!(vault.lp.total_supply() > 0, ENotBootstrapped);
-    config.begin_valuation();
-    PoolValuation {
+    assert!(vault.valuation.is_none(), EPoolValuationAlreadyStored);
+    config.begin_snapshot();
+    vault.snapshot_seq = vault.snapshot_seq + 1;
+    PoolSnapshot {
         pool_vault_id: vault.id(),
-        expected_expiry_markets: vault.expiry_accounting.active_expiry_markets(),
-        valued_expiry_markets: vector[],
-        total_nav: 0,
+        unprepared_markets: vault.expiry_accounting.active_expiry_markets(),
+        pending_markets: vector[],
+        aggregate_market_cash: 0,
     }
 }
 
-/// Abort unless this valuation belongs to `vault`.
-fun assert_pool_vault(valuation: &PoolValuation, vault: &PoolVault) {
-    assert!(valuation.pool_vault_id == vault.id(), EWrongPoolVault);
-}
-
-/// Abort unless the market is in the snapshot and not already valued (exactly-once).
-fun assert_expiry_ready_to_value(valuation: &PoolValuation, expiry_market_id: ID) {
-    assert!(valuation.expected_expiry_markets.contains(&expiry_market_id), EExpiryMarketNotActive);
-    assert!(
-        !valuation.valued_expiry_markets.contains(&expiry_market_id),
-        EExpiryMarketAlreadyValued,
-    );
-}
-
-/// The exactly-once completeness proof: the valued set must equal the snapshot
-/// (a missed market means a wrong pool NAV). `value_expiry` already rejects
-/// non-snapshot and duplicate ids, so equal lengths plus full coverage suffice.
-fun assert_all_expected_valued(expected: &vector<ID>, valued: &vector<ID>) {
-    assert!(valued.length() == expected.length(), EMissingExpiryValuation);
-    expected.do_ref!(|id| assert!(valued.contains(id), EMissingExpiryValuation));
+fun assert_pool_vault(snapshot: &PoolSnapshot, vault: &PoolVault) {
+    assert!(snapshot.pool_vault_id == vault.id(), EWrongPoolVault);
 }
 
 // === Test-Only Functions ===

--- a/packages/predict/sources/pricing/pricing.move
+++ b/packages/predict/sources/pricing/pricing.move
@@ -20,9 +20,8 @@ use propbook::{
 };
 use sui::clock::Clock;
 
-/// Validated live oracle inputs bound to one expiry market. `Pricer` has no
-/// `store` ability and must be created again in each transaction that prices.
-public struct Pricer has copy, drop {
+/// Validated live oracle inputs bound to one expiry market.
+public struct Pricer has copy, drop, store {
     /// Expiry market this snapshot was loaded for.
     expiry_market_id: ID,
     forward: u64,
@@ -61,7 +60,7 @@ public struct RawSVI has copy, drop {
 /// a full raw unit — which a short-dated surface cannot afford, because its whole
 /// total variance is only about ten raw units at 1e9. Keeping the rolled values at
 /// 1e18 hands `variance_sqrt_and_d2` the same domain it already computes in.
-public struct PricingSVI has copy, drop {
+public struct PricingSVI has copy, drop, store {
     /// Rolled-down SVI `a`, magnitude at 1e18, sign in `a_is_negative`.
     a_magnitude: u128,
     a_is_negative: bool,

--- a/packages/predict/sources/registry/registry.move
+++ b/packages/predict/sources/registry/registry.move
@@ -243,7 +243,7 @@ public fun create_and_share_expiry_market(
     config.assert_version();
     registry.assert_valid_lifecycle_cap(lifecycle_cap);
     config.assert_trading_allowed();
-    config.assert_not_valuation_in_progress();
+    config.assert_not_snapshot_in_progress();
     let deployable = registry
         .market_manager
         .next_deployable_market(propbook_registry, propbook_underlying_id, cadence_id, clock);

--- a/packages/predict/sources/strike_exposure/index/strike_payout_tree.move
+++ b/packages/predict/sources/strike_exposure/index/strike_payout_tree.move
@@ -189,22 +189,28 @@ public(package) fun walk_linear(tree: &StrikePayoutTree, pricer: &Pricer, tick_s
     (tree.base + start_total).saturating_sub(end_total)
 }
 
-/// Value the quantity-weighted liability frozen by `set_snapshot_pricer`.
+/// Consume and value the quantity-weighted liability frozen by
+/// `set_snapshot_pricer`.
 ///
 /// Nodes untouched since the snapshot still hold their snapshot quantities in
 /// the live fields. Nodes first mutated after it copied those live fields before
 /// applying the mutation, and nodes created after it carry a matching zero copy.
-public(package) fun walk_linear_snapshot(tree: &StrikePayoutTree, tick_size: u64): u64 {
+/// A successful walk retires the stored pricer and removes every boundary with no
+/// live quantity. If the transaction aborts, both retirement and pruning revert.
+public(package) fun consume_walk_linear_snapshot(tree: &mut StrikePayoutTree, tick_size: u64): u64 {
+    let pricer = tree.snapshot_pricer.extract();
     let mut previous_price = option::none();
     let (start_total, end_total) = walk_linear_subtree(
         &tree.nodes,
         tree.root,
-        tree.snapshot_pricer.borrow(),
+        &pricer,
         tick_size,
         option::some(tree.snapshot_seq),
         &mut previous_price,
     );
-    (tree.snapshot_base + start_total).saturating_sub(end_total)
+    let liability = (tree.snapshot_base + start_total).saturating_sub(end_total);
+    tree.prune_empty_nodes();
+    liability
 }
 
 /// Create an empty sparse payout tree.
@@ -386,6 +392,53 @@ fun apply_at(
             );
     };
 
+    option::some(rebalance(nodes, root_tick, node))
+}
+
+/// Reclaim boundaries retained solely for the snapshot that was just consumed.
+/// Empty ticks are collected before deletion so each structural change travels
+/// through the existing one-node AVL deletion path.
+fun prune_empty_nodes(tree: &mut StrikePayoutTree) {
+    let mut empty_ticks = vector[];
+    collect_empty_ticks(&tree.nodes, tree.root, &mut empty_ticks);
+    while (!empty_ticks.is_empty()) {
+        let tick = empty_ticks.pop_back();
+        tree.root = remove_empty_node(&mut tree.nodes, tree.root, tick);
+        tree.node_count = tree.node_count - 1;
+    };
+    empty_ticks.destroy_empty();
+}
+
+fun collect_empty_ticks(
+    nodes: &Table<u64, PayoutNode>,
+    root: Option<u64>,
+    empty_ticks: &mut vector<u64>,
+) {
+    if (root.is_none()) return;
+    let tick = *root.borrow();
+    let node = nodes[tick];
+    collect_empty_ticks(nodes, node.left, empty_ticks);
+    if (is_empty_node(node)) empty_ticks.push_back(tick);
+    collect_empty_ticks(nodes, node.right, empty_ticks);
+}
+
+fun remove_empty_node(
+    nodes: &mut Table<u64, PayoutNode>,
+    root: Option<u64>,
+    tick: u64,
+): Option<u64> {
+    let root_tick = *root.borrow();
+    let mut node = nodes[root_tick];
+    if (tick == root_tick) {
+        let _removed = nodes.remove(root_tick);
+        return join_subtrees(nodes, node.left, node.right)
+    };
+
+    if (tick < root_tick) {
+        node.left = remove_empty_node(nodes, node.left, tick);
+    } else {
+        node.right = remove_empty_node(nodes, node.right, tick);
+    };
     option::some(rebalance(nodes, root_tick, node))
 }
 

--- a/packages/predict/sources/strike_exposure/index/strike_payout_tree.move
+++ b/packages/predict/sources/strike_exposure/index/strike_payout_tree.move
@@ -38,7 +38,6 @@ use sui::table::{Self, Table};
 const EInsufficientPayoutQuantity: u64 = 0;
 const EMaxPayoutTreeNodes: u64 = 1;
 const ENonMonotonePrice: u64 = 2;
-const ESnapshotTimestampNotIncreasing: u64 = 3;
 
 /// Sparse payout-liability tree keyed by finite strike tick.
 public struct StrikePayoutTree has store {
@@ -48,9 +47,11 @@ public struct StrikePayoutTree has store {
     /// Aggregate order quantity over the open-lower prefix, which is also its
     /// aggregate settled payout.
     base: u64,
-    /// Zero selects live state. A positive value selects the tree state frozen
-    /// at that timestamp, captured lazily in nodes as they next mutate.
-    snapshot_timestamp_ms: u64,
+    /// Frozen pricing state for the most recently requested snapshot. Setting a
+    /// new snapshot overwrites it without applying lifecycle or freshness policy.
+    snapshot_pricer: Option<Pricer>,
+    /// Pool-owned generation used by each node's lazy snapshot copy.
+    snapshot_seq: u64,
     snapshot_base: u64,
 }
 
@@ -79,12 +80,12 @@ public struct PayoutNode has copy, drop, store {
     /// recomputed without deriving locals by subtracting child summaries.
     local_start: u64,
     local_end: u64,
-    /// Boundary terms immediately before this node's first mutation at
-    /// `snapshot_timestamp_ms`. A matching timestamp with zero terms means the
-    /// node was created after the snapshot.
+    /// Boundary terms immediately before this node's first mutation in
+    /// `snapshot_seq`. A matching sequence with zero terms means the node was
+    /// created after that snapshot.
     snapshot_local_start: u64,
     snapshot_local_end: u64,
-    snapshot_timestamp_ms: u64,
+    snapshot_seq: u64,
     summary: PayoutSummary,
 }
 
@@ -170,13 +171,9 @@ public(package) fun settled_payout_liability(
 /// The start and end sides accumulate as two non-negative totals: a node's net
 /// `local_start - local_end` quantity is signed, so a single running `u64` would
 /// underflow mid-walk. They combine once at the top:
-/// `base + start_total - end_total`. The selected base is the `P(-inf) = 1`
+/// `base + start_total - end_total`. `tree.base` is the `P(-inf) = 1`
 /// anchor for `(-inf, h]` ranges (its quantity enters at face value); `+inf` ends
 /// are never stored (`P = 0`).
-///
-/// Before the first snapshot this reads live boundaries. Once a timestamp is set,
-/// it reads each boundary as it existed at that timestamp while live updates keep
-/// using the same tree.
 public(package) fun walk_linear(tree: &StrikePayoutTree, pricer: &Pricer, tick_size: u64): u64 {
     let mut previous_price = option::none();
     let (start_total, end_total) = walk_linear_subtree(
@@ -184,17 +181,30 @@ public(package) fun walk_linear(tree: &StrikePayoutTree, pricer: &Pricer, tick_s
         tree.root,
         pricer,
         tick_size,
-        tree.snapshot_timestamp_ms,
+        option::none(),
         &mut previous_price,
     );
     // Boundary products are rounded per node and the signed aggregate is floored
     // once. This can differ from pricing and flooring each order independently.
-    let base = if (tree.snapshot_timestamp_ms == 0) {
-        tree.base
-    } else {
-        tree.snapshot_base
-    };
-    (base + start_total).saturating_sub(end_total)
+    (tree.base + start_total).saturating_sub(end_total)
+}
+
+/// Value the quantity-weighted liability frozen by `set_snapshot_pricer`.
+///
+/// Nodes untouched since the snapshot still hold their snapshot quantities in
+/// the live fields. Nodes first mutated after it copied those live fields before
+/// applying the mutation, and nodes created after it carry a matching zero copy.
+public(package) fun walk_linear_snapshot(tree: &StrikePayoutTree, tick_size: u64): u64 {
+    let mut previous_price = option::none();
+    let (start_total, end_total) = walk_linear_subtree(
+        &tree.nodes,
+        tree.root,
+        tree.snapshot_pricer.borrow(),
+        tick_size,
+        option::some(tree.snapshot_seq),
+        &mut previous_price,
+    );
+    (tree.snapshot_base + start_total).saturating_sub(end_total)
 }
 
 /// Create an empty sparse payout tree.
@@ -204,20 +214,21 @@ public(package) fun new(ctx: &mut TxContext): StrikePayoutTree {
         nodes: table::new(ctx),
         node_count: 0,
         base: 0,
-        snapshot_timestamp_ms: 0,
+        snapshot_pricer: option::none(),
+        snapshot_seq: 0,
         snapshot_base: 0,
     }
 }
 
-/// Freeze the current tree state for subsequent linear walks. Nodes capture their
-/// boundary terms lazily immediately before their first mutation under this
-/// timestamp; untouched nodes remain their own snapshot.
-public(package) fun set_snapshot_timestamp(
+/// Overwrite the frozen pricer and bind the lazy position snapshot to the pool's
+/// canonical snapshot generation.
+public(package) fun set_snapshot_pricer(
     tree: &mut StrikePayoutTree,
-    snapshot_timestamp_ms: u64,
+    pricer: Pricer,
+    snapshot_seq: u64,
 ) {
-    assert!(snapshot_timestamp_ms > tree.snapshot_timestamp_ms, ESnapshotTimestampNotIncreasing);
-    tree.snapshot_timestamp_ms = snapshot_timestamp_ms;
+    tree.snapshot_pricer = option::some(pricer);
+    tree.snapshot_seq = snapshot_seq;
     tree.snapshot_base = tree.base;
 }
 
@@ -291,7 +302,11 @@ fun apply_boundary_delta(
     add: bool,
 ) {
     let had_node = tree.nodes.contains(tick);
-    let snapshot_timestamp_ms = tree.snapshot_timestamp_ms;
+    let snapshot_seq = if (tree.snapshot_pricer.is_some()) {
+        option::some(tree.snapshot_seq)
+    } else {
+        option::none()
+    };
     let new_root = apply_at(
         &mut tree.nodes,
         tree.root,
@@ -299,7 +314,7 @@ fun apply_boundary_delta(
         quantity,
         is_start,
         add,
-        snapshot_timestamp_ms,
+        snapshot_seq,
     );
     tree.root = new_root;
 
@@ -318,11 +333,11 @@ fun apply_at(
     quantity: u64,
     is_start: bool,
     add: bool,
-    snapshot_timestamp_ms: u64,
+    snapshot_seq: Option<u64>,
 ): Option<u64> {
     if (root.is_none()) {
         assert!(add, EInsufficientPayoutQuantity);
-        let leaf = new_leaf(quantity, is_start, snapshot_timestamp_ms);
+        let leaf = new_leaf(quantity, is_start, snapshot_seq);
         nodes.add(tick, leaf);
         return option::some(tick)
     };
@@ -331,13 +346,13 @@ fun apply_at(
     let mut node = nodes[root_tick];
 
     if (tick == root_tick) {
-        capture_snapshot_if_stale(&mut node, snapshot_timestamp_ms);
+        capture_snapshot_if_stale(&mut node, snapshot_seq);
         if (is_start) {
             apply_net_delta(&mut node.local_start, quantity, add);
         } else {
             apply_net_delta(&mut node.local_end, quantity, add);
         };
-        if (is_empty_node(node) && !has_snapshot_quantity(node, snapshot_timestamp_ms)) {
+        if (is_empty_node(node) && !has_snapshot_quantity(node, snapshot_seq)) {
             let _removed = nodes.remove(root_tick);
             return join_subtrees(nodes, node.left, node.right)
         };
@@ -356,7 +371,7 @@ fun apply_at(
                 quantity,
                 is_start,
                 add,
-                snapshot_timestamp_ms,
+                snapshot_seq,
             );
     } else {
         node.right =
@@ -367,14 +382,14 @@ fun apply_at(
                 quantity,
                 is_start,
                 add,
-                snapshot_timestamp_ms,
+                snapshot_seq,
             );
     };
 
     option::some(rebalance(nodes, root_tick, node))
 }
 
-fun new_leaf(quantity: u64, is_start: bool, snapshot_timestamp_ms: u64): PayoutNode {
+fun new_leaf(quantity: u64, is_start: bool, snapshot_seq: Option<u64>): PayoutNode {
     let (start, end) = if (is_start) {
         (quantity, 0)
     } else {
@@ -389,7 +404,11 @@ fun new_leaf(quantity: u64, is_start: bool, snapshot_timestamp_ms: u64): PayoutN
         local_end: end,
         snapshot_local_start: 0,
         snapshot_local_end: 0,
-        snapshot_timestamp_ms,
+        snapshot_seq: if (snapshot_seq.is_some()) {
+            *snapshot_seq.borrow()
+        } else {
+            0
+        },
         summary: boundary_summary(start, end),
     }
 }
@@ -545,16 +564,20 @@ fun window_summary(
 
 /// Accumulate start and end boundary products separately during an in-order walk.
 ///
-/// Every boundary selected by the live or snapshot view is priced, including one
-/// whose start and end quantities cancel. A zero snapshot boundary is skipped: it
-/// was created after the frozen state and therefore did not exist in that pricing
-/// surface.
+/// Every boundary with quantity in the selected view is priced, including one
+/// whose local start and end quantities cancel. Only the arithmetic is skipped
+/// there, because such a boundary contributes `price * q - price * q = 0` to the
+/// netted aggregate at any price. The pricing call itself must not be skipped: it
+/// is where monotonicity is observed, and a cancelling boundary is still the
+/// shared edge of two positions in that view. An inversion sitting on it does not
+/// move this walk's total, but it does move what per-position pricing pays, so
+/// skipping the observation would let NAV understate liability without aborting.
 fun walk_linear_subtree(
     nodes: &Table<u64, PayoutNode>,
     root: Option<u64>,
     pricer: &Pricer,
     tick_size: u64,
-    snapshot_timestamp_ms: u64,
+    snapshot_seq: Option<u64>,
     previous_price: &mut Option<u64>,
 ): (u64, u64) {
     if (root.is_none()) return (0, 0);
@@ -566,12 +589,13 @@ fun walk_linear_subtree(
         node.left,
         pricer,
         tick_size,
-        snapshot_timestamp_ms,
+        snapshot_seq,
         previous_price,
     );
 
     let (local_start, local_end) = if (
-        snapshot_timestamp_ms != 0 && node.snapshot_timestamp_ms == snapshot_timestamp_ms
+        snapshot_seq.is_some()
+            && node.snapshot_seq == *snapshot_seq.borrow()
     ) {
         (node.snapshot_local_start, node.snapshot_local_end)
     } else {
@@ -601,7 +625,7 @@ fun walk_linear_subtree(
         node.right,
         pricer,
         tick_size,
-        snapshot_timestamp_ms,
+        snapshot_seq,
         previous_price,
     );
     (start_total + left_start + right_start, end_total + left_end + right_end)
@@ -673,17 +697,19 @@ fun is_empty_node(node: PayoutNode): bool {
     node.local_start == 0 && node.local_end == 0
 }
 
-fun has_snapshot_quantity(node: PayoutNode, snapshot_timestamp_ms: u64): bool {
-    snapshot_timestamp_ms != 0
-        && node.snapshot_timestamp_ms == snapshot_timestamp_ms
+fun has_snapshot_quantity(node: PayoutNode, snapshot_seq: Option<u64>): bool {
+    snapshot_seq.is_some()
+        && node.snapshot_seq == *snapshot_seq.borrow()
         && (node.snapshot_local_start != 0 || node.snapshot_local_end != 0)
 }
 
-fun capture_snapshot_if_stale(node: &mut PayoutNode, snapshot_timestamp_ms: u64) {
-    if (snapshot_timestamp_ms == 0 || node.snapshot_timestamp_ms == snapshot_timestamp_ms) return;
+fun capture_snapshot_if_stale(node: &mut PayoutNode, snapshot_seq: Option<u64>) {
+    if (snapshot_seq.is_none()) return;
+    let snapshot_seq = *snapshot_seq.borrow();
+    if (node.snapshot_seq == snapshot_seq) return;
     node.snapshot_local_start = node.local_start;
     node.snapshot_local_end = node.local_end;
-    node.snapshot_timestamp_ms = snapshot_timestamp_ms;
+    node.snapshot_seq = snapshot_seq;
 }
 
 fun apply_net_delta(value: &mut u64, delta: u64, add: bool) {

--- a/packages/predict/sources/strike_exposure/index/strike_payout_tree.move
+++ b/packages/predict/sources/strike_exposure/index/strike_payout_tree.move
@@ -38,6 +38,7 @@ use sui::table::{Self, Table};
 const EInsufficientPayoutQuantity: u64 = 0;
 const EMaxPayoutTreeNodes: u64 = 1;
 const ENonMonotonePrice: u64 = 2;
+const ESnapshotTimestampNotIncreasing: u64 = 3;
 
 /// Sparse payout-liability tree keyed by finite strike tick.
 public struct StrikePayoutTree has store {
@@ -47,6 +48,10 @@ public struct StrikePayoutTree has store {
     /// Aggregate order quantity over the open-lower prefix, which is also its
     /// aggregate settled payout.
     base: u64,
+    /// Zero selects live state. A positive value selects the tree state frozen
+    /// at that timestamp, captured lazily in nodes as they next mutate.
+    snapshot_timestamp_ms: u64,
+    snapshot_base: u64,
 }
 
 /// Subtree payout totals and max static payout prefix gain.
@@ -74,6 +79,12 @@ public struct PayoutNode has copy, drop, store {
     /// recomputed without deriving locals by subtracting child summaries.
     local_start: u64,
     local_end: u64,
+    /// Boundary terms immediately before this node's first mutation at
+    /// `snapshot_timestamp_ms`. A matching timestamp with zero terms means the
+    /// node was created after the snapshot.
+    snapshot_local_start: u64,
+    snapshot_local_end: u64,
+    snapshot_timestamp_ms: u64,
     summary: PayoutSummary,
 }
 
@@ -159,9 +170,13 @@ public(package) fun settled_payout_liability(
 /// The start and end sides accumulate as two non-negative totals: a node's net
 /// `local_start - local_end` quantity is signed, so a single running `u64` would
 /// underflow mid-walk. They combine once at the top:
-/// `base + start_total - end_total`. `tree.base` is the `P(-inf) = 1`
+/// `base + start_total - end_total`. The selected base is the `P(-inf) = 1`
 /// anchor for `(-inf, h]` ranges (its quantity enters at face value); `+inf` ends
 /// are never stored (`P = 0`).
+///
+/// Before the first snapshot this reads live boundaries. Once a timestamp is set,
+/// it reads each boundary as it existed at that timestamp while live updates keep
+/// using the same tree.
 public(package) fun walk_linear(tree: &StrikePayoutTree, pricer: &Pricer, tick_size: u64): u64 {
     let mut previous_price = option::none();
     let (start_total, end_total) = walk_linear_subtree(
@@ -169,11 +184,17 @@ public(package) fun walk_linear(tree: &StrikePayoutTree, pricer: &Pricer, tick_s
         tree.root,
         pricer,
         tick_size,
+        tree.snapshot_timestamp_ms,
         &mut previous_price,
     );
     // Boundary products are rounded per node and the signed aggregate is floored
     // once. This can differ from pricing and flooring each order independently.
-    (tree.base + start_total).saturating_sub(end_total)
+    let base = if (tree.snapshot_timestamp_ms == 0) {
+        tree.base
+    } else {
+        tree.snapshot_base
+    };
+    (base + start_total).saturating_sub(end_total)
 }
 
 /// Create an empty sparse payout tree.
@@ -183,7 +204,21 @@ public(package) fun new(ctx: &mut TxContext): StrikePayoutTree {
         nodes: table::new(ctx),
         node_count: 0,
         base: 0,
+        snapshot_timestamp_ms: 0,
+        snapshot_base: 0,
     }
+}
+
+/// Freeze the current tree state for subsequent linear walks. Nodes capture their
+/// boundary terms lazily immediately before their first mutation under this
+/// timestamp; untouched nodes remain their own snapshot.
+public(package) fun set_snapshot_timestamp(
+    tree: &mut StrikePayoutTree,
+    snapshot_timestamp_ms: u64,
+) {
+    assert!(snapshot_timestamp_ms > tree.snapshot_timestamp_ms, ESnapshotTimestampNotIncreasing);
+    tree.snapshot_timestamp_ms = snapshot_timestamp_ms;
+    tree.snapshot_base = tree.base;
 }
 
 /// Insert interval payout quantity for the order tick range `(lower_tick, higher_tick]`.
@@ -256,6 +291,7 @@ fun apply_boundary_delta(
     add: bool,
 ) {
     let had_node = tree.nodes.contains(tick);
+    let snapshot_timestamp_ms = tree.snapshot_timestamp_ms;
     let new_root = apply_at(
         &mut tree.nodes,
         tree.root,
@@ -263,6 +299,7 @@ fun apply_boundary_delta(
         quantity,
         is_start,
         add,
+        snapshot_timestamp_ms,
     );
     tree.root = new_root;
 
@@ -281,10 +318,11 @@ fun apply_at(
     quantity: u64,
     is_start: bool,
     add: bool,
+    snapshot_timestamp_ms: u64,
 ): Option<u64> {
     if (root.is_none()) {
         assert!(add, EInsufficientPayoutQuantity);
-        let leaf = new_leaf(quantity, is_start);
+        let leaf = new_leaf(quantity, is_start, snapshot_timestamp_ms);
         nodes.add(tick, leaf);
         return option::some(tick)
     };
@@ -293,12 +331,13 @@ fun apply_at(
     let mut node = nodes[root_tick];
 
     if (tick == root_tick) {
+        capture_snapshot_if_stale(&mut node, snapshot_timestamp_ms);
         if (is_start) {
             apply_net_delta(&mut node.local_start, quantity, add);
         } else {
             apply_net_delta(&mut node.local_end, quantity, add);
         };
-        if (is_empty_node(node)) {
+        if (is_empty_node(node) && !has_snapshot_quantity(node, snapshot_timestamp_ms)) {
             let _removed = nodes.remove(root_tick);
             return join_subtrees(nodes, node.left, node.right)
         };
@@ -309,15 +348,33 @@ fun apply_at(
     // The descent is a plain BST insert; every structural decision is deferred to
     // `rebalance` on the way back up, which reads only measured heights.
     if (tick < root_tick) {
-        node.left = apply_at(nodes, node.left, tick, quantity, is_start, add);
+        node.left =
+            apply_at(
+                nodes,
+                node.left,
+                tick,
+                quantity,
+                is_start,
+                add,
+                snapshot_timestamp_ms,
+            );
     } else {
-        node.right = apply_at(nodes, node.right, tick, quantity, is_start, add);
+        node.right =
+            apply_at(
+                nodes,
+                node.right,
+                tick,
+                quantity,
+                is_start,
+                add,
+                snapshot_timestamp_ms,
+            );
     };
 
     option::some(rebalance(nodes, root_tick, node))
 }
 
-fun new_leaf(quantity: u64, is_start: bool): PayoutNode {
+fun new_leaf(quantity: u64, is_start: bool, snapshot_timestamp_ms: u64): PayoutNode {
     let (start, end) = if (is_start) {
         (quantity, 0)
     } else {
@@ -330,6 +387,9 @@ fun new_leaf(quantity: u64, is_start: bool): PayoutNode {
         right: option::none(),
         local_start: start,
         local_end: end,
+        snapshot_local_start: 0,
+        snapshot_local_end: 0,
+        snapshot_timestamp_ms,
         summary: boundary_summary(start, end),
     }
 }
@@ -485,19 +545,16 @@ fun window_summary(
 
 /// Accumulate start and end boundary products separately during an in-order walk.
 ///
-/// EVERY node is priced, including one whose local start and end quantities cancel.
-/// Only the arithmetic is skipped there, because such a boundary contributes
-/// `price * q - price * q = 0` to the netted aggregate at any price. The pricing
-/// call itself must not be skipped: it is where monotonicity is observed, and a
-/// cancelling boundary is still the shared edge of two live orders. An inversion
-/// sitting on it does not move this walk's total, but it does move what
-/// `redeem_live` pays per order (`range_price` is evaluated per order, not netted),
-/// so skipping the observation would let NAV understate liability without aborting.
+/// Every boundary selected by the live or snapshot view is priced, including one
+/// whose start and end quantities cancel. A zero snapshot boundary is skipped: it
+/// was created after the frozen state and therefore did not exist in that pricing
+/// surface.
 fun walk_linear_subtree(
     nodes: &Table<u64, PayoutNode>,
     root: Option<u64>,
     pricer: &Pricer,
     tick_size: u64,
+    snapshot_timestamp_ms: u64,
     previous_price: &mut Option<u64>,
 ): (u64, u64) {
     if (root.is_none()) return (0, 0);
@@ -509,23 +566,34 @@ fun walk_linear_subtree(
         node.left,
         pricer,
         tick_size,
+        snapshot_timestamp_ms,
         previous_price,
     );
 
-    let price = pricer.up_price(range_codec::strike_from_tick(tick, tick_size));
-    // UP price is non-increasing in strike and the in-order walk visits ascending
-    // ticks, so a rising price is a non-monotone surface: the netted aggregate
-    // below would understate the per-order liability the protocol actually honors.
-    if (previous_price.is_some()) {
-        assert!(price <= *previous_price.borrow(), ENonMonotonePrice);
+    let (local_start, local_end) = if (
+        snapshot_timestamp_ms != 0 && node.snapshot_timestamp_ms == snapshot_timestamp_ms
+    ) {
+        (node.snapshot_local_start, node.snapshot_local_end)
+    } else {
+        (node.local_start, node.local_end)
     };
-    *previous_price = option::some(price);
 
     let mut start_total = 0;
     let mut end_total = 0;
-    if (node.local_start != node.local_end) {
-        start_total = math::mul_down(price, node.local_start);
-        end_total = math::mul_down(price, node.local_end);
+    if (local_start != 0 || local_end != 0) {
+        let price = pricer.up_price(range_codec::strike_from_tick(tick, tick_size));
+        // UP price is non-increasing in strike and the in-order walk visits ascending
+        // ticks, so a rising price is a non-monotone surface: the netted aggregate
+        // below would understate the per-order liability the protocol actually honors.
+        if (previous_price.is_some()) {
+            assert!(price <= *previous_price.borrow(), ENonMonotonePrice);
+        };
+        *previous_price = option::some(price);
+
+        if (local_start != local_end) {
+            start_total = math::mul_down(price, local_start);
+            end_total = math::mul_down(price, local_end);
+        };
     };
 
     let (right_start, right_end) = walk_linear_subtree(
@@ -533,6 +601,7 @@ fun walk_linear_subtree(
         node.right,
         pricer,
         tick_size,
+        snapshot_timestamp_ms,
         previous_price,
     );
     (start_total + left_start + right_start, end_total + left_end + right_end)
@@ -602,6 +671,19 @@ fun positive_net_delta(start: u64, end: u64, gain: u64): u64 {
 
 fun is_empty_node(node: PayoutNode): bool {
     node.local_start == 0 && node.local_end == 0
+}
+
+fun has_snapshot_quantity(node: PayoutNode, snapshot_timestamp_ms: u64): bool {
+    snapshot_timestamp_ms != 0
+        && node.snapshot_timestamp_ms == snapshot_timestamp_ms
+        && (node.snapshot_local_start != 0 || node.snapshot_local_end != 0)
+}
+
+fun capture_snapshot_if_stale(node: &mut PayoutNode, snapshot_timestamp_ms: u64) {
+    if (snapshot_timestamp_ms == 0 || node.snapshot_timestamp_ms == snapshot_timestamp_ms) return;
+    node.snapshot_local_start = node.local_start;
+    node.snapshot_local_end = node.local_end;
+    node.snapshot_timestamp_ms = snapshot_timestamp_ms;
 }
 
 fun apply_net_delta(value: &mut u64, delta: u64, add: bool) {

--- a/packages/predict/sources/strike_exposure/strike_exposure.move
+++ b/packages/predict/sources/strike_exposure/strike_exposure.move
@@ -153,6 +153,20 @@ public(package) fun live_marked_liability(exposure: &StrikeExposure, pricer: &Pr
     exposure.payout.walk_linear(pricer, exposure.tick_size)
 }
 
+/// Freeze the pricer used by the payout tree's lazy position snapshot.
+public(package) fun set_snapshot_pricer(
+    exposure: &mut StrikeExposure,
+    pricer: Pricer,
+    snapshot_seq: u64,
+) {
+    exposure.payout.set_snapshot_pricer(pricer, snapshot_seq);
+}
+
+/// Return the marked liability from the payout tree's frozen pricer and position view.
+public(package) fun snapshot_marked_liability(exposure: &StrikeExposure): u64 {
+    exposure.payout.walk_linear_snapshot(exposure.tick_size)
+}
+
 /// Return one live order's full-close range value without consulting book state.
 public(package) fun live_order_value(
     exposure: &StrikeExposure,

--- a/packages/predict/sources/strike_exposure/strike_exposure.move
+++ b/packages/predict/sources/strike_exposure/strike_exposure.move
@@ -162,9 +162,10 @@ public(package) fun set_snapshot_pricer(
     exposure.payout.set_snapshot_pricer(pricer, snapshot_seq);
 }
 
-/// Return the marked liability from the payout tree's frozen pricer and position view.
-public(package) fun snapshot_marked_liability(exposure: &StrikeExposure): u64 {
-    exposure.payout.walk_linear_snapshot(exposure.tick_size)
+/// Return the marked liability from the payout tree's frozen pricer and position
+/// view, retiring that snapshot and reclaiming snapshot-only boundaries.
+public(package) fun consume_snapshot_marked_liability(exposure: &mut StrikeExposure): u64 {
+    exposure.payout.consume_walk_linear_snapshot(exposure.tick_size)
 }
 
 /// Return one live order's full-close range value without consulting book state.


### PR DESCRIPTION
## Summary

- Split PLP flush valuation into an atomic pool snapshot followed by resumable per-market liability walks and finalization.
- Keep trading and new LP requests live after the atomic snapshot while preserving the exact snapshotted market positions, pricers, cash, and request boundary.
- Give `PoolVault` one canonical snapshot sequence used by payout-tree lazy copies, LP request eligibility, idempotent valuation calls, and flush events.

## Why

The PLP flush computes the pool value used to fill queued supply and withdrawal requests. The existing single transaction walks every active market's payout tree, so their dynamic-field reads accumulate against one transaction object budget and can prevent an otherwise valid per-market valuation from completing. The flush needs to preserve one exact pool state while allowing each expensive market walk to execute independently and without stopping trading for the full valuation window.

## Linear / Context

- [DBU-754](https://linear.app/mysten-labs/issue/DBU-754/make-the-full-pool-flush-resumable-without-pausing-trading-lock-free)
- Related staged-flush proposal: [#1265](https://github.com/MystenLabs/deepbookv3/pull/1265)

## Key decisions

- `start_pool_valuation` increments the sequence and returns a transaction-local `PoolSnapshot`. The same transaction prepares every active market and stores the reduced `PoolValuation` in `PoolVault`.
- Each payout tree stores its frozen `Pricer`, base quantity, and one lazy snapshot copy per mutated node. Live quantities continue updating normally.
- The atomic stage reduces pool state to remaining LP assets and remaining profit. Each asynchronous market liability subtracts from both values, so no separate aggregate-liability field is retained.
- Successful per-market valuation consumes the payout-tree snapshot: it extracts the stored pricer, calculates frozen liability, retires the snapshot, and reclaims every boundary with no live quantity through the existing AVL deletion path.
- LP requests record the current pool sequence. Finalization drains only requests from earlier sequences; requests submitted after the snapshot wait for the next mark.
- Protocol profit share, supply and withdrawal fees, limit-miss policy, and the pool-value cap are read from current config at finalization.
- Duplicate market valuation and already-completed finalization calls are no-ops. LP request cancellation remains blocked while a frozen valuation is readable.

## Scope / Descoped

- This draft changes source smart contracts only. Unit tests, TypeScript transaction builders, keeper integration, simulations, and design documentation are not updated.
- No package publication, deployment, or migration work is included.
- Recovery from a deterministic frozen-liability failure is not included. Such a failure leaves that valuation pending until a recovery or supersede mechanism is added.

## Test plan

- [x] `bash checks/format-move.sh <changed Move source files>` — all changed source files match the repository-pinned formatter.
- [x] `/Users/aslantashtanov/.local/share/suiup/binaries/testnet/sui-v1.74.1 move build --path packages/predict --warnings-are-errors` — the Predict package builds successfully.
- [x] Bounded arithmetic cross-check — 8,154,531 combinations produced identical pool values for aggregate-liability and sequential-reduction forms.
- [ ] `sui move test --path packages/predict --gas-limit 100000000000` — intentionally not run for this source-only design draft.

## Risk / Rollout

This is a pre-deploy source and object-layout change with public function and event signature changes. `value_expiry` now mutates its market so snapshot retirement is atomic with liability aggregation; it serializes with other mutations of that market for the valuation transaction but introduces no persistent trading lock. Protocol profit share is intentionally a finalization-time policy input rather than frozen snapshot state. Downstream callers and tests must be synchronized before the draft is made ready.
