### PR TITLE
server: simulate against the current DeepBook package

### DIFF
--- a/crates/server/src/grpc.rs
+++ b/crates/server/src/grpc.rs
@@ -8,7 +8,8 @@ use crate::error::DeepBookError;
 use sui_rpc::field::{FieldMask, FieldMaskUtil};
 use sui_rpc::proto::sui::rpc::v2::simulate_transaction_request::TransactionChecks;
 use sui_rpc::proto::sui::rpc::v2::{
-    owner::OwnerKind, GetObjectRequest, GetServiceInfoRequest, SimulateTransactionRequest,
+    execution_error::ErrorDetails, owner::OwnerKind, GetObjectRequest, GetServiceInfoRequest,
+    SimulateTransactionRequest, SimulateTransactionResponse,
 };
 use sui_rpc::Client;
 use sui_sdk_types::{Address, Digest, Transaction, TypeTag};
@@ -145,7 +146,12 @@ pub async fn simulate_returns(
             SimulateTransactionRequest::default()
                 .with_transaction(transaction)
                 // Without this mask `command_outputs` comes back empty rather than erroring.
-                .with_read_mask(FieldMask::from_paths(["command_outputs"]))
+                // `status` costs one extra field and is the only thing that distinguishes a
+                // Move abort from a genuinely empty response — see `simulation_failure`.
+                .with_read_mask(FieldMask::from_paths([
+                    "command_outputs",
+                    "transaction.effects.status",
+                ]))
                 // Disabled checks let us call non-entry public view functions with no gas and no
                 // real sender, exactly as dev_inspect did.
                 .with_checks(TransactionChecks::Disabled),
@@ -154,7 +160,10 @@ pub async fn simulate_returns(
         .into_inner();
 
     if response.command_outputs.is_empty() {
-        return Err(DeepBookError::rpc("No results from simulate_transaction"));
+        return Err(DeepBookError::rpc(format!(
+            "No results from simulate_transaction: {}",
+            simulation_failure(&response)
+        )));
     }
 
     Ok(response
@@ -168,4 +177,55 @@ pub async fn simulate_returns(
                 .collect()
         })
         .collect())
+}
+
+/// Explains an empty `command_outputs`.
+///
+/// A command that aborts produces no outputs at all, so on its own an empty result cannot be
+/// told apart from a successful simulation that returned nothing. The execution status is the
+/// only place the abort code, the failing command index and the aborting module survive, and
+/// without them a retired package version and a malformed PTB report identically.
+fn simulation_failure(response: &SimulateTransactionResponse) -> String {
+    let Some(status) = response
+        .transaction
+        .as_ref()
+        .and_then(|executed| executed.effects.as_ref())
+        .and_then(|effects| effects.status.as_ref())
+    else {
+        return "node returned no execution status".to_string();
+    };
+
+    let Some(error) = status.error.as_ref() else {
+        return "execution reported no error".to_string();
+    };
+
+    // The node renders the abort code, the command index and the aborting function into
+    // `description`, so reassembling those below would only repeat it. The structured fields
+    // are the fallback for a node that leaves the description unset.
+    if let Some(description) = error.description.as_ref() {
+        return description.clone();
+    }
+
+    let mut parts = Vec::new();
+    if let Some(command) = error.command {
+        parts.push(format!("command {command}"));
+    }
+    if let Some(ErrorDetails::Abort(abort)) = error.error_details.as_ref() {
+        if let Some(code) = abort.abort_code {
+            parts.push(format!("abort code {code}"));
+        }
+        if let Some(location) = abort.location.as_ref() {
+            if let (Some(package), Some(module)) =
+                (location.package.as_ref(), location.module.as_ref())
+            {
+                parts.push(format!("in {package}::{module}"));
+            }
+        }
+    }
+
+    if parts.is_empty() {
+        "execution failed with no further detail".to_string()
+    } else {
+        parts.join(", ")
+    }
 }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -28,15 +28,19 @@ struct Args {
         default_value = "postgres://postgres:postgrespw@localhost:5432/deepbook"
     )]
     database_url: Url,
+    /// Network to serve. Supplies the defaults for `--rpc-url` and `--deepbook-package-id`.
+    // The variable is `DEEPBOOK_ENV` rather than the `ENV` clap would derive from the field
+    // name, which the shell already defines.
+    #[clap(env = "DEEPBOOK_ENV", long = "env", default_value = "mainnet")]
+    env: DeepbookEnv,
     /// Full node gRPC endpoint (`sui.rpc.v2`). Same host/port as the old JSON-RPC URL.
