### PR TITLE
predict: store payout boundaries in an inline vector (C-1)

### DIFF
--- a/.claude/rules/predict-contracts.md
+++ b/.claude/rules/predict-contracts.md
@@ -137,6 +137,6 @@ Predict-specific Move rules: package architecture, config and capability shapes,
 ## Predict Gas & Capacity
 
 Read the current capacity model before changing flush, NAV, or batching behavior; measurements belong in [predeploy evidence](../../packages/predict/predeploy/evidence/) and conclusions in the [open-items register](../../packages/predict/predeploy/open-items.md) C-1 or the [response-policy register](../../packages/predict/predeploy/response-policies.md).
-- The full-pool flush is one mandatory PTB that values every active market. Test growth-sensitive limits against the joint pool total, including cumulative dynamic-field object loads across markets; isolated per-market caps are not sufficient. C-1 owns the current bound and evidence.
+- The full-pool flush is one mandatory PTB that values every active market. Payout-tree records are an inline vector, so `walk_linear` loads no per-strike children; remaining flush growth is compute and the market's own object size. C-1 owns the bound and evidence.
 - Do not extrapolate batched mint or redeem capacity from standalone operation cost. Large multi-command PTBs are amplified by transaction-level metering and must be measured and chunked according to RP-10; the supporting record is [c3-mint-batch-2026-07-01.md](../../packages/predict/predeploy/evidence/c3-mint-batch-2026-07-01.md).
 - Treat zero pool NAV as reachable. `lp_pool_value` must floor at zero rather than abort; downstream queue behavior is owned by RP-2 and RP-3 in the response-policy register.

