### PR TITLE
scripts: stop interpolating GAS_OBJECT into a shell for upgrades

### DIFF
--- a/.claude/rules/scripts.md
+++ b/.claude/rules/scripts.md
@@ -12,6 +12,7 @@ paths:
 `scripts/` holds only the **protocol package-upgrade** transactions and a couple of SDK examples:
 
 - `scripts/transactions/mainPackageUpgrade.ts`, `marginPackageUpgrade.ts`, `vaultPackageUpgrade.ts` — run `sui client upgrade` and serialize an unsigned upgrade tx to `tx/tx-data.txt` for the multisig.
+- `scripts/transactions/serializeUnsignedUpgrade.ts` — shared `GAS_OBJECT` check and `execFileSync` argv invocation for those upgrade scripts.
 - `scripts/transactions/createPermissionlessPool.ts`, `deepbookMarketMaker.ts` — SDK usage examples.
 - `scripts/config/constants.ts` — the DeepBook core `upgradeCapID`.
 - `scripts/tx/` — output directory for serialized transaction bytes.
@@ -56,6 +57,6 @@ To decode:
 
 ## Environment Variables
 - `RPC_URL` - Custom RPC endpoint
-- `GAS_OBJECT` - Gas coin object ID for the upgrade tx
+- `GAS_OBJECT` - Gas coin object ID for the upgrade tx (`0x` plus 1-64 hex characters; passed as one `sui` argv, not interpolated into a shell)
 - `SUI_BINARY` - Path to sui binary (default: `sui`)
 - `NODE_ENV=development` - Outputs to `tx-data-local.txt`

--- a/scripts/transactions/mainPackageUpgrade.ts
+++ b/scripts/transactions/mainPackageUpgrade.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { execSync } from "child_process";
 import { writeFileSync } from "fs";
 import { upgradeCapID } from "../config/constants.js";
+import { serializeUnsignedUpgrade } from "./serializeUnsignedUpgrade.js";
 
 const network = "mainnet";
 
