### PR TITLE
indexer: store balance event amounts as NUMERIC

### DIFF
--- a/crates/indexer/src/handlers/balances_handler.rs
+++ b/crates/indexer/src/handlers/balances_handler.rs
@@ -1,3 +1,5 @@
+use bigdecimal::BigDecimal;
+
 use crate::models::deepbook::balance_manager::BalanceEvent;
 use deepbook_schema::models::Balances;
 
@@ -16,7 +18,7 @@ define_handler! {
         package: meta.package(),
         balance_manager_id: event.balance_manager_id.to_string(),
         asset: event.asset.to_string(),
-        amount: event.amount as i64,
+        amount: BigDecimal::from(event.amount),
         deposit: event.deposit,
     }
 }

--- a/crates/schema/migrations/2026-08-28-000000-0000_balances_amount_to_numeric/down.sql
+++ b/crates/schema/migrations/2026-08-28-000000-0000_balances_amount_to_numeric/down.sql
@@ -1,0 +1,18 @@
+DROP MATERIALIZED VIEW IF EXISTS net_deposits_hourly;
+
+ALTER TABLE balances
+    ALTER COLUMN amount TYPE BIGINT USING amount::BIGINT;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS net_deposits_hourly AS
+SELECT
+    asset,
+    (checkpoint_timestamp_ms / 3600000) * 3600000 AS hour_bucket_ms,
+    SUM(CASE WHEN deposit THEN amount ELSE -amount END)::BIGINT AS net_amount_delta
+FROM balances
+GROUP BY asset, (checkpoint_timestamp_ms / 3600000) * 3600000;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_net_deposits_hourly_asset_bucket
+    ON net_deposits_hourly (asset, hour_bucket_ms);
+
+CREATE INDEX IF NOT EXISTS idx_net_deposits_hourly_bucket_asset
+    ON net_deposits_hourly (hour_bucket_ms, asset);

--- a/crates/schema/migrations/2026-08-28-000000-0000_balances_amount_to_numeric/up.sql
+++ b/crates/schema/migrations/2026-08-28-000000-0000_balances_amount_to_numeric/up.sql
@@ -1,0 +1,22 @@
+-- Store on-chain u64 deposit amounts losslessly. The previous BIGINT column
+-- (signed i64) wrapped values above i64::MAX via `amount as i64` in the indexer.
+-- net_deposits_hourly depends on balances.amount, so drop it before the type change.
+
+DROP MATERIALIZED VIEW IF EXISTS net_deposits_hourly;
+
+ALTER TABLE balances
+    ALTER COLUMN amount TYPE NUMERIC USING amount::NUMERIC;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS net_deposits_hourly AS
+SELECT
+    asset,
+    (checkpoint_timestamp_ms / 3600000) * 3600000 AS hour_bucket_ms,
+    SUM(CASE WHEN deposit THEN amount ELSE -amount END) AS net_amount_delta
+FROM balances
+GROUP BY asset, (checkpoint_timestamp_ms / 3600000) * 3600000;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_net_deposits_hourly_asset_bucket
+    ON net_deposits_hourly (asset, hour_bucket_ms);
+
+CREATE INDEX IF NOT EXISTS idx_net_deposits_hourly_bucket_asset
+    ON net_deposits_hourly (hour_bucket_ms, asset);

--- a/crates/schema/src/models.rs
+++ b/crates/schema/src/models.rs
@@ -244,7 +244,7 @@ pub struct Balances {
     pub package: String,
     pub balance_manager_id: String,
     pub asset: String,
-    pub amount: i64,
+    pub amount: BigDecimal,
     pub deposit: bool,
 }
 

--- a/crates/schema/src/schema.rs
+++ b/crates/schema/src/schema.rs
@@ -73,7 +73,7 @@ diesel::table! {
         package -> Text,
         balance_manager_id -> Text,
         asset -> Text,
-        amount -> Int8,
+        amount -> Numeric,
         deposit -> Bool,
     }
 }

--- a/crates/server/src/reader.rs
+++ b/crates/server/src/reader.rs
@@ -17,7 +17,7 @@ use diesel::expression::QueryMetadata;
 use diesel::pg::Pg;
 use diesel::query_builder::{Query, QueryFragment, QueryId};
 use diesel::query_dsl::CompatibleType;