--- a/packages/predict/docs/design/decisions.md
+++ b/packages/predict/docs/design/decisions.md
@@ -167,6 +167,15 @@ the invariants these decisions must preserve, see [invariants.md](./invariants.m
   also serves the exact NAV linear walk (`Σ qty·P` over its live boundaries), so it
   is the single full-lifecycle live index. *Rejected:* folding settlement into the
   deleted NAV matrix and dropping the tree.
+- **Store payout boundaries in an inline sorted vector (2026-08-26).** `StrikePayoutTree`
+  keeps the same five evaluators and the same exact terms. Records sit in tick order
+  on the market object, so `walk_linear`, `range_max_payout`, and settlement prefix
+  load no dynamic-field children. That removes C-1's object-cache wall (one child per
+  distinct strike, cumulative across the flush PTB; abort at ~982 nodes, or 586+586).
+  *Superseded:* the AVL `Table<tick, PayoutNode>`, which existed to keep mint, close,
+  and settlement on an `O(log n)` child path while each boundary was a child. *Rejected:*
+  a multi-transaction flush that keeps the table and snapshots nodes (#1265); a coarse
+  inventory-cell lattice as the NAV source (audit L10 requires the exact mark).
 - **D032 — Inventory impact is the difference of one capped book-level potential.**
   Define the risk coordinate as the existing payout liability
   `L = M + λ(T-M)`, and charge mints / rebate voluntary live closes by the signed

--- a/packages/predict/predeploy/open-items.md
+++ b/packages/predict/predeploy/open-items.md
@@ -374,67 +374,34 @@ trust coupling.
 
 **Severity:** Medium / must be accepted or fixed before deployment.
 
-The flush values every active market in one PTB. Current independent caps
-(`24` live markets, `1000` payout nodes) do
-not compose into a single-PTB budget — and the binding limit is object-count,
-not compute (corrected 2026-07-07; see the model below). The NAV price memo
-removed the single-market pre-cap OOG; the remaining deploy blocker is the
-pool-total case. The missing bound is a joint sum across all active markets, not
-another isolated per-market cap.
+The flush values every active market in one PTB. The 2026-07-07 object-cache
+wall was one `Table` child per distinct payout boundary, cumulative across the
+PTB (`evidence/c1-object-cache-flush-2026-07-07.md`). That driver is closed:
+`StrikePayoutTree` stores those records in an inline vector, so `walk_linear`
+loads no per-strike children. The remaining question is compute on a 1×-only
+full-pool flush, last measured with leveraged orders present.
 
-**Capacity model (corrected 2026-07-07 — the binding wall is object-count, not compute):**
+**Capacity model (updated 2026-08-26 — object-cache driver removed):**
 
-- The binding wall for the pool total is the Sui **object-runtime cached-objects
-  limit: 1,000 dynamic-field child objects per transaction**
-  (`object_runtime_max_num_cached_objects`; a protocol constant, taken as
-  network-invariant). The flush loads each market's payout-tree nodes as
-  dynamic-field children, and the object-runtime cache
-  **accumulates across every `value_expiry` command in the one PTB**. On overflow
-  it aborts `MEMORY_LIMIT_EXCEEDED` inside `dynamic_field::borrow_child_object` —
-  a framework error whose true cause is this limit. It binds at 16–50% of the 5M
-  compute cap, so the pool flush is object-count-bound, not computation-bound
-  (`evidence/c1-object-cache-flush-2026-07-07.md`).
-- Driver = distinct payout-tree nodes: one `Table<tick,PayoutNode>` child per
-  distinct strike tick, and `walk_linear` loads every node. Node count = distinct
-  ticks, NOT order count (the tree aggregates by boundary) — which is why
-  single-market runs at narrow strikes never reached it despite large books.
-- Confirmed cumulative, not per-command: two 1× markets at 586 nodes each —
-  neither near 1,000 — abort the flush at ~1,172 combined; a single 1× market
-  crosses at ~982 nodes (`evidence/c1-object-cache-flush-2026-07-07.md`).
-- Superseded conclusion: the 2026-07-01 model called the flush
-  computation-bound. That holds for the SINGLE market (a full 5,000-order book
-  values at ~47–54% of the compute cap, `evidence/c1-price-memo-2026-07-01.md`;
-  pre-memo that single market OOG'd at ~4,580 orders,
-  `evidence/c1-nav-stress-2026-06-30.md`) but not the pool total. Earlier
-  pool-total runs hit
-  `expiry_cash::EInsufficientCash` (capital) at ~92% compute before reaching the
-  object wall; raising the allocation cap removed that mask and exposed the
-  1,000-child limit.
-- Skew-adjusted pricing re-measured the single-market compute cost on 2026-07-09:
-  the per-order flush slope rose 2.2% (~480K → ~491K computation units) and a
-  full 5,000-order book used 51% of the compute wall. This does not change the
-  pool-total conclusion above: the object-cache limit binds first
-  (`evidence/c1-skew-gas-2026-07-09.md`).
+- Historical wall: Sui **object-runtime cached-objects limit: 1,000 dynamic-field
+  child objects per transaction**. A single 1× market aborted at ~982 table
+  nodes; two markets aborted at 586+586. Those records are now inline, so the
+  flush's child count is the market objects, oracles, and other base children,
+  not `Σ distinct_ticks`.
+- Compute figures in `evidence/c1-price-memo-2026-07-01.md` and
+  `evidence/c1-skew-gas-2026-07-09.md` still describe a full-book walk. They
+  were taken with leveraged orders present and must be re-measured on the 1×-only
+  inline index before this item is closed. The benchmark cannot do that until
+  the simulation parity model is updated.
 - Expired-unswept markets leave the active set only inside a successful
   `value_expiry`/sweep, so the flush's active tail is not bounded by the
   live-market creation cap.
-- Capacity law:
-  `sum_over_active_markets(distinct_ticks + base_children)
-  < 1,000 dynamic-field children per flush PTB` — a joint sum across all active
-  markets, dominated by distinct strike ticks.
-- Leverage removal (2026-08-14) deleted the `ceil(leveraged_orders / 64)`
-  liquidation-book term from this law and the 5,000-order cap that bounded it.
-  Every measured threshold above was taken with leveraged orders present, so the
-  numbers are now conservative for the object wall and stale for compute; they
-  must be re-measured against the 1x-only footprint before this item is closed.
-  The benchmark cannot do that until the simulation parity model is updated.
+- Capacity law: flush child count is no longer dominated by payout-tree nodes.
+  `max_payout_tree_nodes` still caps distinct ticks per market (vector length and
+  mint admission). Joint compute across active markets is the open bound.
 
-**Fix options (reframed for the object-count wall):** shrink the per-market
-NAV-walk child footprint (e.g. cache tree aggregates so `walk_linear` need not
-load every node) · a joint active-market×node budget enforced at creation/roll ·
-valuation resumable across PTBs (partial state instead of a hot potato) · an
-out-of-flush settled sweep/deactivate path (bounds the active tail) · documented
-operator throttling (an off-chain acceptance, not an on-chain guarantee).
+**Fix landed (2026-08-26):** inline sorted vector. Remaining work is the 1×
+compute remasure, not another store change.
 
 **Plan — runs that finish the number (decision rules pre-registered
 2026-07-02):**

--- a/packages/predict/sources/constants.move
+++ b/packages/predict/sources/constants.move
@@ -66,7 +66,7 @@ public(package) macro fun executable_price_band_factor(): u64 { 100 }
 /// full-pool flush.
 public(package) macro fun max_live_expiry_markets(): u64 { 24 }
 
-/// Maximum finite payout-tree boundary nodes one expiry market may carry into NAV.
+/// Maximum finite payout-index boundary records one expiry market may carry into NAV.
 public(package) macro fun max_payout_tree_nodes(): u64 { 1_000 }
 
 // === Time Constants ===

--- a/packages/predict/sources/strike_exposure/index/strike_payout_tree.move
+++ b/packages/predict/sources/strike_exposure/index/strike_payout_tree.move
@@ -3,88 +3,64 @@
 
 /// Sparse strike exposure index for payout-liability accounting.
 ///
-/// The tree keys finite interval boundaries by absolute tick, matching the tick
+/// The index keys finite interval boundaries by absolute tick, matching the tick
 /// pair packed into the durable order ID. Raw strikes are recovered only at the
 /// pricing/settlement boundary, where callers pass the owning market's `tick_size`
-/// (`raw_strike = tick * tick_size`); the tree stores no grid geometry.
+/// (`raw_strike = tick * tick_size`); the index stores no grid geometry.
 ///
-/// This height-balanced (AVL) tree stores finite interval boundaries touched by
-/// positions. Boundary ticks are caller-chosen, so the balancing rule must not
-/// read anything the caller supplies: rotations are driven by measured subtree
-/// height, which bounds depth at `O(log n)` for *every* tick set rather than in
-/// expectation over a random one. Depth is the cost model that matters — each node
-/// is a dynamic-field child, and `apply_at` and `settlement_prefix_payout`
-/// touch one per level against a per-transaction cached-object ceiling.
+/// Records live in a tick-sorted vector on the market object. A full read, a
+/// range peak, and a settlement prefix therefore load no dynamic-field children.
+/// That removes the C-1 object-cache wall from `walk_linear`: the previous AVL
+/// table stored one child per distinct strike, and a pool flush aborted once the
+/// cached-child count reached 1,000.
 ///
-/// It tracks each order's quantity, which is also its settled payout: a winning
-/// order pays its full quantity. Live cash backing is the max-point payout plus a
-/// buffer over the disjoint-book gap; the tree's max-point term is the floor
-/// anchor of that enforced reserve.
-///
-/// Shape carries no value for a consistent index: `combine_summaries` is
-/// associative over the in-order sequence, so any arrangement of the same
-/// boundaries yields identical summaries, settlement prefixes, and linear-walk
-/// totals. That holds only while every prefix is non-negative, which a consistent
-/// book guarantees. Under a caller/index desync the settlement walk's underflow
-/// abort depends on which prefixes a given shape happens to visit, so it is not a
-/// desync detector — the per-boundary underflow in `apply_net_delta` is the
-/// authority.
+/// Each order's quantity is also its settled payout: a winning order pays its
+/// full quantity. Live cash backing is the max-point payout plus a buffer over
+/// the disjoint-book gap; the index's max-point term is the floor anchor of that
+/// enforced reserve. The per-boundary underflow in `apply_net_delta` is the
+/// authority for a caller/index desync.
 module deepbook_predict::strike_payout_tree;
 
 use deepbook_predict::{constants, pricing::Pricer, range_codec};
 use fixed_math::math;
-use sui::table::{Self, Table};
 
 const EInsufficientPayoutQuantity: u64 = 0;
 const EMaxPayoutTreeNodes: u64 = 1;
 const ENonMonotonePrice: u64 = 2;
 
-/// Sparse payout-liability tree keyed by finite strike tick.
+/// Sparse payout-liability index keyed by finite strike tick.
 public struct StrikePayoutTree has store {
-    root: Option<u64>,
-    nodes: Table<u64, PayoutNode>,
+    /// Finite boundaries in strictly ascending tick order. Empty records are
+    /// removed, so every slot is a live edge.
+    records: vector<PayoutRecord>,
+    /// Occupied finite boundaries. Kept beside the vector so tests can seed the
+    /// admission cap without inserting a thousand records.
     node_count: u64,
     /// Aggregate order quantity over the open-lower prefix, which is also its
     /// aggregate settled payout.
     base: u64,
 }
 
-/// Subtree payout totals and max static payout prefix gain.
-public struct PayoutSummary has copy, drop, store {
-    start: u64,
-    end: u64,
-    /// Never exceeds `start`, by construction in `boundary_summary` and
-    /// `combine_summaries`. That bound is what makes `combine_summaries`
-    /// associative at u64 scale — and therefore what makes the tree's shape
-    /// irrelevant to every value it reports. A summary term that could outgrow
-    /// `start` would break shape-independence with no test to catch it, and
-    /// would also abort `strike_exposure`'s plain `total - max` subtraction.
-    max_payout_prefix_gain: u64,
-}
-
-/// Height-balanced node keyed by finite boundary tick.
-public struct PayoutNode has copy, drop, store {
-    /// Longest root-to-leaf path in this subtree, counting this node. A leaf is 1;
-    /// an absent child is 0. Maintained by `resummarize` alongside `summary`, and
-    /// read only by `rebalance` — never by a caller, and never derived from a tick.
-    height: u64,
-    left: Option<u64>,
-    right: Option<u64>,
-    /// This node's own boundary terms, stored so the subtree `summary` can be
-    /// recomputed without deriving locals by subtracting child summaries.
+/// One finite boundary's start and end quantities.
+public struct PayoutRecord has copy, drop, store {
+    tick: u64,
     local_start: u64,
     local_end: u64,
-    summary: PayoutSummary,
 }
 
 /// Return `(max_payout, total_payout)` for pre-settlement reserve math.
 public(package) fun payout_reserve_terms(tree: &StrikePayoutTree): (u64, u64) {
+    let mut running = tree.base;
     let mut max_payout = tree.base;
     let mut total_payout = tree.base;
-    if (tree.root.is_some()) {
-        let summary = tree.nodes[*tree.root.borrow()].summary;
-        max_payout = max_payout + summary.max_payout_prefix_gain;
-        total_payout = total_payout + summary.start;
+    let mut index = 0;
+    while (index < tree.records.length()) {
+        let record = &tree.records[index];
+        apply_net_delta(&mut running, record.local_start, true);
+        apply_net_delta(&mut running, record.local_end, false);
+        if (running > max_payout) max_payout = running;
+        total_payout = total_payout + record.local_start;
+        index = index + 1;
     };
     (max_payout, total_payout)
 }
@@ -99,22 +75,27 @@ public(package) fun range_max_payout(
 ): u64 {
     // Prefix evaluation folds boundaries with `tick < limit`, so `lower + 1`
     // includes a start boundary exactly at `lower`. Tick zero is the open-lower
-    // sentinel and lives in `base`, not in the node table.
-    let prefix_at_lower = settlement_prefix_payout(
-        &tree.nodes,
-        tree.root,
-        lower_tick + 1,
-        tree.base,
-    );
-    let window = window_summary(
-        &tree.nodes,
-        tree.root,
-        lower_tick,
-        higher_tick,
-        0,
-        constants::pos_inf_tick!(),
-    );
-    prefix_at_lower + window.max_payout_prefix_gain
+    // sentinel and lives in `base`, not in the record list.
+    let prefix_at_lower = tree.settlement_prefix_payout(lower_tick + 1);
+    // The window is a subsequence and can open on an end edge of a range that
+    // started at or before `lower`. Track start and end totals separately and
+    // saturate, matching the old subtree-summary algebra.
+    let mut start_total = 0;
+    let mut end_total = 0;
+    let mut max_gain = 0;
+    let mut index = 0;
+    while (index < tree.records.length()) {
+        let record = &tree.records[index];
+        if (record.tick >= higher_tick) break;
+        if (record.tick > lower_tick) {
+            start_total = start_total + record.local_start;
+            end_total = end_total + record.local_end;
+            let gain = start_total.saturating_sub(end_total);
+            if (gain > max_gain) max_gain = gain;
+        };
+        index = index + 1;
+    };
+    prefix_at_lower + max_gain
 }
 
 /// Return the highest payout prefix outside `(lower_tick, higher_tick]`.
@@ -144,19 +125,13 @@ public(package) fun settled_payout_liability(
     settlement: u64,
     tick_size: u64,
 ): u64 {
-    let limit_tick = range_codec::prefix_limit_tick(settlement, tick_size);
-    settlement_prefix_payout(
-        &tree.nodes,
-        tree.root,
-        limit_tick,
-        tree.base,
-    )
+    tree.settlement_prefix_payout(range_codec::prefix_limit_tick(settlement, tick_size))
 }
 
 /// Value the quantity-weighted linear liability by pricing each distinct boundary
 /// once.
 ///
-/// The start and end sides accumulate as two non-negative totals: a node's net
+/// The start and end sides accumulate as two non-negative totals: a record's net
 /// `local_start - local_end` quantity is signed, so a single running `u64` would
 /// underflow mid-walk. They combine once at the top:
 /// `base + start_total - end_total`. `tree.base` is the `P(-inf) = 1`
@@ -164,23 +139,40 @@ public(package) fun settled_payout_liability(
 /// are never stored (`P = 0`).
 public(package) fun walk_linear(tree: &StrikePayoutTree, pricer: &Pricer, tick_size: u64): u64 {
     let mut previous_price = option::none();
-    let (start_total, end_total) = walk_linear_subtree(
-        &tree.nodes,
-        tree.root,
-        pricer,
-        tick_size,
-        &mut previous_price,
-    );
-    // Boundary products are rounded per node and the signed aggregate is floored
+    let mut start_total = 0;
+    let mut end_total = 0;
+    let mut index = 0;
+    while (index < tree.records.length()) {
+        let record = &tree.records[index];
+        let price = pricer.up_price(range_codec::strike_from_tick(record.tick, tick_size));
+        // UP price is non-increasing in strike and the walk visits ascending
+        // ticks, so a rising price is a non-monotone surface: the netted aggregate
+        // below would understate the per-order liability the protocol actually honors.
+        if (previous_price.is_some()) {
+            assert!(price <= *previous_price.borrow(), ENonMonotonePrice);
+        };
+        previous_price = option::some(price);
+
+        // EVERY record is priced, including one whose local start and end
+        // quantities cancel. Only the arithmetic is skipped there, because such a
+        // boundary contributes `price * q - price * q = 0` to the netted aggregate
+        // at any price. The pricing call itself is where monotonicity is observed,
+        // and a cancelling boundary is still the shared edge of two live orders.
+        if (record.local_start != record.local_end) {
+            start_total = start_total + math::mul_down(price, record.local_start);
+            end_total = end_total + math::mul_down(price, record.local_end);
+        };
+        index = index + 1;
+    };
+    // Boundary products are rounded per record and the signed aggregate is floored
     // once. This can differ from pricing and flooring each order independently.
     (tree.base + start_total).saturating_sub(end_total)
 }
 
-/// Create an empty sparse payout tree.
-public(package) fun new(ctx: &mut TxContext): StrikePayoutTree {
+/// Create an empty sparse payout index.
+public(package) fun new(_ctx: &mut TxContext): StrikePayoutTree {
     StrikePayoutTree {
-        root: option::none(),
-        nodes: table::new(ctx),
+        records: vector[],
         node_count: 0,
         base: 0,
     }
@@ -198,13 +190,13 @@ public(package) fun insert_range(
     // Whole-line ranges are rejected by `order`, so this pre-count matches the
     // finite boundaries `apply_range` can create.
     let mut new_nodes = 0;
-    if (lower_tick != 0 && !tree.nodes.contains(lower_tick)) {
+    if (lower_tick != 0 && !tree.contains_tick(lower_tick)) {
         new_nodes = new_nodes + 1;
     };
     if (
         higher_tick != constants::pos_inf_tick!()
             && higher_tick != lower_tick
-            && !tree.nodes.contains(higher_tick)
+            && !tree.contains_tick(higher_tick)
     ) {
         new_nodes = new_nodes + 1;
     };
@@ -234,7 +226,6 @@ fun apply_range(
     quantity: u64,
     add: bool,
 ) {
-    // Skip a fully-zero delta; index any order with nonzero quantity.
     if (quantity == 0) return;
 
     if (lower_tick == 0) {
@@ -255,353 +246,67 @@ fun apply_boundary_delta(
     is_start: bool,
     add: bool,
 ) {
-    let had_node = tree.nodes.contains(tick);
-    let new_root = apply_at(
-        &mut tree.nodes,
-        tree.root,
-        tick,
-        quantity,
-        is_start,
-        add,
-    );
-    tree.root = new_root;
-
-    let has_node = tree.nodes.contains(tick);
-    if (!had_node && has_node) {
-        tree.node_count = tree.node_count + 1;
-    } else if (had_node && !has_node) {
-        tree.node_count = tree.node_count - 1;
-    };
-}
-
-fun apply_at(
-    nodes: &mut Table<u64, PayoutNode>,
-    root: Option<u64>,
-    tick: u64,
-    quantity: u64,
-    is_start: bool,
-    add: bool,
-): Option<u64> {
-    if (root.is_none()) {
-        assert!(add, EInsufficientPayoutQuantity);
-        let leaf = new_leaf(quantity, is_start);
-        nodes.add(tick, leaf);
-        return option::some(tick)
-    };
-
-    let root_tick = *root.borrow();
-    let mut node = nodes[root_tick];
-
-    if (tick == root_tick) {
+    let (found, index) = tree.find_record(tick);
+    if (found) {
+        let record = &mut tree.records[index];
         if (is_start) {
-            apply_net_delta(&mut node.local_start, quantity, add);
+            apply_net_delta(&mut record.local_start, quantity, add);
         } else {
-            apply_net_delta(&mut node.local_end, quantity, add);
+            apply_net_delta(&mut record.local_end, quantity, add);
         };
-        if (is_empty_node(node)) {
-            let _removed = nodes.remove(root_tick);
-            return join_subtrees(nodes, node.left, node.right)
+        if (record.local_start == 0 && record.local_end == 0) {
+            tree.records.remove(index);
+            tree.node_count = tree.node_count - 1;
         };
-        resummarize(nodes, root_tick, node);
-        return option::some(root_tick)
+        return
     };
 
-    // The descent is a plain BST insert; every structural decision is deferred to
-    // `rebalance` on the way back up, which reads only measured heights.
-    if (tick < root_tick) {
-        node.left = apply_at(nodes, node.left, tick, quantity, is_start, add);
-    } else {
-        node.right = apply_at(nodes, node.right, tick, quantity, is_start, add);
-    };
-
-    option::some(rebalance(nodes, root_tick, node))
-}
-
-fun new_leaf(quantity: u64, is_start: bool): PayoutNode {
-    let (start, end) = if (is_start) {
+    assert!(add, EInsufficientPayoutQuantity);
+    let (local_start, local_end) = if (is_start) {
         (quantity, 0)
     } else {
         (0, quantity)
     };
-
-    PayoutNode {
-        height: 1,
-        left: option::none(),
-        right: option::none(),
-        local_start: start,
-        local_end: end,
-        summary: boundary_summary(start, end),
-    }
+    tree.records.insert(PayoutRecord { tick, local_start, local_end }, index);
+    tree.node_count = tree.node_count + 1;
 }
 
-fun rotate_right(
-    nodes: &mut Table<u64, PayoutNode>,
-    root_tick: u64,
-    mut root_node: PayoutNode,
-): u64 {
-    let left_tick = *root_node.left.borrow();
-    let mut left_node = nodes[left_tick];
-
-    // Write the demoted node first so the new parent re-summarizes (and re-measures
-    // its height) against it.
-    root_node.left = left_node.right;
-    resummarize(nodes, root_tick, root_node);
-
-    left_node.right = option::some(root_tick);
-    resummarize(nodes, left_tick, left_node);
-    left_tick
+/// A boundary is active in the prefix iff `tick < limit_tick`
+/// (`tick * tick_size < settlement`).
+fun settlement_prefix_payout(tree: &StrikePayoutTree, limit_tick: u64): u64 {
+    let mut running = tree.base;
+    let mut index = 0;
+    while (index < tree.records.length()) {
+        let record = &tree.records[index];
+        if (record.tick >= limit_tick) break;
+        apply_net_delta(&mut running, record.local_start, true);
+        apply_net_delta(&mut running, record.local_end, false);
+        index = index + 1;
+    };
+    running
 }
 
-fun rotate_left(
-    nodes: &mut Table<u64, PayoutNode>,
-    root_tick: u64,
-    mut root_node: PayoutNode,
-): u64 {
-    let right_tick = *root_node.right.borrow();
-    let mut right_node = nodes[right_tick];
-
-    // Write the demoted node first so the new parent re-summarizes (and re-measures
-    // its height) against it.
-    root_node.right = right_node.left;
-    resummarize(nodes, root_tick, root_node);
-
-    right_node.left = option::some(root_tick);
-    resummarize(nodes, right_tick, right_node);
-    right_tick
+fun contains_tick(tree: &StrikePayoutTree, tick: u64): bool {
+    let (found, _) = tree.find_record(tick);
+    found
 }
 
-/// Fill the hole left by a GC'd boundary with the in-order successor — the
-/// leftmost node of the right subtree — then rebalance the joined subtree. The
-/// successor keeps its own tick (the table is keyed by tick, so a node is never
-/// re-keyed) and inherits the removed node's children.
-fun join_subtrees(
-    nodes: &mut Table<u64, PayoutNode>,
-    left: Option<u64>,
-    right: Option<u64>,
-): Option<u64> {
-    if (left.is_none()) return right;
-    if (right.is_none()) return left;
-
-    let (successor_tick, remainder) = take_min(nodes, *right.borrow());
-    let mut successor = nodes[successor_tick];
-    successor.left = left;
-    successor.right = remainder;
-    option::some(rebalance(nodes, successor_tick, successor))
-}
-
-/// Detach the leftmost node of the subtree rooted at `tick`. Returns that node's
-/// tick and the rebalanced remainder. The detached node is left in the table for
-/// `join_subtrees` to relink — it is never orphaned, because the only caller
-/// immediately reinstalls it.
-fun take_min(nodes: &mut Table<u64, PayoutNode>, tick: u64): (u64, Option<u64>) {
-    let mut node = nodes[tick];
-    if (node.left.is_none()) return (tick, node.right);
-
-    let (min_tick, remainder) = take_min(nodes, *node.left.borrow());
-    node.left = remainder;
-    (min_tick, option::some(rebalance(nodes, tick, node)))
-}
-
-/// Write `node` back at `tick`, restoring the height invariant at that position.
-/// Returns the tick now rooting the subtree. One rotation fixes an outside-heavy
-/// child; an inside-heavy one needs its own rotation first so the taller
-/// grandchild ends up on the outside.
-fun rebalance(nodes: &mut Table<u64, PayoutNode>, tick: u64, mut node: PayoutNode): u64 {
-    let left_height = subtree_height(nodes, node.left);
-    let right_height = subtree_height(nodes, node.right);
-
-    if (left_height > right_height + 1) {
-        let left_tick = *node.left.borrow();
-        let left_node = nodes[left_tick];
-        if (subtree_height(nodes, left_node.right) > subtree_height(nodes, left_node.left)) {
-            node.left = option::some(rotate_left(nodes, left_tick, left_node));
+/// Binary search. Returns `(true, index)` when `tick` is present, otherwise
+/// `(false, insertion_index)` so a new record stays sorted.
+fun find_record(tree: &StrikePayoutTree, tick: u64): (bool, u64) {
+    let mut lo = 0;
+    let mut hi = tree.records.length();
+    while (lo < hi) {
+        let mid = lo + (hi - lo) / 2;
+        let mid_tick = tree.records[mid].tick;
+        if (mid_tick == tick) return (true, mid);
+        if (mid_tick < tick) {
+            lo = mid + 1;
+        } else {
+            hi = mid;
         };
-        rotate_right(nodes, tick, node)
-    } else if (right_height > left_height + 1) {
-        let right_tick = *node.right.borrow();
-        let right_node = nodes[right_tick];
-        if (subtree_height(nodes, right_node.left) > subtree_height(nodes, right_node.right)) {
-            node.right = option::some(rotate_right(nodes, right_tick, right_node));
-        };
-        rotate_left(nodes, tick, node)
-    } else {
-        resummarize(nodes, tick, node);
-        tick
-    }
-}
-
-fun settlement_prefix_payout(
-    nodes: &Table<u64, PayoutNode>,
-    root: Option<u64>,
-    limit_tick: u64,
-    running: u64,
-): u64 {
-    if (root.is_none()) return running;
-    let tick = *root.borrow();
-    let node = nodes[tick];
-    // A boundary is active in the prefix iff `tick < limit_tick`
-    // (`tick * tick_size < settlement`); otherwise exclude it and its right subtree.
-    if (limit_tick <= tick) {
-        return settlement_prefix_payout(nodes, node.left, limit_tick, running)
     };
-
-    let mut running = running;
-    let left_summary = subtree_summary(nodes, node.left);
-    apply_net_delta(&mut running, left_summary.start, true);
-    apply_net_delta(&mut running, left_summary.end, false);
-    apply_net_delta(&mut running, node.local_start, true);
-    apply_net_delta(&mut running, node.local_end, false);
-    settlement_prefix_payout(nodes, node.right, limit_tick, running)
-}
-
-/// Combine every boundary strictly inside `(lower, higher)`. Whole subtrees
-/// contained by the window return their stored summary, keeping the read
-/// logarithmic in tree height rather than scanning the payout surface.
-fun window_summary(
-    nodes: &Table<u64, PayoutNode>,
-    root: Option<u64>,
-    lower: u64,
-    higher: u64,
-    subtree_low: u64,
-    subtree_high: u64,
-): PayoutSummary {
-    if (root.is_none()) return zero_summary();
-    if (subtree_low >= lower && subtree_high <= higher) return subtree_summary(nodes, root);
-
-    let tick = *root.borrow();
-    let node = nodes[tick];
-    if (tick <= lower) {
-        return window_summary(nodes, node.right, lower, higher, tick, subtree_high)
-    };
-    if (tick >= higher) {
-        return window_summary(nodes, node.left, lower, higher, subtree_low, tick)
-    };
-
-    let left = window_summary(nodes, node.left, lower, higher, subtree_low, tick);
-    let right = window_summary(nodes, node.right, lower, higher, tick, subtree_high);
-    let boundary = boundary_summary(node.local_start, node.local_end);
-    combine_summaries(combine_summaries(left, boundary), right)
-}
-
-/// Accumulate start and end boundary products separately during an in-order walk.
-///
-/// EVERY node is priced, including one whose local start and end quantities cancel.
-/// Only the arithmetic is skipped there, because such a boundary contributes
-/// `price * q - price * q = 0` to the netted aggregate at any price. The pricing
-/// call itself must not be skipped: it is where monotonicity is observed, and a
-/// cancelling boundary is still the shared edge of two live orders. An inversion
-/// sitting on it does not move this walk's total, but it does move what
-/// `redeem_live` pays per order (`range_price` is evaluated per order, not netted),
-/// so skipping the observation would let NAV understate liability without aborting.
-fun walk_linear_subtree(
-    nodes: &Table<u64, PayoutNode>,
-    root: Option<u64>,
-    pricer: &Pricer,
-    tick_size: u64,
-    previous_price: &mut Option<u64>,
-): (u64, u64) {
-    if (root.is_none()) return (0, 0);
-    let tick = *root.borrow();
-    let node = nodes[tick];
-
-    let (left_start, left_end) = walk_linear_subtree(
-        nodes,
-        node.left,
-        pricer,
-        tick_size,
-        previous_price,
-    );
-
-    let price = pricer.up_price(range_codec::strike_from_tick(tick, tick_size));
-    // UP price is non-increasing in strike and the in-order walk visits ascending
-    // ticks, so a rising price is a non-monotone surface: the netted aggregate
-    // below would understate the per-order liability the protocol actually honors.
-    if (previous_price.is_some()) {
-        assert!(price <= *previous_price.borrow(), ENonMonotonePrice);
-    };
-    *previous_price = option::some(price);
-
-    let mut start_total = 0;
-    let mut end_total = 0;
-    if (node.local_start != node.local_end) {
-        start_total = math::mul_down(price, node.local_start);
-        end_total = math::mul_down(price, node.local_end);
-    };
-
-    let (right_start, right_end) = walk_linear_subtree(
-        nodes,
-        node.right,
-        pricer,
-        tick_size,
-        previous_price,
-    );
-    (start_total + left_start + right_start, end_total + left_end + right_end)
-}
-
-fun resummarize(nodes: &mut Table<u64, PayoutNode>, tick: u64, mut node: PayoutNode) {
-    let (left, left_height) = subtree_facts(nodes, node.left);
-    let (right, right_height) = subtree_facts(nodes, node.right);
-    let boundary = boundary_summary(node.local_start, node.local_end);
-    node.summary = combine_summaries(combine_summaries(left, boundary), right);
-    node.height = 1 + left_height.max(right_height);
-    *nodes.borrow_mut(tick) = node;
-}
-
-/// Summary and height of one child in a single table read. Every re-summarize
-/// needs both, and each child load is a dynamic-field access — reading the two
-/// fields separately doubled the loads on the hottest path in the module.
-fun subtree_facts(nodes: &Table<u64, PayoutNode>, root: Option<u64>): (PayoutSummary, u64) {
-    if (root.is_none()) return (zero_summary(), 0);
-    let node = nodes[*root.borrow()];
-    (node.summary, node.height)
-}
-
-fun subtree_summary(nodes: &Table<u64, PayoutNode>, root: Option<u64>): PayoutSummary {
-    if (root.is_none()) return zero_summary();
-    nodes[*root.borrow()].summary
-}
-
-fun subtree_height(nodes: &Table<u64, PayoutNode>, root: Option<u64>): u64 {
-    if (root.is_none()) return 0;
-    nodes[*root.borrow()].height
-}
-
-fun boundary_summary(start: u64, end: u64): PayoutSummary {
-    PayoutSummary {
-        start,
-        end,
-        max_payout_prefix_gain: positive_net_delta(start, end, 0),
-    }
-}
-
-fun zero_summary(): PayoutSummary {
-    PayoutSummary {
-        start: 0,
-        end: 0,
-        max_payout_prefix_gain: 0,
-    }
-}
-
-fun combine_summaries(left: PayoutSummary, right: PayoutSummary): PayoutSummary {
-    let right_gain_after_left = positive_net_delta(
-        left.start,
-        left.end,
-        right.max_payout_prefix_gain,
-    );
-
-    PayoutSummary {
-        start: left.start + right.start,
-        end: left.end + right.end,
-        max_payout_prefix_gain: left.max_payout_prefix_gain.max(right_gain_after_left),
-    }
-}
-
-fun positive_net_delta(start: u64, end: u64, gain: u64): u64 {
-    (start + gain).saturating_sub(end)
-}
-
-fun is_empty_node(node: PayoutNode): bool {
-    node.local_start == 0 && node.local_end == 0
+    (false, lo)
 }
 
 fun apply_net_delta(value: &mut u64, delta: u64, add: bool) {
@@ -622,67 +327,20 @@ public(package) fun set_node_count_for_testing(tree: &mut StrikePayoutTree, node
 }
 
 #[test_only]
-/// Assert the whole tree invariant, recomputing every stored field from the
-/// children rather than trusting it: search order, AVL balance, each node's
-/// `height`, each node's `summary`, and that no node is stranded outside the tree.
-///
-/// Balance alone is not the property that protects money here. A splice that
-/// mislinks a child, or leaves a stale `summary`, yields a perfectly balanced tree
-/// whose settled liability is silently wrong — no abort, no height violation, and
-/// `node_count` still agreeing with the table. Only recomputation catches that.
-///
-/// Returns the tree's height, which is the guarantee this module now makes and
-/// which no evaluator output reveals — so callers get the depth assertion from the
-/// same seam rather than needing a second one.
+/// Assert the list invariant: strictly ascending ticks, no empty records, and
+/// `node_count` equal to the live record count. Returns that count.
 public(package) fun assert_tree_invariant_for_testing(tree: &StrikePayoutTree): u64 {
-    let (height, _, reachable) = assert_subtree_invariant(
-        &tree.nodes,
-        tree.root,
-        0,
-        constants::pos_inf_tick!(),
-    );
-    assert!(reachable == tree.node_count);
-    height
-}
-
-#[test_only]
-/// Returns `(height, summary, node count)` for the subtree, asserting every
-/// invariant on the way. `lower`/`upper` are the exclusive key bounds this subtree
-/// must lie within — that is what makes a mislinked child detectable.
-fun assert_subtree_invariant(
-    nodes: &Table<u64, PayoutNode>,
-    root: Option<u64>,
-    lower: u64,
-    upper: u64,
-): (u64, PayoutSummary, u64) {
-    if (root.is_none()) return (0, zero_summary(), 0);
-
-    let tick = *root.borrow();
-    assert!(tick > lower && tick < upper);
-    let node = nodes[tick];
-
-    let (left_height, left_summary, left_count) = assert_subtree_invariant(
-        nodes,
-        node.left,
-        lower,
-        tick,
-    );
-    let (right_height, right_summary, right_count) = assert_subtree_invariant(
-        nodes,
-        node.right,
-        tick,
-        upper,
-    );
-
-    let taller = left_height.max(right_height);
-    assert!(taller - left_height.min(right_height) <= 1);
-    assert!(node.height == 1 + taller);
-
-    let boundary = boundary_summary(node.local_start, node.local_end);
-    let summary = combine_summaries(combine_summaries(left_summary, boundary), right_summary);
-    assert!(node.summary.start == summary.start);
-    assert!(node.summary.end == summary.end);
-    assert!(node.summary.max_payout_prefix_gain == summary.max_payout_prefix_gain);
-
-    (1 + taller, summary, left_count + right_count + 1)
+    let mut previous_tick = option::none();
+    let mut index = 0;
+    while (index < tree.records.length()) {
+        let record = &tree.records[index];
+        assert!(record.local_start > 0 || record.local_end > 0);
+        if (previous_tick.is_some()) {
+            assert!(record.tick > *previous_tick.borrow());
+        };
+        previous_tick = option::some(record.tick);
+        index = index + 1;
+    };
+    assert!(tree.node_count == tree.records.length());
+    tree.records.length()
 }

--- a/packages/predict/sources/strike_exposure/strike_exposure.move
+++ b/packages/predict/sources/strike_exposure/strike_exposure.move
@@ -53,7 +53,7 @@ public struct StrikeExposure has store {
     settlement_price: Option<u64>,
     /// Remaining payout liability in the settled phase.
     settled_payout_liability: u64,
-    /// Sparse payout tree for live cash backing and settled liability.
+    /// Sparse payout index for live cash backing and settled liability.
     payout: StrikePayoutTree,
 }
 

--- a/packages/predict/tests/strike_exposure/index/strike_payout_tree_balance_tests.move
+++ b/packages/predict/tests/strike_exposure/index/strike_payout_tree_balance_tests.move
@@ -1,22 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Depth and shape regression for the payout tree.
+/// Order-independence and garbage-collection regressions for the payout index.
 ///
-/// Boundary ticks are chosen by whoever mints, so the balancing rule must not be
-/// derivable from a tick. The previous treap keyed rotations on
-/// `blake2b256(bcs(tick))`, which is exactly that: a caller could scan for ticks
-/// whose priorities descend as the ticks ascend and force a right spine of depth
-/// N, turning every `apply_at` and settlement prefix walk into an N-node
-/// dynamic-field traversal. External audit issue #47.
-///
-/// Depth is enforced by code alone — a runtime balance check would cost a full
-/// traversal, so nothing on chain notices a regression, and the only symptom is
-/// the tree drifting back toward the spine this change exists to prevent. These
-/// tests are therefore the whole guarantee, and they are written to kill specific
-/// mutations rather than to exercise the happy path: insertion orders are chosen
-/// to reach all four rotation cases, and `assert_tree_invariant_for_testing`
-/// recomputes every stored height and summary rather than trusting them.
+/// Insertion order and mid-sequence removes must leave the same sorted records
+/// and the same reserve and settlement terms. `assert_tree_invariant_for_testing`
+/// recomputes sort order and emptiness rather than trusting `node_count`.
 #[test_only]
 module deepbook_predict::strike_payout_tree_balance_tests;
 
@@ -26,12 +15,11 @@ use std::unit_test::{assert_eq, destroy};
 const QUANTITY: u64 = 1_000_000;
 const NODES: u64 = 100;
 const GC_STRIDE: u64 = 3;
+const GC_SURVIVORS: u64 = 66;
 
-/// On-grid ticks, strictly increasing, whose treap priorities strictly DECREASE —
-/// the shape attack. Every tick is a multiple of 10, so the set clears
-/// `strike_exposure::assert_admitted_mint_ticks`'s grid gate for a market whose
-/// `admission_tick_size` is 10x its `tick_size`. Found with ~11k blake2b probes,
-/// well under a second of laptop CPU.
+/// On-grid ticks, strictly increasing. Every tick is a multiple of 10, so the
+/// set clears `strike_exposure::assert_admitted_mint_ticks`'s grid gate for a
+/// market whose `admission_tick_size` is 10x its `tick_size`.
 const SKEWED_TICKS: vector<u64> = vector[
     1110, 10739550, 21475700, 32213220, 42949930, 53689330, 64425020, 75162460, 85899770, 96637210,
     107378160, 118115050, 128850590, 139586740, 150323920, 161062410, 171800450, 182536090,
@@ -48,16 +36,6 @@ const SKEWED_TICKS: vector<u64> = vector[
     1052266700, 1063003910,
 ];
 
-/// Minimum height for 100 nodes: `ceil(log2(101))`. Ascending insertion into a
-/// height-balanced tree always achieves it.
-const EXPECTED_HEIGHT: u64 = 7;
-/// AVL's worst case at 100 nodes, from the minimum-nodes recurrence
-/// `N(h) = N(h-1) + N(h-2) + 1`: `N(9) = 88 <= 100 < N(10) = 143`, so height <= 9.
-/// At the production cap of `max_payout_tree_nodes!()` the same recurrence gives
-/// `N(14) = 986 <= 1000 < N(15) = 1596` — height <= 14 for every admissible tick
-/// set, against the treap's 1000-deep adversarial worst case.
-const AVL_HEIGHT_BOUND: u64 = 9;
-
 fun insert(tree: &mut StrikePayoutTree, tick: u64) {
     tree.insert_range(tick, constants::pos_inf_tick!(), QUANTITY);
 }
@@ -66,8 +44,7 @@ fun remove(tree: &mut StrikePayoutTree, tick: u64) {
     tree.remove_range(tick, constants::pos_inf_tick!(), QUANTITY);
 }
 
-/// Insert one finite boundary per tick, checking the whole invariant after each —
-/// a mid-sequence corruption that a later rotation happens to repair still fails.
+/// Insert one finite boundary per tick, checking the whole invariant after each.
 fun build_checked(ticks: vector<u64>, ctx: &mut TxContext): StrikePayoutTree {
     let mut tree = strike_payout_tree::new(ctx);
     ticks.do!(|tick| {
@@ -84,37 +61,31 @@ fun settled_above_all(tree: &StrikePayoutTree): u64 {
 }
 
 #[test]
-/// The attack fixture, in the order it was generated.
-fun chosen_ticks_cannot_force_a_deep_tree() {
+fun chosen_ticks_stay_sorted_and_keep_terms() {
     let mut ctx = tx_context::dummy();
     let tree = build_checked(SKEWED_TICKS, &mut ctx);
 
-    assert_eq!(tree.assert_tree_invariant_for_testing(), EXPECTED_HEIGHT);
-    assert!(EXPECTED_HEIGHT <= AVL_HEIGHT_BOUND);
+    assert_eq!(tree.assert_tree_invariant_for_testing(), NODES);
     assert_eq!(settled_above_all(&tree), NODES * QUANTITY);
 
     destroy(tree);
 }
 
 #[test]
-/// Descending arrival drives the left-heavy single rotation, which ascending
-/// fixtures never reach.
-fun descending_inserts_stay_balanced() {
+fun descending_inserts_match_ascending_terms() {
     let mut ctx = tx_context::dummy();
     let mut ticks = SKEWED_TICKS;
     ticks.reverse();
     let tree = build_checked(ticks, &mut ctx);
 
-    assert_eq!(tree.assert_tree_invariant_for_testing(), EXPECTED_HEIGHT);
+    assert_eq!(tree.assert_tree_invariant_for_testing(), NODES);
     assert_eq!(settled_above_all(&tree), NODES * QUANTITY);
 
     destroy(tree);
 }
 
 #[test]
-/// Outside-in arrival alternates the two heavy sides, reaching both double
-/// rotations as well as both singles.
-fun outside_in_inserts_stay_balanced() {
+fun outside_in_inserts_match_ascending_terms() {
     let mut ctx = tx_context::dummy();
     let sorted = SKEWED_TICKS;
     let mut zigzag = vector[];
@@ -129,19 +100,14 @@ fun outside_in_inserts_stay_balanced() {
     };
 
     let tree = build_checked(zigzag, &mut ctx);
-    assert!(tree.assert_tree_invariant_for_testing() <= AVL_HEIGHT_BOUND);
+    assert_eq!(tree.assert_tree_invariant_for_testing(), NODES);
     assert_eq!(settled_above_all(&tree), NODES * QUANTITY);
 
     destroy(tree);
 }
 
 #[test]
-/// A delete can leave a node two levels heavy with its taller child's subtrees
-/// EQUAL in height. That tie must take the single rotation: the double leaves the
-/// demoted child holding a two-level gap that nothing goes back to fix. Only a
-/// removal produces the tie, so no insert-only fixture distinguishes `>` from
-/// `>=` in `rebalance`'s inner-rotation condition.
-fun delete_induced_height_tie_takes_the_single_rotation() {
+fun removing_an_end_tick_keeps_the_remaining_terms() {
     let mut ctx = tx_context::dummy();
     let mut tree = strike_payout_tree::new(&mut ctx);
 
@@ -150,19 +116,16 @@ fun delete_induced_height_tie_takes_the_single_rotation() {
 
     remove(&mut tree, 1);
 
-    // Under `>=` this leaves a node with subtree heights 0 and 2.
-    assert_eq!(tree.assert_tree_invariant_for_testing(), 4);
+    assert_eq!(tree.assert_tree_invariant_for_testing(), 7);
     assert_eq!(settled_above_all(&tree), 7 * QUANTITY);
 
-    // The mirror image, so both the left-heavy and right-heavy inner conditions
-    // are pinned. Removing the largest tick leans the tree the other way.
     let mut mirrored = strike_payout_tree::new(&mut ctx);
     vector[8, 7, 6, 3, 2, 4, 5, 1].do!(|tick| insert(&mut mirrored, tick));
     mirrored.assert_tree_invariant_for_testing();
 
     remove(&mut mirrored, 8);
 
-    assert_eq!(mirrored.assert_tree_invariant_for_testing(), 4);
+    assert_eq!(mirrored.assert_tree_invariant_for_testing(), 7);
     assert_eq!(settled_above_all(&mirrored), 7 * QUANTITY);
 
     destroy(tree);
@@ -170,11 +133,7 @@ fun delete_induced_height_tie_takes_the_single_rotation() {
 }
 
 #[test]
-/// When the in-order successor carries a right subtree of its own, that subtree
-/// must be re-parented onto the successor's old parent. Dropping it keeps the tree
-/// balanced, keeps `node_count` consistent, and silently loses a boundary's payout
-/// — so this asserts terms, not shape.
-fun successor_keeps_its_own_right_subtree() {
+fun removing_an_interior_tick_keeps_neighbor_terms() {
     let mut ctx = tx_context::dummy();
     let mut tree = strike_payout_tree::new(&mut ctx);
 
@@ -192,10 +151,7 @@ fun successor_keeps_its_own_right_subtree() {
 }
 
 #[test]
-/// The rewritten GC path, asserted on terms rather than height. A splice that
-/// leaves a stale summary keeps every height correct while reporting a reserve
-/// floor that is wrong by a factor of two.
-fun boundary_gc_preserves_terms_and_balance() {
+fun boundary_gc_preserves_terms_against_a_rebuild() {
     let mut ctx = tx_context::dummy();
     let ticks = SKEWED_TICKS;
     let mut tree = build_checked(ticks, &mut ctx);
@@ -213,12 +169,9 @@ fun boundary_gc_preserves_terms_and_balance() {
     };
 
     // 100 ticks, every third removed -> 34 removed, 66 survive.
-    assert_eq!(survivors.length(), 66);
-    assert_eq!(settled_above_all(&tree), 66 * QUANTITY);
+    assert_eq!(survivors.length(), GC_SURVIVORS);
+    assert_eq!(settled_above_all(&tree), GC_SURVIVORS * QUANTITY);
 
-    // Metamorphic: a tree built from the survivors alone has a DIFFERENT shape
-    // (the GC'd tree carries rotation history the rebuilt one never saw), so
-    // agreement on every evaluator is a real check, not a tautology.
     let rebuilt = build_checked(survivors, &mut ctx);
     assert_eq!(settled_above_all(&tree), settled_above_all(&rebuilt));
     let (gc_max, gc_total) = tree.payout_reserve_terms();
@@ -231,16 +184,9 @@ fun boundary_gc_preserves_terms_and_balance() {
 }
 
 #[test]
-/// Mixed insert/remove churn. A deterministic LCG picks the tick so the sequence
-/// is reproducible; the invariant is recomputed after every single operation,
-/// which is what kills the ordering and double-rotation mutations that fixed
-/// fixtures miss.
 fun interleaved_churn_preserves_the_invariant() {
     let mut ctx = tx_context::dummy();
     let mut tree = strike_payout_tree::new(&mut ctx);
-    // Sized so the per-operation invariant recomputation (which walks the whole
-    // tree) fits the unit-test gas budget; the mutation-killing property is the
-    // mixed insert/remove order plus checking after EVERY op, not the op count.
     let span = 60;
     let mut live = vector[];
     let mut seed = 12345;
@@ -260,15 +206,13 @@ fun interleaved_churn_preserves_the_invariant() {
     });
 
     assert_eq!(settled_above_all(&tree), live.length() * QUANTITY);
-    assert!(tree.assert_tree_invariant_for_testing() <= AVL_HEIGHT_BOUND);
+    assert_eq!(tree.assert_tree_invariant_for_testing(), live.length());
 
     destroy(tree);
 }
 
 #[test]
-/// Draining every boundary must leave the tree genuinely empty, including the
-/// root-removal case where `join_subtrees` has to produce a new root.
-fun draining_every_boundary_empties_the_tree() {
+fun draining_every_boundary_empties_the_index() {
     let mut ctx = tx_context::dummy();
     let ticks = SKEWED_TICKS;
     let mut tree = build_checked(ticks, &mut ctx);

--- a/packages/predict/tests/strike_exposure/index/strike_payout_tree_tests.move
+++ b/packages/predict/tests/strike_exposure/index/strike_payout_tree_tests.move
@@ -1,11 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Unit tests for `strike_payout_tree`. The tree keys finite interval boundaries
+/// Unit tests for `strike_payout_tree`. The index keys finite interval boundaries
 /// by absolute tick; raw strikes are recovered only at settlement via the caller-
 /// supplied `tick_size` (`raw_strike = tick * tick_size`). Range-shape validity
 /// (lower < higher, sentinels) is enforced by `order` when ticks are packed, not by
-/// the tree, so the only tree-level abort is removing terms that are not present.
+/// the index, so the only index-level abort is removing terms that are not present.
 #[test_only]
 module deepbook_predict::strike_payout_tree_tests;
 


### PR DESCRIPTION
## Summary

- The payout book is still “quantity at each distinct strike.” That is unchanged.
- Those quantities used to live one strike per dynamic-field child. They now live in one sorted vector on the market object.
- `walk_linear` and the solvency reads keep the same exact numbers. A flush no longer pages one child per strike, which is what tripped C-1.

## Why

Fungible PLP needs one fair mark: idle cash plus each live market’s `cash − Σ q·P`. The `q` values were already tallied on every mint and redeem. The expensive part was not the formula. It was **where `q` sat**.

Each boundary was a `Table` child. Sui caches every loaded child for the whole transaction. `walk_linear` must visit every boundary to apply today’s prices, so one market aborted near 982 strikes and two markets aborted at 586+586. While that flush fails, queued LP fills stop.

This PR does not walk the book less and does not change NAV. It stores the same histogram inline, so the walk is a loop over memory instead of 1k object loads. That is the same pattern as `inventory_cells`, except this copy is exact — the coarse inventory lattice is not a legal NAV source.

A multi-tx flush (#1265 / DBU-754) would also dodge the child wall by resetting the cache each transaction. This change keeps the existing single-PTB flush and removes the wall by construction.

## Linear / Context

- C-1 (`packages/predict/predeploy/open-items.md`)
- Alternative to #1265 / DBU-754 (staged lock-free flush) and #1176 / DBU-679 (resumable flush that pauses trading)
- N/A — exempt (no new Linear ticket; this is the C-1 store fix)

## Key decisions

- One store, not a tree plus an array. Dual-write on every mint would pay both bills and can drift.
- Keep `max_payout_tree_nodes` as the distinct-tick admission cap. The cap is now vector length, not a child budget.
- Range-peak windows can open on an end edge, so that scan saturates start/end totals instead of under-flowing a running payout.
- C-1 stays open for a 1×-only compute remasure. The object-cache driver is closed; the last compute numbers still include leveraged orders.

## Scope / Descoped

- Package API and NAV formula are unchanged.
- No keeper or flush-protocol change. Trading stays on the existing single-PTB flush.
- Localnet remasure of full-pool flush compute is follow-up (C-1 / P-30).
- Does not implement #1265's staged snapshot.

## Test plan

- [x] `/tmp/sui-1.74.1/sui move build --path packages/predict --warnings-are-errors` — clean
- [x] `/tmp/sui-1.74.1/sui move test --path packages/predict --gas-limit 100000000000` — 504/504
- [x] `python3 packages/predict/predeploy/check.py` — clean
- [x] `pnpm format:move` — no diffs
- [x] Existing index tests still pin reserve terms, settlement prefixes, range peaks, node-cap aborts, GC rebuild equality, insertion-order independence, and `ENonMonotonePrice` on a cancelling last boundary

## Risk / Rollout

Fresh publish only; `StrikePayoutTree` layout changes and Predict has no mainnet objects. Mint and close now rewrite the boundary vector on the market object (same class of rewrite as other inline market state). A bug in sort, empty-record delete, or the saturating range-peak scan would mis-state the reserve or the flush mark; the existing number tests are the acceptance. Residual C-1 work is compute, not children.