@@ -11,24 +11,15 @@ const network = "mainnet";
 // if upgradeCap & gasObject is on mainnet, it has to be on mainnet.
 // Github actions are always on mainnet.
 const mainPackageUpgrade = async () => {
-  const gasObjectId = process.env.GAS_OBJECT;
-
-  // Enabling the gas Object check only on mainnet, to allow testnet multisig tests.
-  if (!gasObjectId)
-    throw new Error("No gas object supplied for a mainnet transaction");
-
   const currentDir = process.cwd();
   const deepbookDir = `${currentDir}/../packages/deepbook`;
   const txFilePath = `${currentDir}/tx/tx-data.txt`;
-  // Use gas-price of 1000 to avoid RGP increases between tx generation and execution
-  const upgradeCall = `sui client upgrade --upgrade-capability ${upgradeCapID[network]} --gas-budget 2000000000 --gas ${gasObjectId} --gas-price 1000 --serialize-unsigned-transaction`;
 
   try {
-    // Execute the command with the specified working directory and capture the output
-    const output = execSync(upgradeCall, {
+    const output = serializeUnsignedUpgrade({
       cwd: deepbookDir,
-      stdio: "pipe",
-    }).toString();
+      extraArgs: ["--upgrade-capability", upgradeCapID[network]],
+    });
 
     writeFileSync(txFilePath, output);
     console.log(

--- a/scripts/transactions/marginPackageUpgrade.ts
+++ b/scripts/transactions/marginPackageUpgrade.ts
@@ -1,31 +1,21 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { execSync } from "child_process";
 import { writeFileSync } from "fs";
+import { serializeUnsignedUpgrade } from "./serializeUnsignedUpgrade.js";
 
 // Active env of sui has to be the same with the env we're publishing to.
 // if upgradeCap & gasObject is on mainnet, it has to be on mainnet.
 // Github actions are always on mainnet.
 const marginPackageUpgrade = async () => {
-  const gasObjectId = process.env.GAS_OBJECT;
-
-  // Enabling the gas Object check only on mainnet, to allow testnet multisig tests.
-  if (!gasObjectId)
-    throw new Error("No gas object supplied for a mainnet transaction");
-
   const currentDir = process.cwd();
   const marginDir = `${currentDir}/../packages/deepbook_margin`;
   const txFilePath = `${currentDir}/tx/tx-data.txt`;
-  // Use gas-price of 1000 to avoid RGP increases between tx generation and execution
-  const upgradeCall = `sui client upgrade --gas-budget 2000000000 --gas ${gasObjectId} --gas-price 1000 --serialize-unsigned-transaction`;
 
   try {
-    // Execute the command with the specified working directory and capture the output
-    const output = execSync(upgradeCall, {
+    const output = serializeUnsignedUpgrade({
       cwd: marginDir,
-      stdio: "pipe",
-    }).toString();
+    });
 
     // Extract only the base64 transaction bytes (last non-empty line)
     const lines = output.trim().split("\n");

--- a/scripts/transactions/serializeUnsignedUpgrade.ts
+++ b/scripts/transactions/serializeUnsignedUpgrade.ts
@@ -1,0 +1,49 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { execFileSync } from "child_process";
+
+const SUI_OBJECT_ID = /^0x[0-9a-fA-F]{1,64}$/;
+
+function requireGasObjectId(): string {
+  const gasObjectId = process.env.GAS_OBJECT?.trim();
+  if (!gasObjectId) {
+    throw new Error("No gas object supplied for a mainnet transaction");
+  }
+  if (!SUI_OBJECT_ID.test(gasObjectId)) {
+    throw new Error(
+      `Invalid GAS_OBJECT: expected 0x followed by 1-64 hex characters, got ${JSON.stringify(gasObjectId)}`,
+    );
+  }
+  return gasObjectId;
+}
+
+/** Run `sui client upgrade --serialize-unsigned-transaction` without a shell. */
+export function serializeUnsignedUpgrade(options: {
+  cwd: string;
+  extraArgs?: string[];
+}): string {
+  const gasObjectId = requireGasObjectId();
+  const sui = process.env.SUI_BINARY ?? "sui";
+  return execFileSync(
+    sui,
+    [
+      "client",
+      "upgrade",
+      ...(options.extraArgs ?? []),
+      "--gas-budget",
+      "2000000000",
+      "--gas",
+      gasObjectId,
+      // Use gas-price of 1000 to avoid RGP increases between tx generation and execution
+      "--gas-price",
+      "1000",
+      "--serialize-unsigned-transaction",
+    ],
+    {
+      cwd: options.cwd,
+      stdio: "pipe",
+      encoding: "utf8",
+    },
+  );
+}

--- a/scripts/transactions/vaultPackageUpgrade.ts
+++ b/scripts/transactions/vaultPackageUpgrade.ts
@@ -1,31 +1,21 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { execSync } from "child_process";
 import { writeFileSync } from "fs";
+import { serializeUnsignedUpgrade } from "./serializeUnsignedUpgrade.js";
 
 // Active env of sui has to be the same with the env we're publishing to.
 // if upgradeCap & gasObject is on mainnet, it has to be on mainnet.
 // Github actions are always on mainnet.
 const vaultPackageUpgrade = async () => {
-  const gasObjectId = process.env.GAS_OBJECT;
-
-  // Enabling the gas Object check only on mainnet, to allow testnet multisig tests.
-  if (!gasObjectId)
-    throw new Error("No gas object supplied for a mainnet transaction");
-
   const currentDir = process.cwd();
   const vaultDir = `${currentDir}/../packages/margin_liquidation`;
   const txFilePath = `${currentDir}/tx/tx-data.txt`;
-  // Use gas-price of 1000 to avoid RGP increases between tx generation and execution
-  const upgradeCall = `sui client upgrade --gas-budget 2000000000 --gas ${gasObjectId} --gas-price 1000 --serialize-unsigned-transaction`;
 
   try {
-    // Execute the command with the specified working directory and capture the output
-    const output = execSync(upgradeCall, {
+    const output = serializeUnsignedUpgrade({
       cwd: vaultDir,
-      stdio: "pipe",
-    }).toString();
+    });
 
     // Extract only the base64 transaction bytes (last non-empty line)
     const lines = output.trim().split("\n");


### PR DESCRIPTION
## Summary

- The package-upgrade scripts now reject `GAS_OBJECT` values that are not `0x` plus 1–64 hex characters.
- `sui client upgrade` is invoked with `execFileSync` and an explicit argument array, so the gas object id is one CLI argument instead of part of a shell string.
- Vault upgrades get the same treatment as protocol and margin; they had the same interpolation.

## Why

`Build Deepbook TX` takes a free-form `gas_object_id` from workflow dispatch and the upgrade scripts used to concatenate it into `execSync("sui client upgrade ... --gas ${gasObjectId} ...")`. That string is run by `/bin/sh`, so shell metacharacters in the input can replace the stdout that becomes the unsigned mainnet upgrade artifact. Anyone with write access can dispatch the trusted `main` workflow without changing the script. On-chain execution still needs the normal signer path, but the generated artifact is part of that authorization chain.

## Linear / Context

N/A — exempt. Mechanical hardening of the existing upgrade dispatcher; no protocol behavior change.

## Key decisions

Validation plus `execFileSync`, not the larger signer-binding / environment-approval work from the original write-up. A hex allowlist closes this input; passing argv means a later interpolated field cannot reopen a shell. Canonical object-id normalization, decoded-tx publication, and dispatch-permission changes are deferred.

## Scope / Descoped

In scope: the three upgrade scripts and a shared helper. Descoped: workflow permission changes, artifact hashing, binding the signing step to a digest, and writing bytes from a dedicated sui output file instead of captured stdout.

## Test plan

- [x] `GAS_OBJECT=` empty / missing — helper throws `No gas object supplied for a mainnet transaction`.
- [x] `GAS_OBJECT='0xabc; printf pwned #'` — helper throws `Invalid GAS_OBJECT` before spawning `sui`.
- [x] `GAS_OBJECT` without a `0x` prefix — rejected.
- [x] Valid 64-hex id with `SUI_BINARY=/bin/echo` — argv is `client upgrade ... --gas 0x<id> ...` as separate arguments (no shell parsing).
- [ ] Dispatcher still generates an unsigned upgrade when run with a real mainnet gas coin (unchanged `sui client upgrade` flags, including `--gas-price 1000`).

## Risk / Rollout

Upgrade generation fails closed on a malformed gas id instead of interpolating it. Valid ids in the existing `0x` + hex form, including the workflow default, are unchanged. Rollback is revert; no on-chain or package-manifest effect.


Made with [Cursor](https://cursor.com)