### PR TITLE
sessions: bind spot grants to an explicit pool allowlist

### DIFF
--- a/packages/sessions/README.md
+++ b/packages/sessions/README.md
@@ -10,13 +10,15 @@ The Account registry administrator must authorize `SessionsApp` before any wrapp
 
 An Account owner opts in by calling `authorize_session` on the Account's shared `AccountWrapper`. Owner authorization is derived from the transaction sender, so this flow supports EOA-owned Accounts and does not authorize object-owned Accounts.
 
-A session grant contains only the session address and its expiration timestamp in milliseconds. Each Account may store at most 20 session addresses. The requested duration must be greater than zero and no more than 30 days. Expiration is calculated from the on-chain `Clock` at execution time, and reauthorizing the same address replaces its stored expiration without consuming another slot.
+A session grant contains the session address, its expiration timestamp in milliseconds, and the DeepBook pool IDs that session may trade. Each Account may store at most 20 session addresses, and each grant may list at most 20 pool IDs. Duplicate pool IDs abort. An empty pool list is valid and means the session cannot call any spot wrapper. The requested duration must be greater than zero and no more than 30 days. Expiration is calculated from the on-chain `Clock` at execution time, and reauthorizing the same address replaces its stored expiration and pool allowlist without consuming another slot.
 
 Every trading wrapper requires both of these conditions:
 
 - The executing Sessions package version is at or above the shared `SessionsConfig.version_watermark`.
 - The transaction sender has a stored session grant for the supplied Account.
 - The current clock timestamp is strictly less than the stored expiration.
+
+DeepBook spot wrappers also require the supplied pool's ID to be in that grant's allowlist.
 
 At the exact expiration timestamp, the session is no longer authorized.
 
@@ -28,11 +30,17 @@ public fun session_expiration_ms(
     session: address,
 ): Option<u64>
 
+public fun session_allowed_pools(
+    wrapper: &AccountWrapper,
+    session: address,
+): Option<vector<ID>>
+
 public fun authorize_session(
     wrapper: &mut AccountWrapper,
     sessions_config: &SessionsConfig,
     session: address,
     duration_ms: u64,
+    allowed_pools: vector<ID>,
     clock: &Clock,
     ctx: &mut TxContext,
 )
