### PR TITLE
margin: hold last-update time when interest truncates to zero

### DIFF
--- a/packages/deepbook_margin/sources/helper/margin_constants.move
+++ b/packages/deepbook_margin/sources/helper/margin_constants.move
@@ -6,7 +6,7 @@ module deepbook_margin::margin_constants;
 // Bump ahead of EVERY on-chain package upgrade. After the upgrade the admin must
 // also call `enable_version(N)` on the live `MarginRegistry` (and later
 // `disable_version(N-1)`), or all entries abort `EPackageVersionDisabled`.
-const MARGIN_VERSION: u64 = 7;
+const MARGIN_VERSION: u64 = 8;
 const MAX_RISK_RATIO: u64 = 1_000 * 1_000_000_000; // Risk ratio above 1000 will be considered as 1000
 const DEFAULT_USER_LIQUIDATION_REWARD: u64 = 10_000_000; // 1%
 const DEFAULT_POOL_LIQUIDATION_REWARD: u64 = 40_000_000; // 4%

--- a/packages/deepbook_margin/sources/margin_pool/margin_state.move
+++ b/packages/deepbook_margin/sources/margin_pool/margin_state.move
@@ -18,6 +18,9 @@ public struct State has drop, store {
     total_borrow: u64,
     supply_shares: u64,
     borrow_shares: u64,
+    // Last timestamp whose elapsed time was applied to interest, or confirmed
+    // idle (zero borrow). Short calls that truncate to zero interest against
+    // outstanding borrow do not advance this.
     last_update_timestamp: u64,
     extra_fields: VecMap<String, u64>,
 }