-    #[clap(env, long, default_value = "https://fullnode.mainnet.sui.io:443")]
-    rpc_url: Url,
-    #[clap(
-        env,
-        long,
-        default_value = "0x2c8d603bc51326b8c13cef9dd07031a408a48dddb541963357661df5d3204809"
-    )]
-    deepbook_package_id: String,
+    /// Defaults to the public full node for `--env`.
+    #[clap(env, long)]
+    rpc_url: Option<Url>,
+    /// DeepBook core package that `/orderbook` and `/fees` simulate against.
+    /// Defaults to the latest published package for `--env`.
+    #[clap(env, long)]
+    deepbook_package_id: Option<String>,
     #[clap(
         env,
         long,
@@ -95,6 +99,42 @@ struct Args {
     pyth_pro_chart_history_max_range_secs: u64,
 }
 
+/// Network the server reads from, mirroring the indexer's `--env`.
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+enum DeepbookEnv {
+    Mainnet,
+    Testnet,
+}
+
+impl DeepbookEnv {
+    fn rpc_url(&self) -> Url {
+        let url = match self {
+            DeepbookEnv::Mainnet => "https://fullnode.mainnet.sui.io:443",
+            DeepbookEnv::Testnet => "https://fullnode.testnet.sui.io:443",
+        };
+        Url::parse(url).unwrap()
+    }
+
+    /// Latest published DeepBook core package, matching `packages/deepbook/Published.toml`.
+    ///
+    /// This tracks the newest package address, never the original one. A pool caches an
+    /// `allowed_versions` set and `pool::load_inner` asserts the calling package's
+    /// `CURRENT_VERSION` belongs to it, so calls through a package whose version has been
+    /// retired by `registry::disable_version` abort. An aborted command produces no outputs,
+    /// which surfaces as an empty simulation result rather than as a version error — see
+    /// `grpc::simulate_returns`.
+    fn deepbook_package_id(&self) -> &'static str {
+        match self {
+            DeepbookEnv::Mainnet => {
+                "0x0e735f8c93a95722efd73521aca7a7652c0bb71ed1daf41b26dfd7d1ff71f748"
+            }
+            DeepbookEnv::Testnet => {
+                "0xd874d2417a55bfa6479bffa06ad950fea144ef93a94cc6c49f32b03e386bbb24"
+            }
+        }
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     let _guard = telemetry_subscribers::TelemetryConfig::new()
@@ -106,6 +146,7 @@ async fn main() -> Result<(), anyhow::Error> {
         server_port,
         metrics_address,
         database_url,
+        env,
         rpc_url,
         deepbook_package_id,
         deep_token_package_id,
@@ -126,6 +167,9 @@ async fn main() -> Result<(), anyhow::Error> {
         pyth_pro_chart_history_cache_max_entries,
         pyth_pro_chart_history_max_range_secs,
     } = Args::parse();
+    let rpc_url = rpc_url.unwrap_or_else(|| env.rpc_url());
+    let deepbook_package_id =
+        deepbook_package_id.unwrap_or_else(|| env.deepbook_package_id().to_string());
     // Read the secret from the environment only so it never needs to appear in
     // process arguments or clap's help output.
     let pyth_pro_api_key = std::env::var("PYTH_PRO_API_KEY").ok();

--- a/docker/deepbook-server/entry.sh
+++ b/docker/deepbook-server/entry.sh
@@ -3,10 +3,11 @@
 export RUST_BACKTRACE=1
 export RUST_LOG=debug
 
+# RPC_URL, DEEPBOOK_PACKAGE_ID and DEEPBOOK_ENV are read straight from the environment by the
+# binary. Forwarding them here instead would pass an empty string when they are unset, which
+# overrides the per-network default rather than leaving it in place.
 /opt/mysten/bin/deepbook-server \
   --database-url "$DATABASE_URL" \
-  --rpc-url "$RPC_URL" \
-  --deepbook-package-id "$DEEPBOOK_PACKAGE_ID" \
   --deep-token-package-id "$DEEP_TOKEN_PACKAGE_ID" \
   --deep-treasury-id "$DEEP_TREASURY_ID" \
   --margin-package-id "$MARGIN_PACKAGE_ID" \


### PR DESCRIPTION
## Summary

- `/orderbook` and `/fees` simulate against the DeepBook core package chosen by a new `--env` flag (`mainnet` by default), which resolves to the latest published package for that network instead of the hardcoded original package address.
- `simulate_returns` now reports the execution status behind an empty simulation result, so a Move abort no longer reads identically to a response that genuinely carried no return values.
- `docker/deepbook-server/entry.sh` stops forwarding `RPC_URL` and `DEEPBOOK_PACKAGE_ID` on the command line, so an unset variable reaches the new default instead of overriding it with an empty string. This only affects runs that use the entry point's own command; anything that supplies its own arguments is unchanged.

## Why

The server answers `/orderbook` and `/fees` by simulating read-only Move calls into DeepBook core, and it defaulted to that package's original address, which is version 1. A pool caches an `allowed_versions` set, and `pool::load_inner` asserts that the calling package's `constants::CURRENT_VERSION` is a member, so retiring a version through `registry::disable_version` makes every call through that package address abort. Version 1 has now been retired on mainnet, and because an aborting command produces no command outputs at all, both endpoints started returning `RPC error: No results from simulate_transaction`.

Pinning the original address means the next version retirement breaks the same two endpoints again, and the error text gave no way to tell an abort apart from an empty result — the two are indistinguishable without the execution status, which the read mask did not request.

## Linear / Context

- Fixes #1290

## Key decisions

- **A network flag rather than a replacement constant.** Swapping the literal would fix mainnet and leave testnet running on a mainnet default it has to override. `--env` mirrors the flag the indexer already has, keeps both networks' addresses in one place next to the reason they must track the newest package, and lets `--rpc-url` follow the same choice so `--env testnet` cannot silently point a testnet package at a mainnet node. The cost is two addresses to update per upgrade instead of one.
- **Static addresses rather than resolving the latest version at startup.** Reading the package lineage or the allowed set from the node at boot would survive future retirements automatically, but it makes startup depend on a node round-trip and lets the effective configuration differ between restarts of the same build. Rejected for now; the per-network constant stays reviewable in the diff.
- **`DEEPBOOK_ENV`, not the `ENV` clap derives from the field name.** `ENV` is already meaningful to the shell, so a stray value in the environment would fail to parse and stop the server from starting.
- **`entry.sh` stops forwarding the two variables it no longer needs to.** clap reads them from the environment on its own, so passing them explicitly only changed behaviour when they were unset, where it forwarded an empty string that overrode the default rather than leaving it in place. This is a small robustness fix, not the mechanism that carries the new default into a deployment — a deployment that passes its own `--deepbook-package-id` still wins, by design.

## Scope / Descoped

- The indexer's per-version package lists are unchanged. Object and event types carry a package's original address, so `is_deepbook_tx` still matches every DeepBook transaction regardless of which version was called.
- `entry.sh` still forwards `DEEP_TOKEN_PACKAGE_ID`, `DEEP_TREASURY_ID` and `MARGIN_PACKAGE_ID` unconditionally, and those flags keep their existing defaults. Giving them the same treatment is a separate change.
- No change to how a retired version is detected at runtime. The server still simulates against whatever address it is configured with; it just defaults to a current one and explains the failure when the call aborts.

## Test plan

- [x] `cargo build -p deepbook-server` — compiles, no warnings.
- [x] `cargo fmt -p deepbook-server -- --check` — clean.
- [ ] `cargo nextest run -E 'package(deepbook-server)'` — not completed locally; the test-profile build ran the machine out of disk. The crate's tests cover the OHLCV paths and `run_server`'s signature is unchanged, so the diff has no test surface, but CI is the check that counts.
- [x] `deepbook-server --help` — `--env` shows `[env: DEEPBOOK_ENV=] [default: mainnet] [possible values: mainnet, testnet]`, and `--rpc-url` / `--deepbook-package-id` are optional with their env bindings intact.
- [x] Simulated the level-2 call the `/orderbook` handler builds against mainnet, once per package version, using the handler's posture (sender `0x0`, gas objects cleared, checks disabled):

  | Package | Result |
  | --- | --- |
  | version 1 (the old default) | aborts in `pool::load_inner`, 0 command outputs |
  | version 6 | 1 command, 4 return values |
  | version 7 | 1 command, 4 return values |
  | version 8 (the new mainnet default) | 1 command, 4 return values |

  The four return values are the bid prices, bid quantities, ask prices and ask quantities the handler decodes. The same check on testnet returns 4 return values for both the original package and version 20, which is the new testnet default — testnet has retired no versions, which is why it never broke.

## Risk / Rollout

- **Merging this does not by itself fix a running deployment.** An explicit `--deepbook-package-id`, or a `DEEPBOOK_PACKAGE_ID` in the environment, still overrides the new default — that is the point of keeping it overridable. A deployment that pins the retired address keeps aborting until its configuration is updated to the current package, or drops the pin so the per-network default applies. The accompanying configuration change is tracked outside this repository.
- Both endpoints are read-only simulations, so there is no state to migrate and rollback is reverting the commit.
- The new default has to be updated on the next core upgrade, in the same way `Published.toml` is. A version that is published but not yet allowed by the pools would abort exactly as version 1 does now — the improved error names the aborting module and code, so that case is no longer silent.
