### PR TITLE
Bind auto-approve review to the pinned base and head

### DIFF
--- a/.github/AUTO_APPROVE.md
+++ b/.github/AUTO_APPROVE.md
@@ -7,18 +7,24 @@ Slack.
 
 ## Behavior
 
-- The workflow only handles open, non-draft pull requests targeting the
-  repository's default branch.
+- The workflow only handles open, non-draft pull requests targeting `main`,
+  the repository's default branch. The trigger is limited to that base so
+  `pull_request_target` cannot load this workflow from a retargeted branch.
 - Authorization is based on the pull request author's live membership in
   `MystenLabs/defi-eng`.
-- Approval is bound to the head commit that was current when the label was
-  applied.
+- Authorization pins both the head commit and the base branch tip. Codex
+  reviews the immutable `base_sha...head_sha` compare, not the live pull
+  request diff.
+- Approval is bound to that same head commit, the authorized base branch, and
+  a base tip that is still the pinned commit or a fast-forward of it.
 - The `auto-approve` label is removed after the workflow attempt, whether or
   not approval is submitted. A later attempt requires the label to be applied
   again.
-- A push after auto-approval invalidates the bot review. The workflow first
-  tries to dismiss the old approval and falls back to `REQUEST_CHANGES` if the
-  repository does not let the App dismiss protected-branch reviews.
+- A push after auto-approval invalidates the bot review. Changing the pull
+  request base also dismisses the bot review and cancels an in-progress
+  auto-approve run. The workflow first tries to dismiss the old approval and
+  falls back to `REQUEST_CHANGES` if the repository does not let the App
+  dismiss protected-branch reviews.
 - Significant Codex findings, a missing or failed Codex review, and invalid
   Codex output prevent the bot from approving the pull request.
 - Codex output is validated against the complete expected schema before it can
@@ -91,9 +97,9 @@ The Codex GitHub Action uses API billing; a personal Codex or ChatGPT
 subscription is not used by this workflow.
 
 Codex is deliberately isolated from GitHub write access. The workflow checks
-out only the trusted base commit, downloads the pull request diff as untrusted
-review input, and runs Codex with the `:read-only` permission profile and the
-`drop-sudo` safety strategy.
+out only the trusted base commit, downloads the immutable compare of the
+pinned base and head commits as untrusted review input, and runs Codex with
+the `:read-only` permission profile and the `drop-sudo` safety strategy.
 
 The official Codex Action initializes the authenticated runtime with a harmless
 prompt. The actual review runs in a separate silenced `codex exec` process that
@@ -170,7 +176,15 @@ Use a small test pull request authored by a `defi-eng` member:
 11. Push another commit and confirm it is not automatically re-approved.
    Confirm the old approval is dismissed or replaced with `REQUEST_CHANGES`.
 12. Apply the label to a PR from a non-member and confirm authorization fails.
+13. After a clean approval, retarget the pull request away from `main` and
+   back. Confirm the bot review is dismissed or replaced and is not reused
+   for the restored `main` diff.
+14. Apply `auto-approve`, then retarget the base before Codex finishes.
+   Confirm the in-progress run is cancelled or the approval step refuses to
+   submit, and that Codex did not review a live pull-request diff against
+   the new base.
 
 The GitHub Actions workflow uses `pull_request_target` so it can access secrets.
-It must continue checking out only the trusted base commit and must never run
-code from the pull request branch.
+It must continue checking out only the trusted base commit, reviewing only the
+pinned `base_sha...head_sha` compare, and must never run code from the pull
+request branch.

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -2,9 +2,14 @@ name: Auto-approve after Codex review
 
 on:
   pull_request_target:
+    # pull_request_target loads this file from the PR base. Limit the trigger to
+    # main so a retarget cannot run a workflow from an untrusted base.
+    branches:
+      - main
     types:
       - labeled
       - synchronize
+      - edited
 
 permissions:
   contents: read
@@ -126,6 +131,7 @@ jobs:
             }
 
             core.setOutput("author", pull.user.login);