@@ -117,6 +120,12 @@ public(package) fun decrease_borrow_shares(
 
 /// Update the supply and borrow with the interest and protocol fees.
 /// Returns the protocol fees accrued since last update.
+///
+/// Zero incremental interest against outstanding borrow does not consume
+/// the elapsed interval. The year-fraction conversion floors short windows
+/// to zero; advancing the timestamp anyway would let frequent updates
+/// discard time. Idle pools (zero borrow) still advance so a later borrow
+/// is not charged for the idle window.
 public(package) fun update(self: &mut State, config: &ProtocolConfig, clock: &Clock): u64 {
     let now = clock.timestamp_ms();
     let elapsed = now - self.last_update_timestamp;
@@ -126,6 +135,10 @@ public(package) fun update(self: &mut State, config: &ProtocolConfig, clock: &Cl
         elapsed,
         self.total_borrow,
     );
+    if (interest == 0 && self.total_borrow > 0) {
+        return 0
+    };
+
     let protocol_fees = math::mul(interest, config.protocol_spread());
     self.total_supply = self.total_supply + interest - protocol_fees;
     self.total_borrow = self.total_borrow + interest;

--- a/packages/deepbook_margin/tests/margin_pool/margin_state_tests.move
+++ b/packages/deepbook_margin/tests/margin_pool/margin_state_tests.move
@@ -9,6 +9,18 @@ use deepbook_margin::{margin_constants, margin_state, protocol_config_tests, tes
 use std::unit_test::{assert_eq, destroy};
 use sui::{clock, test_scenario::begin};
 
+// floor(year_ms / 1e9) + 1: `math::div(elapsed, year_ms)` is 0 below this.
+const YEAR_FRACTION_QUANTUM_MS: u64 = 32;
+const ZERO_INTEREST_STEP_MS: u64 = 1;
+const ZERO_INTEREST_STEPS: u64 = 31;
+const THIRTY_DAYS_MS: u64 = 30 * 24 * 60 * 60 * 1000;
+const SUPPLY_TOKENS: u64 = 1000;
+const BORROW_TOKENS: u64 = 500;
+const FIRST_QUANTUM_INTEREST: u64 = 50;
+const FIRST_QUANTUM_PROTOCOL_FEES: u64 = 5;
+const THIRTY_DAY_PLUS_HELD_INTEREST: u64 = 4_109_589_050;
+const THIRTY_DAY_PLUS_HELD_PROTOCOL_FEES: u64 = 410_958_905;
+
 #[test]
 fun margin_state_operations_work() {
     let mut test = begin(test_constants::admin());
@@ -159,6 +171,153 @@ fun margin_state_with_supply_and_borrow_accrues_interest() {
     assert_eq!(state.supply_shares(), 0);
     assert_eq!(state.borrow_shares(), 0);
     assert_eq!(state.last_update_timestamp(), clock.timestamp_ms());
+
+    destroy(clock);
+    test.end();
+}
+
+#[test]
+fun zero_interest_update_holds_timestamp_while_borrowed() {
+    let mut test = begin(test_constants::admin());
+    let mut clock = clock::create_for_testing(test.ctx());
+    let mut state = margin_state::default(&clock);
+    let config = protocol_config_tests::create_test_protocol_config();
+    let supply_amount = SUPPLY_TOKENS * constants::float_scaling();
+    let borrow_amount = BORROW_TOKENS * constants::float_scaling();
+
+    state.increase_supply(&config, supply_amount, &clock);
+    state.increase_borrow(&config, borrow_amount, &clock);
+    let timestamp_at_borrow = state.last_update_timestamp();
+    assert_eq!(timestamp_at_borrow, clock.timestamp_ms());
+
+    // 1ms is below the year-fraction quantum (ceil(year_ms / 1e9) = 32), so
+    // incremental interest is independently 0 for any borrow size.
+    assert_eq!(
+        YEAR_FRACTION_QUANTUM_MS,
+        margin_constants::year_ms() / constants::float_scaling() + 1,
+    );
+    assert!(ZERO_INTEREST_STEP_MS < YEAR_FRACTION_QUANTUM_MS);
+    clock.increment_for_testing(ZERO_INTEREST_STEP_MS);
+    let protocol_fees = state.update(&config, &clock);
+    assert_eq!(protocol_fees, 0);
+    assert_eq!(state.last_update_timestamp(), timestamp_at_borrow);
+    assert_eq!(state.total_supply(), supply_amount);
+    assert_eq!(state.total_borrow(), borrow_amount);
+
+    destroy(clock);
+    test.end();
+}
+
+#[test]
+fun zero_interest_update_advances_timestamp_when_idle() {
+    let mut test = begin(test_constants::admin());
+    let mut clock = clock::create_for_testing(test.ctx());
+    let mut state = margin_state::default(&clock);
+    let config = protocol_config_tests::create_test_protocol_config();
+    let supply_amount = SUPPLY_TOKENS * constants::float_scaling();
+
+    state.increase_supply(&config, supply_amount, &clock);
+    assert_eq!(state.total_borrow(), 0);
+    let timestamp_at_supply = state.last_update_timestamp();
+
+    clock.increment_for_testing(ZERO_INTEREST_STEP_MS);
+    let protocol_fees = state.update(&config, &clock);
+    assert_eq!(protocol_fees, 0);
+    assert_eq!(state.last_update_timestamp(), clock.timestamp_ms());
+    assert!(state.last_update_timestamp() > timestamp_at_supply);
+    assert_eq!(state.total_supply(), supply_amount);
+    assert_eq!(state.total_borrow(), 0);
+
+    destroy(clock);
+    test.end();
+}
+
+#[test]
+fun repeated_zero_interest_updates_match_one_shot_accrual() {
+    let mut test = begin(test_constants::admin());
+    let mut grind_clock = clock::create_for_testing(test.ctx());
+    let mut oneshot_clock = clock::create_for_testing(test.ctx());
+    let mut grind = margin_state::default(&grind_clock);
+    let mut oneshot = margin_state::default(&oneshot_clock);
+    let config = protocol_config_tests::create_test_protocol_config();
+    let supply_amount = SUPPLY_TOKENS * constants::float_scaling();
+    let borrow_amount = BORROW_TOKENS * constants::float_scaling();
+
+    grind.increase_supply(&config, supply_amount, &grind_clock);
+    grind.increase_borrow(&config, borrow_amount, &grind_clock);
+    oneshot.increase_supply(&config, supply_amount, &oneshot_clock);
+    oneshot.increase_borrow(&config, borrow_amount, &oneshot_clock);
+    let timestamp_at_borrow = grind.last_update_timestamp();
+    assert_eq!(ZERO_INTEREST_STEPS, YEAR_FRACTION_QUANTUM_MS - 1);
+
+    let mut step = 0;
+    while (step < ZERO_INTEREST_STEPS) {
+        grind_clock.increment_for_testing(ZERO_INTEREST_STEP_MS);
+        let protocol_fees = grind.update(&config, &grind_clock);
+        assert_eq!(protocol_fees, 0);
+        assert_eq!(grind.last_update_timestamp(), timestamp_at_borrow);
+        step = step + 1;
+    };
+    assert_eq!(grind.total_supply(), supply_amount);
+    assert_eq!(grind.total_borrow(), borrow_amount);
+
+    let held_ms = ZERO_INTEREST_STEPS * ZERO_INTEREST_STEP_MS;
+    grind_clock.increment_for_testing(THIRTY_DAYS_MS);
+    oneshot_clock.increment_for_testing(held_ms + THIRTY_DAYS_MS);
+
+    let grind_fees = grind.update(&config, &grind_clock);
+    let oneshot_fees = oneshot.update(&config, &oneshot_clock);
+    assert_eq!(grind_fees, oneshot_fees);
+    assert_eq!(grind.total_supply(), oneshot.total_supply());
+    assert_eq!(grind.total_borrow(), oneshot.total_borrow());
+    assert_eq!(grind.last_update_timestamp(), oneshot.last_update_timestamp());
+    assert_eq!(grind.last_update_timestamp(), grind_clock.timestamp_ms());
+
+    // 500 tokens at 10% for (30d + 31ms):
+    // time_factor = floor(2_592_000_031 * 1e9 / 31_536_000_000) = 82_191_781
+    // interest = floor(50e9 * 82_191_781 / 1e9) = 4_109_589_050
+    // protocol fees = floor(4_109_589_050 * 0.1) = 410_958_905
+    assert_eq!(oneshot_fees, THIRTY_DAY_PLUS_HELD_PROTOCOL_FEES);
+    assert_eq!(oneshot.total_borrow(), borrow_amount + THIRTY_DAY_PLUS_HELD_INTEREST);
+    assert_eq!(
+        oneshot.total_supply(),
+        supply_amount + THIRTY_DAY_PLUS_HELD_INTEREST - THIRTY_DAY_PLUS_HELD_PROTOCOL_FEES,
+    );
+
+    destroy(grind_clock);
+    destroy(oneshot_clock);
+    test.end();
+}
+
+#[test]
+fun first_year_fraction_quantum_accrues_and_advances() {
+    let mut test = begin(test_constants::admin());
+    let mut clock = clock::create_for_testing(test.ctx());
+    let mut state = margin_state::default(&clock);
+    let config = protocol_config_tests::create_test_protocol_config();
+    let supply_amount = SUPPLY_TOKENS * constants::float_scaling();
+    let borrow_amount = BORROW_TOKENS * constants::float_scaling();
+
+    state.increase_supply(&config, supply_amount, &clock);
+    state.increase_borrow(&config, borrow_amount, &clock);
+
+    clock.increment_for_testing(YEAR_FRACTION_QUANTUM_MS - 1);
+    assert_eq!(state.update(&config, &clock), 0);
+    assert_eq!(state.last_update_timestamp(), 0);
+    assert_eq!(state.total_supply(), supply_amount);
+    assert_eq!(state.total_borrow(), borrow_amount);
+
+    // 500 tokens at 10% for 32ms: time_factor = 1, interest = 50, fees = 5
+    clock.increment_for_testing(1);
+    assert_eq!(clock.timestamp_ms(), YEAR_FRACTION_QUANTUM_MS);
+    let protocol_fees = state.update(&config, &clock);
+    assert_eq!(protocol_fees, FIRST_QUANTUM_PROTOCOL_FEES);
+    assert_eq!(state.last_update_timestamp(), YEAR_FRACTION_QUANTUM_MS);
+    assert_eq!(state.total_borrow(), borrow_amount + FIRST_QUANTUM_INTEREST);
+    assert_eq!(
+        state.total_supply(),
+        supply_amount + FIRST_QUANTUM_INTEREST - FIRST_QUANTUM_PROTOCOL_FEES,
+    );
 
     destroy(clock);
     test.end();


### PR DESCRIPTION
## Summary

- Margin pool interest accrual no longer advances `last_update_timestamp` when a call computes zero incremental interest against outstanding borrow.
- Idle pools (zero borrow) still advance so a later borrow is not charged for the idle window.
- `MARGIN_VERSION` is bumped from 7 to 8 for the upgrade.

## Why

Margin pool interest converts elapsed milliseconds into a 9-decimal year fraction. Any window shorter than 32ms floors that fraction to zero, and even slightly longer windows can still produce zero interest after the second multiply. `update` used to write `now` into `last_update_timestamp` anyway, so a borrower or bot that touched the pool often enough discarded the leftover interval instead of carrying it forward. Suppliers earned less than a single update over the same wall-clock span.

## Linear / Context

N/A — exempt

## Key decisions

Hold the timestamp only when interest is zero **and** `total_borrow > 0`. A blanket "don't advance on zero interest" would store a huge idle elapsed window and then charge the first post-borrow update as if that borrow had existed the whole time.

This does not change the interest formula or accumulate remainders. Frequent updates that produce a tiny *nonzero* interest still lose floor dust (on the order of a few percent at checkpoint cadence). Making many small updates bit-identical to one large update across all pool sizes would need higher-precision math; that is left out of this change.

## Scope / Descoped

In scope: `margin_state::update` timestamp hold, version bump, and unit tests for the hold, idle advance, 31ms/32ms boundary, and many-sub-quantum updates vs one shot.

Descoped: remainder accumulation, a combined `borrow * rate * elapsed / (year * 1e9)` formula, and a minimum accrual interval.

## Test plan

- [x] `sui move test --path packages/deepbook_margin --gas-limit 100000000000 zero_interest` — hold, idle advance, and many-small-vs-one-shot tests pass
- [x] `sui move test --path packages/deepbook_margin --gas-limit 100000000000 margin_state` — existing plus new margin-state tests pass (6/6)
- [x] `sui move test --path packages/deepbook_margin --gas-limit 100000000000` — full package suite passes (459/459)
- [x] `pnpm format:move` — no formatter drift

## Risk / Rollout

This is a deployed package. After the upgrade, admin must `enable_version(8)` on the live `MarginRegistry` (then disable 7) or every entry aborts `EPackageVersionDisabled`.

No object layout change. View helpers already use the same interest formula, so they stay consistent with a held timestamp (they also return 0 until elapsed is large enough to accrue). A later update applies current utilization to the full held interval rather than a piecewise path through skipped calls; that matches lazy accrual when intermediate updates are omitted.

Rollback is a package downgrade plus `enable_version(7)`.

Made with [Cursor](https://cursor.com)