### PR TITLE
predict: harden harness git dependency staging

### DIFF
--- a/packages/predict/harness/config.py
+++ b/packages/predict/harness/config.py
@@ -56,10 +56,18 @@ LOCAL_CLOSURE = [
     "predict",
 ]
 
-# Upstream packages that localnet must publish independently. Their repository,
-# subdirectory, and exact revision are read from the canonical Predict/Propbook
-# manifests by staging.py; the harness keeps no duplicate dependency pins.
+# Upstream packages that localnet must publish independently. Subdirectory and
+# exact revision are read from the canonical Predict/Propbook manifests; the
+# harness keeps no duplicate revision pins. Repository URLs must match this
+# allowlist — a new upstream is a deliberate harness change.
 GIT_DEP_NAMES = ("wormhole", "pyth_lazer", "bs_oracle", "bs_sid")
+ALLOWED_GIT_REPOS = frozenset(
+    {
+        "https://github.com/pyth-network/pyth-crosschain.git",
+        "https://github.com/pyth-network/wormhole.git",
+        "https://github.com/blockscholes/sui-signed-oracle.git",
+    }
+)
 
 # Directory names never worth copying into the scratch workspace.
 STAGE_IGNORE = (

--- a/packages/predict/harness/staging.py
+++ b/packages/predict/harness/staging.py
@@ -20,6 +20,8 @@ from . import cancellation, config
 
 _IGNORE = shutil.ignore_patterns(*config.STAGE_IGNORE)
 _FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
+_CONTROL = re.compile(r"[\x00-\x1f\x7f]")
+_SAFE_SUBDIR_PART = re.compile(r"^[A-Za-z0-9._][A-Za-z0-9._-]*$")
 
 
 @dataclass(frozen=True)
@@ -54,6 +56,24 @@ def _git_source(manifest: dict, name: str) -> dict:
     return {field: str(source[field]) for field in required}
 
 
+def validate_git_coordinate(repo: str, subdir: str) -> None:
+    """Reject a git coordinate that is not a safe, allowlisted fetch target."""
+    if _CONTROL.search(repo) or _CONTROL.search(subdir):
+        raise ValueError("git dependency coordinate contains a control character")
+    if repo not in config.ALLOWED_GIT_REPOS:
+        raise ValueError(f"git dependency repository is not allowlisted: {repo}")
+    parts = subdir.split("/")
+    if (
+        not subdir
+        or subdir.startswith("/")
+        or "\\" in subdir
+        or ":" in subdir
+        or any(part in {".", ".."} or part.startswith("-") for part in parts)
+        or not all(_SAFE_SUBDIR_PART.fullmatch(part) for part in parts)
+    ):
+        raise ValueError(f"git dependency subdir is not a safe relative path: {subdir}")
+
+
 def external_dependency_specs(
     packages_dir: Path = config.PACKAGES_DIR,
 ) -> dict[str, GitDependency]:
@@ -77,6 +97,7 @@ def external_dependency_specs(
         source = next(iter(sources.values()))
         if not _FULL_SHA.fullmatch(source["rev"]):
             raise ValueError(f"{name} must use a full 40-character commit SHA")
+        validate_git_coordinate(source["git"], source["subdir"])
         specs[name] = GitDependency(
             name=name,
             repo=source["git"],
@@ -191,6 +212,7 @@ def _stage_git_dep(
     destination: Path,
     cancel_event: threading.Event | None = None,
 ) -> None:
+    validate_git_coordinate(spec.repo, spec.subdir)
     cache = spec.cache_root()
     if _git_has_commit(cache, spec.rev, cancel_event):
         _export_git_tree(
@@ -210,7 +232,20 @@ def _stage_git_dep(
         capture_output=True,
     )
     cancellation.run(
-        ["git", "-C", str(checkout), "fetch", "-q", "--depth", "1", spec.repo, spec.rev],
+        [
+            "git",
+            "-C",
+            str(checkout),
+            "-c",
+            "protocol.ext.allow=never",
+            "fetch",
+            "-q",
+            "--depth",
+            "1",
+            "--",
+            spec.repo,
+            spec.rev,
+        ],
         cancel_event=cancel_event,
         check_result=True,
         capture_output=True,
@@ -235,7 +270,15 @@ def _git_has_commit(
     if not repository.is_dir():
         return False
     result = cancellation.run(
-        ["git", "-C", str(repository), "cat-file", "-e", f"{revision}^{{commit}}"],
+        [
+            "git",
+            "-C",
+            str(repository),
+            "cat-file",
+            "-e",
+            "--",
+            f"{revision}^{{commit}}",
+        ],
         cancel_event=cancel_event,
         capture_output=True,
     )
@@ -255,8 +298,11 @@ def _export_git_tree(
             "git",
             "-C",
             str(repository),
+            "-c",
+            "protocol.ext.allow=never",
             "archive",
             "--format=tar",
+            "--",
             f"{revision}:{subdir}",
         ],
         cancel_event=cancel_event,

--- a/packages/predict/harness/tests/test_staging_publish.py
+++ b/packages/predict/harness/tests/test_staging_publish.py
@@ -28,6 +28,49 @@ from harness import (
 )
 
 
+_PINNED_REV = "1111111111111111111111111111111111111111"
+_PYTH_REPO = "https://github.com/pyth-network/pyth-crosschain.git"
+_WORMHOLE_REPO = "https://github.com/pyth-network/wormhole.git"
+_BS_REPO = "https://github.com/blockscholes/sui-signed-oracle.git"
+
+
+def _git_dep(name: str, repo: str, subdir: str, rev: str = _PINNED_REV) -> str:
+    return f'{name} = {{ git = "{repo}", subdir = "{subdir}", rev = "{rev}" }}\n'
+
+
+def _write_canonical_consumers(
+    packages: Path,
+    *,
+    pyth_repo: str = _PYTH_REPO,
+    pyth_subdir: str = "lazer/contracts/sui",
+    wormhole_repo: str = _WORMHOLE_REPO,
+    wormhole_subdir: str = "sui/wormhole",
+    bs_repo: str = _BS_REPO,
+    bs_oracle_subdir: str = "move/bs_oracle",
+    bs_sid_subdir: str = "move/bs_sid",
+) -> None:
+    """Write matching Predict/Propbook manifests for coordinate-validation tests."""
+    predict = (
+        "[package]\nname = \"deepbook_predict\"\n\n[dependencies]\n"
+        + _git_dep("pyth_lazer", pyth_repo, pyth_subdir)
+        + _git_dep("bs_oracle", bs_repo, bs_oracle_subdir)
+        + "\n[dep-replacements.testnet]\n"
+        + _git_dep("wormhole", wormhole_repo, wormhole_subdir)
+    )
+    propbook = (
+        "[package]\nname = \"propbook\"\n\n[dependencies]\n"
+        + _git_dep("pyth_lazer", pyth_repo, pyth_subdir)
+        + _git_dep("bs_oracle", bs_repo, bs_oracle_subdir)
+        + _git_dep("bs_sid", bs_repo, bs_sid_subdir)
+        + "\n[dep-replacements.testnet]\n"
+        + _git_dep("wormhole", wormhole_repo, wormhole_subdir)
+    )
+    for name, text in (("predict", predict), ("propbook", propbook)):
+        package = packages / name
+        package.mkdir(parents=True)
+        (package / "Move.toml").write_text(text)
+
+
 class StagingTests(unittest.TestCase):
     def test_external_specs_come_from_matching_canonical_manifests(self) -> None:
         specs = staging.external_dependency_specs()
@@ -36,7 +79,7 @@ class StagingTests(unittest.TestCase):
         for spec in specs.values():
             self.assertEqual(len(spec.rev), 40)
             self.assertRegex(spec.rev, r"^[0-9a-f]{40}$")
-            self.assertTrue(spec.repo.startswith("https://"))
+            self.assertIn(spec.repo, config.ALLOWED_GIT_REPOS)
             self.assertTrue(spec.subdir)
 
     def test_checkout_fingerprint_includes_publication_metadata(self) -> None:
@@ -154,7 +197,7 @@ class StagingTests(unittest.TestCase):
             destination = root / "destination"
             spec = staging.GitDependency(
                 name="upstream",
-                repo="https://example.com/upstream.git",
+                repo=_BS_REPO,
                 rev=revision,
                 subdir="move/package",
             )
@@ -171,6 +214,101 @@ class StagingTests(unittest.TestCase):
                 '[package]\nname = "upstream"\n',
             )
             self.assertFalse((destination / "Published.toml").exists())
+
+    def test_disallowed_repo_is_rejected_before_git_starts(self) -> None:
+        spec = staging.GitDependency(
+            name="pyth_lazer",
+            repo="--upload-pack=true",
+            rev=_PINNED_REV,
+            subdir="lazer/contracts/sui",
+        )
+        with mock.patch.object(staging.cancellation, "run") as run:
+            with self.assertRaisesRegex(ValueError, "not allowlisted"):
+                staging._stage_git_dep(spec, Path("/unused"))
+        run.assert_not_called()
+
+    def test_unlisted_https_repo_is_rejected_before_git_starts(self) -> None:
+        spec = staging.GitDependency(
+            name="pyth_lazer",
+            repo="https://github.com/octocat/Hello-World.git",
+            rev=_PINNED_REV,
+            subdir="lazer/contracts/sui",
+        )
+        with mock.patch.object(staging.cancellation, "run") as run:
+            with self.assertRaisesRegex(ValueError, "not allowlisted"):
+                staging._stage_git_dep(spec, Path("/unused"))
+        run.assert_not_called()
+
+    def test_unsafe_subdir_is_rejected_before_git_starts(self) -> None:
+        cases = (
+            "../secret",
+            "/absolute/path",
+            "move:evil",
+            "-output",
+            "move\\oracle",
+            "",
+        )
+        for subdir in cases:
+            spec = staging.GitDependency(
+                name="bs_oracle",
+                repo=_BS_REPO,
+                rev=_PINNED_REV,
+                subdir=subdir,
+            )
+            with self.subTest(subdir=subdir), mock.patch.object(
+                staging.cancellation, "run"
+            ) as run:
+                with self.assertRaisesRegex(ValueError, "safe relative path"):
+                    staging._stage_git_dep(spec, Path("/unused"))
+                run.assert_not_called()
+
+    def test_manifest_coordinate_is_rejected_before_git_starts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            packages = Path(tmp)
+            _write_canonical_consumers(packages, pyth_repo="--upload-pack=true")
+            with mock.patch.object(staging.cancellation, "run") as run:
+                with self.assertRaisesRegex(ValueError, "not allowlisted"):
+                    staging.external_dependency_specs(packages)
+            run.assert_not_called()
+
+    def test_git_fetch_uses_end_of_options_and_disables_ext(self) -> None:
+        spec = staging.GitDependency(
+            name="pyth_lazer",
+            repo=_PYTH_REPO,
+            rev=_PINNED_REV,
+            subdir="lazer/contracts/sui",
+        )
+        recorded: list[list[str]] = []
+
+        def record(command, **_kwargs):
+            recorded.append(list(command))
+            if "fetch" in command:
+                raise RuntimeError("stop after recording fetch argv")
+            return mock.Mock(returncode=0, stdout=b"", stderr=b"")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            destination = Path(tmp) / "pyth_lazer"
+            with (
+                mock.patch.object(staging, "_git_has_commit", return_value=False),
+                mock.patch.object(staging.cancellation, "run", side_effect=record),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "stop after recording"):
+                    staging._stage_git_dep(spec, destination)
+
+        self.assertGreaterEqual(len(recorded), 2)
+        self.assertEqual(recorded[0][:3], ["git", "init", "-q"])
+        fetch = recorded[1]
+        self.assertEqual(fetch[:8], [
+            "git",
+            "-C",
+            fetch[2],
+            "-c",
+            "protocol.ext.allow=never",
+            "fetch",
+            "-q",
+            "--depth",
+        ])
+        self.assertEqual(fetch[8:], ["1", "--", spec.repo, spec.rev])
 
 
 class PublicationPlanTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Harness staging now accepts only the three known HTTPS git remotes already pinned in Predict/Propbook `Move.toml`.
- Manifest `git` and `subdir` coordinates are rejected in Python before any `git` subprocess starts.
- `git fetch` / `git archive` run with `protocol.ext.allow=never` and pass repository operands after `--`.

## Why

The localnet harness publishes Wormhole, Pyth, and Block Scholes from git source because those packages are not on the empty chain. It reads the repository URL from `Move.toml` and used to pass that string to `git fetch` in option-parsing position. A pull request that only changes a dependency coordinate can look like inert metadata; running `harness smoke` (or any staging command) then treats that field as a live Git remote. That is argument injection into Git, not a Move-compiler issue.

## Linear / Context

N/A — exempt

## Key decisions

- Exact repository URL allowlist, not a host allowlist. `github.com` alone would still accept any GitHub repo. A new upstream is a harness change so the trust expansion is reviewable.
- Do not read `main` at runtime to build the list. The allowlist is the three remotes currently used by the canonical manifests.

## Scope / Descoped

Harness staging only. This does not change `sui move build` dependency fetching, on-chain packages, or the pinned revisions.

## Test plan

- [x] `cd packages/predict && python3 -m unittest discover -s harness/tests -p 'test_*.py' -v` — full harness suite, including new tests that a hyphen-prefixed `git` value, an unlisted HTTPS URL, and an unsafe `subdir` raise before `cancellation.run` is called, and that fetch argv contains `--` and `protocol.ext.allow=never`.

## Risk / Rollout

None — tooling only. A legitimate new git upstream will fail staging until `ALLOWED_GIT_REPOS` is updated in the same change. Current Predict/Propbook pins already match the allowlist.


Made with [Cursor](https://cursor.com)