+            core.setOutput("base_ref", pull.base.ref);
             core.setOutput("base_sha", pull.base.sha);
             core.setOutput("body", pull.body || "");
             core.setOutput("changed_files", String(pull.changed_files));
@@ -225,6 +231,8 @@ jobs:
         if: steps.config.outputs.codex == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
+          EXPECTED_BASE_REF: ${{ steps.authorize.outputs.base_ref }}
+          EXPECTED_BASE_SHA: ${{ steps.authorize.outputs.base_sha }}
           EXPECTED_HEAD_SHA: ${{ steps.authorize.outputs.head_sha }}
           PR_NUMBER: ${{ steps.authorize.outputs.number }}
         with:
@@ -234,31 +242,58 @@ jobs:
             const path = require("path");
             const { owner, repo } = context.repo;
             const pullNumber = Number(process.env.PR_NUMBER);
+            const expectedBaseRef = process.env.EXPECTED_BASE_REF;
+            const expectedBaseSha = process.env.EXPECTED_BASE_SHA;
+            const expectedHeadSha = process.env.EXPECTED_HEAD_SHA;
+
+            const assertAuthorizedPull = async (pull, when) => {
+              if (pull.head.sha !== expectedHeadSha) {
+                throw new Error(
+                  `PR #${pullNumber} ${when}: head changed; remove and re-add auto-approve`,
+                );
+              }
+              if (pull.base.ref !== expectedBaseRef) {
+                throw new Error(
+                  `PR #${pullNumber} ${when}: targets ${pull.base.ref}; only ${expectedBaseRef} is eligible`,
+                );
+              }
+              if (pull.base.sha === expectedBaseSha) {
+                return;
+              }
+              const { data: compare } = await github.rest.repos.compareCommitsWithBasehead({
+                owner,
+                repo,
+                basehead: `${expectedBaseSha}...${pull.base.sha}`,
+              });
+              if (compare.status !== "ahead" && compare.status !== "identical") {
+                throw new Error(
+                  `PR #${pullNumber} ${when}: base ${pull.base.sha.slice(0, 12)} is ${compare.status} relative to authorized ${expectedBaseSha.slice(0, 12)}`,
+                );
+              }
+            };
 
             const { data: pullBefore } = await github.rest.pulls.get({
               owner,
               repo,
               pull_number: pullNumber,
             });
-            if (pullBefore.head.sha !== process.env.EXPECTED_HEAD_SHA) {
-              throw new Error(
-                `PR #${pullNumber} changed before Codex review input was prepared`,
-              );
-            }
+            await assertAuthorizedPull(pullBefore, "before Codex review input was prepared");
 
             const { data: diff } = await github.request(
-              "GET /repos/{owner}/{repo}/pulls/{pull_number}",
+              "GET /repos/{owner}/{repo}/compare/{basehead}",
               {
                 owner,
                 repo,
-                pull_number: pullNumber,
+                basehead: `${expectedBaseSha}...${expectedHeadSha}`,
                 headers: {
                   accept: "application/vnd.github.diff",
                 },
               },
             );
             if (typeof diff !== "string" || diff.length === 0) {
-              throw new Error(`GitHub returned an empty diff for PR #${pullNumber}`);
+              throw new Error(
+                `GitHub returned an empty compare diff for ${expectedBaseSha.slice(0, 12)}...${expectedHeadSha.slice(0, 12)}`,
+              );
             }
 
             const { data: pullAfter } = await github.rest.pulls.get({
@@ -266,11 +301,7 @@ jobs:
               repo,
               pull_number: pullNumber,
             });
