### PR TITLE
sessions: scope session grants to the assets they name (DBU-765)

### DIFF
--- a/packages/sessions/sources/sessions.move
+++ b/packages/sessions/sources/sessions.move
@@ -23,6 +23,8 @@ use sui::{accumulator::AccumulatorRoot, clock::Clock, event, vec_map::{Self, Vec
 const EInvalidSessionDuration: u64 = 0;
 const ESessionNotAuthorized: u64 = 1;
 const ESessionLimitExceeded: u64 = 2;
+const EInvalidSessionVenues: u64 = 3;
+const EVenueNotGranted: u64 = 4;
 
 // === Constants ===
 
@@ -30,20 +32,36 @@ macro fun max_session_duration_ms(): u64 { 30 * 24 * 60 * 60 * 1000 }
 
 macro fun max_sessions(): u64 { 20 }
 
+macro fun max_session_venues(): u64 { 20 }
+
 // === Structs ===
 
 /// App witness for Account registry authorization and per-account data namespacing.
 public struct SessionsApp has drop {}
 
-/// Session expiration timestamps keyed by transaction signer address.
-public struct SessionsData has store {
-    sessions: VecMap<address, u64>,
+/// The terms a session was granted: where it may act, and until when.
+/// A grant confers no authority outside these venues, so widening a session's
+/// reach requires a fresh owner-signed `authorize_session`.
+public struct SessionGrant has copy, drop, store {
+    /// Execution time past which the grant is inert.
+    expires_at_ms: u64,
+    /// Shared objects this session may act on: DeepBook `Pool` ids for the spot
+    /// entrypoints, `ExpiryMarket` ids for the Predict entrypoints. Allowlist —
+    /// an id absent here is refused, and the set is never empty.
+    venues: vector<ID>,
 }
 
-/// A session was authorized or reauthorized through `expires_at_ms`.
+/// Session grants keyed by transaction signer address.
+public struct SessionsData has store {
+    sessions: VecMap<address, SessionGrant>,
+}
+
+/// A session was authorized or reauthorized on `venues` through `expires_at_ms`.
+/// Reauthorization replaces the previous terms outright rather than adding to them.
 public struct SessionAuthorized has copy, drop {
     account_id: ID,
     session: address,
+    venues: vector<ID>,
     expires_at_ms: u64,
 }
 
@@ -58,25 +76,36 @@ public struct SessionRevoked has copy, drop {
 
 /// Return a known session's expiration timestamp for SDK and devInspect reads.
 public fun session_expiration_ms(wrapper: &AccountWrapper, session: address): Option<u64> {
-    let account = wrapper.load_account();
-    if (!account.has_data<SessionsApp>()) return option::none();
-    let data = account.borrow_data<SessionsApp, SessionsData>();
-    data.sessions.try_get(&session)
+    let grant = session_grant(wrapper, session);
+    if (grant.is_none()) option::none() else option::some(grant.borrow().expires_at_ms)
 }
 
-/// Authorize `session` from execution time for at most 30 days.
-/// Accounts may store at most 20 addresses; reauthorization replaces in place.
+/// Return the venues a known session may act on, for SDK and devInspect reads.
+public fun session_venues(wrapper: &AccountWrapper, session: address): Option<vector<ID>> {
+    let grant = session_grant(wrapper, session);
+    if (grant.is_none()) option::none() else option::some(grant.borrow().venues)
+}
+
+/// Authorize `session` on `venues` from execution time for at most 30 days.
+/// `venues` are the DeepBook `Pool` and `ExpiryMarket` ids the session may act on;
+/// it must name at least one and at most 20 distinct ids, because a grant carries
+/// no authority beyond the venues it names.
+/// Accounts may store at most 20 addresses; reauthorization replaces the grant in
+/// place, so re-granting is how a session's venues or expiry change.
 public fun authorize_session(
     wrapper: &mut AccountWrapper,
     sessions_config: &SessionsConfig,
     session: address,
+    venues: vector<ID>,
     duration_ms: u64,
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
     sessions_config.assert_version();
     assert!(duration_ms > 0 && duration_ms <= max_session_duration_ms!(), EInvalidSessionDuration);
+    assert_distinct_venues(&venues);
     let expires_at_ms = clock.timestamp_ms() + duration_ms;
+    let grant = SessionGrant { expires_at_ms, venues };
     let account = wrapper.load_account_mut(account::generate_auth(ctx));
     let account_id = account.account_id();
     if (!account.has_data<SessionsApp>()) {
@@ -84,12 +113,17 @@ public fun authorize_session(
     };
     let data = account.borrow_data_mut<SessionsApp, SessionsData>(permit<SessionsApp>());
     if (data.sessions.contains(&session)) {
-        *data.sessions.get_mut(&session) = expires_at_ms;
+        *data.sessions.get_mut(&session) = grant;
     } else {
         assert!(data.sessions.length() < max_sessions!(), ESessionLimitExceeded);
-        data.sessions.insert(session, expires_at_ms);
+        data.sessions.insert(session, grant);
     };
-    event::emit(SessionAuthorized { account_id, session, expires_at_ms });
+    event::emit(SessionAuthorized {
+        account_id,
+        session,
+        venues: grant.venues,
+        expires_at_ms,
+    });
 }
 
 /// Revoke `session` if it is present. Only the Account owner may call this function.
@@ -99,8 +133,8 @@ public fun revoke_session(wrapper: &mut AccountWrapper, session: address, ctx: &
     let account_id = account.account_id();
     let data = account.borrow_data_mut<SessionsApp, SessionsData>(permit<SessionsApp>());
     if (!data.sessions.contains(&session)) return;
-    let (_, expires_at_ms) = data.sessions.remove(&session);
-    event::emit(SessionRevoked { account_id, session, expires_at_ms });
+    let (_, grant) = data.sessions.remove(&session);
+    event::emit(SessionRevoked { account_id, session, expires_at_ms: grant.expires_at_ms });
 }
 
 /// Place a DeepBook spot limit order for an Account with an active session.
@@ -122,7 +156,14 @@ public fun place_limit_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ): OrderInfo {
-    let auth = generate_auth_as_session(sessions_config, account_registry, wrapper, clock, ctx);
+    let auth = generate_auth_as_session(
+        sessions_config,
+        account_registry,
+        wrapper,
+        pool.id(),
+        clock,
+        ctx,
+    );
     deepbook_core_account::place_limit_order(
         pool,
         deepbook_registry,
@@ -159,7 +200,14 @@ public fun place_market_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ): OrderInfo {
-    let auth = generate_auth_as_session(sessions_config, account_registry, wrapper, clock, ctx);
+    let auth = generate_auth_as_session(
+        sessions_config,
+        account_registry,
+        wrapper,
+        pool.id(),
+        clock,
+        ctx,
+    );
     deepbook_core_account::place_market_order(
         pool,
         deepbook_registry,
@@ -187,7 +235,14 @@ public fun cancel_live_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    let auth = generate_auth_as_session(sessions_config, account_registry, wrapper, clock, ctx);
+    let auth = generate_auth_as_session(
+        sessions_config,
+        account_registry,
+        wrapper,
+        pool.id(),
+        clock,
+        ctx,
+    );
     deepbook_core_account::cancel_live_order(pool, wrapper, auth, order_id, clock, ctx);
 }
 
@@ -201,7 +256,14 @@ public fun cancel_live_orders<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    let auth = generate_auth_as_session(sessions_config, account_registry, wrapper, clock, ctx);
+    let auth = generate_auth_as_session(
+        sessions_config,
+        account_registry,
+        wrapper,
+        pool.id(),
+        clock,
+        ctx,
+    );
     deepbook_core_account::cancel_live_orders(pool, wrapper, auth, order_ids, clock, ctx);
 }
 
@@ -214,7 +276,14 @@ public fun withdraw_settled_amounts<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    let auth = generate_auth_as_session(sessions_config, account_registry, wrapper, clock, ctx);
+    let auth = generate_auth_as_session(
+        sessions_config,
+        account_registry,
+        wrapper,
+        pool.id(),
+        clock,
+        ctx,
+    );
     deepbook_core_account::withdraw_settled_amounts(pool, wrapper, auth, ctx);
 }
 
@@ -235,7 +304,14 @@ public fun mint_exact_quantity(
     clock: &Clock,
     ctx: &mut TxContext,
 ): u256 {
-    let auth = generate_auth_as_session(sessions_config, account_registry, wrapper, clock, ctx);
+    let auth = generate_auth_as_session(
+        sessions_config,
+        account_registry,
+        wrapper,
+        market.id(),
+        clock,
+        ctx,
+    );
     market.mint_exact_quantity(
         wrapper,
         auth,
@@ -269,7 +345,14 @@ public fun mint_exact_amount(
     clock: &Clock,
     ctx: &mut TxContext,
 ): u256 {
-    let auth = generate_auth_as_session(sessions_config, account_registry, wrapper, clock, ctx);
+    let auth = generate_auth_as_session(
+        sessions_config,
+        account_registry,
+        wrapper,
+        market.id(),
+        clock,
+        ctx,
+    );
     market.mint_exact_amount(
         wrapper,
         auth,
@@ -302,7 +385,14 @@ public fun redeem_live(
     clock: &Clock,
     ctx: &mut TxContext,
 ): Option<u256> {
-    let auth = generate_auth_as_session(sessions_config, account_registry, wrapper, clock, ctx);
+    let auth = generate_auth_as_session(
+        sessions_config,
+        account_registry,
+        wrapper,
+        market.id(),
+        clock,
+        ctx,
+    );
     market.redeem_live(
         wrapper,
         auth,
@@ -330,7 +420,14 @@ public fun redeem_settled(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    let auth = generate_auth_as_session(sessions_config, account_registry, wrapper, clock, ctx);
+    let auth = generate_auth_as_session(
+        sessions_config,
+        account_registry,
+        wrapper,
+        market.id(),
+        clock,
+        ctx,
+    );
     market.redeem_settled(
         wrapper,
         auth,
@@ -344,16 +441,42 @@ public fun redeem_settled(
 
 // === Private Functions ===
 
+/// Mint app auth for the transaction sender's session, bound to `venue`.
+/// Every wrapper passes the id of the object it is about to act on, so a session
+/// cannot reach a pool or market its grant does not name — including one the
+/// caller created to sit on the other side of the trade.
 fun generate_auth_as_session(
     sessions_config: &SessionsConfig,
     account_registry: &AccountRegistry,
     wrapper: &AccountWrapper,
+    venue: ID,
     clock: &Clock,
     ctx: &TxContext,
 ): Auth {
     sessions_config.assert_version();
-    let expiration = session_expiration_ms(wrapper, ctx.sender());
-    assert!(expiration.is_some(), ESessionNotAuthorized);
-    assert!(clock.timestamp_ms() < *expiration.borrow(), ESessionNotAuthorized);
+    let grant = session_grant(wrapper, ctx.sender());
+    assert!(grant.is_some(), ESessionNotAuthorized);
+    let grant = grant.destroy_some();
+    assert!(clock.timestamp_ms() < grant.expires_at_ms, ESessionNotAuthorized);
+    assert!(grant.venues.contains(&venue), EVenueNotGranted);
     account_registry.generate_auth_as_app<SessionsApp>(permit<SessionsApp>())
+}
+
+fun assert_distinct_venues(venues: &vector<ID>) {
+    let count = venues.length();
+    assert!(count > 0 && count <= max_session_venues!(), EInvalidSessionVenues);
+    count.do!(|i| {
+        let mut j = i + 1;
+        while (j < count) {
+            assert!(venues[i] != venues[j], EInvalidSessionVenues);
+            j = j + 1;
+        };
+    });
+}
+
+fun session_grant(wrapper: &AccountWrapper, session: address): Option<SessionGrant> {
+    let account = wrapper.load_account();
+    if (!account.has_data<SessionsApp>()) return option::none();
+    let data = account.borrow_data<SessionsApp, SessionsData>();
+    data.sessions.try_get(&session)
 }

--- a/packages/sessions/sources/sessions.move
+++ b/packages/sessions/sources/sessions.move
@@ -15,7 +15,7 @@ use deepbook_predict::{
     protocol_config::ProtocolConfig
 };
 use deepbook_sessions::session_config::{Self, SessionsConfig};
-use std::internal::permit;
+use std::{internal::permit, type_name::{Self, TypeName}};
 use sui::{accumulator::AccumulatorRoot, clock::Clock, event, vec_map::{Self, VecMap}};
 
 // === Errors ===
@@ -23,8 +23,8 @@ use sui::{accumulator::AccumulatorRoot, clock::Clock, event, vec_map::{Self, Vec
 const EInvalidSessionDuration: u64 = 0;
 const ESessionNotAuthorized: u64 = 1;
 const ESessionLimitExceeded: u64 = 2;
-const EInvalidSessionVenues: u64 = 3;
-const EVenueNotGranted: u64 = 4;
+const EInvalidSessionCoins: u64 = 3;
+const ECoinNotGranted: u64 = 4;
 
 // === Constants ===
 
@@ -32,23 +32,26 @@ macro fun max_session_duration_ms(): u64 { 30 * 24 * 60 * 60 * 1000 }
 
 macro fun max_sessions(): u64 { 20 }
 
-macro fun max_session_venues(): u64 { 20 }
+macro fun max_session_coins(): u64 { 20 }
 
 // === Structs ===
 
 /// App witness for Account registry authorization and per-account data namespacing.
 public struct SessionsApp has drop {}
 
-/// The terms a session was granted: where it may act, and until when.
-/// A grant confers no authority outside these venues, so widening a session's
-/// reach requires a fresh owner-signed `authorize_session`.
+/// The terms a session was granted: which assets it may trade, and until when.
+/// Widening a grant requires a fresh owner-signed `authorize_session`.
 public struct SessionGrant has copy, drop, store {
     /// Execution time past which the grant is inert.
     expires_at_ms: u64,
-    /// Shared objects this session may act on: DeepBook `Pool` ids for the spot
-    /// entrypoints, `ExpiryMarket` ids for the Predict entrypoints. Allowlist —
-    /// an id absent here is refused, and the set is never empty.
-    venues: vector<ID>,
+    /// Coin types, by defining id, that the DeepBook spot wrappers may name as the
+    /// base or quote of a trade. Allowlist — a type absent here is refused, and the
+    /// list is never empty. Because DeepBook registers at most one pool per asset
+    /// pair, naming the assets pins the session to the canonical pools for them,
+    /// including pools created after the grant. The Predict wrappers are not gated
+    /// on it: they take no type parameters and settle only in DUSDC, so the caller
+    /// chooses no coin type there.
+    coins: vector<TypeName>,
 }
 
 /// Session grants keyed by transaction signer address.
@@ -56,12 +59,12 @@ public struct SessionsData has store {
     sessions: VecMap<address, SessionGrant>,
 }
 
-/// A session was authorized or reauthorized on `venues` through `expires_at_ms`.
+/// A session was authorized or reauthorized on `coins` through `expires_at_ms`.
 /// Reauthorization replaces the previous terms outright rather than adding to them.
 public struct SessionAuthorized has copy, drop {
     account_id: ID,
     session: address,
-    venues: vector<ID>,
+    coins: vector<TypeName>,
     expires_at_ms: u64,
 }
 
@@ -80,32 +83,32 @@ public fun session_expiration_ms(wrapper: &AccountWrapper, session: address): Op
     if (grant.is_none()) option::none() else option::some(grant.borrow().expires_at_ms)
 }
 
-/// Return the venues a known session may act on, for SDK and devInspect reads.
-public fun session_venues(wrapper: &AccountWrapper, session: address): Option<vector<ID>> {
+/// Return the coin types a known session may trade, for SDK and devInspect reads.
+public fun session_coins(wrapper: &AccountWrapper, session: address): Option<vector<TypeName>> {
     let grant = session_grant(wrapper, session);
-    if (grant.is_none()) option::none() else option::some(grant.borrow().venues)
+    if (grant.is_none()) option::none() else option::some(grant.borrow().coins)
 }
 
-/// Authorize `session` on `venues` from execution time for at most 30 days.
-/// `venues` are the DeepBook `Pool` and `ExpiryMarket` ids the session may act on;
-/// it must name at least one and at most 20 distinct ids, because a grant carries
-/// no authority beyond the venues it names.
+/// Authorize `session` on `coins` from execution time for at most 30 days.
+/// `coins` are the coin types the session may trade on the DeepBook spot wrappers;
+/// it must name at least one and at most 20 distinct types, because the spot
+/// wrappers carry no authority over an asset the grant does not name.
 /// Accounts may store at most 20 addresses; reauthorization replaces the grant in
 /// place, so re-granting is how a session's venues or expiry change.
 public fun authorize_session(
     wrapper: &mut AccountWrapper,
     sessions_config: &SessionsConfig,
     session: address,
-    venues: vector<ID>,
+    coins: vector<TypeName>,
     duration_ms: u64,
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
     sessions_config.assert_version();
     assert!(duration_ms > 0 && duration_ms <= max_session_duration_ms!(), EInvalidSessionDuration);
-    assert_distinct_venues(&venues);
+    assert_distinct_coins(&coins);
     let expires_at_ms = clock.timestamp_ms() + duration_ms;
-    let grant = SessionGrant { expires_at_ms, venues };
+    let grant = SessionGrant { expires_at_ms, coins };
     let account = wrapper.load_account_mut(account::generate_auth(ctx));
     let account_id = account.account_id();
     if (!account.has_data<SessionsApp>()) {
@@ -121,7 +124,7 @@ public fun authorize_session(
     event::emit(SessionAuthorized {
         account_id,
         session,
-        venues: grant.venues,
+        coins: grant.coins,
         expires_at_ms,
     });
 }
@@ -156,11 +159,10 @@ public fun place_limit_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ): OrderInfo {
-    let auth = generate_auth_as_session(
+    let auth = generate_spot_auth_as_session<BaseAsset, QuoteAsset>(
         sessions_config,
         account_registry,
         wrapper,
-        pool.id(),
         clock,
         ctx,
     );
@@ -200,11 +202,10 @@ public fun place_market_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ): OrderInfo {
-    let auth = generate_auth_as_session(
+    let auth = generate_spot_auth_as_session<BaseAsset, QuoteAsset>(
         sessions_config,
         account_registry,
         wrapper,
-        pool.id(),
         clock,
         ctx,
     );
@@ -235,11 +236,10 @@ public fun cancel_live_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    let auth = generate_auth_as_session(
+    let auth = generate_spot_auth_as_session<BaseAsset, QuoteAsset>(
         sessions_config,
         account_registry,
         wrapper,
-        pool.id(),
         clock,
         ctx,
     );
@@ -256,11 +256,10 @@ public fun cancel_live_orders<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    let auth = generate_auth_as_session(
+    let auth = generate_spot_auth_as_session<BaseAsset, QuoteAsset>(
         sessions_config,
         account_registry,
         wrapper,
-        pool.id(),
         clock,
         ctx,
     );
@@ -276,11 +275,10 @@ public fun withdraw_settled_amounts<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    let auth = generate_auth_as_session(
+    let auth = generate_spot_auth_as_session<BaseAsset, QuoteAsset>(
         sessions_config,
         account_registry,
         wrapper,
-        pool.id(),
         clock,
         ctx,
     );
@@ -304,14 +302,7 @@ public fun mint_exact_quantity(
     clock: &Clock,
     ctx: &mut TxContext,
 ): u256 {
-    let auth = generate_auth_as_session(
-        sessions_config,
-        account_registry,
-        wrapper,
-        market.id(),
-        clock,
-        ctx,
-    );
+    let auth = generate_auth_as_session(sessions_config, account_registry, wrapper, clock, ctx);
     market.mint_exact_quantity(
         wrapper,
         auth,
@@ -345,14 +336,7 @@ public fun mint_exact_amount(
     clock: &Clock,
     ctx: &mut TxContext,
 ): u256 {
-    let auth = generate_auth_as_session(
-        sessions_config,
-        account_registry,
-        wrapper,
-        market.id(),
-        clock,
-        ctx,
-    );
+    let auth = generate_auth_as_session(sessions_config, account_registry, wrapper, clock, ctx);
     market.mint_exact_amount(
         wrapper,
         auth,
@@ -385,14 +369,7 @@ public fun redeem_live(
     clock: &Clock,
     ctx: &mut TxContext,
 ): Option<u256> {
-    let auth = generate_auth_as_session(
-        sessions_config,
-        account_registry,
-        wrapper,
-        market.id(),
-        clock,
-        ctx,
-    );
+    let auth = generate_auth_as_session(sessions_config, account_registry, wrapper, clock, ctx);
     market.redeem_live(
         wrapper,
         auth,
@@ -420,14 +397,7 @@ public fun redeem_settled(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    let auth = generate_auth_as_session(
-        sessions_config,
-        account_registry,
-        wrapper,
-        market.id(),
-        clock,
-        ctx,
-    );
+    let auth = generate_auth_as_session(sessions_config, account_registry, wrapper, clock, ctx);
     market.redeem_settled(
         wrapper,
         auth,
@@ -441,37 +411,62 @@ public fun redeem_settled(
 
 // === Private Functions ===
 
-/// Mint app auth for the transaction sender's session, bound to `venue`.
-/// Every wrapper passes the id of the object it is about to act on, so a session
-/// cannot reach a pool or market its grant does not name — including one the
-/// caller created to sit on the other side of the trade.
+/// Mint app auth for the transaction sender's live session.
+/// Predict entrypoints use this directly: they are non-generic and settle only in
+/// DUSDC, so there is no caller-chosen asset to check, and gating them on the
+/// market would strand a session every time the cadence rolls a new expiry.
 fun generate_auth_as_session(
     sessions_config: &SessionsConfig,
     account_registry: &AccountRegistry,
     wrapper: &AccountWrapper,
-    venue: ID,
     clock: &Clock,
     ctx: &TxContext,
 ): Auth {
+    live_session_grant(sessions_config, wrapper, clock, ctx);
+    account_registry.generate_auth_as_app<SessionsApp>(permit<SessionsApp>())
+}
+
+/// Mint app auth for a spot trade, refusing an asset the grant does not name.
+/// The spot wrappers are generic and fund an order from the account's whole
+/// balance, so an ungated session could name a pool pairing a real holding
+/// against a coin the caller minted and take the other side of the trade.
+fun generate_spot_auth_as_session<BaseAsset, QuoteAsset>(
+    sessions_config: &SessionsConfig,
+    account_registry: &AccountRegistry,
+    wrapper: &AccountWrapper,
+    clock: &Clock,
+    ctx: &TxContext,
+): Auth {
+    let grant = live_session_grant(sessions_config, wrapper, clock, ctx);
+    assert!(grant.coins.contains(&type_name::with_defining_ids<BaseAsset>()), ECoinNotGranted);
+    assert!(grant.coins.contains(&type_name::with_defining_ids<QuoteAsset>()), ECoinNotGranted);
+    account_registry.generate_auth_as_app<SessionsApp>(permit<SessionsApp>())
+}
+
+fun assert_distinct_coins(coins: &vector<TypeName>) {
+    let count = coins.length();
+    assert!(count > 0 && count <= max_session_coins!(), EInvalidSessionCoins);
+    count.do!(|i| {
+        let mut j = i + 1;
+        while (j < count) {
+            assert!(coins[i] != coins[j], EInvalidSessionCoins);
+            j = j + 1;
+        };
+    });
+}
+
+fun live_session_grant(
+    sessions_config: &SessionsConfig,
+    wrapper: &AccountWrapper,
+    clock: &Clock,
+    ctx: &TxContext,
+): SessionGrant {
     sessions_config.assert_version();
     let grant = session_grant(wrapper, ctx.sender());
     assert!(grant.is_some(), ESessionNotAuthorized);
     let grant = grant.destroy_some();
     assert!(clock.timestamp_ms() < grant.expires_at_ms, ESessionNotAuthorized);
-    assert!(grant.venues.contains(&venue), EVenueNotGranted);
-    account_registry.generate_auth_as_app<SessionsApp>(permit<SessionsApp>())
-}
-
-fun assert_distinct_venues(venues: &vector<ID>) {
-    let count = venues.length();
-    assert!(count > 0 && count <= max_session_venues!(), EInvalidSessionVenues);
-    count.do!(|i| {
-        let mut j = i + 1;
-        while (j < count) {
-            assert!(venues[i] != venues[j], EInvalidSessionVenues);
-            j = j + 1;
-        };
-    });
+    grant
 }
 
 fun session_grant(wrapper: &AccountWrapper, session: address): Option<SessionGrant> {

--- a/packages/sessions/tests/sessions_tests.move
+++ b/packages/sessions/tests/sessions_tests.move
@@ -78,6 +78,11 @@ const EXCESS_SESSION_INDEX: u64 = 20;
 const POST_REVOKE_EXPIRES_AT_MS: u64 = 62_000; // 2_000 + 60_000.
 const ONE_EVENT: u64 = 1;
 const EUnexpectedSuccess: u64 = 999;
+/// A venue id no fixture object has, for grants that are never exercised.
+const OTHER_VENUE: address = @0x0E;
+const FIRST_VENUE: address = @0x0E1;
+const SECOND_VENUE: address = @0x0E2;
+const ABOVE_MAX_SESSION_VENUES: u64 = 21;
 
 const FLOW_SESSION_EXPIRES_AT_MS: u64 = 180_000; // 120_000 + 60_000.
 const SETTLEMENT_SESSION_DURATION_MS: u64 = 180_000;
@@ -99,6 +104,7 @@ const FUTURE_VERSION: u64 = 2;
 public struct ExpectedSessionAuthorized has copy, drop {
     account_id: ID,
     session: address,
+    venues: vector<ID>,
     expires_at_ms: u64,
 }
 
@@ -153,6 +159,7 @@ fun owner_authorizes_reauthorizes_and_revokes_session() {
         &mut wrapper,
         &sessions_config,
         SESSION,
+        vector[other_venue()],
         SESSION_DURATION_MS,
         &clock,
         scenario.ctx(),
@@ -167,6 +174,7 @@ fun owner_authorizes_reauthorizes_and_revokes_session() {
         &authorized[0],
         account_id,
         SESSION,
+        vector[other_venue()],
         SESSION_EXPIRES_AT_MS,
     );
     return_shared(sessions_config);
@@ -180,6 +188,7 @@ fun owner_authorizes_reauthorizes_and_revokes_session() {
         &mut wrapper,
         &sessions_config,
         SESSION,
+        vector[other_venue()],
         REAUTH_DURATION_MS,
         &clock,
         scenario.ctx(),
@@ -194,6 +203,7 @@ fun owner_authorizes_reauthorizes_and_revokes_session() {
         &reauthorized[0],
         account_id,
         SESSION,
+        vector[other_venue()],
         REAUTH_EXPIRES_AT_MS,
     );
     return_shared(sessions_config);
@@ -236,6 +246,7 @@ fun maximum_session_duration_is_accepted() {
         &mut wrapper,
         &sessions_config,
         SESSION,
+        vector[other_venue()],
         MAX_SESSION_DURATION_MS,
         &clock,
         scenario.ctx(),
@@ -264,6 +275,7 @@ fun session_limit_allows_reauthorization_and_reuse_after_revocation() {
             &mut wrapper,
             &sessions_config,
             session_addresses[index],
+            vector[other_venue()],
             SESSION_DURATION_MS,
             &clock,
             scenario.ctx(),
@@ -284,6 +296,7 @@ fun session_limit_allows_reauthorization_and_reuse_after_revocation() {
         &mut wrapper,
         &sessions_config,
         session_addresses[LAST_SESSION_INDEX],
+        vector[other_venue()],
         REAUTH_DURATION_MS,
         &clock,
         scenario.ctx(),
@@ -305,6 +318,7 @@ fun session_limit_allows_reauthorization_and_reuse_after_revocation() {
         &mut wrapper,
         &sessions_config,
         session_addresses[EXCESS_SESSION_INDEX],
+        vector[other_venue()],
         SESSION_DURATION_MS,
         &clock,
         scenario.ctx(),
@@ -337,6 +351,7 @@ fun twenty_first_distinct_session_aborts() {
             &mut wrapper,
             &sessions_config,
             session_addresses[index],
+            vector[other_venue()],
             SESSION_DURATION_MS,
             &clock,
             scenario.ctx(),
@@ -352,12 +367,119 @@ fun twenty_first_distinct_session_aborts() {
         &mut wrapper,
         &sessions_config,
         session_addresses[EXCESS_SESSION_INDEX],
+        vector[other_venue()],
         SESSION_DURATION_MS,
         &clock,
         scenario.ctx(),
     );
 
     abort EUnexpectedSuccess
+}
+
+#[test, expected_failure(abort_code = sessions::EInvalidSessionVenues)]
+fun empty_venue_list_aborts() {
+    let (mut scenario, clock, wrapper_id, sessions_config_id) = setup_account();
+    scenario.next_tx(ALICE);
+    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let sessions_config = scenario.take_shared_by_id<SessionsConfig>(sessions_config_id);
+
+    // An empty allowlist would authorize nothing, so it is rejected rather than stored.
+    sessions::authorize_session(
+        &mut wrapper,
+        &sessions_config,
+        SESSION,
+        vector[],
+        SESSION_DURATION_MS,
+        &clock,
+        scenario.ctx(),
+    );
+
+    abort EUnexpectedSuccess
+}
+
+#[test, expected_failure(abort_code = sessions::EInvalidSessionVenues)]
+fun duplicate_venues_abort() {
+    let (mut scenario, clock, wrapper_id, sessions_config_id) = setup_account();
+    scenario.next_tx(ALICE);
+    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let sessions_config = scenario.take_shared_by_id<SessionsConfig>(sessions_config_id);
+
+    sessions::authorize_session(
+        &mut wrapper,
+        &sessions_config,
+        SESSION,
+        vector[other_venue(), other_venue()],
+        SESSION_DURATION_MS,
+        &clock,
+        scenario.ctx(),
+    );
+
+    abort EUnexpectedSuccess
+}
+
+#[test, expected_failure(abort_code = sessions::EInvalidSessionVenues)]
+fun twenty_first_venue_aborts() {
+    let (mut scenario, clock, wrapper_id, sessions_config_id) = setup_account();
+    scenario.next_tx(ALICE);
+    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let sessions_config = scenario.take_shared_by_id<SessionsConfig>(sessions_config_id);
+    // 21 distinct venue ids: one past the 20 a single grant may name.
+    let mut venues = vector[];
+    ABOVE_MAX_SESSION_VENUES.do!(
+        |i| venues.push_back(
+            object::id_from_address(sui::address::from_u256(i as u256)),
+        ),
+    );
+
+    sessions::authorize_session(
+        &mut wrapper,
+        &sessions_config,
+        SESSION,
+        venues,
+        SESSION_DURATION_MS,
+        &clock,
+        scenario.ctx(),
+    );
+
+    abort EUnexpectedSuccess
+}
+
+#[test]
+fun reauthorization_replaces_venues_rather_than_adding() {
+    let (mut scenario, clock, wrapper_id, sessions_config_id) = setup_account();
+    scenario.next_tx(ALICE);
+    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let sessions_config = scenario.take_shared_by_id<SessionsConfig>(sessions_config_id);
+    let first = object::id_from_address(FIRST_VENUE);
+    let second = object::id_from_address(SECOND_VENUE);
+
+    sessions::authorize_session(
+        &mut wrapper,
+        &sessions_config,
+        SESSION,
+        vector[first],
+        SESSION_DURATION_MS,
+        &clock,
+        scenario.ctx(),
+    );
+    assert_eq!(sessions::session_venues(&wrapper, SESSION), option::some(vector[first]));
+
+    // Re-granting narrows as well as widens: the first venue is gone, not retained.
+    sessions::authorize_session(
+        &mut wrapper,
+        &sessions_config,
+        SESSION,
+        vector[second],
+        SESSION_DURATION_MS,
+        &clock,
+        scenario.ctx(),
+    );
+    assert_eq!(sessions::session_venues(&wrapper, SESSION), option::some(vector[second]));
+
+    return_shared(sessions_config);
+    return_shared(wrapper);
+    clock.destroy_for_testing();
+    scenario.end();
 }
 
 #[test, expected_failure(abort_code = sessions::EInvalidSessionDuration)]
@@ -371,6 +493,7 @@ fun zero_session_duration_aborts() {
         &mut wrapper,
         &sessions_config,
         SESSION,
+        vector[other_venue()],
         ZERO_DURATION_MS,
         &clock,
         scenario.ctx(),
@@ -390,6 +513,7 @@ fun session_duration_above_maximum_aborts() {
         &mut wrapper,
         &sessions_config,
         SESSION,
+        vector[other_venue()],
         ABOVE_MAX_SESSION_DURATION_MS,
         &clock,
         scenario.ctx(),
@@ -409,6 +533,7 @@ fun non_owner_cannot_authorize_session() {
         &mut wrapper,
         &sessions_config,
         SESSION,
+        vector[other_venue()],
         SESSION_DURATION_MS,
         &clock,
         scenario.ctx(),
@@ -427,6 +552,7 @@ fun non_owner_cannot_revoke_session() {
         &mut wrapper,
         &sessions_config,
         SESSION,
+        vector[other_venue()],
         SESSION_DURATION_MS,
         &clock,
         scenario.ctx(),
@@ -453,6 +579,7 @@ fun retired_package_version_cannot_authorize_session() {
         &mut wrapper,
         &sessions_config,
         SESSION,
+        vector[other_venue()],
         SESSION_DURATION_MS,
         &clock,
         scenario.ctx(),
@@ -471,6 +598,7 @@ fun retired_package_version_keeps_reads_and_revocation_available() {
         &mut wrapper,
         &sessions_config,
         SESSION,
+        vector[other_venue()],
         SESSION_DURATION_MS,
         &clock,
         scenario.ctx(),
@@ -1085,9 +1213,10 @@ fun assert_session_authorized_event(
     actual: &SessionAuthorized,
     account_id: ID,
     session: address,
+    venues: vector<ID>,
     expires_at_ms: u64,
 ) {
-    let expected = ExpectedSessionAuthorized { account_id, session, expires_at_ms };
+    let expected = ExpectedSessionAuthorized { account_id, session, venues, expires_at_ms };
     assert_eq!(bcs::to_bytes(actual), bcs::to_bytes(&expected));
 }
 
@@ -1146,7 +1275,20 @@ fun setup_flow_fixture(expiry_ms: u64): SessionFlowFixture {
     }
 }
 
+fun other_venue(): ID {
+    object::id_from_address(OTHER_VENUE)
+}
+
 fun authorize_flow_session(fixture: &mut SessionFlowFixture, duration_ms: u64) {
+    let market_id = fixture.market_id;
+    authorize_flow_session_on(fixture, duration_ms, vector[market_id]);
+}
+
+fun authorize_flow_session_on(
+    fixture: &mut SessionFlowFixture,
+    duration_ms: u64,
+    venues: vector<ID>,
+) {
     let clock = &fixture.clock;
     let scenario = fixture.predict.scenario_mut();
     scenario.next_tx(fixture.owner);
@@ -1156,6 +1298,7 @@ fun authorize_flow_session(fixture: &mut SessionFlowFixture, duration_ms: u64) {
         &mut wrapper,
         &sessions_config,
         SESSION,
+        venues,
         duration_ms,
         clock,
         scenario.ctx(),

--- a/packages/sessions/tests/sessions_tests.move
+++ b/packages/sessions/tests/sessions_tests.move
@@ -27,7 +27,7 @@ use propbook::{
     pyth_feed::PythFeed,
     registry::{Self as propbook_registry, OracleRegistry}
 };
-use std::{bcs, unit_test::{assert_eq, destroy}};
+use std::{bcs, type_name::{Self, TypeName}, unit_test::{assert_eq, destroy}};
 use sui::{
     accumulator::AccumulatorRoot,
     clock::{Self as clock, Clock},
@@ -78,11 +78,7 @@ const EXCESS_SESSION_INDEX: u64 = 20;
 const POST_REVOKE_EXPIRES_AT_MS: u64 = 62_000; // 2_000 + 60_000.
 const ONE_EVENT: u64 = 1;
 const EUnexpectedSuccess: u64 = 999;
-/// A venue id no fixture object has, for grants that are never exercised.
-const OTHER_VENUE: address = @0x0E;
-const FIRST_VENUE: address = @0x0E1;
-const SECOND_VENUE: address = @0x0E2;
-const ABOVE_MAX_SESSION_VENUES: u64 = 21;
+const ABOVE_MAX_SESSION_COINS: u64 = 21;
 
 const FLOW_SESSION_EXPIRES_AT_MS: u64 = 180_000; // 120_000 + 60_000.
 const SETTLEMENT_SESSION_DURATION_MS: u64 = 180_000;
@@ -101,10 +97,32 @@ const MISSING_ORDER_ID: u256 = 1;
 const CLOSE_QUANTITY: u64 = 1;
 const FUTURE_VERSION: u64 = 2;
 
+public struct Coin0 has store {}
+public struct Coin1 has store {}
+public struct Coin2 has store {}
+public struct Coin3 has store {}
+public struct Coin4 has store {}
+public struct Coin5 has store {}
+public struct Coin6 has store {}
+public struct Coin7 has store {}
+public struct Coin8 has store {}
+public struct Coin9 has store {}
+public struct Coin10 has store {}
+public struct Coin11 has store {}
+public struct Coin12 has store {}
+public struct Coin13 has store {}
+public struct Coin14 has store {}
+public struct Coin15 has store {}
+public struct Coin16 has store {}
+public struct Coin17 has store {}
+public struct Coin18 has store {}
+public struct Coin19 has store {}
+public struct Coin20 has store {}
+
 public struct ExpectedSessionAuthorized has copy, drop {
     account_id: ID,
     session: address,
-    venues: vector<ID>,
+    coins: vector<TypeName>,
     expires_at_ms: u64,
 }
 
@@ -159,7 +177,7 @@ fun owner_authorizes_reauthorizes_and_revokes_session() {
         &mut wrapper,
         &sessions_config,
         SESSION,
-        vector[other_venue()],
+        granted_coins(),
         SESSION_DURATION_MS,
         &clock,
         scenario.ctx(),
@@ -174,7 +192,7 @@ fun owner_authorizes_reauthorizes_and_revokes_session() {
         &authorized[0],
         account_id,
         SESSION,
-        vector[other_venue()],
+        granted_coins(),
         SESSION_EXPIRES_AT_MS,
     );
     return_shared(sessions_config);
@@ -188,7 +206,7 @@ fun owner_authorizes_reauthorizes_and_revokes_session() {
         &mut wrapper,
         &sessions_config,
         SESSION,
-        vector[other_venue()],
+        granted_coins(),
         REAUTH_DURATION_MS,
         &clock,
         scenario.ctx(),
@@ -203,7 +221,7 @@ fun owner_authorizes_reauthorizes_and_revokes_session() {
         &reauthorized[0],
         account_id,
         SESSION,
-        vector[other_venue()],
+        granted_coins(),
         REAUTH_EXPIRES_AT_MS,
     );
     return_shared(sessions_config);
@@ -246,7 +264,7 @@ fun maximum_session_duration_is_accepted() {
         &mut wrapper,
         &sessions_config,
         SESSION,
-        vector[other_venue()],
+        granted_coins(),
         MAX_SESSION_DURATION_MS,
         &clock,
         scenario.ctx(),
@@ -275,7 +293,7 @@ fun session_limit_allows_reauthorization_and_reuse_after_revocation() {
             &mut wrapper,
             &sessions_config,
             session_addresses[index],
-            vector[other_venue()],
+            granted_coins(),
             SESSION_DURATION_MS,
             &clock,
             scenario.ctx(),
@@ -296,7 +314,7 @@ fun session_limit_allows_reauthorization_and_reuse_after_revocation() {
         &mut wrapper,
         &sessions_config,
         session_addresses[LAST_SESSION_INDEX],
-        vector[other_venue()],
+        granted_coins(),
         REAUTH_DURATION_MS,
         &clock,
         scenario.ctx(),
@@ -318,7 +336,7 @@ fun session_limit_allows_reauthorization_and_reuse_after_revocation() {
         &mut wrapper,
         &sessions_config,
         session_addresses[EXCESS_SESSION_INDEX],
-        vector[other_venue()],
+        granted_coins(),
         SESSION_DURATION_MS,
         &clock,
         scenario.ctx(),
@@ -351,7 +369,7 @@ fun twenty_first_distinct_session_aborts() {
             &mut wrapper,
             &sessions_config,
             session_addresses[index],
-            vector[other_venue()],
+            granted_coins(),
             SESSION_DURATION_MS,
             &clock,
             scenario.ctx(),
@@ -367,7 +385,7 @@ fun twenty_first_distinct_session_aborts() {
         &mut wrapper,
         &sessions_config,
         session_addresses[EXCESS_SESSION_INDEX],
-        vector[other_venue()],
+        granted_coins(),
         SESSION_DURATION_MS,
         &clock,
         scenario.ctx(),
@@ -376,14 +394,14 @@ fun twenty_first_distinct_session_aborts() {
     abort EUnexpectedSuccess
 }
 
-#[test, expected_failure(abort_code = sessions::EInvalidSessionVenues)]
-fun empty_venue_list_aborts() {
+#[test, expected_failure(abort_code = sessions::EInvalidSessionCoins)]
+fun empty_coin_list_aborts() {
     let (mut scenario, clock, wrapper_id, sessions_config_id) = setup_account();
     scenario.next_tx(ALICE);
     let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
     let sessions_config = scenario.take_shared_by_id<SessionsConfig>(sessions_config_id);
 
-    // An empty allowlist would authorize nothing, so it is rejected rather than stored.
+    // An empty allowlist would authorize no spot trading, so it is rejected, not stored.
     sessions::authorize_session(
         &mut wrapper,
         &sessions_config,
@@ -397,8 +415,8 @@ fun empty_venue_list_aborts() {
     abort EUnexpectedSuccess
 }
 
-#[test, expected_failure(abort_code = sessions::EInvalidSessionVenues)]
-fun duplicate_venues_abort() {
+#[test, expected_failure(abort_code = sessions::EInvalidSessionCoins)]
+fun duplicate_coins_abort() {
     let (mut scenario, clock, wrapper_id, sessions_config_id) = setup_account();
     scenario.next_tx(ALICE);
     let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
@@ -408,7 +426,7 @@ fun duplicate_venues_abort() {
         &mut wrapper,
         &sessions_config,
         SESSION,
-        vector[other_venue(), other_venue()],
+        vector[type_name::with_defining_ids<Coin0>(), type_name::with_defining_ids<Coin0>()],
         SESSION_DURATION_MS,
         &clock,
         scenario.ctx(),
@@ -417,25 +435,21 @@ fun duplicate_venues_abort() {
     abort EUnexpectedSuccess
 }
 
-#[test, expected_failure(abort_code = sessions::EInvalidSessionVenues)]
-fun twenty_first_venue_aborts() {
+#[test, expected_failure(abort_code = sessions::EInvalidSessionCoins)]
+fun twenty_first_coin_aborts() {
     let (mut scenario, clock, wrapper_id, sessions_config_id) = setup_account();
     scenario.next_tx(ALICE);
     let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
     let sessions_config = scenario.take_shared_by_id<SessionsConfig>(sessions_config_id);
-    // 21 distinct venue ids: one past the 20 a single grant may name.
-    let mut venues = vector[];
-    ABOVE_MAX_SESSION_VENUES.do!(
-        |i| venues.push_back(
-            object::id_from_address(sui::address::from_u256(i as u256)),
-        ),
-    );
+    // 21 distinct coin types: one past the 20 a single grant may name.
+    let coins = all_marker_coins();
+    assert_eq!(coins.length(), ABOVE_MAX_SESSION_COINS);
 
     sessions::authorize_session(
         &mut wrapper,
         &sessions_config,
         SESSION,
-        venues,
+        coins,
         SESSION_DURATION_MS,
         &clock,
         scenario.ctx(),
@@ -445,36 +459,36 @@ fun twenty_first_venue_aborts() {
 }
 
 #[test]
-fun reauthorization_replaces_venues_rather_than_adding() {
+fun reauthorization_replaces_coins_rather_than_adding() {
     let (mut scenario, clock, wrapper_id, sessions_config_id) = setup_account();
     scenario.next_tx(ALICE);
     let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
     let sessions_config = scenario.take_shared_by_id<SessionsConfig>(sessions_config_id);
-    let first = object::id_from_address(FIRST_VENUE);
-    let second = object::id_from_address(SECOND_VENUE);
+    let first = vector[type_name::with_defining_ids<Coin1>()];
+    let second = vector[type_name::with_defining_ids<Coin2>()];
 
     sessions::authorize_session(
         &mut wrapper,
         &sessions_config,
         SESSION,
-        vector[first],
+        first,
         SESSION_DURATION_MS,
         &clock,
         scenario.ctx(),
     );
-    assert_eq!(sessions::session_venues(&wrapper, SESSION), option::some(vector[first]));
+    assert_eq!(sessions::session_coins(&wrapper, SESSION), option::some(first));
 
-    // Re-granting narrows as well as widens: the first venue is gone, not retained.
+    // Re-granting narrows as well as widens: the first coin is gone, not retained.
     sessions::authorize_session(
         &mut wrapper,
         &sessions_config,
         SESSION,
-        vector[second],
+        second,
         SESSION_DURATION_MS,
         &clock,
         scenario.ctx(),
     );
-    assert_eq!(sessions::session_venues(&wrapper, SESSION), option::some(vector[second]));
+    assert_eq!(sessions::session_coins(&wrapper, SESSION), option::some(second));
 
     return_shared(sessions_config);
     return_shared(wrapper);
@@ -493,7 +507,7 @@ fun zero_session_duration_aborts() {
         &mut wrapper,
         &sessions_config,
         SESSION,
-        vector[other_venue()],
+        granted_coins(),
         ZERO_DURATION_MS,
         &clock,
         scenario.ctx(),
@@ -513,7 +527,7 @@ fun session_duration_above_maximum_aborts() {
         &mut wrapper,
         &sessions_config,
         SESSION,
-        vector[other_venue()],
+        granted_coins(),
         ABOVE_MAX_SESSION_DURATION_MS,
         &clock,
         scenario.ctx(),
@@ -533,7 +547,7 @@ fun non_owner_cannot_authorize_session() {
         &mut wrapper,
         &sessions_config,
         SESSION,
-        vector[other_venue()],
+        granted_coins(),
         SESSION_DURATION_MS,
         &clock,
         scenario.ctx(),
@@ -552,7 +566,7 @@ fun non_owner_cannot_revoke_session() {
         &mut wrapper,
         &sessions_config,
         SESSION,
-        vector[other_venue()],
+        granted_coins(),
         SESSION_DURATION_MS,
         &clock,
         scenario.ctx(),
@@ -579,7 +593,7 @@ fun retired_package_version_cannot_authorize_session() {
         &mut wrapper,
         &sessions_config,
         SESSION,
-        vector[other_venue()],
+        granted_coins(),
         SESSION_DURATION_MS,
         &clock,
         scenario.ctx(),
@@ -598,7 +612,7 @@ fun retired_package_version_keeps_reads_and_revocation_available() {
         &mut wrapper,
         &sessions_config,
         SESSION,
-        vector[other_venue()],
+        granted_coins(),
         SESSION_DURATION_MS,
         &clock,
         scenario.ctx(),
@@ -1213,10 +1227,10 @@ fun assert_session_authorized_event(
     actual: &SessionAuthorized,
     account_id: ID,
     session: address,
-    venues: vector<ID>,
+    coins: vector<TypeName>,
     expires_at_ms: u64,
 ) {
-    let expected = ExpectedSessionAuthorized { account_id, session, venues, expires_at_ms };
+    let expected = ExpectedSessionAuthorized { account_id, session, coins, expires_at_ms };
     assert_eq!(bcs::to_bytes(actual), bcs::to_bytes(&expected));
 }
 
@@ -1275,19 +1289,46 @@ fun setup_flow_fixture(expiry_ms: u64): SessionFlowFixture {
     }
 }
 
-fun other_venue(): ID {
-    object::id_from_address(OTHER_VENUE)
+/// The 21 marker coin types, one past the per-grant limit.
+fun all_marker_coins(): vector<TypeName> {
+    vector[
+        type_name::with_defining_ids<Coin0>(),
+        type_name::with_defining_ids<Coin1>(),
+        type_name::with_defining_ids<Coin2>(),
+        type_name::with_defining_ids<Coin3>(),
+        type_name::with_defining_ids<Coin4>(),
+        type_name::with_defining_ids<Coin5>(),
+        type_name::with_defining_ids<Coin6>(),
+        type_name::with_defining_ids<Coin7>(),
+        type_name::with_defining_ids<Coin8>(),
+        type_name::with_defining_ids<Coin9>(),
+        type_name::with_defining_ids<Coin10>(),
+        type_name::with_defining_ids<Coin11>(),
+        type_name::with_defining_ids<Coin12>(),
+        type_name::with_defining_ids<Coin13>(),
+        type_name::with_defining_ids<Coin14>(),
+        type_name::with_defining_ids<Coin15>(),
+        type_name::with_defining_ids<Coin16>(),
+        type_name::with_defining_ids<Coin17>(),
+        type_name::with_defining_ids<Coin18>(),
+        type_name::with_defining_ids<Coin19>(),
+        type_name::with_defining_ids<Coin20>(),
+    ]
+}
+
+/// A one-coin grant for tests that never exercise the spot wrappers.
+fun granted_coins(): vector<TypeName> {
+    vector[type_name::with_defining_ids<Coin0>()]
 }
 
 fun authorize_flow_session(fixture: &mut SessionFlowFixture, duration_ms: u64) {
-    let market_id = fixture.market_id;
-    authorize_flow_session_on(fixture, duration_ms, vector[market_id]);
+    authorize_flow_session_on(fixture, duration_ms, granted_coins());
 }
 
 fun authorize_flow_session_on(
     fixture: &mut SessionFlowFixture,
     duration_ms: u64,
-    venues: vector<ID>,
+    coins: vector<TypeName>,
 ) {
     let clock = &fixture.clock;
     let scenario = fixture.predict.scenario_mut();
@@ -1298,7 +1339,7 @@ fun authorize_flow_session_on(
         &mut wrapper,
         &sessions_config,
         SESSION,
-        venues,
+        coins,
         duration_ms,
         clock,
         scenario.ctx(),

--- a/packages/sessions/tests/spot_sessions_tests.move
+++ b/packages/sessions/tests/spot_sessions_tests.move
@@ -23,7 +23,7 @@ use deepbook_sessions::{
     session_config::{Self as session_config, SessionsConfig},
     sessions::{Self as sessions, SessionsApp}
 };
-use std::unit_test::{assert_eq, destroy};
+use std::{type_name::{Self, TypeName}, unit_test::{assert_eq, destroy}};
 use sui::{
     accumulator::{Self as accumulator, AccumulatorRoot},
     clock::{Self as clock, Clock},
@@ -54,8 +54,6 @@ const TWO_OPEN_ORDERS: u64 = 2;
 const ZERO_BALANCE: u64 = 0;
 const ZERO_ORDER_ID: u128 = 0;
 const EUnexpectedSuccess: u64 = 999;
-/// A venue id no fixture object has, standing in for a pool the grant never named.
-const OTHER_VENUE: address = @0x0E;
 const FUTURE_VERSION: u64 = 2;
 
 public struct BASE has store {}
@@ -448,12 +446,13 @@ fun unapproved_session_cannot_place_spot_order() {
     abort EUnexpectedSuccess
 }
 
-#[test, expected_failure(abort_code = sessions::EVenueNotGranted)]
-fun session_cannot_place_spot_order_on_ungranted_pool() {
+#[test, expected_failure(abort_code = sessions::ECoinNotGranted)]
+fun session_cannot_trade_an_ungranted_asset() {
     let mut fixture = setup_spot_fixture();
-    // The grant names a different venue, so routing the account into this pool is
-    // refused even though the session itself is live and the pool is real.
-    authorize_session_on(&mut fixture, vector[other_venue()]);
+    // The grant names the base asset but not the quote, so this pair is refused even
+    // though the session is live and the pool is real. This is what stops a session
+    // pairing a held asset against a coin the caller minted.
+    authorize_session_on(&mut fixture, vector[type_name::with_defining_ids<BASE>()]);
     let registry_id = fixture.registry_id;
     let pool_id = fixture.pool_id;
     let wrapper_id = fixture.wrapper_id;
@@ -490,16 +489,15 @@ fun session_cannot_place_spot_order_on_ungranted_pool() {
 }
 
 #[test]
-fun granted_venues_read_back_for_the_granted_session_only() {
+fun granted_coins_read_back_for_the_granted_session_only() {
     let mut fixture = setup_spot_fixture();
-    let pool_id = fixture.pool_id;
     let wrapper_id = fixture.wrapper_id;
     authorize_session(&mut fixture);
 
     fixture.scenario.next_tx(ALICE);
     let wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
-    assert_eq!(sessions::session_venues(&wrapper, SESSION), option::some(vector[pool_id]));
-    assert!(sessions::session_venues(&wrapper, BOB).is_none());
+    assert_eq!(sessions::session_coins(&wrapper, SESSION), option::some(traded_coins()));
+    assert!(sessions::session_coins(&wrapper, BOB).is_none());
     return_shared(wrapper);
     finish_spot_fixture(fixture);
 }
@@ -635,16 +633,16 @@ fun setup_spot_fixture(): SpotFixture {
     SpotFixture { scenario, registry_id, pool_id, wrapper_id, sessions_config_id }
 }
 
-fun other_venue(): ID {
-    object::id_from_address(OTHER_VENUE)
-}
-
 fun authorize_session(fixture: &mut SpotFixture) {
-    let pool_id = fixture.pool_id;
-    authorize_session_on(fixture, vector[pool_id]);
+    authorize_session_on(fixture, traded_coins());
 }
 
-fun authorize_session_on(fixture: &mut SpotFixture, venues: vector<ID>) {
+/// The pool's own pair — what a session that is meant to trade it would be granted.
+fun traded_coins(): vector<TypeName> {
+    vector[type_name::with_defining_ids<BASE>(), type_name::with_defining_ids<QUOTE>()]
+}
+
+fun authorize_session_on(fixture: &mut SpotFixture, coins: vector<TypeName>) {
     let wrapper_id = fixture.wrapper_id;
     fixture.scenario.next_tx(ALICE);
     let mut wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
@@ -656,7 +654,7 @@ fun authorize_session_on(fixture: &mut SpotFixture, venues: vector<ID>) {
         &mut wrapper,
         &sessions_config,
         SESSION,
-        venues,
+        coins,
         SESSION_DURATION_MS,
         &clock,
         fixture.scenario.ctx(),

--- a/packages/sessions/tests/spot_sessions_tests.move
+++ b/packages/sessions/tests/spot_sessions_tests.move
@@ -54,6 +54,8 @@ const TWO_OPEN_ORDERS: u64 = 2;
 const ZERO_BALANCE: u64 = 0;
 const ZERO_ORDER_ID: u128 = 0;
 const EUnexpectedSuccess: u64 = 999;
+/// A venue id no fixture object has, standing in for a pool the grant never named.
+const OTHER_VENUE: address = @0x0E;
 const FUTURE_VERSION: u64 = 2;
 
 public struct BASE has store {}
@@ -446,6 +448,62 @@ fun unapproved_session_cannot_place_spot_order() {
     abort EUnexpectedSuccess
 }
 
+#[test, expected_failure(abort_code = sessions::EVenueNotGranted)]
+fun session_cannot_place_spot_order_on_ungranted_pool() {
+    let mut fixture = setup_spot_fixture();
+    // The grant names a different venue, so routing the account into this pool is
+    // refused even though the session itself is live and the pool is real.
+    authorize_session_on(&mut fixture, vector[other_venue()]);
+    let registry_id = fixture.registry_id;
+    let pool_id = fixture.pool_id;
+    let wrapper_id = fixture.wrapper_id;
+
+    fixture.scenario.next_tx(SESSION);
+    let registry = fixture.scenario.take_shared_by_id<Registry>(registry_id);
+    let account_registry = fixture.scenario.take_shared<AccountRegistry>();
+    let mut pool = fixture.scenario.take_shared_by_id<Pool<BASE, QUOTE>>(pool_id);
+    let mut wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let sessions_config = fixture
+        .scenario
+        .take_shared_by_id<SessionsConfig>(fixture.sessions_config_id);
+    let root = fixture.scenario.take_shared<AccumulatorRoot>();
+    let clock = fixture.scenario.take_shared<Clock>();
+    let _ = sessions::place_limit_order<BASE, QUOTE>(
+        &mut pool,
+        &registry,
+        &account_registry,
+        &mut wrapper,
+        &sessions_config,
+        LIMIT_ORDER_CLIENT_ID,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        constants::float_scaling(),
+        constants::min_size(),
+        false,
+        true,
+        constants::max_u64(),
+        &root,
+        &clock,
+        fixture.scenario.ctx(),
+    );
+    abort EUnexpectedSuccess
+}
+
+#[test]
+fun granted_venues_read_back_for_the_granted_session_only() {
+    let mut fixture = setup_spot_fixture();
+    let pool_id = fixture.pool_id;
+    let wrapper_id = fixture.wrapper_id;
+    authorize_session(&mut fixture);
+
+    fixture.scenario.next_tx(ALICE);
+    let wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    assert_eq!(sessions::session_venues(&wrapper, SESSION), option::some(vector[pool_id]));
+    assert!(sessions::session_venues(&wrapper, BOB).is_none());
+    return_shared(wrapper);
+    finish_spot_fixture(fixture);
+}
+
 #[test, expected_failure(abort_code = sessions::ESessionNotAuthorized)]
 fun session_at_exact_expiration_cannot_place_spot_market_order() {
     let mut fixture = setup_spot_fixture();
@@ -577,7 +635,16 @@ fun setup_spot_fixture(): SpotFixture {
     SpotFixture { scenario, registry_id, pool_id, wrapper_id, sessions_config_id }
 }
 
+fun other_venue(): ID {
+    object::id_from_address(OTHER_VENUE)
+}
+
 fun authorize_session(fixture: &mut SpotFixture) {
+    let pool_id = fixture.pool_id;
+    authorize_session_on(fixture, vector[pool_id]);
+}
+
+fun authorize_session_on(fixture: &mut SpotFixture, venues: vector<ID>) {
     let wrapper_id = fixture.wrapper_id;
     fixture.scenario.next_tx(ALICE);
     let mut wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
@@ -589,6 +656,7 @@ fun authorize_session(fixture: &mut SpotFixture) {
         &mut wrapper,
         &sessions_config,
         SESSION,
+        venues,
         SESSION_DURATION_MS,
         &clock,
         fixture.scenario.ctx(),


### PR DESCRIPTION
## Summary

- `authorize_session` now takes the coin types a session may trade, and stores them with the expiry.
- The DeepBook spot entrypoints refuse a trade whose base or quote the grant does not name.
- The Predict entrypoints are not gated on the grant's contents; they check only that the session is live.
- `session_coins` exposes a grant's coin types for SDK and devInspect reads, and `SessionAuthorized` carries them.

## Why

The sessions package lets an Account owner delegate trading to a session address so a frontend can act without the owner signing every transaction. A grant previously recorded only an expiry, so a live session could mint app auth for whichever pool the caller passed in. App auth carries no owner or operation restriction, and the spot wrappers fund an order by withdrawing the account's entire base, quote and DEEP balance, so a session could name a pool pairing a held asset against a coin the caller minted and take the other side of the trade at a price it also chose. Session keys are held by frontends by design, so what one leaked key can reach should be bounded by what the owner granted.

Coin types rather than pool ids because the grant has to survive the venue set changing. DeepBook registers at most one pool per asset pair (`registry::register_pool` asserts the pair is unregistered in both orderings), so naming the assets pins a session to the canonical pools for them and keeps working for pools created after the grant.

## Linear / Context

- DBU-765

## Key decisions

- **The Predict entrypoints are deliberately not gated on the grant's contents.** They take no type parameters, settle only in DUSDC, withdraw the quoted cost rather than the account balance, and bind the pricer to the market, so there is no caller-chosen venue or asset to constrain. Gating them on market ids was tried and reverted: cadences run as short as one minute over a rolling deployment horizon, so the markets a session needs next do not exist when the owner authorizes it, and up to sixty can be live against a twenty-entry grant. That would have made a session re-authorize every few minutes, which is the cost sessions exist to remove.
- An empty coin list is rejected rather than read as "unrestricted", so the permissive reading is not reachable by omission.
- Reauthorization replaces the grant instead of merging into it, so narrowing a session is the same operation as widening one.
- The cancel and settled-sweep wrappers are gated with the trading ones. They do not move value out, but they are generic over the same pair, and one rule across the spot surface means a reader does not have to work out which entrypoints differ.

## Scope / Descoped

**This bounds which assets a session can reach, not how much it can lose.** The spot wrappers still fund an order by withdrawing the account's whole balance for the pair, and both `price` and `price_limit` come from the caller; DeepBook spot enforces no price band beyond `MIN_PRICE`/`MAX_PRICE`. So a session granted an asset can still market-order the full balance through the canonical pool for that pair, and a caller willing to lock capital in a far-from-mid resting order can take the far side of it. What that costs the owner is bounded by the real liquidity sitting between mid and that order — meaningful in a deep pool, small in a thin one — not by the grant. Removing the cheap zero-capital version of the attack is worth landing on its own, but it should not be read as a loss bound.

A loss bound needs a per-asset spend allowance carried in the grant and charged against the net balance change across the call. That is deliberately not in this PR: it changes the funding path the owner entrypoints share and deserves its own review. The same applies to the Predict side, where a live session can spend account DUSDC on legitimate markets up to whatever `max_cost` each call names.

## Test plan

- [ ] `sui move test --path packages/sessions --gas-limit 100000000000` — 36 tests pass, no failures, no warnings. Run against the toolchain `move_test.yml` pins (`testnet-v1.74.1`), not a local newer CLI.
- [ ] `session_cannot_trade_an_ungranted_asset` — a live session granted the base asset but not the quote is refused `ECoinNotGranted` on the real pool. Negative in both directions: with the check removed the order succeeds and the test fails on `EUnexpectedSuccess`.
- [ ] The Predict flow tests (mint, redeem live, redeem settled) pass while the session's grant names a coin type unrelated to the market, which is what shows a rolling expiry cannot strand a live session.
- [ ] `empty_coin_list_aborts`, `duplicate_coins_abort`, `twenty_first_coin_aborts` — `EInvalidSessionCoins` at the empty, duplicate and over-limit boundaries.
- [ ] `reauthorization_replaces_coins_rather_than_adding` — the second grant's coin list replaces the first's rather than accumulating.
- [ ] `granted_coins_read_back_for_the_granted_session_only` — `session_coins` returns the granted pair for the session and `none` for an unknown address.

## Risk / Rollout

`authorize_session` gains a required parameter and `SessionsData` changes shape, so this breaks callers of the package. The package is published on testnet only, and no Move or TypeScript caller in this repository constructs `authorize_session`, so there is nothing to migrate here; any external caller must start passing coin types. `SessionAuthorized` gains a `coins` field, so event consumers should tolerate it before this ships. A grant must name every asset the session will trade, including DEEP when orders pay fees in it.
