### PR TITLE
server: bound the work an intervalized volume request can cost

### DIFF
--- a/crates/indexer/deepbook-indexer-openapi.yaml
+++ b/crates/indexer/deepbook-indexer-openapi.yaml
@@ -363,7 +363,7 @@ paths:
           schema: { type: integer, format: int64, minimum: 0 }
           description: |
             Unix seconds. Defaults to 24 hours before end_time. The window must be ordered and at
-            most 90 days wide.
+            most 365 days wide.
         - in: query
           name: end_time
           schema: { type: integer, format: int64, minimum: 0 }
@@ -388,7 +388,7 @@ paths:
                 $ref: "#/components/schemas/IntervalMakerTakerVolumes"
         "400":
           description: |
-            Invalid interval, unordered or negative window, a window wider than 90 days, a window
+            Invalid interval, unordered or negative window, a window wider than 365 days, a window
             needing more than 500 buckets, or no valid pool names.
       x-docs: "https://docs.sui.io/standards/deepbookv3-indexer"
 

--- a/crates/indexer/deepbook-indexer-openapi.yaml
+++ b/crates/indexer/deepbook-indexer-openapi.yaml
@@ -370,11 +370,11 @@ paths:
           description: Unix seconds. Defaults to now.
         - in: query
           name: interval
-          required: true
           schema: { type: integer, format: int64, minimum: 1, default: 3600 }
           description: |
-            Interval length in seconds. The window is split into at most 500 buckets, so the
-            interval must be at least (end_time - start_time) / 500.
+            Interval length in seconds. The window is split into floor((end_time - start_time) /
+            interval) buckets, which must not exceed 500. A window narrower than one interval
+            yields no buckets and returns an empty object.
         - in: query
           name: volume_in_base
           schema: { type: boolean, default: false }

--- a/crates/indexer/deepbook-indexer-openapi.yaml
+++ b/crates/indexer/deepbook-indexer-openapi.yaml
@@ -360,15 +360,21 @@ paths:
           schema: { type: string }
         - in: query
           name: start_time
-          schema: { type: integer, format: int64 }
+          schema: { type: integer, format: int64, minimum: 0 }
+          description: |
+            Unix seconds. Defaults to 24 hours before end_time. The window must be ordered and at
+            most 90 days wide.
         - in: query
           name: end_time
-          schema: { type: integer, format: int64 }
+          schema: { type: integer, format: int64, minimum: 0 }
+          description: Unix seconds. Defaults to now.
         - in: query
           name: interval
           required: true
-          schema: { type: integer, format: int64, minimum: 1 }
-          description: Interval length in seconds.
+          schema: { type: integer, format: int64, minimum: 1, default: 3600 }
+          description: |
+            Interval length in seconds. The window is split into at most 500 buckets, so the
+            interval must be at least (end_time - start_time) / 500.
         - in: query
           name: volume_in_base
           schema: { type: boolean, default: false }
@@ -380,6 +386,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/IntervalMakerTakerVolumes"
+        "400":
+          description: |
+            Invalid interval, unordered or negative window, a window wider than 90 days, a window
+            needing more than 500 buckets, or no valid pool names.
       x-docs: "https://docs.sui.io/standards/deepbookv3-indexer"
 
   /summary:

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -758,8 +758,9 @@ fn volume_interval_ms(params: &HashMap<String, String>) -> Result<i64, DeepBookE
     })
 }
 
-/// Number of buckets the intervalized historical-volume endpoint will walk for this window, or a
-/// 400 when the request exceeds the per-request work budget.
+/// Number of buckets the intervalized historical-volume endpoint will walk for this window — the
+/// value that drives the walk itself — or a 400 when the request exceeds the per-request work
+/// budget.
 ///
 /// Every bucket costs one database query, so the window is bounded before any query runs: the
 /// timestamps must be non-negative and ordered, the window may not exceed