-            if (pullAfter.head.sha !== process.env.EXPECTED_HEAD_SHA) {
-              throw new Error(
-                `PR #${pullNumber} changed while Codex review input was prepared`,
-              );
-            }
+            await assertAuthorizedPull(pullAfter, "while Codex review input was prepared");
 
             const reviewDirectory = path.join(
               process.env.GITHUB_WORKSPACE,
@@ -290,8 +321,9 @@ jobs:
                 title: pullAfter.title,
                 body: pullAfter.body || "",
                 author: pullAfter.user.login,
-                base_sha: pullAfter.base.sha,
-                head_sha: pullAfter.head.sha,
+                base_ref: expectedBaseRef,
+                base_sha: expectedBaseSha,
+                head_sha: expectedHeadSha,
                 changed_files: pullAfter.changed_files,
                 additions: pullAfter.additions,
                 deletions: pullAfter.deletions,
@@ -651,6 +683,8 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          BASE_REF: ${{ steps.authorize.outputs.base_ref }}
+          BASE_SHA: ${{ steps.authorize.outputs.base_sha }}
           HEAD_SHA: ${{ steps.authorize.outputs.head_sha }}
           PR_AUTHOR: ${{ steps.authorize.outputs.author }}
           PR_NUMBER: ${{ steps.authorize.outputs.number }}
@@ -661,7 +695,10 @@ jobs:
             const { owner, repo } = context.repo;
             const pullNumber = Number(process.env.PR_NUMBER);
             const botLogin = `${process.env.APP_SLUG}[bot]`;
-            const shortSha = process.env.HEAD_SHA.slice(0, 12);
+            const expectedBaseRef = process.env.BASE_REF;
+            const expectedBaseSha = process.env.BASE_SHA;
+            const expectedHeadSha = process.env.HEAD_SHA;
+            const shortSha = expectedHeadSha.slice(0, 12);
             const codexLine = "Codex found no significant issues in its review of this commit.";
 
             const { data: livePull } = await github.rest.pulls.get({
@@ -669,10 +706,27 @@ jobs:
               repo,
               pull_number: pullNumber,
             });
-            if (livePull.head.sha !== process.env.HEAD_SHA) {
+            if (livePull.head.sha !== expectedHeadSha) {
               throw new Error(
                 `PR #${pullNumber} changed before approval; remove and re-add auto-approve`,
               );
+            }
+            if (livePull.base.ref !== expectedBaseRef) {
+              throw new Error(
+                `PR #${pullNumber} now targets ${livePull.base.ref}; only ${expectedBaseRef} is eligible`,
+              );
+            }
+            if (livePull.base.sha !== expectedBaseSha) {
+              const { data: compare } = await github.rest.repos.compareCommitsWithBasehead({
+                owner,
+                repo,
+                basehead: `${expectedBaseSha}...${livePull.base.sha}`,
+              });
+              if (compare.status !== "ahead" && compare.status !== "identical") {
+                throw new Error(
+                  `PR #${pullNumber} base ${livePull.base.sha.slice(0, 12)} is ${compare.status} relative to authorized ${expectedBaseSha.slice(0, 12)}`,
+                );
+              }
             }
 
             const reviews = await github.paginate(github.rest.pulls.listReviews, {
@@ -934,12 +988,14 @@ jobs:
 
   invalidate-stale-approval:
     name: Invalidate stale bot approval
-    if: github.event.action == 'synchronize'
+    if: >-
+      github.event.action == 'synchronize' ||
+      (github.event.action == 'edited' && github.event.changes.base.ref != null)
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
     concurrency:
-      group: invalidate-auto-approve-${{ github.repository }}-${{ github.event.pull_request.number }}
+      group: auto-approve-${{ github.repository }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true
 
     steps:
@@ -989,6 +1045,9 @@ jobs:
             const pullNumber = context.payload.pull_request.number;
             const currentHeadSha = context.payload.pull_request.head.sha;
             const botLogin = `${process.env.APP_SLUG}[bot]`;
+            const baseRetargeted = context.payload.action === "edited";
+            const previousBaseRef = context.payload.changes?.base?.ref?.from;
+            const currentBaseRef = context.payload.pull_request.base.ref;
 
             const reviews = await github.paginate(github.rest.pulls.listReviews, {
               owner,
@@ -1001,9 +1060,12 @@ jobs:
               .sort((left, right) => left.id - right.id)
               .at(-1);
 
-            if (!latestBotReview
-              || latestBotReview.state !== "APPROVED"
-              || latestBotReview.commit_id === currentHeadSha) {
+            if (!latestBotReview || latestBotReview.state !== "APPROVED") {
+              core.info("No stale auto-approval needs to be invalidated");
+              core.setOutput("invalidated", "false");
+              return;
+            }
+            if (!baseRetargeted && latestBotReview.commit_id === currentHeadSha) {
               core.info("No stale auto-approval needs to be invalidated");
               core.setOutput("invalidated", "false");
               return;
@@ -1011,6 +1073,19 @@ jobs:
 
             const oldShortSha = latestBotReview.commit_id.slice(0, 12);
             const newShortSha = currentHeadSha.slice(0, 12);
+            const dismissMessage = baseRetargeted
+              ? `Pull request base changed from ${previousBaseRef} to ${currentBaseRef}; dismissing auto-approval of ${oldShortSha}`
+              : `New commit ${newShortSha} replaced auto-approved ${oldShortSha}`;
+            const fallbackBody = baseRetargeted
+              ? [
+                  `The pull request base changed from \`${previousBaseRef}\` to \`${currentBaseRef}\``,
+                  `after auto-approved commit \`${oldShortSha}\`.`,
+                  "Reapply the `auto-approve` label after the pull request targets the default branch again.",
+                ].join(" ")
+              : [
+                  `Commit \`${newShortSha}\` was pushed after auto-approved commit \`${oldShortSha}\`.`,
+                  "Reapply the `auto-approve` label to authorize the new commit.",
+                ].join(" ");
             let method = "dismissed";
             try {
               await github.request(
@@ -1020,7 +1095,7 @@ jobs:
                   repo,
                   pull_number: pullNumber,
                   review_id: latestBotReview.id,
-                  message: `New commit ${newShortSha} replaced auto-approved ${oldShortSha}`,
+                  message: dismissMessage,
                   event: "DISMISS",
                 },
               );
@@ -1033,36 +1108,41 @@ jobs:
                 pull_number: pullNumber,
                 commit_id: currentHeadSha,
                 event: "REQUEST_CHANGES",
-                body: [
-                  `Commit \`${newShortSha}\` was pushed after auto-approved commit \`${oldShortSha}\`.`,
-                  "Reapply the `auto-approve` label to authorize the new commit.",
-                ].join(" "),
+                body: fallbackBody,
               });
             }
 
             core.setOutput("invalidated", "true");
             core.setOutput("method", method);
             core.setOutput("old_head_sha", latestBotReview.commit_id);
+            core.setOutput("reason", baseRetargeted ? "base-retargeted" : "head-changed");
 
       - name: Record invalidation in Slack
         if: steps.config.outputs.slack == 'true' && steps.invalidate.outputs.invalidated == 'true'
         continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
+          CURRENT_BASE_REF: ${{ github.event.pull_request.base.ref }}
           CURRENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           INVALIDATION_METHOD: ${{ steps.invalidate.outputs.method }}
+          INVALIDATION_REASON: ${{ steps.invalidate.outputs.reason }}
           OLD_HEAD_SHA: ${{ steps.invalidate.outputs.old_head_sha }}
+          PREVIOUS_BASE_REF: ${{ github.event.changes.base.ref.from }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
           github-token: ${{ github.token }}
           script: |
+            const reason = process.env.INVALIDATION_REASON;
+            const detail = reason === "base-retargeted"
+              ? `Pull request base changed from \`${process.env.PREVIOUS_BASE_REF}\` to \`${process.env.CURRENT_BASE_REF}\` after approved commit \`${process.env.OLD_HEAD_SHA.slice(0, 12)}\`.`
+              : `Commit \`${process.env.CURRENT_HEAD_SHA.slice(0, 12)}\` replaced approved commit \`${process.env.OLD_HEAD_SHA.slice(0, 12)}\`.`;
             const payload = {
               text: [
                 `*Previous auto-approval invalidated* for <${process.env.PR_URL}|PR #${process.env.PR_NUMBER}>.`,
-                `Commit \`${process.env.CURRENT_HEAD_SHA.slice(0, 12)}\` replaced approved commit \`${process.env.OLD_HEAD_SHA.slice(0, 12)}\`.`,
-                `Method: \`${process.env.INVALIDATION_METHOD}\`. Reapply \`auto-approve\` for the new commit.`,
+                detail,
+                `Method: \`${process.env.INVALIDATION_METHOD}\`. Reapply \`auto-approve\` for the current commit.`,
               ].join("\n"),
               unfurl_links: false,
               unfurl_media: false,


### PR DESCRIPTION
## Summary

- Codex now reviews the immutable `base_sha...head_sha` compare captured at authorization, not the live pull-request diff.
- Approval re-reads the pull request and requires the same head, the authorized base branch, and a base tip that is still that commit or a fast-forward of it.
- Changing the pull-request base dismisses the bot review, cancels an in-progress auto-approve run, and no longer loads this `pull_request_target` workflow from a non-`main` base.

## Why

The auto-approve workflow is the Codex-gated review that can satisfy the repository's required-review rule for `defi-eng` member pull requests. It already pinned `head.sha` and re-checked that SHA before approval, but it fetched review input from the live pull request and never re-checked the base. Retargeting the base does not change the head SHA, so the bot could review a smaller decoy diff, approve that same head, and leave the approval attached after the pull request was pointed back at `main`.

## Linear / Context

N/A — exempt. Workflow integrity fix; no Linear ticket.

## Key decisions

- Review input uses `GET /repos/{owner}/{repo}/compare/{base}...{head}` with the pinned SHAs. That closes the decoy-diff window even if a retarget wins the race after authorization.
- Approval allows the live `main` tip to be a fast-forward of the pinned base SHA so a merge to `main` during the Codex run does not fail the job. A diverged or swapped base fails.
- The workflow trigger is limited to `branches: [main]`. `pull_request_target` loads the workflow file from the pull-request base; without this filter, an `edited` handler would run whatever workflow lives on a retargeted branch and would have access to secrets.
- The invalidate job now shares the auto-approve concurrency group and handles `edited` only when `changes.base.ref` is present, so title or body edits and a `main` tip moving forward do not dismiss reviews.

## Scope / Descoped

- In scope: auto-approve workflow integrity and the matching `AUTO_APPROVE.md` contract.
- Out of scope: repository ruleset changes. `main` still requires one approving review, does not dismiss stale reviews, and has no required status check or merge queue. Those settings still make a GitHub approval the merge gate and should be tightened separately.

## Test plan

- [ ] Inspect `.github/workflows/auto-approve.yml`: review input is `compare/{pinned_base}...{pinned_head}`, and the approve step checks head, `base.ref`, and base tracking.
- [ ] Confirm the workflow trigger includes `edited` and `branches: [main]`, and that invalidate runs only when `changes.base.ref` is set.
- [ ] On a small `defi-eng` member test PR targeting `main`, apply `auto-approve` and confirm a clean run still approves the expected head SHA.
- [ ] After a clean approval, retarget the PR away from `main` and back. Confirm the bot review is dismissed or replaced and is not reused for the restored `main` diff.
- [ ] Apply `auto-approve`, then retarget the base before Codex finishes. Confirm the in-progress run is cancelled or the approval step refuses, and that Codex did not review a live pull-request diff against the new base.
- [ ] Push a new commit to an already approved PR and confirm the existing synchronize invalidation path still dismisses or replaces the bot review.

## Risk / Rollout

The workflow change takes effect on `main` after merge because `pull_request_target` loads from the base. A pull request whose base moves during Codex, or whose `main` tip is rewritten rather than fast-forwarded, will fail approval and need the label re-applied. Rollback is reverting this commit on `main`.

Made with [Cursor](https://cursor.com)