-use diesel::sql_types::{Array, BigInt, Double, Integer, Nullable, SmallInt, Text};
+use diesel::sql_types::{Array, BigInt, Double, Integer, Nullable, Numeric, SmallInt, Text};
 use diesel::{
     BoolExpressionMethods, ExpressionMethods, QueryDsl, QueryableByName, SelectableHelper,
     TextExpressionMethods,
@@ -1484,7 +1484,9 @@ impl Reader {
         &self,
         asset_ids: &[String],
         timestamp_ms: i64,
-    ) -> Result<std::collections::HashMap<String, i64>, DeepBookError> {
+    ) -> Result<std::collections::HashMap<String, String>, DeepBookError> {
+        use bigdecimal::BigDecimal;
+
         let mut connection = self.db.connect().await?;
         let _guard = self.metrics.db_latency.start_timer();
 
@@ -1501,8 +1503,8 @@ impl Reader {
         struct NetDepositRow {
             #[diesel(sql_type = diesel::sql_types::Text)]
             asset: String,
-            #[diesel(sql_type = diesel::sql_types::BigInt)]
-            net_amount: i64,
+            #[diesel(sql_type = Numeric)]
+            net_amount: BigDecimal,
         }
 
         // Query: use refreshed MV buckets before each asset's latest MV bucket, then scan raw
@@ -1544,7 +1546,7 @@ impl Reader {
             )
             SELECT
                 COALESCE(h.asset, p.asset) AS asset,
-                (COALESCE(h.net_amount, 0) + COALESCE(p.net_amount, 0))::bigint AS net_amount
+                (COALESCE(h.net_amount, 0) + COALESCE(p.net_amount, 0)) AS net_amount
             FROM hourly_totals h
             FULL OUTER JOIN raw_totals p ON h.asset = p.asset
             "#,
@@ -1568,7 +1570,7 @@ impl Reader {
                     if !asset.starts_with("0x") {
                         asset.insert_str(0, "0x");
                     }
-                    (asset, row.net_amount)
+                    (asset, row.net_amount.to_plain_string())
                 })
                 .collect()
         })

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -1883,7 +1883,7 @@ async fn margin_supply(
 async fn get_net_deposits(
     Path((asset_ids, timestamp)): Path<(String, String)>,
     State(state): State<Arc<AppState>>,
-) -> Result<Json<HashMap<String, i64>>, DeepBookError> {
+) -> Result<Json<HashMap<String, String>>, DeepBookError> {
     let timestamp_ms = timestamp
         .parse::<i64>()
         .map_err(|_| DeepBookError::bad_request("Invalid timestamp"))?


### PR DESCRIPTION
## Summary

- Indexer now stores `BalanceEvent.amount` as `NUMERIC` via `BigDecimal::from(u64)` instead of `amount as i64`, so on-chain values above `i64::MAX` are no longer wrapped to negatives.
- `net_deposits_hourly` keeps the hourly `SUM` as `NUMERIC` and no longer casts it to `BIGINT`.
- `/get_net_deposits` returns each net as a decimal string so the API cannot overflow signed 64-bit integers or lose precision in JSON.

## Why

The DeepBook indexer records every `BalanceEvent` and the server serves net deposits from a materialized view over that table. On-chain amounts are `u64`; the handler used `as i64` and the view used `SUM(...)::BIGINT`. Values at or above `2^63` silently became negative, and a later `SUM` or `-amount` could abort every view refresh with `bigint out of range`, leaving net-deposit accounting stale for all assets. Collateral events already store amounts as `NUMERIC`; this change applies the same lossless path to balances.

## Linear / Context

N/A — exempt. Fixes the indexer wrap of unbounded on-chain deposit amounts.

## Key decisions

- Use unconstrained `NUMERIC` (not `DECIMAL(20,0)`) so both a single `u64` and an hourly `SUM` of many `u64`s fit. `DECIMAL(20,0)` is enough for one amount and not for aggregation.
- Return net deposits as strings rather than JSON numbers. IEEE-754 cannot represent every integer above `2^53`, and `i64` cannot represent a full `u64` net.
- Do not add coin-type allowlisting or a dead-letter queue in this PR. After the type change, a junk coin is an extra group, not an availability failure.

## Scope / Descoped

- In scope: `balances.amount`, the balances handler, `net_deposits_hourly`, and `/get_net_deposits`.
- Out of scope: other indexer `as i64` quantity columns, coin-type allowlisting, and a balances replay/repair job. Existing rows that already wrapped stay wrong until those events are re-indexed; `ALTER ... USING amount::NUMERIC` cannot recover discarded bits.

## Test plan

- [x] `cargo check -p deepbook-server -p deepbook-indexer -p deepbook-schema` — type-checks the `BigDecimal` / `NUMERIC` wiring.
- [ ] `cargo fmt -p deepbook-server` — CI formatting gate.
- [ ] After migrate: insert a `balances` row with `amount = 18446744073709551615` and refresh `net_deposits_hourly` — refresh succeeds and the stored amount is the full `u64`, not `-1`.
- [ ] `GET /get_net_deposits` for a normal asset — response values are decimal strings and match the previous numeric nets for amounts that fit in `i64`.
- [ ] `cargo test -p deepbook-indexer balances_test` (needs local Postgres) — existing balance snapshots still match.

## Risk / Rollout

- **API break:** `/get_net_deposits` changes from `HashMap<String, i64>` (JSON numbers) to `HashMap<String, String>`. Clients that parse values as numbers must accept strings.
- **Migration:** drops and recreates `net_deposits_hourly`. Refresh must run after deploy before the view is current. Concurrent refresh requires the unique index, which the migration recreates.
- **Already-wrapped rows:** historical `as i64` values remain negative after the type change. Repair is a balances replay from checkpoints, not this migration.
- **Rollback:** the down migration recasts to `BIGINT` and will fail if any stored amount no longer fits in signed 64 bits.


Made with [Cursor](https://cursor.com)