@@ -842,13 +843,14 @@ async fn get_historical_volume_by_balance_manager_id_with_interval(
     let mut metrics_by_interval: HashMap<String, HashMap<String, Vec<i64>>> =
         HashMap::with_capacity(buckets as usize);
 
-    // Saturating: an interval wider than the window saturates past end_time and ends the loop,
-    // rather than wrapping into a bucket that sits before the one it came from.
-    let mut current_start = start_time;
-    while current_start.saturating_add(interval_ms) <= end_time {
-        let current_end = current_start.saturating_add(interval_ms);
-
-        let volume_in_base = params.volume_in_base();
+    // The walk is driven by the budget's own bucket count, so the number the request was admitted
+    // on is the number of queries it can cost. Deriving the end of the walk separately — from a
+    // comparison against end_time — is what let a saturated end_time hold the loop open forever.
+    // Every bucket lands inside [start_time, end_time], so none of this arithmetic can overflow.
+    let volume_in_base = params.volume_in_base();
+    for bucket in 0..buckets {
+        let current_start = start_time + bucket * interval_ms;
+        let current_end = current_start + interval_ms;
 
         let results = state
             .reader
@@ -884,8 +886,6 @@ async fn get_historical_volume_by_balance_manager_id_with_interval(
             format!("[{}, {}]", current_start / 1000, current_end / 1000),
             volume_by_pool,
         );
-
-        current_start = current_end;
     }
 
     Ok(Json(metrics_by_interval))
@@ -2025,7 +2025,10 @@ impl ParameterUtil for HashMap<String, String> {
     fn end_time(&self) -> i64 {
         self.get("end_time")
             .and_then(|v| v.parse::<i64>().ok())
-            .map(|t| t.saturating_mul(1000)) // Convert to milliseconds
+            // Saturating, then floored at the epoch: ~24 handlers subtract a lookback window
+            // from this value with plain arithmetic, and a clamp to i64::MIN would underflow all
+            // of them. A pre-epoch end_time selects nothing either way.
+            .map(|t| t.saturating_mul(1000).max(0))
             .unwrap_or_else(current_time_ms)
     }
 

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -69,6 +69,19 @@ diesel::define_sql_function! {
 /// Default lookback window for the /orders endpoint when no start_time is provided (7 days in ms).
 const DEFAULT_ORDERS_LOOKBACK_MS: i64 = 7 * 24 * 60 * 60 * 1000;
 
+/// Default lookback window for the historical-volume endpoints when no start_time is provided.
+const DEFAULT_VOLUME_LOOKBACK_MS: i64 = 24 * 60 * 60 * 1000;
+
+/// Default bucket length for the intervalized historical-volume endpoint (1 hour, in seconds).
+const DEFAULT_VOLUME_INTERVAL_SECONDS: i64 = 3600;
+
+/// Widest window the intervalized historical-volume endpoint will serve (90 days in ms).
+const MAX_VOLUME_INTERVAL_RANGE_MS: i64 = 90 * 24 * 60 * 60 * 1000;
+
+/// Most buckets one intervalized historical-volume request may ask for. Each bucket costs one
+/// database query, so this is the per-request work budget.
+const MAX_VOLUME_INTERVAL_BUCKETS: i64 = 500;
+
 fn current_time_ms() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -719,31 +732,19 @@ async fn get_historical_volume_by_balance_manager_id(
     Ok(Json(volume_by_pool))
 }
 
-async fn get_historical_volume_by_balance_manager_id_with_interval(
-    Path((pool_names, balance_manager_id)): Path<(String, String)>,
-    Query(params): Query<HashMap<String, String>>,
-    State(state): State<Arc<AppState>>,
-) -> Result<Json<HashMap<String, HashMap<String, Vec<i64>>>>, DeepBookError> {
-    let pools = state.reader.get_pools().await?;
-    let pool_name_to_id: HashMap<String, String> = pools
-        .into_iter()
-        .map(|pool| (pool.pool_name, pool.pool_id))
-        .collect();
-
-    let pool_ids = pool_names
-        .split(',')
-        .filter_map(|name| pool_name_to_id.get(name).cloned())
-        .collect::<Vec<_>>();
-
-    if pool_ids.is_empty() {
-        return Err(DeepBookError::bad_request("No valid pool names provided"));
-    }
-
-    // Parse interval
-    let interval = params
-        .get("interval")
-        .and_then(|v| v.parse::<i64>().ok())
-        .unwrap_or(3600); // Default interval: 1 hour
+/// Bucket length in ms for the intervalized historical-volume endpoint, from the `interval` query
+/// parameter in seconds. Rejects anything that is not a positive number of seconds, and anything
+/// whose millisecond form does not fit in an `i64`.
+fn volume_interval_ms(params: &HashMap<String, String>) -> Result<i64, DeepBookError> {
+    let interval = match params.get("interval") {
+        Some(raw) => raw.parse::<i64>().map_err(|_| {
+            DeepBookError::bad_request(format!(
+                "Invalid interval '{}': expected a whole number of seconds",
+                raw
+            ))
+        })?,
+        None => DEFAULT_VOLUME_INTERVAL_SECONDS,
+    };
 
     if interval <= 0 {
         return Err(DeepBookError::bad_request(
@@ -751,19 +752,100 @@ async fn get_historical_volume_by_balance_manager_id_with_interval(
         ));
     }
 
-    let interval_ms = interval * 1000;
-    // Parse start_time and end_time
-    let end_time = params.end_time();
+    interval.checked_mul(1000).ok_or_else(|| {
+        DeepBookError::bad_request(format!("Interval of {}s is too large", interval))
+    })
+}
 
+/// Number of buckets the intervalized historical-volume endpoint will walk for this window, or a
+/// 400 when the request exceeds the per-request work budget.
+///
+/// Every bucket costs one database query, so the window is bounded before any query runs: the
+/// timestamps must be non-negative and ordered, the window may not exceed
+/// [`MAX_VOLUME_INTERVAL_RANGE_MS`], and it may not need more than [`MAX_VOLUME_INTERVAL_BUCKETS`]
+/// buckets.
+fn volume_interval_buckets(
+    start_time: i64,
+    end_time: i64,
+    interval_ms: i64,
+) -> Result<i64, DeepBookError> {
+    if start_time < 0 {
+        return Err(DeepBookError::bad_request(
+            "start_time must not be negative",
+        ));
+    }
+
+    if end_time <= start_time {
+        return Err(DeepBookError::bad_request(
+            "end_time must be greater than start_time",
+        ));
+    }
+
+    // Ordered and non-negative, so the subtraction cannot overflow.
+    let range_ms = end_time - start_time;
+    if range_ms > MAX_VOLUME_INTERVAL_RANGE_MS {
+        return Err(DeepBookError::bad_request(format!(
+            "Time range of {}s exceeds the maximum of {}s",
+            range_ms / 1000,
+            MAX_VOLUME_INTERVAL_RANGE_MS / 1000
+        )));
+    }
+
+    let buckets = range_ms / interval_ms;
+    if buckets > MAX_VOLUME_INTERVAL_BUCKETS {
+        return Err(DeepBookError::bad_request(format!(
+            "An interval of {}s over a {}s range needs {} buckets, more than the maximum of {}; \
+             widen the interval or narrow the time range",
+            interval_ms / 1000,
+            range_ms / 1000,
+            buckets,
+            MAX_VOLUME_INTERVAL_BUCKETS
+        )));
+    }
+
+    Ok(buckets)
+}
+
+async fn get_historical_volume_by_balance_manager_id_with_interval(
+    Path((pool_names, balance_manager_id)): Path<(String, String)>,
+    Query(params): Query<HashMap<String, String>>,
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<HashMap<String, HashMap<String, Vec<i64>>>>, DeepBookError> {
+    // Bound the work this request may cost before touching the database: the loop below runs one
+    // query per bucket, and every input it walks on is caller-controlled.
+    let interval_ms = volume_interval_ms(&params)?;
+    let end_time = params.end_time();
     let start_time = params
         .start_time() // Convert to milliseconds
-        .unwrap_or_else(|| end_time - 24 * 60 * 60 * 1000);
+        .unwrap_or_else(|| end_time.saturating_sub(DEFAULT_VOLUME_LOOKBACK_MS));
+    let buckets = volume_interval_buckets(start_time, end_time, interval_ms)?;
 
-    let mut metrics_by_interval: HashMap<String, HashMap<String, Vec<i64>>> = HashMap::new();
+    let pools = state.reader.get_pools().await?;
+    let pool_name_to_id: HashMap<String, String> = pools
+        .into_iter()
+        .map(|pool| (pool.pool_name, pool.pool_id))
+        .collect();
 
+    // Deduplicated: a repeated pool name would otherwise widen every per-bucket query's IN list.
+    let mut pool_ids = pool_names
+        .split(',')
+        .filter_map(|name| pool_name_to_id.get(name).cloned())
+        .collect::<Vec<_>>();
+    pool_ids.sort();
+    pool_ids.dedup();
+
+    if pool_ids.is_empty() {
+        return Err(DeepBookError::bad_request("No valid pool names provided"));
+    }
+
+    let mut metrics_by_interval: HashMap<String, HashMap<String, Vec<i64>>> =
+        HashMap::with_capacity(buckets as usize);
+
+    // Saturating: an interval wider than the window saturates past end_time and ends the loop,
+    // rather than wrapping into a bucket that sits before the one it came from.
     let mut current_start = start_time;
-    while current_start + interval_ms <= end_time {
-        let current_end = current_start + interval_ms;
+    while current_start.saturating_add(interval_ms) <= end_time {
+        let current_end = current_start.saturating_add(interval_ms);
 
         let volume_in_base = params.volume_in_base();
 
@@ -1934,13 +2016,15 @@ impl ParameterUtil for HashMap<String, String> {
     fn start_time(&self) -> Option<i64> {
         self.get("start_time")
             .and_then(|v| v.parse::<i64>().ok())
-            .map(|t| t * 1000) // Convert
+            // Saturating: seconds far outside the representable millisecond range clamp to the
+            // bounds instead of wrapping into a plausible-looking timestamp.
+            .map(|t| t.saturating_mul(1000))
     }
 
     fn end_time(&self) -> i64 {
         self.get("end_time")
             .and_then(|v| v.parse::<i64>().ok())
-            .map(|t| t * 1000) // Convert to milliseconds
+            .map(|t| t.saturating_mul(1000)) // Convert to milliseconds
             .unwrap_or_else(current_time_ms)
     }
 

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -75,8 +75,9 @@ const DEFAULT_VOLUME_LOOKBACK_MS: i64 = 24 * 60 * 60 * 1000;
 /// Default bucket length for the intervalized historical-volume endpoint (1 hour, in seconds).
 const DEFAULT_VOLUME_INTERVAL_SECONDS: i64 = 3600;
 
-/// Widest window the intervalized historical-volume endpoint will serve (90 days in ms).
-const MAX_VOLUME_INTERVAL_RANGE_MS: i64 = 90 * 24 * 60 * 60 * 1000;
+/// Widest window the intervalized historical-volume endpoint will serve (365 days in ms). Wide
+/// enough for a year of daily buckets, which stays well inside the bucket budget below.
+const MAX_VOLUME_INTERVAL_RANGE_MS: i64 = 365 * 24 * 60 * 60 * 1000;
 
 /// Most buckets one intervalized historical-volume request may ask for. Each bucket costs one
 /// database query, so this is the per-request work budget.

--- a/crates/server/tests/historical_volume_interval_tests.rs
+++ b/crates/server/tests/historical_volume_interval_tests.rs
@@ -238,12 +238,24 @@ async fn rejects_a_multi_decade_window_bucketed_by_the_second() {
 }
 
 #[tokio::test]
+async fn serves_a_year_of_daily_buckets() {
+    let (_temp_db, router) = setup(&[]).await;
+
+    // The widest window the endpoint exists to serve: a year at daily granularity.
+    let (status, body) = send(&router, &uri(T0_S, T0_S + 365 * DAY_S, "86400")).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    let response: Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(response.as_object().unwrap().len(), 365, "{body}");
+}
+
+#[tokio::test]
 async fn rejects_a_window_wider_than_the_maximum_range() {
     let (_temp_db, router) = setup(&[]).await;
 
+    // A day past the cap, at a bucket count the budget would otherwise allow.
     assert_rejected(
         &router,
-        &uri(T0_S, T0_S + 91 * DAY_S, "86400"),
+        &uri(T0_S, T0_S + 366 * DAY_S, "86400"),
         "exceeds the maximum",
     )
     .await;

--- a/crates/server/tests/historical_volume_interval_tests.rs
+++ b/crates/server/tests/historical_volume_interval_tests.rs
@@ -124,9 +124,18 @@ async fn seed_fill(db: &Db, fill: FillSeed) {
 }
 
 fn uri(start_time_s: i64, end_time_s: i64, interval_s: &str) -> String {
+    uri_for_pools(
+        POOL_NAME,
+        start_time_s,
+        end_time_s,
+        &format!("&interval={interval_s}"),
+    )
+}
+
+fn uri_for_pools(pool_names: &str, start_time_s: i64, end_time_s: i64, interval: &str) -> String {
     format!(
-        "/historical_volume_by_balance_manager_id_with_interval/{POOL_NAME}/{MANAGER_ID}\
-         ?start_time={start_time_s}&end_time={end_time_s}&interval={interval_s}&volume_in_base=true",
+        "/historical_volume_by_balance_manager_id_with_interval/{pool_names}/{MANAGER_ID}\
+         ?start_time={start_time_s}&end_time={end_time_s}{interval}&volume_in_base=true",
     )
 }
 
@@ -230,10 +239,12 @@ async fn rejects_a_window_one_bucket_over_the_budget() {
 }
 
 #[tokio::test]
-async fn rejects_a_multi_decade_window_bucketed_by_the_second() {
+async fn rejects_a_multi_decade_window() {
     let (_temp_db, router) = setup(&[]).await;
 
     // The report's shape: an unauthenticated decades-wide request at a one-second interval.
+    // The window cap fires first here, whatever the interval — the bucket budget is pinned
+    // separately by rejects_a_window_one_bucket_over_the_budget.
     assert_rejected(&router, &uri(0, T0_S, "1"), "exceeds the maximum").await;
 }
 
@@ -313,4 +324,69 @@ async fn rejects_timestamps_that_overflow_the_millisecond_conversion() {
         "end_time must be greater than start_time",
     )
     .await;
+}
+
+#[tokio::test]
+async fn terminates_when_end_time_saturates_to_the_i64_ceiling() {
+    let (_temp_db, router) = setup(&[]).await;
+
+    // end_time in seconds * 1000 clamps to exactly i64::MAX, and start_time defaults to one day
+    // before it, so every budget check passes with 24 buckets. The walk must still terminate.
+    let uri = format!(
+        "/historical_volume_by_balance_manager_id_with_interval/{POOL_NAME}/{MANAGER_ID}\
+         ?end_time=9223372036854776&interval=3600&volume_in_base=true",
+    );
+    let result =
+        tokio::time::timeout(std::time::Duration::from_secs(30), send(&router, &uri)).await;
+    let (status, body) = result.expect("request must terminate");
+    assert_eq!(status, StatusCode::OK, "{body}");
+    let response: Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(response.as_object().unwrap().len(), 24, "{body}");
+}
+
+#[tokio::test]
+async fn repeated_pool_names_do_not_change_the_result() {
+    let (_temp_db, router) = setup(&[FillSeed {
+        tag: "maker-b0",
+        timestamp_ms: (T0_S + HOUR_S / 2) * 1000,
+        maker_balance_manager_id: MANAGER_ID,
+        taker_balance_manager_id: OTHER_MANAGER_ID,
+        base_quantity: 100,
+    }])
+    .await;
+
+    let interval = format!("&interval={HOUR_S}");
+    let end = T0_S + 4 * HOUR_S;
+    let (single_status, single) =
+        send(&router, &uri_for_pools(POOL_NAME, T0_S, end, &interval)).await;
+    let repeated_names = format!("{POOL_NAME},{POOL_NAME},{POOL_NAME}");
+    let (repeated_status, repeated) = send(
+        &router,
+        &uri_for_pools(&repeated_names, T0_S, end, &interval),
+    )
+    .await;
+
+    assert_eq!(single_status, StatusCode::OK, "{single}");
+    assert_eq!(repeated_status, StatusCode::OK, "{repeated}");
+    assert_eq!(
+        serde_json::from_str::<Value>(&single).unwrap(),
+        serde_json::from_str::<Value>(&repeated).unwrap(),
+        "deduplicating the pool list must not change what is served",
+    );
+}
+
+#[tokio::test]
+async fn defaults_to_hourly_buckets_when_no_interval_is_given() {
+    let (_temp_db, router) = setup(&[]).await;
+
+    let (status, body) = send(
+        &router,
+        &uri_for_pools(POOL_NAME, T0_S, T0_S + 4 * HOUR_S, ""),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    let response: Value = serde_json::from_str(&body).unwrap();
+    let buckets = response.as_object().unwrap();
+    assert_eq!(buckets.len(), 4, "{body}");
+    assert!(buckets.contains_key(&bucket(T0_S, T0_S + HOUR_S)), "{body}");
 }

--- a/crates/server/tests/historical_volume_interval_tests.rs
+++ b/crates/server/tests/historical_volume_interval_tests.rs
@@ -1,0 +1,304 @@
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::Router;
+use diesel_async::RunQueryDsl;
+use http_body_util::BodyExt;
+use prometheus::Registry;
+use serde_json::Value;
+use std::sync::Arc;
+use sui_pg_db::temp::TempDb;
+use sui_pg_db::{Db, DbArgs};
+use tower::ServiceExt;
+use url::Url;
+
+use deepbook_server::{
+    pyth::{PythProConfig, DEFAULT_PRO_URL},
+    server::{make_router, AppState},
+};
+
+const POOL_NAME: &str = "BASE_USDC";
+const POOL_ID: &str = "pool-1";
+const MANAGER_ID: &str = "manager-1";
+const OTHER_MANAGER_ID: &str = "manager-2";
+const HOUR_S: i64 = 3600;
+const DAY_S: i64 = 24 * HOUR_S;
+/// Fixed window start (Unix seconds) so bucket keys are deterministic.
+const T0_S: i64 = 1_700_000_000;
+
+#[derive(Clone, Copy, Debug)]
+struct FillSeed {
+    tag: &'static str,
+    timestamp_ms: i64,
+    maker_balance_manager_id: &'static str,
+    taker_balance_manager_id: &'static str,
+    base_quantity: i64,
+}
+
+async fn setup(fills: &[FillSeed]) -> (TempDb, Router) {
+    let temp_db = TempDb::new().expect("postgres binaries must be on PATH");
+    let url: Url = temp_db.database().url().clone();
+    let db = Db::for_write(url.clone(), DbArgs::default()).await.unwrap();
+    db.run_migrations(Some(&deepbook_schema::MIGRATIONS))
+        .await
+        .unwrap();
+
+    seed_pool(&db).await;
+    for fill in fills {
+        seed_fill(&db, *fill).await;
+    }
+
+    let registry = Registry::new();
+    let rpc_url: Url = "http://localhost:1/".parse().unwrap();
+    let state = Arc::new(
+        AppState::new(
+            url,
+            DbArgs::default(),
+            &registry,
+            rpc_url,
+            "deepbook-package".to_string(),
+            "deep-token-package".to_string(),
+            "deep-treasury".to_string(),
+            None,
+            None,
+            100,
+            Url::parse(DEFAULT_PRO_URL).unwrap(),
+            None,
+            PythProConfig::default(),
+        )
+        .await
+        .unwrap(),
+    );
+
+    let router = make_router(state);
+    (temp_db, router)
+}
+
+async fn seed_pool(db: &Db) {
+    let mut conn = db.connect().await.unwrap();
+    diesel::sql_query(
+        "INSERT INTO pools (
+            pool_id, pool_name,
+            base_asset_id, base_asset_decimals, base_asset_symbol, base_asset_name,
+            quote_asset_id, quote_asset_decimals, quote_asset_symbol, quote_asset_name,
+            min_size, lot_size, tick_size
+        ) VALUES (
+            'pool-1', 'BASE_USDC',
+            'base-coin', 9, 'BASE', 'Base Coin',
+            'quote-coin', 9, 'USDC', 'USD Coin',
+            1, 1, 1
+        )",
+    )
+    .execute(&mut conn)
+    .await
+    .unwrap();
+}
+
+async fn seed_fill(db: &Db, fill: FillSeed) {
+    let mut conn = db.connect().await.unwrap();
+    diesel::sql_query(format!(
+        "INSERT INTO order_fills (
+            event_digest, digest, sender, checkpoint, checkpoint_timestamp_ms, package,
+            pool_id, maker_order_id, taker_order_id,
+            maker_client_order_id, taker_client_order_id,
+            price, taker_fee, taker_fee_is_deep, maker_fee, maker_fee_is_deep,
+            taker_is_bid, base_quantity, quote_quantity,
+            maker_balance_manager_id, taker_balance_manager_id, onchain_timestamp
+        ) VALUES (
+            'fill-{tag}', 'tx-{tag}', 'sender', 1, {timestamp_ms}, 'package',
+            '{POOL_ID}', 'maker-order-{tag}', 'taker-order-{tag}',
+            1, 2,
+            1, 0, false, 0, false,
+            false, {base_quantity}, {quote_quantity},
+            '{maker}', '{taker}', {timestamp_ms}
+        )",
+        tag = fill.tag,
+        timestamp_ms = fill.timestamp_ms,
+        base_quantity = fill.base_quantity,
+        quote_quantity = fill.base_quantity * 2,
+        maker = fill.maker_balance_manager_id,
+        taker = fill.taker_balance_manager_id,
+    ))
+    .execute(&mut conn)
+    .await
+    .unwrap();
+}
+
+fn uri(start_time_s: i64, end_time_s: i64, interval_s: &str) -> String {
+    format!(
+        "/historical_volume_by_balance_manager_id_with_interval/{POOL_NAME}/{MANAGER_ID}\
+         ?start_time={start_time_s}&end_time={end_time_s}&interval={interval_s}&volume_in_base=true",
+    )
+}
+
+async fn send(router: &Router, uri: &str) -> (StatusCode, String) {
+    let response = router
+        .clone()
+        .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let status = response.status();
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    (status, String::from_utf8_lossy(&body).into_owned())
+}
+
+async fn assert_rejected(router: &Router, uri: &str, expected_fragment: &str) {
+    let (status, body) = send(router, uri).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "GET {uri} -> {body}");
+    assert!(
+        body.contains(expected_fragment),
+        "GET {uri} -> {body}, expected it to mention {expected_fragment:?}",
+    );
+}
+
+fn bucket(start_s: i64, end_s: i64) -> String {
+    format!("[{start_s}, {end_s}]")
+}
+
+#[tokio::test]
+async fn serves_one_bucket_per_interval_inside_the_budget() {
+    let (_temp_db, router) = setup(&[
+        // Mid-bucket so an inclusive range bound cannot double-count across buckets.
+        FillSeed {
+            tag: "maker-b0",
+            timestamp_ms: (T0_S + HOUR_S / 2) * 1000,
+            maker_balance_manager_id: MANAGER_ID,
+            taker_balance_manager_id: OTHER_MANAGER_ID,
+            base_quantity: 100,
+        },
+        FillSeed {
+            tag: "taker-b2",
+            timestamp_ms: (T0_S + 2 * HOUR_S + HOUR_S / 2) * 1000,
+            maker_balance_manager_id: OTHER_MANAGER_ID,
+            taker_balance_manager_id: MANAGER_ID,
+            base_quantity: 250,
+        },
+        // Another manager's fill in the same bucket must not appear.
+        FillSeed {
+            tag: "other-b3",
+            timestamp_ms: (T0_S + 3 * HOUR_S + HOUR_S / 2) * 1000,
+            maker_balance_manager_id: OTHER_MANAGER_ID,
+            taker_balance_manager_id: OTHER_MANAGER_ID,
+            base_quantity: 900,
+        },
+    ])
+    .await;
+
+    let (status, body) = send(&router, &uri(T0_S, T0_S + 4 * HOUR_S, "3600")).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    let response: Value = serde_json::from_str(&body).unwrap();
+    let buckets = response.as_object().unwrap();
+
+    assert_eq!(buckets.len(), 4, "{body}");
+    assert_eq!(
+        buckets[&bucket(T0_S, T0_S + HOUR_S)][POOL_NAME],
+        serde_json::json!([100, 0])
+    );
+    assert_eq!(
+        buckets[&bucket(T0_S + HOUR_S, T0_S + 2 * HOUR_S)],
+        serde_json::json!({})
+    );
+    assert_eq!(
+        buckets[&bucket(T0_S + 2 * HOUR_S, T0_S + 3 * HOUR_S)][POOL_NAME],
+        serde_json::json!([0, 250])
+    );
+    assert_eq!(
+        buckets[&bucket(T0_S + 3 * HOUR_S, T0_S + 4 * HOUR_S)],
+        serde_json::json!({})
+    );
+}
+
+#[tokio::test]
+async fn serves_a_window_that_lands_exactly_on_the_bucket_budget() {
+    let (_temp_db, router) = setup(&[]).await;
+
+    let (status, body) = send(&router, &uri(T0_S, T0_S + 500 * HOUR_S, "3600")).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    let response: Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(response.as_object().unwrap().len(), 500, "{body}");
+}
+
+#[tokio::test]
+async fn rejects_a_window_one_bucket_over_the_budget() {
+    let (_temp_db, router) = setup(&[]).await;
+
+    assert_rejected(
+        &router,
+        &uri(T0_S, T0_S + 501 * HOUR_S, "3600"),
+        "needs 501 buckets",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn rejects_a_multi_decade_window_bucketed_by_the_second() {
+    let (_temp_db, router) = setup(&[]).await;
+
+    // The report's shape: an unauthenticated decades-wide request at a one-second interval.
+    assert_rejected(&router, &uri(0, T0_S, "1"), "exceeds the maximum").await;
+}
+
+#[tokio::test]
+async fn rejects_a_window_wider_than_the_maximum_range() {
+    let (_temp_db, router) = setup(&[]).await;
+
+    assert_rejected(
+        &router,
+        &uri(T0_S, T0_S + 91 * DAY_S, "86400"),
+        "exceeds the maximum",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn rejects_an_unordered_or_negative_window() {
+    let (_temp_db, router) = setup(&[]).await;
+
+    assert_rejected(
+        &router,
+        &uri(T0_S + HOUR_S, T0_S, "3600"),
+        "end_time must be greater than start_time",
+    )
+    .await;
+    assert_rejected(
+        &router,
+        &uri(-1, T0_S, "3600"),
+        "start_time must not be negative",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn rejects_an_interval_that_overflows_or_does_not_parse() {
+    let (_temp_db, router) = setup(&[]).await;
+
+    // i64::MAX seconds overflows the conversion to milliseconds.
+    assert_rejected(
+        &router,
+        &uri(T0_S, T0_S + HOUR_S, "9223372036854775807"),
+        "is too large",
+    )
+    .await;
+    assert_rejected(&router, &uri(T0_S, T0_S + HOUR_S, "0"), "greater than 0").await;
+    assert_rejected(
+        &router,
+        &uri(T0_S, T0_S + HOUR_S, "-3600"),
+        "greater than 0",
+    )
+    .await;
+    assert_rejected(&router, &uri(T0_S, T0_S + HOUR_S, "1h"), "Invalid interval").await;
+}
+
+#[tokio::test]
+async fn rejects_timestamps_that_overflow_the_millisecond_conversion() {
+    let (_temp_db, router) = setup(&[]).await;
+
+    // Seconds this large do not fit in milliseconds; the conversion saturates instead of wrapping
+    // into a plausible window, and the saturated window is then rejected on its own terms.
+    assert_rejected(&router, &uri(0, i64::MAX, "3600"), "exceeds the maximum").await;
+    assert_rejected(
+        &router,
+        &uri(i64::MAX, i64::MAX, "3600"),
+        "end_time must be greater than start_time",
+    )
+    .await;
+}


### PR DESCRIPTION
## Summary

- `/historical_volume_by_balance_manager_id_with_interval` now rejects a request before it queries anything when the window is negative, unordered, wider than 365 days, or would need more than 500 buckets, and when `interval` is not a positive number of seconds whose millisecond form fits in an `i64`.
- Second-to-millisecond conversion of `start_time` and `end_time` saturates instead of wrapping, for every endpoint that reads them through `ParameterUtil`.
- Repeated pool names in the path no longer widen the `IN` list of every per-bucket query.
- The bucket walk runs over the bucket count the budget computed, so the number a request is admitted on is the number of queries it can cost.
- `crates/server/tests/historical_volume_interval_tests.rs` covers the served windows, each rejection, and termination; the OpenAPI spec documents the bounds and the 400.

## Why

This endpoint reports maker and taker volume for a BalanceManager split into fixed-length buckets, and it is served without authentication. It walks one database query per bucket, and the only bound between the request and that loop was `interval > 0` — the caller picked both the window and the bucket length. A decades-wide window at a one-second interval therefore asked for billions of serial reads on one connection, and a handful of concurrent requests could hold the reader pool for as long as they liked, degrading every other endpoint behind it. The seconds-to-milliseconds conversions multiplied caller input unchecked, which wraps in release builds and panics in debug ones.

## Linear / Context

- N/A — exempt.

## Key decisions

- The budget is a maximum bucket count (500) alongside a maximum window (365 days), rather than only a minimum interval: bucket count is what the loop actually costs, so it stays meaningful whatever interval the caller picks, and the window cap separately bounds how much of `order_fills` the request may scan.
- The window cap is set at a year because a year of daily buckets — 365 of the 500 available — is the widest thing this endpoint exists to serve. It is not the system's binding constraint on scan size either way: `/historical_volume`, `/all_historical_volume` and the non-intervalized `/historical_volume_by_balance_manager_id` all accept an unbounded window for the same underlying scan.
- The loop is driven by the budget's bucket count rather than by a comparison against `end_time`. Two independent derivations of where the walk ends is what allowed a saturated `end_time` to hold it open; one derivation cannot disagree with itself.
- `end_time` is floored at the epoch, not just saturated. About two dozen handlers subtract a lookback from it with plain arithmetic, so a clamp to `i64::MIN` would underflow all of them; a pre-epoch `end_time` selects nothing either way.
- Out-of-budget requests are rejected, not truncated. A caller that silently receives fewer buckets than it asked for cannot tell a quiet window from a clipped one.
- An `interval` that does not parse is now a 400 instead of silently becoming one hour. The parameter is documented as required, so a request carrying a malformed value was being answered for a window it never asked for.
- Conversions saturate rather than fail, so no in-range caller's timestamps change meaning; an out-of-range value clamps and is then caught by the window checks.

## Scope / Descoped

- **Requests that used to succeed and now return 400.** No in-repo caller sends this path — the exposure is external integrators against docs.sui.io — so the list is explicit rather than assumed:

  | request | buckets | before | after |
  |---|---|---|---|
  | 30 days of hourly buckets | 720 | 200 | 400 |
  | 1 day of minute buckets | 1440 | 200 | 400 |
  | `end_time <= start_time` | 0 | `200 {}` | 400 |
  | malformed `interval` (`1h`, `3600.0`, empty) | — | 200, hourly | 400 |

  Minute-granularity charting is `/ohclv`'s job — one query over a materialized view, default limit 1000 — not this endpoint's. Callers wanting more than 500 buckets page the window; the 400 says so.
- A request inside the budget still costs up to 500 queries. Collapsing the loop into one set-based aggregation is the durable fix for that amplification and is left as follow-up; this PR bounds the cost.
- **The budget bounds queries, not rows per query.** One bucket spanning a year is 1 query in budget, with no `LIMIT` and the sum done in Rust; `/historical_volume`, `/all_historical_volume` and the non-intervalized sibling accept an unbounded window for that same scan today, so this PR does not make that class better or worse. The set-based follow-up is where it gets fixed.
- Timestamp parse failures still fall back to defaults while `interval` parse failures now 400. Deliberate asymmetry: `interval` determines the work budget, the timestamps are already bounded by the window checks.
- The other handlers that compute `end_time - 24h` from caller input keep that arithmetic; flooring `end_time` at the epoch removes the underflow that would otherwise reach them.
- Bucket ranges remain inclusive at both ends (`BETWEEN`), so a fill landing exactly on a boundary is still counted in both adjacent buckets. Pre-existing and unchanged; fewer buckets means marginally fewer boundaries.
- No rate limiting, request timeout, or response-size cap: those belong at the edge and in front of every endpoint, not in this handler.

## Test plan

- [x] `cargo nextest run -E 'package(deepbook-server)'` — 39 passed, 0 failed (CI's own invocation).
- [x] `cargo fmt --check` and `cargo build -p deepbook-server` — clean.
- [x] Reverted only `crates/server/src/server.rs` to `main` and reran the new tests: all 6 rejection/termination cases fail, the decades-wide one-second case never returns (killed at 10 minutes), and all 5 served-window tests — including the full year of daily buckets, the repeated-pool-name case and the default interval — pass unchanged, so the new tests are pinned to these bounds and no served request changed shape.
- [x] `terminates_when_end_time_saturates_to_the_i64_ceiling` reproduces the non-terminating walk against the intermediate commit `55fa2fa9` (30 s timeout, no response) and passes on `3c33fc5e` with 24 buckets.
- Note on coverage: the pool-name dedupe is not observable in a response — SQL `= ANY` already dedupes — so `repeated_pool_names_do_not_change_the_result` guards result-neutrality, not the dedupe itself. Its value is the shorter `IN` list, once per bucket.

## Risk / Rollout

- Caller-visible change: a request outside the budget now gets a 400 instead of an eventual — or never-arriving — 200. A caller wanting more than 500 buckets widens the interval or pages the window.
- No schema change, no migration, no deploy ordering.