@@ -46,9 +54,11 @@ public fun revoke_session(
 
 `session_expiration_ms` returns the stored expiration for a known session and `none` for a session that was never authorized or has been revoked. It does not classify the timestamp as active or expired; callers that need that distinction must compare it with the current on-chain time.
 
-The shared `AccountWrapper` can be supplied as an object input in a programmable transaction block and borrowed immutably for `session_expiration_ms`. SDKs may also use the function through dev-inspect reads.
+`session_allowed_pools` returns the stored DeepBook pool allowlist for a known session and `none` for a session that was never authorized or has been revoked. An empty vector means the session cannot call spot wrappers.
 
-Revoking a known session removes it from the session map immediately, whether it is active or already expired, and frees its slot for another address. Once the Sessions app-data slot has been attached to an Account, it remains attached even when the session map becomes empty. Revoking an unknown session is a no-op. Expired entries are not removed automatically because time passing does not execute Move code; they continue to count toward the 20-session limit until the owner revokes them, while reauthorization replaces the expiration in place.
+The shared `AccountWrapper` can be supplied as an object input in a programmable transaction block and borrowed immutably for the session getters. SDKs may also use the functions through dev-inspect reads.
+
+Revoking a known session removes it from the session map immediately, whether it is active or already expired, and frees its slot for another address. Once the Sessions app-data slot has been attached to an Account, it remains attached even when the session map becomes empty. Revoking an unknown session is a no-op. Expired entries are not removed automatically because time passing does not execute Move code; they continue to count toward the 20-session limit until the owner revokes them, while reauthorization replaces the expiration and pool allowlist in place.
 
 Session reads and revocation remain available after a package version is retired so owners can inspect and remove grants without using a trading-capable package version.
 
@@ -81,9 +91,9 @@ An active session may call these Account-backed DeepBook spot wrappers:
 - `cancel_live_orders`
 - `withdraw_settled_amounts`
 
-Each wrapper validates the package version and session against the supplied Account, generates app authorization internally, and immediately passes it into the corresponding `deepbook_core_account` function. Order parameters remain caller-selected and are validated by the Account wrapper and DeepBook core. The permissionless settled-amount withdrawal is not duplicated here because it does not require session authority.
+Each wrapper validates the package version and session against the supplied Account, checks that the supplied pool ID is in the grant allowlist, generates app authorization internally, and immediately passes it into the corresponding `deepbook_core_account` function. Order parameters remain caller-selected and are validated by the Account wrapper and DeepBook core. The permissionless settled-amount withdrawal is not duplicated here because it does not require session authority.
 
-The session can therefore submit adverse Predict and spot trades, cancel the Account's spot orders, and sweep settled spot proceeds back into Account custody until it expires or is revoked. A grant should be treated as trading authority, not read-only access. Revocation and expiration stop future wrapper calls but do not unwind positions, orders, or transactions that already executed.
+A grant with an empty pool list can still submit adverse Predict trades. A grant with listed pools can submit adverse spot trades on those pools only, cancel the Account's orders there, and sweep settled proceeds from those pools. A grant should be treated as trading authority for Predict and for the listed pools, not read-only access. Revocation and expiration stop future wrapper calls but do not unwind positions, orders, or transactions that already executed.
 
 ## Events
 
@@ -94,6 +104,7 @@ public struct SessionAuthorized has copy, drop {
     account_id: ID,
     session: address,
     expires_at_ms: u64,
+    allowed_pools: vector<ID>,
 }
 ```
 

--- a/packages/sessions/sources/sessions.move
+++ b/packages/sessions/sources/sessions.move
@@ -4,6 +4,7 @@
 /// Owns time-limited trading session grants attached to canonical Accounts.
 /// Account owners grant and revoke sessions; an active session can only generate
 /// app auth inside the Predict and DeepBook spot wrappers exposed here.
+/// Spot wrappers additionally require the pool ID to be in the grant allowlist.
 module deepbook_sessions::sessions;
 
 use account::{account::{Self, AccountWrapper, Auth}, account_registry::AccountRegistry};
@@ -23,6 +24,9 @@ use sui::{accumulator::AccumulatorRoot, clock::Clock, event, vec_map::{Self, Vec
 const EInvalidSessionDuration: u64 = 0;
 const ESessionNotAuthorized: u64 = 1;
 const ESessionLimitExceeded: u64 = 2;
+const EPoolNotAllowed: u64 = 3;
+const EAllowedPoolLimitExceeded: u64 = 4;
+const EDuplicateAllowedPool: u64 = 5;
 
 // === Constants ===
 
@@ -30,14 +34,23 @@ macro fun max_session_duration_ms(): u64 { 30 * 24 * 60 * 60 * 1000 }
 
 macro fun max_sessions(): u64 { 20 }
 
+macro fun max_allowed_pools(): u64 { 20 }
+
 // === Structs ===
 
 /// App witness for Account registry authorization and per-account data namespacing.
 public struct SessionsApp has drop {}
 
-/// Session expiration timestamps keyed by transaction signer address.
+/// Per-session grant. `allowed_pools` is the DeepBook spot allowlist; empty
+/// forbids every spot wrapper.
+public struct SessionGrant has copy, drop, store {
+    expires_at_ms: u64,
+    allowed_pools: vector<ID>,
+}
+
+/// Session grants keyed by transaction signer address.
 public struct SessionsData has store {
-    sessions: VecMap<address, u64>,
+    sessions: VecMap<address, SessionGrant>,
 }
 
 /// A session was authorized or reauthorized through `expires_at_ms`.
@@ -45,6 +58,7 @@ public struct SessionAuthorized has copy, drop {
     account_id: ID,
     session: address,
     expires_at_ms: u64,
+    allowed_pools: vector<ID>,
 }
 
 /// An existing session grant was removed before or after its expiration.
@@ -58,24 +72,34 @@ public struct SessionRevoked has copy, drop {
 
 /// Return a known session's expiration timestamp for SDK and devInspect reads.
 public fun session_expiration_ms(wrapper: &AccountWrapper, session: address): Option<u64> {
-    let account = wrapper.load_account();
-    if (!account.has_data<SessionsApp>()) return option::none();
-    let data = account.borrow_data<SessionsApp, SessionsData>();
-    data.sessions.try_get(&session)
+    let grant = session_grant(wrapper, session);
+    if (grant.is_none()) return option::none();
+    option::some(grant.destroy_some().expires_at_ms)
+}
+
+/// Return a known session's allowed DeepBook pool IDs for SDK and devInspect reads.
+/// `none` means the session is unknown; `some` of empty means no spot wrappers.
+public fun session_allowed_pools(wrapper: &AccountWrapper, session: address): Option<vector<ID>> {
+    let grant = session_grant(wrapper, session);
+    if (grant.is_none()) return option::none();
+    option::some(grant.destroy_some().allowed_pools)
 }
 
 /// Authorize `session` from execution time for at most 30 days.
 /// Accounts may store at most 20 addresses; reauthorization replaces in place.
+/// `allowed_pools` is the DeepBook spot allowlist; empty forbids every spot wrapper.
 public fun authorize_session(
     wrapper: &mut AccountWrapper,
     sessions_config: &SessionsConfig,
     session: address,
     duration_ms: u64,
+    allowed_pools: vector<ID>,
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
     sessions_config.assert_version();
     assert!(duration_ms > 0 && duration_ms <= max_session_duration_ms!(), EInvalidSessionDuration);
+    let allowed_pools = validated_allowed_pools(allowed_pools);
     let expires_at_ms = clock.timestamp_ms() + duration_ms;
     let account = wrapper.load_account_mut(account::generate_auth(ctx));
     let account_id = account.account_id();
@@ -83,13 +107,19 @@ public fun authorize_session(
         account.attach(permit<SessionsApp>(), SessionsData { sessions: vec_map::empty() });
     };
     let data = account.borrow_data_mut<SessionsApp, SessionsData>(permit<SessionsApp>());
+    let grant = SessionGrant { expires_at_ms, allowed_pools };
     if (data.sessions.contains(&session)) {
-        *data.sessions.get_mut(&session) = expires_at_ms;
+        *data.sessions.get_mut(&session) = grant;
     } else {
         assert!(data.sessions.length() < max_sessions!(), ESessionLimitExceeded);
-        data.sessions.insert(session, expires_at_ms);
+        data.sessions.insert(session, grant);
     };
-    event::emit(SessionAuthorized { account_id, session, expires_at_ms });
+    event::emit(SessionAuthorized {
+        account_id,
+        session,
+        expires_at_ms,
+        allowed_pools,
+    });
 }
 
 /// Revoke `session` if it is present. Only the Account owner may call this function.
@@ -99,8 +129,12 @@ public fun revoke_session(wrapper: &mut AccountWrapper, session: address, ctx: &
     let account_id = account.account_id();
     let data = account.borrow_data_mut<SessionsApp, SessionsData>(permit<SessionsApp>());
     if (!data.sessions.contains(&session)) return;
-    let (_, expires_at_ms) = data.sessions.remove(&session);
-    event::emit(SessionRevoked { account_id, session, expires_at_ms });
+    let (_, grant) = data.sessions.remove(&session);
+    event::emit(SessionRevoked {
+        account_id,
+        session,
+        expires_at_ms: grant.expires_at_ms,
+    });
 }
 
 /// Place a DeepBook spot limit order for an Account with an active session.
@@ -122,7 +156,14 @@ public fun place_limit_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ): OrderInfo {
-    let auth = generate_auth_as_session(sessions_config, account_registry, wrapper, clock, ctx);
+    let auth = generate_auth_as_spot_session(
+        sessions_config,
+        account_registry,
+        wrapper,
+        pool,
+        clock,
+        ctx,
+    );
     deepbook_core_account::place_limit_order(
         pool,
         deepbook_registry,
@@ -159,7 +200,14 @@ public fun place_market_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ): OrderInfo {
-    let auth = generate_auth_as_session(sessions_config, account_registry, wrapper, clock, ctx);
+    let auth = generate_auth_as_spot_session(
+        sessions_config,
+        account_registry,
+        wrapper,
+        pool,
+        clock,
+        ctx,
+    );
     deepbook_core_account::place_market_order(
         pool,
         deepbook_registry,
@@ -187,7 +235,14 @@ public fun cancel_live_order<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    let auth = generate_auth_as_session(sessions_config, account_registry, wrapper, clock, ctx);
+    let auth = generate_auth_as_spot_session(
+        sessions_config,
+        account_registry,
+        wrapper,
+        pool,
+        clock,
+        ctx,
+    );
     deepbook_core_account::cancel_live_order(pool, wrapper, auth, order_id, clock, ctx);
 }
 
@@ -201,7 +256,14 @@ public fun cancel_live_orders<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    let auth = generate_auth_as_session(sessions_config, account_registry, wrapper, clock, ctx);
+    let auth = generate_auth_as_spot_session(
+        sessions_config,
+        account_registry,
+        wrapper,
+        pool,
+        clock,
+        ctx,
+    );
     deepbook_core_account::cancel_live_orders(pool, wrapper, auth, order_ids, clock, ctx);
 }
 
@@ -214,7 +276,14 @@ public fun withdraw_settled_amounts<BaseAsset, QuoteAsset>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    let auth = generate_auth_as_session(sessions_config, account_registry, wrapper, clock, ctx);
+    let auth = generate_auth_as_spot_session(
+        sessions_config,
+        account_registry,
+        wrapper,
+        pool,
+        clock,
+        ctx,
+    );
     deepbook_core_account::withdraw_settled_amounts(pool, wrapper, auth, ctx);
 }
 
@@ -344,6 +413,37 @@ public fun redeem_settled(
 
 // === Private Functions ===
 
+fun session_grant(wrapper: &AccountWrapper, session: address): Option<SessionGrant> {
+    let account = wrapper.load_account();
+    if (!account.has_data<SessionsApp>()) return option::none();
+    let data = account.borrow_data<SessionsApp, SessionsData>();
+    data.sessions.try_get(&session)
+}
+
+fun validated_allowed_pools(allowed_pools: vector<ID>): vector<ID> {
+    assert!(allowed_pools.length() <= max_allowed_pools!(), EAllowedPoolLimitExceeded);
+    let mut unique = vector[];
+    allowed_pools.do!(|pool_id| {
+        assert!(!unique.contains(&pool_id), EDuplicateAllowedPool);
+        unique.push_back(pool_id);
+    });
+    unique
+}
+
+fun active_grant(
+    sessions_config: &SessionsConfig,
+    wrapper: &AccountWrapper,
+    clock: &Clock,
+    ctx: &TxContext,
+): SessionGrant {
+    sessions_config.assert_version();
+    let grant = session_grant(wrapper, ctx.sender());
+    assert!(grant.is_some(), ESessionNotAuthorized);
+    let grant = grant.destroy_some();
+    assert!(clock.timestamp_ms() < grant.expires_at_ms, ESessionNotAuthorized);
+    grant
+}
+
 fun generate_auth_as_session(
     sessions_config: &SessionsConfig,
     account_registry: &AccountRegistry,
@@ -351,9 +451,19 @@ fun generate_auth_as_session(
     clock: &Clock,
     ctx: &TxContext,
 ): Auth {
-    sessions_config.assert_version();
-    let expiration = session_expiration_ms(wrapper, ctx.sender());
-    assert!(expiration.is_some(), ESessionNotAuthorized);
-    assert!(clock.timestamp_ms() < *expiration.borrow(), ESessionNotAuthorized);
+    let _grant = active_grant(sessions_config, wrapper, clock, ctx);
+    account_registry.generate_auth_as_app<SessionsApp>(permit<SessionsApp>())
+}
+
+fun generate_auth_as_spot_session<BaseAsset, QuoteAsset>(
+    sessions_config: &SessionsConfig,
+    account_registry: &AccountRegistry,
+    wrapper: &AccountWrapper,
+    pool: &Pool<BaseAsset, QuoteAsset>,
+    clock: &Clock,
+    ctx: &TxContext,
+): Auth {
+    let grant = active_grant(sessions_config, wrapper, clock, ctx);
+    assert!(grant.allowed_pools.contains(&object::id(pool)), EPoolNotAllowed);
     account_registry.generate_auth_as_app<SessionsApp>(permit<SessionsApp>())
 }

--- a/packages/sessions/tests/sessions_tests.move
+++ b/packages/sessions/tests/sessions_tests.move
@@ -72,6 +72,8 @@ const MAX_SESSION_EXPIRES_AT_MS: u64 = 2_592_001_000; // 1_000 + 30 days.
 const ABOVE_MAX_SESSION_DURATION_MS: u64 = 2_592_000_001;
 const ZERO_DURATION_MS: u64 = 0;
 const MAX_SESSIONS: u64 = 20;
+const MAX_ALLOWED_POOLS: u64 = 20;
+const ALLOWED_POOL_ADDRESS: address = @0xB0A;
 const FIRST_SESSION_INDEX: u64 = 0;
 const LAST_SESSION_INDEX: u64 = 19;
 const EXCESS_SESSION_INDEX: u64 = 20;
@@ -100,6 +102,7 @@ public struct ExpectedSessionAuthorized has copy, drop {
     account_id: ID,
     session: address,
     expires_at_ms: u64,
+    allowed_pools: vector<ID>,
 }
 
 public struct ExpectedSessionRevoked has copy, drop {
@@ -149,11 +152,13 @@ fun owner_authorizes_reauthorizes_and_revokes_session() {
     let sessions_config = scenario.take_shared_by_id<SessionsConfig>(sessions_config_id);
     let account_id = wrapper.load_account().account_id();
     assert!(sessions::session_expiration_ms(&wrapper, SESSION).is_none());
+    assert!(sessions::session_allowed_pools(&wrapper, SESSION).is_none());
     sessions::authorize_session(
         &mut wrapper,
         &sessions_config,
         SESSION,
         SESSION_DURATION_MS,
+        vector[],
         &clock,
         scenario.ctx(),
     );
@@ -161,6 +166,7 @@ fun owner_authorizes_reauthorizes_and_revokes_session() {
         sessions::session_expiration_ms(&wrapper, SESSION),
         option::some(SESSION_EXPIRES_AT_MS),
     );
+    assert_eq!(sessions::session_allowed_pools(&wrapper, SESSION), option::some(vector[]));
     let authorized = event::events_by_type<SessionAuthorized>();
     assert_eq!(authorized.length(), ONE_EVENT);
     assert_session_authorized_event(
@@ -168,6 +174,7 @@ fun owner_authorizes_reauthorizes_and_revokes_session() {
         account_id,
         SESSION,
         SESSION_EXPIRES_AT_MS,
+        vector[],
     );
     return_shared(sessions_config);
     return_shared(wrapper);
@@ -176,11 +183,13 @@ fun owner_authorizes_reauthorizes_and_revokes_session() {
     clock.set_for_testing(REAUTH_NOW_MS);
     let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
     let sessions_config = scenario.take_shared_by_id<SessionsConfig>(sessions_config_id);
+    let reauth_pools = vector[object::id_from_address(ALLOWED_POOL_ADDRESS)];
     sessions::authorize_session(
         &mut wrapper,
         &sessions_config,
         SESSION,
         REAUTH_DURATION_MS,
+        reauth_pools,
         &clock,
         scenario.ctx(),
     );
@@ -188,6 +197,7 @@ fun owner_authorizes_reauthorizes_and_revokes_session() {
         sessions::session_expiration_ms(&wrapper, SESSION),
         option::some(REAUTH_EXPIRES_AT_MS),
     );
+    assert_eq!(sessions::session_allowed_pools(&wrapper, SESSION), option::some(reauth_pools));
     let reauthorized = event::events_by_type<SessionAuthorized>();
     assert_eq!(reauthorized.length(), ONE_EVENT);
     assert_session_authorized_event(
@@ -195,6 +205,7 @@ fun owner_authorizes_reauthorizes_and_revokes_session() {
         account_id,
         SESSION,
         REAUTH_EXPIRES_AT_MS,
+        reauth_pools,
     );
     return_shared(sessions_config);
     return_shared(wrapper);
@@ -203,6 +214,7 @@ fun owner_authorizes_reauthorizes_and_revokes_session() {
     let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
     sessions::revoke_session(&mut wrapper, SESSION, scenario.ctx());
     assert!(sessions::session_expiration_ms(&wrapper, SESSION).is_none());
+    assert!(sessions::session_allowed_pools(&wrapper, SESSION).is_none());
     assert!(wrapper.load_account().has_data<SessionsApp>());
     let revoked = event::events_by_type<SessionRevoked>();
     assert_eq!(revoked.length(), ONE_EVENT);
@@ -237,6 +249,7 @@ fun maximum_session_duration_is_accepted() {
         &sessions_config,
         SESSION,
         MAX_SESSION_DURATION_MS,
+        vector[],
         &clock,
         scenario.ctx(),
     );
@@ -265,6 +278,7 @@ fun session_limit_allows_reauthorization_and_reuse_after_revocation() {
             &sessions_config,
             session_addresses[index],
             SESSION_DURATION_MS,
+            vector[],
             &clock,
             scenario.ctx(),
         );
@@ -285,6 +299,7 @@ fun session_limit_allows_reauthorization_and_reuse_after_revocation() {
         &sessions_config,
         session_addresses[LAST_SESSION_INDEX],
         REAUTH_DURATION_MS,
+        vector[],
         &clock,
         scenario.ctx(),
     );
@@ -306,6 +321,7 @@ fun session_limit_allows_reauthorization_and_reuse_after_revocation() {
         &sessions_config,
         session_addresses[EXCESS_SESSION_INDEX],
         SESSION_DURATION_MS,
+        vector[],
         &clock,
         scenario.ctx(),
     );
@@ -338,6 +354,7 @@ fun twenty_first_distinct_session_aborts() {
             &sessions_config,
             session_addresses[index],
             SESSION_DURATION_MS,
+            vector[],
             &clock,
             scenario.ctx(),
         );
@@ -353,6 +370,7 @@ fun twenty_first_distinct_session_aborts() {
         &sessions_config,
         session_addresses[EXCESS_SESSION_INDEX],
         SESSION_DURATION_MS,
+        vector[],
         &clock,
         scenario.ctx(),
     );
@@ -372,6 +390,7 @@ fun zero_session_duration_aborts() {
         &sessions_config,
         SESSION,
         ZERO_DURATION_MS,
+        vector[],
         &clock,
         scenario.ctx(),
     );
@@ -391,11 +410,77 @@ fun session_duration_above_maximum_aborts() {
         &sessions_config,
         SESSION,
         ABOVE_MAX_SESSION_DURATION_MS,
+        vector[],
         &clock,
         scenario.ctx(),
     );
 
     abort EUnexpectedSuccess
+}
+
+#[test, expected_failure(abort_code = sessions::EDuplicateAllowedPool)]
+fun duplicate_allowed_pool_aborts() {
+    let (mut scenario, clock, wrapper_id, sessions_config_id) = setup_account();
+    scenario.next_tx(ALICE);
+    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let sessions_config = scenario.take_shared_by_id<SessionsConfig>(sessions_config_id);
+    let pool_id = object::id_from_address(ALLOWED_POOL_ADDRESS);
+
+    sessions::authorize_session(
+        &mut wrapper,
+        &sessions_config,
+        SESSION,
+        SESSION_DURATION_MS,
+        vector[pool_id, pool_id],
+        &clock,
+        scenario.ctx(),
+    );
+
+    abort EUnexpectedSuccess
+}
+
+#[test, expected_failure(abort_code = sessions::EAllowedPoolLimitExceeded)]
+fun twenty_first_allowed_pool_aborts() {
+    let (mut scenario, clock, wrapper_id, sessions_config_id) = setup_account();
+    scenario.next_tx(ALICE);
+    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let sessions_config = scenario.take_shared_by_id<SessionsConfig>(sessions_config_id);
+
+    sessions::authorize_session(
+        &mut wrapper,
+        &sessions_config,
+        SESSION,
+        SESSION_DURATION_MS,
+        dummy_pool_ids(MAX_ALLOWED_POOLS + 1),
+        &clock,
+        scenario.ctx(),
+    );
+
+    abort EUnexpectedSuccess
+}
+
+#[test]
+fun maximum_allowed_pools_are_accepted() {
+    let (mut scenario, clock, wrapper_id, sessions_config_id) = setup_account();
+    scenario.next_tx(ALICE);
+    let mut wrapper = scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let sessions_config = scenario.take_shared_by_id<SessionsConfig>(sessions_config_id);
+    let allowed_pools = dummy_pool_ids(MAX_ALLOWED_POOLS);
+
+    sessions::authorize_session(
+        &mut wrapper,
+        &sessions_config,
+        SESSION,
+        SESSION_DURATION_MS,
+        allowed_pools,
+        &clock,
+        scenario.ctx(),
+    );
+    assert_eq!(sessions::session_allowed_pools(&wrapper, SESSION), option::some(allowed_pools));
+    return_shared(sessions_config);
+    return_shared(wrapper);
+    clock.destroy_for_testing();
+    scenario.end();
 }
 
 #[test, expected_failure(abort_code = account::EInvalidOwner)]
@@ -410,6 +495,7 @@ fun non_owner_cannot_authorize_session() {
         &sessions_config,
         SESSION,
         SESSION_DURATION_MS,
+        vector[],
         &clock,
         scenario.ctx(),
     );
@@ -428,6 +514,7 @@ fun non_owner_cannot_revoke_session() {
         &sessions_config,
         SESSION,
         SESSION_DURATION_MS,
+        vector[],
         &clock,
         scenario.ctx(),
     );
@@ -454,6 +541,7 @@ fun retired_package_version_cannot_authorize_session() {
         &sessions_config,
         SESSION,
         SESSION_DURATION_MS,
+        vector[],
         &clock,
         scenario.ctx(),
     );
@@ -472,6 +560,7 @@ fun retired_package_version_keeps_reads_and_revocation_available() {
         &sessions_config,
         SESSION,
         SESSION_DURATION_MS,
+        vector[],
         &clock,
         scenario.ctx(),
     );
@@ -1062,6 +1151,39 @@ fun session_addresses(): vector<address> {
     ]
 }
 
+fun dummy_pool_ids(count: u64): vector<ID> {
+    let all = vector[
+        object::id_from_address(@0x1),
+        object::id_from_address(@0x2),
+        object::id_from_address(@0x3),
+        object::id_from_address(@0x4),
+        object::id_from_address(@0x5),
+        object::id_from_address(@0x6),
+        object::id_from_address(@0x7),
+        object::id_from_address(@0x8),
+        object::id_from_address(@0x9),
+        object::id_from_address(@0xA),
+        object::id_from_address(@0xB),
+        object::id_from_address(@0xC),
+        object::id_from_address(@0xD),
+        object::id_from_address(@0xE),
+        object::id_from_address(@0xF),
+        object::id_from_address(@0x10),
+        object::id_from_address(@0x11),
+        object::id_from_address(@0x12),
+        object::id_from_address(@0x13),
+        object::id_from_address(@0x14),
+        object::id_from_address(@0x15),
+    ];
+    let mut ids = vector[];
+    let mut index = 0;
+    while (index < count) {
+        ids.push_back(all[index]);
+        index = index + 1;
+    };
+    ids
+}
+
 fun setup_account(): (Scenario, Clock, ID, ID) {
     let mut scenario = test::begin(ADMIN);
     account_registry::init_for_testing(scenario.ctx());
@@ -1086,8 +1208,9 @@ fun assert_session_authorized_event(
     account_id: ID,
     session: address,
     expires_at_ms: u64,
+    allowed_pools: vector<ID>,
 ) {
-    let expected = ExpectedSessionAuthorized { account_id, session, expires_at_ms };
+    let expected = ExpectedSessionAuthorized { account_id, session, expires_at_ms, allowed_pools };
     assert_eq!(bcs::to_bytes(actual), bcs::to_bytes(&expected));
 }
 
@@ -1157,6 +1280,7 @@ fun authorize_flow_session(fixture: &mut SessionFlowFixture, duration_ms: u64) {
         &sessions_config,
         SESSION,
         duration_ms,
+        vector[],
         clock,
         scenario.ctx(),
     );

--- a/packages/sessions/tests/spot_sessions_tests.move
+++ b/packages/sessions/tests/spot_sessions_tests.move
@@ -58,6 +58,7 @@ const FUTURE_VERSION: u64 = 2;
 
 public struct BASE has store {}
 public struct QUOTE has store {}
+public struct JUNK has store {}
 
 public struct SpotFixture {
     scenario: Scenario,
@@ -545,6 +546,83 @@ fun retired_package_version_cannot_use_spot_wrapper() {
     abort EUnexpectedSuccess
 }
 
+#[test, expected_failure(abort_code = sessions::EPoolNotAllowed)]
+fun empty_allowlist_cannot_place_spot_order() {
+    let mut fixture = setup_spot_fixture();
+    authorize_session_with_pools(&mut fixture, vector[]);
+    let registry_id = fixture.registry_id;
+    let pool_id = fixture.pool_id;
+    let wrapper_id = fixture.wrapper_id;
+
+    fixture.scenario.next_tx(SESSION);
+    let registry = fixture.scenario.take_shared_by_id<Registry>(registry_id);
+    let account_registry = fixture.scenario.take_shared<AccountRegistry>();
+    let mut pool = fixture.scenario.take_shared_by_id<Pool<BASE, QUOTE>>(pool_id);
+    let mut wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
+    let sessions_config = fixture
+        .scenario
+        .take_shared_by_id<SessionsConfig>(fixture.sessions_config_id);
+    let root = fixture.scenario.take_shared<AccumulatorRoot>();
+    let clock = fixture.scenario.take_shared<Clock>();
+    let _ = sessions::place_limit_order<BASE, QUOTE>(
+        &mut pool,
+        &registry,
+        &account_registry,
+        &mut wrapper,
+        &sessions_config,
+        LIMIT_ORDER_CLIENT_ID,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        constants::float_scaling(),
+        constants::min_size(),
+        false,
+        true,
+        constants::max_u64(),
+        &root,
+        &clock,
+        fixture.scenario.ctx(),
+    );
+    abort EUnexpectedSuccess
+}
+
+#[test, expected_failure(abort_code = sessions::EPoolNotAllowed)]
+fun session_cannot_place_spot_order_on_unlisted_pool() {
+    let mut fixture = setup_spot_fixture();
+    let registry_id = fixture.registry_id;
+    let junk_pool_id = create_junk_pool(&mut fixture.scenario, registry_id);
+    authorize_session(&mut fixture);
+
+    fixture.scenario.next_tx(SESSION);
+    let registry = fixture.scenario.take_shared_by_id<Registry>(fixture.registry_id);
+    let account_registry = fixture.scenario.take_shared<AccountRegistry>();
+    let mut pool = fixture.scenario.take_shared_by_id<Pool<JUNK, QUOTE>>(junk_pool_id);
+    let mut wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(fixture.wrapper_id);
+    let sessions_config = fixture
+        .scenario
+        .take_shared_by_id<SessionsConfig>(fixture.sessions_config_id);
+    let root = fixture.scenario.take_shared<AccumulatorRoot>();
+    let clock = fixture.scenario.take_shared<Clock>();
+    let _ = sessions::place_limit_order<JUNK, QUOTE>(
+        &mut pool,
+        &registry,
+        &account_registry,
+        &mut wrapper,
+        &sessions_config,
+        LIMIT_ORDER_CLIENT_ID,
+        constants::no_restriction(),
+        constants::self_matching_allowed(),
+        constants::float_scaling(),
+        constants::min_size(),
+        false,
+        true,
+        constants::max_u64(),
+        &root,
+        &clock,
+        fixture.scenario.ctx(),
+    );
+    abort EUnexpectedSuccess
+}
+
 fun setup_spot_fixture(): SpotFixture {
     let mut scenario = test::begin(ADMIN);
 
@@ -578,6 +656,11 @@ fun setup_spot_fixture(): SpotFixture {
 }
 
 fun authorize_session(fixture: &mut SpotFixture) {
+    let pool_id = fixture.pool_id;
+    authorize_session_with_pools(fixture, vector[pool_id]);
+}
+
+fun authorize_session_with_pools(fixture: &mut SpotFixture, allowed_pools: vector<ID>) {
     let wrapper_id = fixture.wrapper_id;
     fixture.scenario.next_tx(ALICE);
     let mut wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
@@ -590,6 +673,7 @@ fun authorize_session(fixture: &mut SpotFixture) {
         &sessions_config,
         SESSION,
         SESSION_DURATION_MS,
+        allowed_pools,
         &clock,
         fixture.scenario.ctx(),
     );
@@ -597,6 +681,7 @@ fun authorize_session(fixture: &mut SpotFixture) {
         sessions::session_expiration_ms(&wrapper, SESSION),
         option::some(SESSION_EXPIRES_AT_MS),
     );
+    assert_eq!(sessions::session_allowed_pools(&wrapper, SESSION), option::some(allowed_pools));
     return_shared(clock);
     return_shared(sessions_config);
     return_shared(wrapper);
@@ -608,6 +693,7 @@ fun revoke_session(fixture: &mut SpotFixture) {
     let mut wrapper = fixture.scenario.take_shared_by_id<AccountWrapper>(wrapper_id);
     sessions::revoke_session(&mut wrapper, SESSION, fixture.scenario.ctx());
     assert!(sessions::session_expiration_ms(&wrapper, SESSION).is_none());
+    assert!(sessions::session_allowed_pools(&wrapper, SESSION).is_none());
     return_shared(wrapper);
 }
 
@@ -725,6 +811,25 @@ fun create_pool(scenario: &mut Scenario, registry_id: ID): ID {
     let admin_cap = registry::get_admin_cap_for_testing(scenario.ctx());
     let mut registry = scenario.take_shared_by_id<Registry>(registry_id);
     let pool_id = pool::create_pool_admin<BASE, QUOTE>(
+        &mut registry,
+        constants::tick_size(),
+        constants::lot_size(),
+        constants::min_size(),
+        true,
+        false,
+        &admin_cap,
+        scenario.ctx(),
+    );
+    return_shared(registry);
+    destroy(admin_cap);
+    pool_id
+}
+
+fun create_junk_pool(scenario: &mut Scenario, registry_id: ID): ID {
+    scenario.next_tx(ADMIN);
+    let admin_cap = registry::get_admin_cap_for_testing(scenario.ctx());
+    let mut registry = scenario.take_shared_by_id<Registry>(registry_id);
+    let pool_id = pool::create_pool_admin<JUNK, QUOTE>(
         &mut registry,
         constants::tick_size(),
         constants::lot_size(),


### PR DESCRIPTION
## Summary

- Session grants now store a DeepBook pool-ID allowlist. Spot wrappers reject any pool that is not listed.
- An empty allowlist is valid and means the session cannot call spot wrappers. Predict wrappers are unchanged.
- `authorize_session` takes `allowed_pools`. Reauthorization replaces both expiry and the list. `SessionAuthorized` now includes the stored IDs, and `session_allowed_pools` exposes them for SDK and devInspect reads.

## Why

`deepbook_sessions` lets an Account owner authorize an ephemeral address to submit Predict and DeepBook spot trades. The grant was only `(address, expiry)`. Spot wrappers are generic over coin types and take a caller-selected `Pool`, and DeepBook allows permissionless pool creation. A compromised or malicious session could therefore route the Account through a junk book it controlled, cross against its own orders, and take the Account's balances. Binding the grant to explicit pool IDs closes that path. Empty still means none, not all.

## Linear / Context

N/A — exempt. Audit follow-up: session trading grants were broader than a trading-session scope.

## Key decisions

- No Predict-vs-spot capability flag. An empty pool list is the Predict-only grant. A listed pool is the only extra consent needed for spot.
- No spend caps, price limits, or separate trading balance in this change. Those bound adverse trades on an *allowed* official book, which is ordinary trading-delegation risk, not the junk-pool drain.
- Duplicate pool IDs abort. Each grant may list at most 20 pools, matching the existing session-address cap.

## Scope / Descoped

This PR only adds the pool-ID allowlist on session grants and the spot-wrapper check. It does not cap Predict spend, restrict official-book prices, or change `deepbook_core_account`'s withdraw-all funding helper.

## Test plan

- [x] `$HOME/.cache/sui/testnet-v1.74.1/sui move test --path packages/sessions --gas-limit 100000000000` — 35 passed, including empty allowlist rejected, unlisted junk pool rejected, duplicate and 21-pool authorize rejected, and existing Predict and spot flows.
- [x] `$HOME/.cache/sui/testnet-v1.74.1/sui move build --path packages/sessions --warnings-are-errors` — clean build.

## Risk / Rollout

Pre-deploy API break: `authorize_session` gains `allowed_pools`, `SessionAuthorized` gains that field, and stored grant layout changes from a timestamp to `SessionGrant`. Integrators must pass the intended pool IDs at grant time; an omitted list is Predict-only, not unrestricted spot. No migration path for existing grants because Sessions is unpublished. Residual risk: a listed official pool can still be traded at a bad price by a compromised session.

Made with [Cursor](https://cursor.com)