### PR TITLE
deploy: prepare official Predict Testnet deployment (DBU-785)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,11 @@ __pycache__/
 packages/predict/simulations/runs/
 packages/predict/parallel_pool_implementation_plan.md
 
+# Predict deployment operator state and atomic-write temporaries
+packages/predict/deployment/deployment.testnet.state.json
+packages/predict/deployment/deployment.testnet.state.json.tmp
+packages/predict/deployment/deployment.testnet.json.tmp
+
 # Research
 predict_research/
 

--- a/packages/predict/deployment/README.md
+++ b/packages/predict/deployment/README.md
@@ -1,0 +1,58 @@
+# Official Predict Testnet deployment
+
+This directory owns the reproducible `deepbook-predict-testnet` contract deployment. Operator recovery data and the stable public integration surface are separate artifacts.
+
+## Files
+
+-   `deploy.ts` is the resumable deployment state machine. It publishes `fixed_math`, USDC, Account, Propbook, Predict, the DeepBook core Account wrapper, and Sessions; finalizes the USDC and PLP currency registrations; mints Testnet USDC; authorizes the fresh Account apps; wires BTC oracle state; applies cadence policy; bootstraps the pool; fills the initial market windows; hands off both operational capabilities; and audits the result from Testnet.
+-   `deployment.testnet.state.json` is the mode-`0600`, gitignored operator journal. It contains in-flight intent, transaction receipts, temporary currency objects, bootstrap-account data, and privileged capabilities.
+-   `deployment.testnet.json` is the public integration manifest. The script writes it only after the complete Testnet audit and external DeepBook authorization pass.
+-   `deploy.test.ts` pins the non-broadcasting default, state/manifest boundary, official economics, publication plan, package recovery, every irreversible transaction boundary, SID parity, and schema-7 manifest boundary.
+
+No deployment artifact contains signer key material. The workflow reads the selected signer from a mode-restricted snapshot of the existing Sui client configuration and removes the snapshot on exit.
+
+## Run
+
+Use Sui CLI `sui 1.77.1-4e476c5c8184`, a clean committed `deepbook-predict-testnet` branch, and the Testnet client environment whose active address is the funded deployer. Do not set `SUI_KEYSTORE_PATH`; the CLI and SDK both use the keystore pinned by the client configuration.
+
+```sh
+cd packages/predict
+corepack npm exec -- tsx deployment/deploy.ts
+corepack npm exec -- tsx deployment/deploy.ts --execute
+```
+
+The first command builds every package with warnings denied, verifies the seven-package plan and dependency identities, checks the chain, signer, external objects, capability owners, gas for the complete transaction plan, and source bindings, and submits no transaction. The second command broadcasts.
+
+The broadcast publishes `fixed_math`, `usdc`, `account`, `propbook`, `predict`, `deepbook_core_account`, and `sessions` in dependency order. All package upgrade capabilities, the USDC TreasuryCap and MetadataCap, the PLP MetadataCap, and the Account, Propbook, Predict, and Sessions administrative capabilities remain owned by the deployer.
+
+The fresh collateral type is `<usdc-package>::usdc::USDC`; its six-decimal display symbol is `DUSDC`. The workflow permissionlessly finalizes its Sui coin-registry registration, retains its TreasuryCap and MetadataCap, and performs one recorded mint of 100,000,000 USDC to the deployer. It also finalizes the fresh PLP registration before pool bootstrap.
+
+The official initial pool locks 10 USDC and supplies 250,000 USDC to the deployer Account, creating the corresponding PLP position. The protocol retains the source defaults of a 500,000 USDC maximum LP-attributable pool value and a five-minute maximum valuation window.
+
+BTC is the only registered underlying. The workflow enables only 1-minute and 5-minute cadences; each has a two-market window, 2,000 USDC initial expiry cash, 10,000 USDC maximum allocation, a 0.01 USD pricing tick, and a 1 USD admission tick. The remaining cadence records are explicitly disabled.
+
+The workflow creates the fresh BTC Pyth feed and Block Scholes store pair, verifies the on-chain spot, forward, and SVI SIDs against the subscription-side derivation, and requires fresh provider source timestamps before moving collateral. A first execution normally stops with `awaiting_oracle_data` after publishing and wiring the new object IDs; configure the Propbook writer for those IDs, allow observations to land, and rerun the same committed source and state journal.
+
+Each new market receives its exact previous-window Pyth reference tick before pool cash is rebalanced into it. Missing reference observations fail closed and are retried by resuming after the updater has inserted the required boundary observation.
+
+The workflow mints both `MarketLifecycleCap` and `PoolValuationCap` to the deployer for setup. After package, currency, authorization, oracle, configuration, funding, reference-tick, live-market, and pool-accounting audits pass, it transfers both capabilities atomically with `sui::transfer::public_party_transfer` to the configured Predict writer and verifies their `ConsensusAddressOwner` custody.
+
+The existing DeepBook registry's consensus-owned `DeepbookAdminCap` has a different owner. The workflow audits whether that owner has authorized the fresh `DeepbookCoreAccountApp` type; when authorization is absent, the journal remains `awaiting_external_authorization` and no integration manifest is written. After the external owner authorizes the type, rerun the same command to verify the mutated DeepBook registry, establish the final checkpoint fence, and complete.
+
+No transaction targets the existing Predict v4 packages or shared objects. Reusing the v4 writer addresses only selects final custody; it does not launch a duplicate keeper or updater.
+
+If a run is interrupted, preserve the source commit, exact Sui binary, client configuration, gas budgets, generated `Published.toml` files, and state journal, then rerun the execute command. A successful known digest is reconciled on-chain, including reconstruction of missing publication metadata from the verified receipt; a definitively failed digest is checkpointed and made retryable, and an unknown submission outcome fails closed until it is reconciled.
+
+Commit the reviewed workflow before the first execute run; that commit is the immutable source anchor for every resume. After the final audit succeeds, commit the generated `Published.toml` files and integration manifest without changing the source anchor. Never commit the state journal or regenerated `Move.lock` files.
+
+```sh
+cd packages/predict
+corepack npm run build
+corepack npm exec -- tsx --test deployment/deploy.test.ts
+```
+
+## Integration manifest
+
+The schema-7 manifest contains the seven fresh package IDs, finalized currency and shared-object IDs, coin types, oracle bindings, writer identities, lifecycle and pool-valuation capabilities, earliest publication checkpoint, completed DeepBook wrapper authorization, numeric units, and the initial protocol and cadence snapshot. Mutable `ProtocolConfig`, Predict `Registry`, Propbook `OracleRegistry`, `SessionsConfig`, and DeepBook `Registry` values are anchored to the exact object versions and digests bracketing the final audit reads.
+
+The manifest excludes the deployer, transaction digests, receipts, bootstrap accounts, temporary markets, balances, rebalances, and publisher, upgrade, admin, treasury, or metadata capabilities. Runtime consumers must read mutable protocol and cadence policy from the shared objects on-chain.

--- a/packages/predict/deployment/deploy.test.ts
+++ b/packages/predict/deployment/deploy.test.ts
@@ -1,0 +1,843 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+    CADENCES,
+    EXPECTED_PROTOCOL_CONFIG,
+    MANIFEST_RELATIVE,
+    STATE_RELATIVE,
+    assertDeploymentTarget,
+    assertExactPackageGraph,
+    assertExecutionBindings,
+    assertNoKeystoreOverride,
+    assertIntegrationManifest,
+    assertMatchingSid,
+    assertPackagePlan,
+    assertRecoverableInFlight,
+    assertSourceBinding,
+    assertSuiCliVersion,
+    buildIntegrationManifest,
+    checkpointRecoveredTransaction,
+    createDeploymentState,
+    irreversibleDeploymentSteps,
+    irreversibleStepDigest,
+    isUnderlyingNotRegisteredError,
+    maximumTransactionCountPerRun,
+    parseDeploymentArgs,
+    parseOptionBlockScholesStorePair,
+    parsePackageMetadata,
+    plannedTransactionCount,
+    plannedTransactionSteps,
+    publishedMetadataText,
+    reconcileJournaledInFlight,
+    recordVerifiedTransactionFailure,
+    removeRecoveryTemporaries,
+    runBroadcastBoundary,
+    sameObjectReference,
+    unexpectedDeploymentPaths,
+    type IntegrationManifest,
+} from "./deploy.ts";
+
+const id = (digit: string) => `0x${digit.repeat(64)}`;
+
+function manifestFixture(): IntegrationManifest {
+    const predict = id("4");
+    const usdc = id("2");
+    return {
+        schemaVersion: 7,
+        deployment: "deepbook-predict-testnet",
+        network: "testnet",
+        chainId: "4c78adac",
+        sourceCommit: "a".repeat(40),
+        packages: {
+            fixedMath: id("1"),
+            usdc,
+            account: id("2"),
+            propbook: id("3"),
+            predict,
+            deepbookCoreAccount: id("5"),
+            sessions: id("6"),
+        },
+        coinTypes: {
+            usdc: `${usdc}::usdc::USDC`,
+            deep: "0x36dbef866a1d62bf7328989a10fb2f07d769f4ee587c0de4a0a256e57e0a58a8::deep::DEEP",
+            plp: `${predict}::plp::PLP`,
+        },
+        objects: {
+            usdcCurrency: id("d"),
+            plpCurrency: id("e"),
+            accountRegistry: id("7"),
+            oracleRegistry: id("8"),
+            protocolConfig: id("9"),
+            poolVault: id("a"),
+            registry: id("b"),
+            sessionsConfig: id("c"),
+            deepbookRegistry: "0x7c256edbda983a2cd6f946655f4bf3f00a41043993781f8674a7046e8c0e11d1",
+            accumulatorRoot: "0x0000000000000000000000000000000000000000000000000000000000000acc",
+            clock: "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+        underlyings: {
+            BTC: {
+                symbol: "BTC",
+                name: "BTC_USD",
+                propbookUnderlyingId: 1,
+                pythLazerFeedId: 1,
+                blockScholesSourceId: 1,
+                pythFeed: id("d"),
+                blockScholesValueStore: id("e"),
+                blockScholesSviStore: id("f"),
+            },
+        },
+        writers: {
+            keeper: {
+                address: "0xff241a369609060d3f34828b97a47a2d330644615ff57dfdd49f4f0dd299207f",
+                lifecycleCap: id("1"),
+                poolValuationCap: id("2"),
+            },
+            priceUpdater: {
+                address: "0x921e2bd3432c784dce15b4073ba666d5067e6f8a41704eb63555235fec2e2e41",
+                pythLazerPackage:
+                    "0xf5bd2141967507050a91b58de3d95e77c432cd90d1799ee46effc27430a68c21",
+                pythLazerState:
+                    "0xe2b9096a5ea341a9f1eef126b2203727e29e73fdb0641ade2e1e32942f97e4d8",
+                blockScholesOraclePackage:
+                    "0x9d2cf38611d971a0e918b93fc0113d279f5c923f43e62c407a9ad0f9d82f6698",
+                blockScholesSignerRegistry:
+                    "0x94d0198a6fa973bb457603ed39b39b76c98468114808ad5b518745b7b957c414",
+            },
+        },
+        externalAuthorizations: {
+            deepbookCoreAccount: {
+                authorized: true,
+                appType: `${id("5")}::account_data::DeepbookCoreAccountApp`,
+                registry: "0x7c256edbda983a2cd6f946655f4bf3f00a41043993781f8674a7046e8c0e11d1",
+            },
+        },
+        indexing: { startCheckpoint: "1" },
+        initialConfiguration: {
+            verifiedAfterCheckpoint: "2",
+            stateAnchors: {
+                protocolConfig: { objectVersion: "1", digest: "protocol" },
+                registry: { objectVersion: "1", digest: "registry" },
+                oracleRegistry: { objectVersion: "1", digest: "oracle" },
+                sessionsConfig: { objectVersion: "1", digest: "sessions" },
+                deepbookRegistry: { objectVersion: "1", digest: "deepbook" },
+            },
+            units: {
+                fixedPointScale: "1000000000",
+                quoteCoinDecimals: 6,
+                plpCoinDecimals: 6,
+                deepCoinDecimals: 6,
+                positionQuantityDecimals: 6,
+                positionLotSize: "10000",
+                timestampUnit: "milliseconds",
+            },
+            liveProtocol: {
+                pricing: {
+                    usePythSpotForForward: EXPECTED_PROTOCOL_CONFIG.usePythSpotForForward,
+                    pythSpotFreshnessMs: EXPECTED_PROTOCOL_CONFIG.pythSpotFreshnessMs,
+                    blockScholesPriceFreshnessMs:
+                        EXPECTED_PROTOCOL_CONFIG.blockScholesPriceFreshnessMs,
+                    blockScholesSviFreshnessMs: EXPECTED_PROTOCOL_CONFIG.blockScholesSviFreshnessMs,
+                },
+                ewmaPenalty: {
+                    alpha: EXPECTED_PROTOCOL_CONFIG.ewmaAlpha,
+                    zScoreThreshold: EXPECTED_PROTOCOL_CONFIG.ewmaZScoreThreshold,
+                    penaltyRate: EXPECTED_PROTOCOL_CONFIG.ewmaPenaltyRate,
+                    enabled: EXPECTED_PROTOCOL_CONFIG.ewmaEnabled,
+                },
+                protocolReserveProfitShare: EXPECTED_PROTOCOL_CONFIG.protocolReserveProfitShare,
+                referralFeeRate: EXPECTED_PROTOCOL_CONFIG.referralFeeRate,
+                plpSupplyFeeRate: EXPECTED_PROTOCOL_CONFIG.plpSupplyFeeRate,
+                plpWithdrawFeeRate: EXPECTED_PROTOCOL_CONFIG.plpWithdrawFeeRate,
+                lpRequestLimitFlushAttempts: EXPECTED_PROTOCOL_CONFIG.lpRequestLimitFlushAttempts,
+                maxLpPoolValue: EXPECTED_PROTOCOL_CONFIG.maxLpPoolValue,
+                maxValuationWindowMs: EXPECTED_PROTOCOL_CONFIG.maxValuationWindowMs,
+            },
+            futureMarketTemplate: {
+                backingBufferLambda: EXPECTED_PROTOCOL_CONFIG.backingBufferLambda,
+                inventoryImpactMaxRate: EXPECTED_PROTOCOL_CONFIG.inventoryImpactMaxRate,
+                baseFee: EXPECTED_PROTOCOL_CONFIG.baseFee,
+                minFee: EXPECTED_PROTOCOL_CONFIG.minFee,
+                minEntryProbability: EXPECTED_PROTOCOL_CONFIG.minEntryProbability,
+                maxEntryProbability: EXPECTED_PROTOCOL_CONFIG.maxEntryProbability,
+                expiryFeeWindowMs: EXPECTED_PROTOCOL_CONFIG.expiryFeeWindowMs,
+                expiryFeeMaxMultiplier: EXPECTED_PROTOCOL_CONFIG.expiryFeeMaxMultiplier,
+            },
+            cadences: {
+                BTC: CADENCES.map((cadence) => ({
+                    id: cadence.id,
+                    name: cadence.name,
+                    periodMs: cadence.periodMs.toString(),
+                    enabled: cadence.windowSize > 0n,
+                    tickSize: cadence.tickSize.toString(),
+                    admissionTickSize: cadence.admissionTickSize.toString(),
+                    maxExpiryAllocation: cadence.maxExpiryAllocation.toString(),
+                    initialExpiryCash: cadence.initialExpiryCash.toString(),
+                    windowSize: cadence.windowSize.toString(),
+                })),
+            },
+        },
+    };
+}
+
+function objectEvidence(objectId: string, version = "1", digest = `digest-${objectId}`) {
+    return {
+        objectId,
+        type: "fixture",
+        owner: "shared",
+        version,
+        digest,
+        previousTransaction: null,
+    };
+}
+
+function completeStateFixture() {
+    const manifest = manifestFixture();
+    const state = createDeploymentState();
+    state.status = "complete";
+    state.sourceCommit = manifest.sourceCommit;
+    state.completedAt = "2026-08-21T00:00:00.000Z";
+    state.verification = {
+        verifiedAt: state.completedAt,
+        chainId: manifest.chainId,
+        indexingStartCheckpoint: manifest.indexing.startCheckpoint,
+        verifiedAfterCheckpoint: manifest.initialConfiguration.verifiedAfterCheckpoint,
+        packages: {
+            fixed_math: objectEvidence(manifest.packages.fixedMath),
+            usdc: objectEvidence(manifest.packages.usdc),
+            account: objectEvidence(manifest.packages.account),
+            propbook: objectEvidence(manifest.packages.propbook),
+            predict: objectEvidence(manifest.packages.predict),
+            deepbook_core_account: objectEvidence(manifest.packages.deepbookCoreAccount),
+            sessions: objectEvidence(manifest.packages.sessions),
+        },
+        linkedPackages: {
+            deepbook: objectEvidence(
+                "0xd874d2417a55bfa6479bffa06ad950fea144ef93a94cc6c49f32b03e386bbb24",
+            ),
+            deep: objectEvidence(manifest.coinTypes.deep.split("::")[0]),
+            pyth_lazer: objectEvidence(manifest.writers.priceUpdater.pythLazerPackage),
+            wormhole: objectEvidence(
+                "0xd5afd4e456e5451f1ca1e7b3d734ce7a0a3b397811a6cb72a4bd1dfc387839f2",
+            ),
+            bs_oracle: objectEvidence(manifest.writers.priceUpdater.blockScholesOraclePackage),
+            bs_sid: objectEvidence(
+                "0x6a54299d593fca24edf6b17bf8c3aff0b7ba8bc8f4276e9c1065689c50223bba",
+            ),
+        },
+        linkedObjects: {
+            clock: objectEvidence(manifest.objects.clock),
+            accumulatorRoot: objectEvidence(manifest.objects.accumulatorRoot),
+            pythLazerState: objectEvidence(manifest.writers.priceUpdater.pythLazerState),
+            wormholeState: objectEvidence(
+                "0x3c89c52e413edb9b0d9a145e02258c96916c79b1e57a12861bb61791ee5c5f81",
+            ),
+            blockScholesSignerRegistry: objectEvidence(
+                manifest.writers.priceUpdater.blockScholesSignerRegistry,
+            ),
+            deepbookRegistry: objectEvidence(
+                manifest.objects.deepbookRegistry,
+                manifest.initialConfiguration.stateAnchors.deepbookRegistry.objectVersion,
+                manifest.initialConfiguration.stateAnchors.deepbookRegistry.digest,
+            ),
+        },
+        sharedObjects: {
+            account: {
+                "account_registry::AccountRegistry": objectEvidence(
+                    manifest.objects.accountRegistry,
+                ),
+            },
+            propbook: {
+                "registry::OracleRegistry": objectEvidence(
+                    manifest.objects.oracleRegistry,
+                    manifest.initialConfiguration.stateAnchors.oracleRegistry.objectVersion,
+                    manifest.initialConfiguration.stateAnchors.oracleRegistry.digest,
+                ),
+            },
+            predict: {
+                "protocol_config::ProtocolConfig": objectEvidence(
+                    manifest.objects.protocolConfig,
+                    manifest.initialConfiguration.stateAnchors.protocolConfig.objectVersion,
+                    manifest.initialConfiguration.stateAnchors.protocolConfig.digest,
+                ),
+                "plp::PoolVault": objectEvidence(manifest.objects.poolVault),
+                "registry::Registry": objectEvidence(
+                    manifest.objects.registry,
+                    manifest.initialConfiguration.stateAnchors.registry.objectVersion,
+                    manifest.initialConfiguration.stateAnchors.registry.digest,
+                ),
+            },
+            sessions: {
+                "session_config::SessionsConfig": objectEvidence(
+                    manifest.objects.sessionsConfig,
+                    manifest.initialConfiguration.stateAnchors.sessionsConfig.objectVersion,
+                    manifest.initialConfiguration.stateAnchors.sessionsConfig.digest,
+                ),
+            },
+        },
+        ownedCaps: {},
+        oracleObjects: {
+            pythFeed: objectEvidence(manifest.underlyings.BTC.pythFeed),
+            blockScholesValueStore: objectEvidence(manifest.underlyings.BTC.blockScholesValueStore),
+            blockScholesSviStore: objectEvidence(manifest.underlyings.BTC.blockScholesSviStore),
+        },
+        account: {
+            predictAppAuthorized: true,
+            deepbookCoreAppAuthorized: true,
+            sessionsAppAuthorized: true,
+            deepbookCoreAuthorized: true,
+            accountWrapper: objectEvidence(id("a")),
+        },
+        currencies: {
+            usdc: objectEvidence(manifest.objects.usdcCurrency),
+            plp: objectEvidence(manifest.objects.plpCurrency),
+            mintedAmount: "100000000000000",
+            deployerBalance: "99749990000000",
+        },
+        lifecycleCap: objectEvidence(manifest.writers.keeper.lifecycleCap),
+        valuationCap: objectEvidence(manifest.writers.keeper.poolValuationCap),
+        oracleReadiness: [],
+        cadences: CADENCES.map((cadence) => ({
+            id: cadence.id,
+            name: cadence.name,
+            tickSize: cadence.tickSize.toString(),
+            admissionTickSize: cadence.admissionTickSize.toString(),
+            maxExpiryAllocation: cadence.maxExpiryAllocation.toString(),
+            initialExpiryCash: cadence.initialExpiryCash.toString(),
+            windowSize: cadence.windowSize.toString(),
+            setTx: null,
+        })),
+        protocolConfig: { ...EXPECTED_PROTOCOL_CONFIG },
+        pool: {
+            totalSupply: "0",
+            idleBalance: "0",
+            supplyRequestsPending: "0",
+            withdrawRequestsPending: "0",
+            activeMarketIds: [],
+            activeMarketCash: "0",
+            deployerAccountPlpBalance: "0",
+        },
+        markets: [],
+    };
+    return state;
+}
+
+test("the default invocation is non-broadcasting", async () => {
+    assert.deepEqual(parseDeploymentArgs([]), { execute: false, sessions: false, smoke: false });
+    assert.deepEqual(parseDeploymentArgs(["--execute"]), {
+        execute: true,
+        sessions: false,
+        smoke: false,
+    });
+    assert.throws(() => parseDeploymentArgs(["--sessions"]), /unknown deployment arguments/);
+    assert.throws(() => parseDeploymentArgs(["--smoke"]), /unknown deployment arguments/);
+    let broadcasts = 0;
+    assert.equal(
+        await runBroadcastBoundary(false, async () => {
+            broadcasts++;
+        }),
+        false,
+    );
+    assert.equal(broadcasts, 0);
+});
+
+test("operator state and integration manifest are separate artifacts", () => {
+    assert.notEqual(STATE_RELATIVE, MANIFEST_RELATIVE);
+    assert.match(STATE_RELATIVE, /\.state\.json$/);
+    assert.equal(MANIFEST_RELATIVE.endsWith(".state.json"), false);
+    const gitignore = readFileSync(new URL("../../../.gitignore", import.meta.url), "utf8");
+    assert.match(gitignore, new RegExp(`^${STATE_RELATIVE}$`, "m"));
+    assert.match(gitignore, new RegExp(`^${STATE_RELATIVE}\\.tmp$`, "m"));
+    assert.match(gitignore, new RegExp(`^${MANIFEST_RELATIVE}\\.tmp$`, "m"));
+});
+
+test("the deployment policy pins approved defaults and cadence windows", () => {
+    assert.equal(EXPECTED_PROTOCOL_CONFIG.baseFee, "100000000");
+    assert.equal(EXPECTED_PROTOCOL_CONFIG.minFee, "22000000");
+    assert.equal(EXPECTED_PROTOCOL_CONFIG.backingBufferLambda, "310000000");
+    assert.equal(EXPECTED_PROTOCOL_CONFIG.protocolReserveProfitShare, "100000000");
+    assert.equal(EXPECTED_PROTOCOL_CONFIG.pythSpotFreshnessMs, "2000");
+    assert.equal(EXPECTED_PROTOCOL_CONFIG.blockScholesPriceFreshnessMs, "2000");
+    assert.equal(EXPECTED_PROTOCOL_CONFIG.maxLpPoolValue, "500000000000");
+    assert.equal(EXPECTED_PROTOCOL_CONFIG.maxValuationWindowMs, "300000");
+    assert.deepEqual(
+        CADENCES.map(
+            ({
+                name,
+                tickSize,
+                admissionTickSize,
+                maxExpiryAllocation,
+                initialExpiryCash,
+                windowSize,
+            }) => ({
+                name,
+                tickSize: tickSize.toString(),
+                admissionTickSize: admissionTickSize.toString(),
+                maxExpiryAllocation: maxExpiryAllocation.toString(),
+                initialExpiryCash: initialExpiryCash.toString(),
+                windowSize: windowSize.toString(),
+            }),
+        ),
+        [
+            {
+                name: "1m",
+                tickSize: "10000000",
+                admissionTickSize: "1000000000",
+                maxExpiryAllocation: "10000000000",
+                initialExpiryCash: "2000000000",
+                windowSize: "2",
+            },
+            {
+                name: "5m",
+                tickSize: "10000000",
+                admissionTickSize: "1000000000",
+                maxExpiryAllocation: "10000000000",
+                initialExpiryCash: "2000000000",
+                windowSize: "2",
+            },
+            {
+                name: "1h",
+                tickSize: "0",
+                admissionTickSize: "0",
+                maxExpiryAllocation: "0",
+                initialExpiryCash: "0",
+                windowSize: "0",
+            },
+            {
+                name: "1d",
+                tickSize: "0",
+                admissionTickSize: "0",
+                maxExpiryAllocation: "0",
+                initialExpiryCash: "0",
+                windowSize: "0",
+            },
+            {
+                name: "1w",
+                tickSize: "0",
+                admissionTickSize: "0",
+                maxExpiryAllocation: "0",
+                initialExpiryCash: "0",
+                windowSize: "0",
+            },
+            {
+                name: "1mo",
+                tickSize: "0",
+                admissionTickSize: "0",
+                maxExpiryAllocation: "0",
+                initialExpiryCash: "0",
+                windowSize: "0",
+            },
+        ],
+    );
+    const state = createDeploymentState();
+    assert.equal(state.wiring.bootstrap.lockCapitalAmount, "10000000");
+    assert.equal(state.wiring.bootstrap.supplyAmount, "250000000000");
+    assert.equal(state.wiring.currencies.usdc.mintedAmount, "100000000000000");
+    assert.equal(state.wiring.lifecycleCap.recipient, state.wiring.valuationCap.recipient);
+});
+
+test("the package plan is complete and topological", () => {
+    assert.doesNotThrow(() => assertPackagePlan());
+    assert.throws(
+        () =>
+            assertPackagePlan([
+                "sessions",
+                "deepbook_core_account",
+                "predict",
+                "propbook",
+                "account",
+                "usdc",
+                "fixed_math",
+            ]),
+        /planned before local dependency/,
+    );
+});
+
+test("gas funding derives the complete fresh transaction plan", () => {
+    assert.equal(plannedTransactionCount(), 28);
+    assert.equal(maximumTransactionCountPerRun(), 40);
+    assert.equal(irreversibleDeploymentSteps().length, 35);
+});
+
+test("target, toolchain, source, and worktree bindings fail closed", () => {
+    assert.doesNotThrow(() =>
+        assertDeploymentTarget(
+            "testnet",
+            "4c78adac",
+            "0x364c09b14bc64320dd8ced0848e7e4efe75510bd7ee05a88253a5330b6f22bef",
+        ),
+    );
+    assert.throws(
+        () =>
+            assertDeploymentTarget(
+                "mainnet",
+                "4c78adac",
+                "0x364c09b14bc64320dd8ced0848e7e4efe75510bd7ee05a88253a5330b6f22bef",
+            ),
+        /deployment target/,
+    );
+    assert.throws(() => assertDeploymentTarget("testnet", "bad", id("a")), /deployment target/);
+    assert.doesNotThrow(() => assertSuiCliVersion("sui 1.77.1-4e476c5c8184"));
+    assert.throws(() => assertSuiCliVersion("sui 1.78.0"), /Sui CLI must be/);
+    assert.doesNotThrow(() => assertNoKeystoreOverride(undefined));
+    assert.throws(() => assertNoKeystoreOverride("/tmp/alternate.keystore"), /unsupported/);
+    assert.doesNotThrow(() => assertSourceBinding("a".repeat(40), "a".repeat(40)));
+    assert.throws(
+        () => assertSourceBinding("a".repeat(40), "b".repeat(40)),
+        /source commit changed/,
+    );
+    assert.deepEqual(
+        unexpectedDeploymentPaths(
+            [STATE_RELATIVE, "packages/account/Published.toml", "packages/predict/sources/x.move"],
+            ["account"],
+        ),
+        ["packages/predict/sources/x.move"],
+    );
+    assert.deepEqual(unexpectedDeploymentPaths([MANIFEST_RELATIVE], [], true), []);
+    const state = createDeploymentState();
+    const bindings = {
+        suiVersion: "sui 1.77.1-4e476c5c8184",
+        suiBinaryPath: "/opt/sui",
+        suiBinaryDigest: "binary",
+        rpcUrl: "https://example.testnet.invalid",
+        clientConfigDigest: "config",
+        packageGasBudget: "5000000000",
+        transactionGasBudget: "1000000000",
+    };
+    state.suiVersion = bindings.suiVersion;
+    state.suiBinaryPath = bindings.suiBinaryPath;
+    state.suiBinaryDigest = bindings.suiBinaryDigest;
+    state.rpcUrl = bindings.rpcUrl;
+    state.clientConfigDigest = bindings.clientConfigDigest;
+    state.packageGasBudget = bindings.packageGasBudget;
+    state.transactionGasBudget = bindings.transactionGasBudget;
+    assert.doesNotThrow(() => assertExecutionBindings(state, bindings));
+    assert.throws(
+        () => assertExecutionBindings(state, { ...bindings, suiBinaryDigest: "changed" }),
+        /execution bindings changed/,
+    );
+});
+
+test("publish recovery can reconstruct the generated Testnet metadata", () => {
+    const packageId = id("a");
+    const upgradeCapability = id("b");
+    assert.equal(
+        publishedMetadataText(packageId, upgradeCapability),
+        `# Generated by Move
+# This file contains metadata about published versions of this package in different environments
+# This file SHOULD be committed to source control
+
+[published.testnet]
+chain-id = "4c78adac"
+published-at = "${packageId}"
+original-id = "${packageId}"
+version = 1
+toolchain-version = "1.77.1"
+build-config = { flavor = "sui", edition = "2024" }
+upgrade-capability = "${upgradeCapability}"
+`,
+    );
+});
+
+test("known-digest recovery checkpoints once and unknown outcomes fail closed", () => {
+    const state = createDeploymentState();
+    state.inFlight = {
+        kind: "transaction",
+        label: "mint_lifecycle_cap",
+        package: null,
+        startedAt: "2026-08-21T00:00:00.000Z",
+        digest: "known-digest",
+    };
+    assert.doesNotThrow(() => assertRecoverableInFlight(state.inFlight!, true));
+    checkpointRecoveredTransaction(state);
+    checkpointRecoveredTransaction(state);
+    assert.equal(state.transactions.mint_lifecycle_cap, "known-digest");
+    assert.equal(state.inFlight, null);
+    assert.throws(
+        () =>
+            assertRecoverableInFlight(
+                {
+                    kind: "publish",
+                    label: "publish_predict",
+                    package: "predict",
+                    startedAt: "2026-08-21T00:00:00.000Z",
+                    digest: null,
+                },
+                false,
+            ),
+        /no known digest; fail closed/,
+    );
+    assert.throws(
+        () =>
+            assertRecoverableInFlight(
+                {
+                    kind: "transaction",
+                    label: "bootstrap_pool",
+                    package: null,
+                    startedAt: "2026-08-21T00:00:00.000Z",
+                    digest: "missing-digest",
+                },
+                false,
+            ),
+        /not visible; fail closed/,
+    );
+});
+
+test("every irreversible publish and transaction boundary resumes without rebroadcast", async () => {
+    const runtimeMarketIds = CADENCES.filter((cadence) => cadence.marketsToCreate > 0).flatMap(
+        (cadence) =>
+            Array.from({ length: cadence.marketsToCreate }, (_, index) =>
+                id(`${cadence.id + 1}${index + 1}`),
+            ),
+    );
+    const transactionLabels = [
+        ...plannedTransactionSteps().filter(
+            (label) =>
+                !label.startsWith("set_reference_tick_") && !label.startsWith("rebalance_market_"),
+        ),
+        ...runtimeMarketIds.map((marketId) => `set_reference_tick_${marketId}`),
+        ...runtimeMarketIds.map((marketId) => `rebalance_market_${marketId}`),
+    ];
+    const cases = [
+        ...(
+            [
+                "fixed_math",
+                "usdc",
+                "account",
+                "propbook",
+                "predict",
+                "deepbook_core_account",
+                "sessions",
+            ] as const
+        ).map((pkg) => ({ kind: "publish" as const, label: `publish_${pkg}`, pkg })),
+        ...transactionLabels.map((label) => ({
+            kind: "transaction" as const,
+            label,
+            pkg: null,
+        })),
+    ];
+    for (const boundary of cases) {
+        const state = createDeploymentState();
+        const digest = `success-${boundary.label}`;
+        state.inFlight = {
+            kind: boundary.kind,
+            label: boundary.label,
+            package: boundary.pkg,
+            startedAt: "2026-08-21T00:00:00.000Z",
+            digest,
+        };
+        let receiptReads = 0;
+        let publishRecoveries = 0;
+        let persists = 0;
+        await reconcileJournaledInFlight(state, {
+            loadReceipt: async (requestedDigest) => {
+                receiptReads++;
+                assert.equal(requestedDigest, digest);
+                return { digest, effects: { status: { success: true } } };
+            },
+            recoverPublish: async (pkg) => {
+                publishRecoveries++;
+                state.packages[pkg] = id(`${cases.indexOf(boundary) + 1}`);
+                state.publishTx[pkg] = digest;
+            },
+            persist: () => persists++,
+        });
+        assert.equal(receiptReads, 1);
+        assert.equal(publishRecoveries, boundary.kind === "publish" ? 1 : 0);
+        assert.equal(persists, 1);
+        assert.equal(state.inFlight, null);
+        assert.equal(
+            irreversibleStepDigest(state, boundary.kind, boundary.label, boundary.pkg),
+            digest,
+        );
+        assert.equal(
+            await reconcileJournaledInFlight(state, {
+                loadReceipt: async () =>
+                    assert.fail("a completed step must not be reconciled twice"),
+                recoverPublish: async () =>
+                    assert.fail("a completed publish must not be recovered twice"),
+                persist: () => assert.fail("a completed step must not be rewritten"),
+            }),
+            null,
+        );
+    }
+});
+
+test("manifest validation requires all seven fresh packages and mutable-state anchors", () => {
+    const manifest = manifestFixture();
+    assert.doesNotThrow(() => assertIntegrationManifest(manifest));
+    const missingSessions = structuredClone(manifest) as unknown as Record<string, unknown>;
+    delete (missingSessions.packages as Record<string, unknown>).sessions;
+    assert.throws(() => assertIntegrationManifest(missingSessions), /packages keys/);
+    const operatorField = structuredClone(manifest) as unknown as Record<string, unknown>;
+    operatorField.deployer = id("a");
+    assert.throws(() => assertIntegrationManifest(operatorField), /integration manifest keys/);
+    const unauthorized = structuredClone(manifest);
+    unauthorized.externalAuthorizations.deepbookCoreAccount.authorized = false;
+    assert.throws(() => assertIntegrationManifest(unauthorized), /externalAuthorizations/);
+});
+
+test("a complete audited state generates the independent schema-7 fixture", () => {
+    assert.deepEqual(buildIntegrationManifest(completeStateFixture()), manifestFixture());
+});
+
+test("a manifest cannot be generated before the chain audit completes", () => {
+    assert.throws(() => buildIntegrationManifest(createDeploymentState()), /complete, verified/);
+});
+
+test("Block Scholes SID parity fails closed", () => {
+    assert.doesNotThrow(() => assertMatchingSid("BTC spot", 7n, 7n));
+    assert.throws(() => assertMatchingSid("BTC spot", 7n, 8n), /subscription derives/);
+});
+
+test("Block Scholes store-pair inspection decodes both IDs and the base asset", () => {
+    const left = id("a");
+    const right = id("b");
+    const bytes = (value: string) => Array.from(Buffer.from(value.slice(2), "hex"));
+    const baseAsset = Array.from(Buffer.from("BTC"));
+    assert.deepEqual(
+        parseOptionBlockScholesStorePair([
+            1,
+            ...bytes(left),
+            ...bytes(right),
+            baseAsset.length,
+            ...baseAsset,
+        ]),
+        {
+            valueStoreId: left,
+            sviStoreId: right,
+            baseAsset: "BTC",
+        },
+    );
+    assert.equal(parseOptionBlockScholesStorePair([0]), null);
+    assert.throws(() => parseOptionBlockScholesStorePair([1]), /invalid Option/);
+});
+
+test("stale publication recovery temporaries are removed before resume", () => {
+    const directory = mkdtempSync(join(tmpdir(), "predict-publish-recovery-"));
+    const temporary = join(directory, "Published.toml.recovery.tmp");
+    try {
+        writeFileSync(temporary, "partial");
+        removeRecoveryTemporaries([temporary]);
+        assert.equal(existsSync(temporary), false);
+        assert.doesNotThrow(() => removeRecoveryTemporaries([temporary]));
+    } finally {
+        rmSync(directory, { recursive: true, force: true });
+    }
+});
+
+test("only the Predict missing-underlying abort is treated as an absent registration", () => {
+    const missing = new Error(
+        'MoveAbort(MoveLocation { module: ModuleId { name: Identifier("market_manager") }, function_name: Some("underlying_config") }, 0) in command 0',
+    );
+    assert.equal(isUnderlyingNotRegisteredError(missing), true);
+    assert.equal(
+        isUnderlyingNotRegisteredError(
+            new Error(
+                'predict_underlying_registered simulation failed: {"success":false,"error":{"$kind":"MoveAbort","message":"MoveAbort in 1st command, abort code: 0, in \'0x1::market_manager::underlying_config\'","MoveAbort":{"abortCode":"0","location":{"module":"market_manager","functionName":"underlying_config"}}}}',
+            ),
+        ),
+        true,
+    );
+    assert.equal(
+        isUnderlyingNotRegisteredError(
+            new Error(
+                'MoveAbort(MoveLocation { module: ModuleId { name: Identifier("market_manager") }, function_name: Some("underlying_config") }, 1) in command 0',
+            ),
+        ),
+        false,
+    );
+    assert.equal(isUnderlyingNotRegisteredError(new Error("network unavailable")), false);
+});
+
+test("published package metadata decoding preserves exact bytecode, lineage, and origins", () => {
+    const packageId = id("9");
+    const dependency = id("1");
+    const metadata = parsePackageMetadata({
+        content: {
+            Package: {
+                version: 1,
+                module_map: { beta: [3, 4], alpha: [1, 2] },
+                linkage_table: {
+                    [dependency]: { upgraded_id: dependency, upgraded_version: 1 },
+                },
+                type_origin_table: [
+                    { module_name: "alpha", datatype_name: "Thing", package: packageId },
+                ],
+            },
+        },
+    });
+    assert.deepEqual(metadata, {
+        packageVersion: "1",
+        modules: { alpha: "AQI=", beta: "AwQ=" },
+        linkage: [{ originalId: dependency, upgradedId: dependency, upgradedVersion: "1" }],
+        typeOrigins: [{ module: "alpha", datatype: "Thing", packageId }],
+    });
+    const compiled = {
+        modules: ["AQI=", "AwQ="],
+        dependencies: [dependency],
+        typeOrigins: [{ module: "alpha", datatype: "Thing" }],
+    };
+    assert.doesNotThrow(() =>
+        assertExactPackageGraph("fixture", packageId, compiled, metadata, () => ({
+            originalId: dependency,
+            upgradedVersion: "1",
+        })),
+    );
+    assert.throws(
+        () =>
+            assertExactPackageGraph(
+                "fixture",
+                packageId,
+                { ...compiled, dependencies: [] },
+                metadata,
+                () => ({ originalId: dependency, upgradedVersion: "1" }),
+            ),
+        /linkage does not match/,
+    );
+    assert.throws(
+        () =>
+            assertExactPackageGraph("fixture", packageId, compiled, metadata, () => ({
+                originalId: id("2"),
+                upgradedVersion: "2",
+            })),
+        /original\/version/,
+    );
+    const movedOrigin = structuredClone(metadata);
+    movedOrigin.typeOrigins[0].packageId = id("8");
+    assert.throws(
+        () =>
+            assertExactPackageGraph("fixture", packageId, compiled, movedOrigin, () => ({
+                originalId: dependency,
+                upgradedVersion: "1",
+            })),
+        /type origins do not match/,
+    );
+    assert.equal(
+        sameObjectReference(
+            {
+                objectId: id("1"),
+                type: "x",
+                owner: "shared",
+                version: "1",
+                digest: "a",
+                previousTransaction: null,
+            },
+            {
+                objectId: id("1"),
+                type: "y",
+                owner: "shared",
+                version: "1",
+                digest: "a",
+                previousTransaction: "tx",
+            },
+        ),
+        true,
+    );
+});

--- a/packages/predict/deployment/deploy.ts
+++ b/packages/predict/deployment/deploy.ts
@@ -1,0 +1,5348 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Publish and fully configure an independent Predict deployment on Sui Testnet.
+ *
+ * A run publishes fixed_math, USDC, Account, Propbook, Predict, the DeepBook core
+ * Account wrapper, and Sessions; finalizes both currency registrations; mints the
+ * Testnet collateral; authorizes the apps; wires BTC oracle state; stores the
+ * cadence policy; bootstraps and funds the live windows; and atomically hands both
+ * operational capabilities to the Predict writer. Resumable operator-only progress
+ * is written to deployment.testnet.state.json. The public integration manifest is
+ * derived only after the full Testnet audit and external DeepBook authorization.
+ *
+ * The default invocation is non-broadcasting:
+ *   SUI_BINARY=/path/to/sui node --import tsx packages/predict/deployment/deploy.ts
+ *
+ * Broadcast only from a committed deployment branch:
+ *   SUI_BINARY=/path/to/sui node --import tsx packages/predict/deployment/deploy.ts --execute
+ *
+ * Package publication keeps Sui dependency verification enabled. Preflight
+ * compiles with warnings denied and proves that every resolved dependency ID is
+ * the expected Testnet package.
+ */
+import { execFileSync } from "node:child_process";
+import {
+    chmodSync,
+    closeSync,
+    copyFileSync,
+    cpSync,
+    existsSync,
+    mkdtempSync,
+    openSync,
+    readdirSync,
+    readFileSync,
+    realpathSync,
+    renameSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createHash, randomUUID } from "node:crypto";
+import { bcs } from "@mysten/sui/bcs";
+import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
+import { SuiGrpcClient } from "@mysten/sui/grpc";
+import {
+    coinWithBalance,
+    Transaction,
+    TransactionDataBuilder,
+    type TransactionArgument,
+    type TransactionResult,
+} from "@mysten/sui/transactions";
+import { fromBase58, fromBase64, toHex } from "@mysten/sui/utils";
+import { forwardSid, spotSid, sviSid } from "../devtools/ts/blockScholesSid.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, "..", "..", "..");
+export const STATE_RELATIVE = "packages/predict/deployment/deployment.testnet.state.json";
+export const MANIFEST_RELATIVE = "packages/predict/deployment/deployment.testnet.json";
+const STATE = resolve(REPO_ROOT, STATE_RELATIVE);
+const STATE_TEMP = `${STATE}.tmp`;
+const MANIFEST = resolve(REPO_ROOT, MANIFEST_RELATIVE);
+const MANIFEST_TEMP = `${MANIFEST}.tmp`;
+const SUI = process.env.SUI_BINARY ?? "sui";
+const PACKAGE_GAS_BUDGET = process.env.PACKAGE_GAS_BUDGET ?? "5000000000";
+const TRANSACTION_GAS_BUDGET = BigInt(process.env.TRANSACTION_GAS_BUDGET ?? "1000000000");
+const NETWORK = "testnet";
+const CHAIN_ID = "4c78adac";
+const DEPLOYMENT = "deepbook-predict-testnet";
+const DEPLOYER = "0x364c09b14bc64320dd8ced0848e7e4efe75510bd7ee05a88253a5330b6f22bef";
+const PREDICT_WRITER = "0xff241a369609060d3f34828b97a47a2d330644615ff57dfdd49f4f0dd299207f";
+const PROPBOOK_WRITER = "0x921e2bd3432c784dce15b4073ba666d5067e6f8a41704eb63555235fec2e2e41";
+const SUI_VERSION = "sui 1.77.1-4e476c5c8184";
+const OBJECT_ID = /^0x[0-9a-f]{64}$/;
+const CLOCK_ID = "0x0000000000000000000000000000000000000000000000000000000000000006";
+const ACCUMULATOR_ROOT_ID = "0x0000000000000000000000000000000000000000000000000000000000000acc";
+const DEEPBOOK_REGISTRY = "0x7c256edbda983a2cd6f946655f4bf3f00a41043993781f8674a7046e8c0e11d1";
+const DEEPBOOK_ADMIN_CAP = "0x29a62a5385c549dd8e9565312265d2bda0b8700c1560b3e34941671325daae77";
+const DEEPBOOK_ADMIN_OWNER = "0xb3d277c50f7b846a5f609a8d13428ae482b5826bb98437997373f3a0d60d280e";
+const DEEPBOOK_ORIGINAL = "0xfb28c4cbc6865bd1c897d26aecbe1f8792d1509a20ffec692c800660cbec6982";
+const MARKET_ROLLOVER_RESERVE_PER_CADENCE = 2;
+
+const PACKAGES = [
+    "fixed_math",
+    "usdc",
+    "account",
+    "propbook",
+    "predict",
+    "deepbook_core_account",
+    "sessions",
+] as const;
+type PackageName = (typeof PACKAGES)[number];
+
+export interface DeploymentMode {
+    execute: boolean;
+    sessions: false;
+    smoke: false;
+}
+
+const LINKED = {
+    deepbook: "0xd874d2417a55bfa6479bffa06ad950fea144ef93a94cc6c49f32b03e386bbb24",
+    deep: "0x36dbef866a1d62bf7328989a10fb2f07d769f4ee587c0de4a0a256e57e0a58a8",
+    pyth_lazer: "0xf5bd2141967507050a91b58de3d95e77c432cd90d1799ee46effc27430a68c21",
+    wormhole: "0xd5afd4e456e5451f1ca1e7b3d734ce7a0a3b397811a6cb72a4bd1dfc387839f2",
+    bs_oracle: "0x9d2cf38611d971a0e918b93fc0113d279f5c923f43e62c407a9ad0f9d82f6698",
+    bs_sid: "0x6a54299d593fca24edf6b17bf8c3aff0b7ba8bc8f4276e9c1065689c50223bba",
+} as const;
+
+const LINKED_OBJECTS = {
+    clock: CLOCK_ID,
+    accumulatorRoot: ACCUMULATOR_ROOT_ID,
+    pythLazerState: "0xe2b9096a5ea341a9f1eef126b2203727e29e73fdb0641ade2e1e32942f97e4d8",
+    wormholeState: "0x3c89c52e413edb9b0d9a145e02258c96916c79b1e57a12861bb61791ee5c5f81",
+    blockScholesSignerRegistry:
+        "0x94d0198a6fa973bb457603ed39b39b76c98468114808ad5b518745b7b957c414",
+    deepbookRegistry: DEEPBOOK_REGISTRY,
+} as const;
+
+const EXPECTED_SHARED: Record<PackageName, readonly string[]> = {
+    fixed_math: [],
+    usdc: [],
+    account: ["account_registry::AccountRegistry"],
+    propbook: ["registry::OracleRegistry"],
+    predict: ["plp::PoolVault", "protocol_config::ProtocolConfig", "registry::Registry"],
+    deepbook_core_account: [],
+    sessions: ["session_config::SessionsConfig"],
+};
+
+const USDC_SCALING = 1_000_000n;
+const USDC_MINT_AMOUNT = 100_000_000n * USDC_SCALING;
+const LOCK_CAPITAL_AMOUNT = 10n * USDC_SCALING;
+const BOOTSTRAP_SUPPLY_AMOUNT = 250_000n * USDC_SCALING;
+const ASSET = {
+    name: "BTC_USD",
+    propbookUnderlyingId: 1,
+    pythLazerFeedId: 1,
+    blockScholesSourceId: 1,
+    blockScholesBaseAsset: "BTC",
+} as const;
+
+interface CadenceSpec {
+    id: number;
+    name: string;
+    periodMs: number;
+    tickSize: bigint;
+    admissionTickSize: bigint;
+    maxExpiryAllocation: bigint;
+    initialExpiryCash: bigint;
+    windowSize: bigint;
+    marketsToCreate: number;
+}
+
+export const CADENCES: readonly CadenceSpec[] = [
+    {
+        id: 0,
+        name: "1m",
+        periodMs: 60_000,
+        tickSize: 10_000_000n,
+        admissionTickSize: 1_000_000_000n,
+        maxExpiryAllocation: 10_000n * USDC_SCALING,
+        initialExpiryCash: 2_000n * USDC_SCALING,
+        windowSize: 2n,
+        marketsToCreate: 2,
+    },
+    {
+        id: 1,
+        name: "5m",
+        periodMs: 5 * 60_000,
+        tickSize: 10_000_000n,
+        admissionTickSize: 1_000_000_000n,
+        maxExpiryAllocation: 10_000n * USDC_SCALING,
+        initialExpiryCash: 2_000n * USDC_SCALING,
+        windowSize: 2n,
+        marketsToCreate: 2,
+    },
+    {
+        id: 2,
+        name: "1h",
+        periodMs: 60 * 60_000,
+        tickSize: 0n,
+        admissionTickSize: 0n,
+        maxExpiryAllocation: 0n,
+        initialExpiryCash: 0n,
+        windowSize: 0n,
+        marketsToCreate: 0,
+    },
+    {
+        id: 3,
+        name: "1d",
+        periodMs: 24 * 60 * 60_000,
+        tickSize: 0n,
+        admissionTickSize: 0n,
+        maxExpiryAllocation: 0n,
+        initialExpiryCash: 0n,
+        windowSize: 0n,
+        marketsToCreate: 0,
+    },
+    {
+        id: 4,
+        name: "1w",
+        periodMs: 7 * 24 * 60 * 60_000,
+        tickSize: 0n,
+        admissionTickSize: 0n,
+        maxExpiryAllocation: 0n,
+        initialExpiryCash: 0n,
+        windowSize: 0n,
+        marketsToCreate: 0,
+    },
+    {
+        id: 5,
+        name: "1mo",
+        periodMs: 30 * 24 * 60 * 60_000,
+        tickSize: 0n,
+        admissionTickSize: 0n,
+        maxExpiryAllocation: 0n,
+        initialExpiryCash: 0n,
+        windowSize: 0n,
+        marketsToCreate: 0,
+    },
+] as const;
+
+export const EXPECTED_PROTOCOL_CONFIG: ProtocolConfigRecord = {
+    usePythSpotForForward: true,
+    pythSpotFreshnessMs: "2000",
+    blockScholesPriceFreshnessMs: "2000",
+    blockScholesSviFreshnessMs: "60000",
+    ewmaAlpha: "10000000",
+    ewmaZScoreThreshold: "3000000000",
+    ewmaPenaltyRate: "1000000",
+    ewmaEnabled: false,
+    protocolReserveProfitShare: "100000000",
+    referralFeeRate: "100000000",
+    plpSupplyFeeRate: "0",
+    plpWithdrawFeeRate: "2000000",
+    lpRequestLimitFlushAttempts: "1",
+    maxLpPoolValue: "500000000000",
+    maxValuationWindowMs: "300000",
+    backingBufferLambda: "310000000",
+    inventoryImpactMaxRate: "0",
+    baseFee: "100000000",
+    minFee: "22000000",
+    minEntryProbability: "10000000",
+    maxEntryProbability: "990000000",
+    expiryFeeWindowMs: "86400000",
+    expiryFeeMaxMultiplier: "1000000000",
+    versionWatermark: "1",
+    tradingPaused: false,
+    frozen: false,
+    valuationInProgress: false,
+};
+
+interface ObjectChange {
+    type?: string;
+    packageId?: string;
+    objectId?: string;
+    objectType?: string;
+    owner?: unknown;
+}
+
+interface EventRecord {
+    type?: string;
+    parsedJson?: unknown;
+}
+
+export interface Receipt {
+    digest?: string;
+    effects?: unknown;
+    objectChanges?: ObjectChange[] | null;
+    events?: EventRecord[] | null;
+}
+
+export interface InFlight {
+    kind: "publish" | "transaction";
+    label: string;
+    package: PackageName | null;
+    startedAt: string;
+    digest: string | null;
+}
+
+interface ObjectEvidence {
+    objectId: string;
+    type: string;
+    owner: string;
+    version: string;
+    digest: string;
+    previousTransaction: string | null;
+}
+
+export interface PublishedPackageMetadata {
+    packageVersion: string;
+    modules: Record<string, string>;
+    linkage: Array<{
+        originalId: string;
+        upgradedId: string;
+        upgradedVersion: string;
+    }>;
+    typeOrigins: Array<{
+        module: string;
+        datatype: string;
+        packageId: string;
+    }>;
+}
+
+export interface CompiledPackageMetadata {
+    modules: string[];
+    dependencies: string[];
+    typeOrigins: Array<{
+        module: string;
+        datatype: string;
+    }>;
+}
+
+interface CadenceRecord {
+    id: number;
+    name: string;
+    tickSize: string;
+    admissionTickSize: string;
+    maxExpiryAllocation: string;
+    initialExpiryCash: string;
+    windowSize: string;
+    setTx: string | null;
+}
+
+interface MarketRecord {
+    id: string;
+    cadenceId: number;
+    cadence: string;
+    expiryMs: string;
+    tickSize: string;
+    admissionTickSize: string;
+    maxExpiryAllocation: string;
+    initialExpiryCash: string;
+    createTx: string | null;
+    referenceTick: string | null;
+    setReferenceTickTx: string | null;
+    rebalanceTx: string | null;
+    cashBalance: string | null;
+}
+
+interface WiringState {
+    version: number;
+    network: string;
+    operator: string;
+    updatedAt: string | null;
+    account: {
+        predictAppAuthorized: boolean;
+        authorizeTx: string | null;
+        deepbookCoreAppAuthorized: boolean;
+        deepbookCoreAuthorizeTx: string | null;
+        sessionsAppAuthorized: boolean;
+        sessionsAuthorizeTx: string | null;
+        accountWrapperId: string | null;
+        createAccountTx: string | null;
+    };
+    deepbook: {
+        coreAppAuthorized: boolean;
+        verifiedAt: string | null;
+    };
+    currencies: {
+        usdc: {
+            pendingId: string | null;
+            id: string | null;
+            finalizeTx: string | null;
+            mintedAmount: string;
+            mintTx: string | null;
+        };
+        plp: {
+            pendingId: string | null;
+            id: string | null;
+            finalizeTx: string | null;
+        };
+    };
+    lifecycleCap: {
+        id: string | null;
+        recipient: string;
+        owner: "deployer" | "recipient" | null;
+        mintTx: string | null;
+        transferTx: string | null;
+    };
+    valuationCap: {
+        id: string | null;
+        recipient: string;
+        owner: "deployer" | "recipient" | null;
+        mintTx: string | null;
+        transferTx: string | null;
+    };
+    asset: {
+        name: string;
+        propbookUnderlyingId: number;
+        pythLazerFeedId: number;
+        blockScholesSourceId: number;
+        pythFeedId: string | null;
+        blockScholesValueStoreId: string | null;
+        blockScholesSviStoreId: string | null;
+        pythFeedCreateTx: string | null;
+        pythBindTx: string | null;
+        blockScholesStoresCreateTx: string | null;
+        predictUnderlyingRegistered: boolean;
+        predictUnderlyingRegisteredTx: string | null;
+    };
+    cadences: CadenceRecord[];
+    bootstrap: {
+        lockCapitalAmount: string;
+        supplyAmount: string;
+        accountId: string | null;
+        requestIndex: string | null;
+        sharesMinted: string | null;
+        accountPlpBalance: string | null;
+        lockCapitalTx: string | null;
+        supplyRequestTx: string | null;
+        flushTx: string | null;
+    };
+    markets: MarketRecord[];
+    marketWindowChecks: Array<{
+        cadenceId: number;
+        cadence: string;
+        target: number;
+        recorded: number;
+        windowFull: boolean;
+        checkedAtChainMs: string;
+        checkedAt: string;
+    }>;
+}
+
+interface ProtocolConfigRecord {
+    usePythSpotForForward: boolean;
+    pythSpotFreshnessMs: string;
+    blockScholesPriceFreshnessMs: string;
+    blockScholesSviFreshnessMs: string;
+    ewmaAlpha: string;
+    ewmaZScoreThreshold: string;
+    ewmaPenaltyRate: string;
+    ewmaEnabled: boolean;
+    protocolReserveProfitShare: string;
+    referralFeeRate: string;
+    plpSupplyFeeRate: string;
+    plpWithdrawFeeRate: string;
+    lpRequestLimitFlushAttempts: string;
+    maxLpPoolValue: string;
+    maxValuationWindowMs: string;
+    backingBufferLambda: string;
+    inventoryImpactMaxRate: string;
+    baseFee: string;
+    minFee: string;
+    minEntryProbability: string;
+    maxEntryProbability: string;
+    expiryFeeWindowMs: string;
+    expiryFeeMaxMultiplier: string;
+    versionWatermark: string;
+    tradingPaused: boolean;
+    frozen: boolean;
+    valuationInProgress: boolean;
+}
+
+interface Verification {
+    verifiedAt: string;
+    chainId: string;
+    indexingStartCheckpoint: string;
+    verifiedAfterCheckpoint: string | null;
+    packages: Record<string, ObjectEvidence>;
+    linkedPackages: Record<string, ObjectEvidence>;
+    linkedObjects: Record<string, ObjectEvidence>;
+    sharedObjects: Record<string, Record<string, ObjectEvidence>>;
+    ownedCaps: Record<string, Record<string, ObjectEvidence>>;
+    oracleObjects: Record<string, ObjectEvidence>;
+    account: {
+        predictAppAuthorized: boolean;
+        deepbookCoreAppAuthorized: boolean;
+        sessionsAppAuthorized: boolean;
+        deepbookCoreAuthorized: boolean;
+        accountWrapper: ObjectEvidence;
+    };
+    currencies: {
+        usdc: ObjectEvidence;
+        plp: ObjectEvidence;
+        mintedAmount: string;
+        deployerBalance: string;
+    };
+    lifecycleCap: ObjectEvidence;
+    valuationCap: ObjectEvidence;
+    oracleReadiness: Array<{
+        expiryMs: string;
+        spotSid: string;
+        forwardSid: string;
+        sviSid: string;
+        spotSourceTimestampMs: string;
+        forwardSourceTimestampMs: string;
+        sviSourceTimestampMs: string;
+    }>;
+    cadences: CadenceRecord[];
+    protocolConfig: ProtocolConfigRecord;
+    pool: {
+        totalSupply: string;
+        idleBalance: string;
+        supplyRequestsPending: string;
+        withdrawRequestsPending: string;
+        activeMarketIds: string[];
+        activeMarketCash: string;
+        deployerAccountPlpBalance: string;
+    };
+    markets: MarketRecord[];
+}
+
+export interface DeploymentResult {
+    schemaVersion: number;
+    status:
+        | "pending"
+        | "publishing"
+        | "wiring"
+        | "verifying"
+        | "handoff"
+        | "awaiting_oracle_data"
+        | "awaiting_external_authorization"
+        | "partial"
+        | "failed"
+        | "ambiguous"
+        | "complete";
+    network: string;
+    chainId: string;
+    buildEnvironment: string;
+    suiVersion: string | null;
+    suiBinaryPath: string | null;
+    suiBinaryDigest: string | null;
+    rpcUrl: string | null;
+    clientConfigDigest: string | null;
+    sourceCommit: string | null;
+    deployer: string;
+    packageGasBudget: string | null;
+    transactionGasBudget: string | null;
+    startedAt: string | null;
+    completedAt: string | null;
+    lastError: string | null;
+    inFlight: InFlight | null;
+    packages: Partial<Record<PackageName, string>>;
+    linked: Record<string, string>;
+    linkedObjects: Record<string, string>;
+    sharedObjects: Partial<Record<PackageName, Record<string, string>>>;
+    ownedCaps: Partial<Record<PackageName, Record<string, string>>>;
+    publishTx: Partial<Record<PackageName, string>>;
+    transactions: Record<string, string>;
+    failedTransactions: Record<string, { digest: string; error: string; recordedAt: string }>;
+    wiring: WiringState;
+    verification: Verification | null;
+}
+
+const FIXED_TRANSACTION_STEPS = [
+    "finalize_usdc_currency_registration",
+    "finalize_plp_currency_registration",
+    "mint_deployer_usdc",
+    "authorize_predict_app",
+    "authorize_deepbook_core_app",
+    "authorize_sessions_app",
+    "mint_lifecycle_cap",
+    "mint_pool_valuation_cap",
+    "create_pyth_feed",
+    "create_block_scholes_stores",
+    "bind_pyth_to_underlying",
+    "register_predict_underlying",
+    "set_cadence_configs",
+    "create_deployer_account",
+    "bootstrap_pool",
+    "transfer_operational_caps_to_keeper",
+] as const;
+
+export function plannedTransactionSteps(): string[] {
+    const marketSteps = CADENCES.flatMap((cadence) =>
+        Array.from({ length: cadence.marketsToCreate }, (_, index) => [
+            `create_market_${cadence.name}_${index}`,
+            `set_reference_tick_${cadence.name}_${index}`,
+            `rebalance_market_${cadence.name}_${index}`,
+        ]).flat(),
+    );
+    return [
+        ...FIXED_TRANSACTION_STEPS.slice(0, -1),
+        ...marketSteps,
+        FIXED_TRANSACTION_STEPS.at(-1)!,
+    ];
+}
+
+export function plannedTransactionCount(): number {
+    return plannedTransactionSteps().length;
+}
+
+export function maximumTransactionCountPerRun(): number {
+    const marketTransactions = CADENCES.reduce(
+        (total, cadence) =>
+            total +
+            (cadence.marketsToCreate === 0
+                ? 0
+                : (cadence.marketsToCreate + MARKET_ROLLOVER_RESERVE_PER_CADENCE) * 3),
+        0,
+    );
+    return FIXED_TRANSACTION_STEPS.length + marketTransactions;
+}
+
+export function irreversibleDeploymentSteps(): string[] {
+    return [...PACKAGES.map((pkg) => `publish_${pkg}`), ...plannedTransactionSteps()];
+}
+
+export interface IntegrationManifest {
+    schemaVersion: 7;
+    deployment: string;
+    network: string;
+    chainId: string;
+    sourceCommit: string;
+    packages: {
+        fixedMath: string;
+        usdc: string;
+        account: string;
+        propbook: string;
+        predict: string;
+        deepbookCoreAccount: string;
+        sessions: string;
+    };
+    coinTypes: {
+        usdc: string;
+        deep: string;
+        plp: string;
+    };
+    objects: {
+        usdcCurrency: string;
+        plpCurrency: string;
+        accountRegistry: string;
+        oracleRegistry: string;
+        protocolConfig: string;
+        poolVault: string;
+        registry: string;
+        sessionsConfig: string;
+        deepbookRegistry: string;
+        accumulatorRoot: string;
+        clock: string;
+    };
+    underlyings: {
+        BTC: {
+            symbol: "BTC";
+            name: string;
+            propbookUnderlyingId: number;
+            pythLazerFeedId: number;
+            blockScholesSourceId: number;
+            pythFeed: string;
+            blockScholesValueStore: string;
+            blockScholesSviStore: string;
+        };
+    };
+    writers: {
+        keeper: {
+            address: string;
+            lifecycleCap: string;
+            poolValuationCap: string;
+        };
+        priceUpdater: {
+            address: string;
+            pythLazerPackage: string;
+            pythLazerState: string;
+            blockScholesOraclePackage: string;
+            blockScholesSignerRegistry: string;
+        };
+    };
+    externalAuthorizations: {
+        deepbookCoreAccount: {
+            authorized: boolean;
+            appType: string;
+            registry: string;
+        };
+    };
+    indexing: {
+        startCheckpoint: string;
+    };
+    initialConfiguration: {
+        verifiedAfterCheckpoint: string;
+        stateAnchors: {
+            protocolConfig: {
+                objectVersion: string;
+                digest: string;
+            };
+            registry: {
+                objectVersion: string;
+                digest: string;
+            };
+            oracleRegistry: {
+                objectVersion: string;
+                digest: string;
+            };
+            sessionsConfig: {
+                objectVersion: string;
+                digest: string;
+            };
+            deepbookRegistry: {
+                objectVersion: string;
+                digest: string;
+            };
+        };
+        units: {
+            fixedPointScale: string;
+            quoteCoinDecimals: number;
+            plpCoinDecimals: number;
+            deepCoinDecimals: number;
+            positionQuantityDecimals: number;
+            positionLotSize: string;
+            timestampUnit: "milliseconds";
+        };
+        liveProtocol: {
+            pricing: {
+                usePythSpotForForward: boolean;
+                pythSpotFreshnessMs: string;
+                blockScholesPriceFreshnessMs: string;
+                blockScholesSviFreshnessMs: string;
+            };
+            ewmaPenalty: {
+                alpha: string;
+                zScoreThreshold: string;
+                penaltyRate: string;
+                enabled: boolean;
+            };
+            protocolReserveProfitShare: string;
+            referralFeeRate: string;
+            plpSupplyFeeRate: string;
+            plpWithdrawFeeRate: string;
+            lpRequestLimitFlushAttempts: string;
+            maxLpPoolValue: string;
+            maxValuationWindowMs: string;
+        };
+        futureMarketTemplate: {
+            backingBufferLambda: string;
+            inventoryImpactMaxRate: string;
+            baseFee: string;
+            minFee: string;
+            minEntryProbability: string;
+            maxEntryProbability: string;
+            expiryFeeWindowMs: string;
+            expiryFeeMaxMultiplier: string;
+        };
+        cadences: {
+            BTC: Array<{
+                id: number;
+                name: string;
+                periodMs: string;
+                enabled: boolean;
+                tickSize: string;
+                admissionTickSize: string;
+                maxExpiryAllocation: string;
+                initialExpiryCash: string;
+                windowSize: string;
+            }>;
+        };
+    };
+}
+
+interface ClientSnapshot {
+    directory: string;
+    configPath: string;
+    rpcUrl: string;
+    keystorePath: string;
+    configDigest: string;
+}
+
+interface Runtime {
+    result: DeploymentResult;
+    snapshot: ClientSnapshot;
+    client: SuiGrpcClient;
+    signer: Ed25519Keypair;
+    sourceCommit: string;
+    packageMetadataCache: Map<string, PublishedPackageMetadata>;
+    marketCreationsThisRun: Record<number, number>;
+}
+
+interface LockHandle {
+    path: string;
+    token: string;
+}
+
+class DryRunFailure extends Error {
+    constructor(
+        label: string,
+        readonly detail: string,
+    ) {
+        super(`${label} dry run failed: ${detail}`);
+    }
+}
+
+class AwaitingOracleData extends Error {}
+
+class AwaitingExternalAuthorization extends Error {}
+
+function asRecord(value: unknown): Record<string, unknown> {
+    return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
+}
+
+function requiredString(value: unknown, label: string): string {
+    if (typeof value !== "string" || value.length === 0) {
+        throw new Error(`${label} is missing`);
+    }
+    return value;
+}
+
+function requiredObjectId(value: unknown, label: string): string {
+    const raw = requiredString(value, label);
+    const id = normalizeId(raw);
+    if (!OBJECT_ID.test(raw) || raw !== id) {
+        throw new Error(`${label} is not a normalized Sui object ID`);
+    }
+    return id;
+}
+
+function exactKeys(
+    value: Record<string, unknown>,
+    expected: readonly string[],
+    label: string,
+): void {
+    const actual = Object.keys(value).sort();
+    const wanted = [...expected].sort();
+    if (JSON.stringify(actual) !== JSON.stringify(wanted)) {
+        throw new Error(`${label} keys are ${actual.join(", ")}, expected ${wanted.join(", ")}`);
+    }
+}
+
+function decimalString(value: unknown, label: string): string {
+    const raw = requiredString(value, label);
+    if (!/^(0|[1-9][0-9]*)$/.test(raw)) throw new Error(`${label} is not an unsigned integer`);
+    return raw;
+}
+
+export function buildIntegrationManifest(result: DeploymentResult): IntegrationManifest {
+    if (
+        result.status !== "complete" ||
+        result.inFlight !== null ||
+        !result.completedAt ||
+        !result.sourceCommit ||
+        !result.verification
+    ) {
+        throw new Error("integration manifest requires a complete, verified deployment state");
+    }
+    const verification = result.verification;
+    if (verification.chainId !== CHAIN_ID) {
+        throw new Error(`verified chain ${verification.chainId} is not ${CHAIN_ID}`);
+    }
+    const verifiedPackage = (name: PackageName): string =>
+        requiredObjectId(verification.packages[name]?.objectId, `verified ${name} package`);
+    const verifiedSharedEvidence = (pkg: PackageName, type: string): ObjectEvidence => {
+        const evidence = verification.sharedObjects[pkg]?.[type];
+        if (!evidence) throw new Error(`verified ${pkg} ${type} is missing`);
+        requiredObjectId(evidence.objectId, `verified ${pkg} ${type}`);
+        decimalString(evidence.version, `verified ${pkg} ${type} version`);
+        requiredString(evidence.digest, `verified ${pkg} ${type} digest`);
+        return evidence;
+    };
+    const verifiedShared = (pkg: PackageName, type: string): string =>
+        verifiedSharedEvidence(pkg, type).objectId;
+    const verifiedLinkedPackage = (name: keyof typeof LINKED): string =>
+        requiredObjectId(verification.linkedPackages[name]?.objectId, `verified ${name} package`);
+    const verifiedLinkedObject = (name: keyof typeof LINKED_OBJECTS): string =>
+        requiredObjectId(verification.linkedObjects[name]?.objectId, `verified ${name} object`);
+    const fixedMath = verifiedPackage("fixed_math");
+    const usdc = verifiedPackage("usdc");
+    const account = verifiedPackage("account");
+    const propbook = verifiedPackage("propbook");
+    const predict = verifiedPackage("predict");
+    const deepbookCoreAccount = verifiedPackage("deepbook_core_account");
+    const sessions = verifiedPackage("sessions");
+    const protocolConfigEvidence = verifiedSharedEvidence(
+        "predict",
+        "protocol_config::ProtocolConfig",
+    );
+    const registryEvidence = verifiedSharedEvidence("predict", "registry::Registry");
+    const oracleRegistryEvidence = verifiedSharedEvidence("propbook", "registry::OracleRegistry");
+    const sessionsConfigEvidence = verifiedSharedEvidence(
+        "sessions",
+        "session_config::SessionsConfig",
+    );
+    const deepbookRegistryEvidence = verification.linkedObjects.deepbookRegistry;
+    if (!deepbookRegistryEvidence) throw new Error("verified DeepBook registry is missing");
+    const protocol = verification.protocolConfig;
+    if (JSON.stringify(protocol) !== JSON.stringify(EXPECTED_PROTOCOL_CONFIG)) {
+        throw new Error("verified ProtocolConfig does not match the deployment policy");
+    }
+    if (!verification.account.deepbookCoreAuthorized) {
+        throw new Error("integration manifest requires DeepBook core wrapper authorization");
+    }
+    const cadences = verification.cadences.map((record) => {
+        const spec = CADENCES.find((candidate) => candidate.id === record.id);
+        if (!spec || !cadenceMatches(record, spec)) {
+            throw new Error(`verified cadence ${record.id} does not match deployment policy`);
+        }
+        return {
+            id: record.id,
+            name: record.name,
+            periodMs: spec.periodMs.toString(),
+            enabled: BigInt(record.windowSize) > 0n,
+            tickSize: record.tickSize,
+            admissionTickSize: record.admissionTickSize,
+            maxExpiryAllocation: record.maxExpiryAllocation,
+            initialExpiryCash: record.initialExpiryCash,
+            windowSize: record.windowSize,
+        };
+    });
+    const manifest: IntegrationManifest = {
+        schemaVersion: 7,
+        deployment: DEPLOYMENT,
+        network: NETWORK,
+        chainId: CHAIN_ID,
+        sourceCommit: result.sourceCommit,
+        packages: {
+            fixedMath,
+            usdc,
+            account,
+            propbook,
+            predict,
+            deepbookCoreAccount,
+            sessions,
+        },
+        coinTypes: {
+            usdc: `${usdc}::usdc::USDC`,
+            deep: `${verifiedLinkedPackage("deep")}::deep::DEEP`,
+            plp: `${predict}::plp::PLP`,
+        },
+        objects: {
+            usdcCurrency: requiredObjectId(
+                verification.currencies.usdc.objectId,
+                "verified USDC currency",
+            ),
+            plpCurrency: requiredObjectId(
+                verification.currencies.plp.objectId,
+                "verified PLP currency",
+            ),
+            accountRegistry: verifiedShared("account", "account_registry::AccountRegistry"),
+            oracleRegistry: verifiedShared("propbook", "registry::OracleRegistry"),
+            protocolConfig: verifiedShared("predict", "protocol_config::ProtocolConfig"),
+            poolVault: verifiedShared("predict", "plp::PoolVault"),
+            registry: verifiedShared("predict", "registry::Registry"),
+            sessionsConfig: verifiedShared("sessions", "session_config::SessionsConfig"),
+            deepbookRegistry: verifiedLinkedObject("deepbookRegistry"),
+            accumulatorRoot: verifiedLinkedObject("accumulatorRoot"),
+            clock: verifiedLinkedObject("clock"),
+        },
+        underlyings: {
+            BTC: {
+                symbol: "BTC",
+                name: ASSET.name,
+                propbookUnderlyingId: ASSET.propbookUnderlyingId,
+                pythLazerFeedId: ASSET.pythLazerFeedId,
+                blockScholesSourceId: ASSET.blockScholesSourceId,
+                pythFeed: requiredObjectId(
+                    verification.oracleObjects.pythFeed?.objectId,
+                    "verified Pyth feed",
+                ),
+                blockScholesValueStore: requiredObjectId(
+                    verification.oracleObjects.blockScholesValueStore?.objectId,
+                    "verified Block Scholes value store",
+                ),
+                blockScholesSviStore: requiredObjectId(
+                    verification.oracleObjects.blockScholesSviStore?.objectId,
+                    "verified Block Scholes SVI store",
+                ),
+            },
+        },
+        writers: {
+            keeper: {
+                address: PREDICT_WRITER,
+                lifecycleCap: requiredObjectId(
+                    verification.lifecycleCap.objectId,
+                    "verified lifecycle cap",
+                ),
+                poolValuationCap: requiredObjectId(
+                    verification.valuationCap.objectId,
+                    "verified pool valuation cap",
+                ),
+            },
+            priceUpdater: {
+                address: PROPBOOK_WRITER,
+                pythLazerPackage: verifiedLinkedPackage("pyth_lazer"),
+                pythLazerState: verifiedLinkedObject("pythLazerState"),
+                blockScholesOraclePackage: verifiedLinkedPackage("bs_oracle"),
+                blockScholesSignerRegistry: verifiedLinkedObject("blockScholesSignerRegistry"),
+            },
+        },
+        externalAuthorizations: {
+            deepbookCoreAccount: {
+                authorized: verification.account.deepbookCoreAuthorized,
+                appType: `${deepbookCoreAccount}::account_data::DeepbookCoreAccountApp`,
+                registry: verifiedLinkedObject("deepbookRegistry"),
+            },
+        },
+        indexing: {
+            startCheckpoint: verification.indexingStartCheckpoint,
+        },
+        initialConfiguration: {
+            verifiedAfterCheckpoint: requiredString(
+                verification.verifiedAfterCheckpoint,
+                "verification checkpoint",
+            ),
+            stateAnchors: {
+                protocolConfig: {
+                    objectVersion: protocolConfigEvidence.version,
+                    digest: protocolConfigEvidence.digest,
+                },
+                registry: {
+                    objectVersion: registryEvidence.version,
+                    digest: registryEvidence.digest,
+                },
+                oracleRegistry: {
+                    objectVersion: oracleRegistryEvidence.version,
+                    digest: oracleRegistryEvidence.digest,
+                },
+                sessionsConfig: {
+                    objectVersion: sessionsConfigEvidence.version,
+                    digest: sessionsConfigEvidence.digest,
+                },
+                deepbookRegistry: {
+                    objectVersion: deepbookRegistryEvidence.version,
+                    digest: deepbookRegistryEvidence.digest,
+                },
+            },
+            units: {
+                fixedPointScale: "1000000000",
+                quoteCoinDecimals: 6,
+                plpCoinDecimals: 6,
+                deepCoinDecimals: 6,
+                positionQuantityDecimals: 6,
+                positionLotSize: "10000",
+                timestampUnit: "milliseconds",
+            },
+            liveProtocol: {
+                pricing: {
+                    usePythSpotForForward: protocol.usePythSpotForForward,
+                    pythSpotFreshnessMs: protocol.pythSpotFreshnessMs,
+                    blockScholesPriceFreshnessMs: protocol.blockScholesPriceFreshnessMs,
+                    blockScholesSviFreshnessMs: protocol.blockScholesSviFreshnessMs,
+                },
+                ewmaPenalty: {
+                    alpha: protocol.ewmaAlpha,
+                    zScoreThreshold: protocol.ewmaZScoreThreshold,
+                    penaltyRate: protocol.ewmaPenaltyRate,
+                    enabled: protocol.ewmaEnabled,
+                },
+                protocolReserveProfitShare: protocol.protocolReserveProfitShare,
+                referralFeeRate: protocol.referralFeeRate,
+                plpSupplyFeeRate: protocol.plpSupplyFeeRate,
+                plpWithdrawFeeRate: protocol.plpWithdrawFeeRate,
+                lpRequestLimitFlushAttempts: protocol.lpRequestLimitFlushAttempts,
+                maxLpPoolValue: protocol.maxLpPoolValue,
+                maxValuationWindowMs: protocol.maxValuationWindowMs,
+            },
+            futureMarketTemplate: {
+                backingBufferLambda: protocol.backingBufferLambda,
+                inventoryImpactMaxRate: protocol.inventoryImpactMaxRate,
+                baseFee: protocol.baseFee,
+                minFee: protocol.minFee,
+                minEntryProbability: protocol.minEntryProbability,
+                maxEntryProbability: protocol.maxEntryProbability,
+                expiryFeeWindowMs: protocol.expiryFeeWindowMs,
+                expiryFeeMaxMultiplier: protocol.expiryFeeMaxMultiplier,
+            },
+            cadences: { BTC: cadences },
+        },
+    };
+    assertIntegrationManifest(manifest);
+    return manifest;
+}
+
+export function assertIntegrationManifest(value: unknown): asserts value is IntegrationManifest {
+    const manifest = asRecord(value);
+    exactKeys(
+        manifest,
+        [
+            "schemaVersion",
+            "deployment",
+            "network",
+            "chainId",
+            "sourceCommit",
+            "packages",
+            "coinTypes",
+            "objects",
+            "underlyings",
+            "writers",
+            "externalAuthorizations",
+            "indexing",
+            "initialConfiguration",
+        ],
+        "integration manifest",
+    );
+    if (
+        manifest.schemaVersion !== 7 ||
+        manifest.deployment !== DEPLOYMENT ||
+        manifest.network !== NETWORK ||
+        manifest.chainId !== CHAIN_ID ||
+        typeof manifest.sourceCommit !== "string" ||
+        !/^[0-9a-f]{40}$/.test(manifest.sourceCommit)
+    ) {
+        throw new Error(`${MANIFEST_RELATIVE} has invalid deployment identity`);
+    }
+    const packages = asRecord(manifest.packages);
+    exactKeys(
+        packages,
+        ["fixedMath", "usdc", "account", "propbook", "predict", "deepbookCoreAccount", "sessions"],
+        "packages",
+    );
+    for (const [name, id] of Object.entries(packages)) requiredObjectId(id, `packages.${name}`);
+
+    const coinTypes = asRecord(manifest.coinTypes);
+    exactKeys(coinTypes, ["usdc", "deep", "plp"], "coinTypes");
+    if (
+        coinTypes.usdc !== `${packages.usdc}::usdc::USDC` ||
+        coinTypes.deep !== `${LINKED.deep}::deep::DEEP` ||
+        coinTypes.plp !== `${packages.predict}::plp::PLP`
+    ) {
+        throw new Error("coinTypes do not match the verified package identities");
+    }
+
+    const objects = asRecord(manifest.objects);
+    exactKeys(
+        objects,
+        [
+            "usdcCurrency",
+            "plpCurrency",
+            "accountRegistry",
+            "oracleRegistry",
+            "protocolConfig",
+            "poolVault",
+            "registry",
+            "sessionsConfig",
+            "deepbookRegistry",
+            "accumulatorRoot",
+            "clock",
+        ],
+        "objects",
+    );
+    for (const [name, id] of Object.entries(objects)) requiredObjectId(id, `objects.${name}`);
+
+    const underlyings = asRecord(manifest.underlyings);
+    exactKeys(underlyings, ["BTC"], "underlyings");
+    const btc = asRecord(underlyings.BTC);
+    exactKeys(
+        btc,
+        [
+            "symbol",
+            "name",
+            "propbookUnderlyingId",
+            "pythLazerFeedId",
+            "blockScholesSourceId",
+            "pythFeed",
+            "blockScholesValueStore",
+            "blockScholesSviStore",
+        ],
+        "underlyings.BTC",
+    );
+    if (
+        btc.symbol !== "BTC" ||
+        btc.name !== ASSET.name ||
+        btc.propbookUnderlyingId !== ASSET.propbookUnderlyingId ||
+        btc.pythLazerFeedId !== ASSET.pythLazerFeedId ||
+        btc.blockScholesSourceId !== ASSET.blockScholesSourceId
+    ) {
+        throw new Error("underlyings.BTC identity does not match the deployment policy");
+    }
+    for (const name of ["pythFeed", "blockScholesValueStore", "blockScholesSviStore"]) {
+        requiredObjectId(btc[name], `underlyings.BTC.${name}`);
+    }
+
+    const writers = asRecord(manifest.writers);
+    exactKeys(writers, ["keeper", "priceUpdater"], "writers");
+    const keeper = asRecord(writers.keeper);
+    exactKeys(keeper, ["address", "lifecycleCap", "poolValuationCap"], "writers.keeper");
+    if (keeper.address !== PREDICT_WRITER) {
+        throw new Error("writers.keeper address does not match the deployment policy");
+    }
+    requiredObjectId(keeper.lifecycleCap, "writers.keeper.lifecycleCap");
+    requiredObjectId(keeper.poolValuationCap, "writers.keeper.poolValuationCap");
+    const priceUpdater = asRecord(writers.priceUpdater);
+    exactKeys(
+        priceUpdater,
+        [
+            "address",
+            "pythLazerPackage",
+            "pythLazerState",
+            "blockScholesOraclePackage",
+            "blockScholesSignerRegistry",
+        ],
+        "writers.priceUpdater",
+    );
+    if (
+        priceUpdater.address !== PROPBOOK_WRITER ||
+        priceUpdater.pythLazerPackage !== LINKED.pyth_lazer ||
+        priceUpdater.pythLazerState !== LINKED_OBJECTS.pythLazerState ||
+        priceUpdater.blockScholesOraclePackage !== LINKED.bs_oracle ||
+        priceUpdater.blockScholesSignerRegistry !== LINKED_OBJECTS.blockScholesSignerRegistry
+    ) {
+        throw new Error("writers.priceUpdater does not match the verified dependencies");
+    }
+
+    const externalAuthorizations = asRecord(manifest.externalAuthorizations);
+    exactKeys(externalAuthorizations, ["deepbookCoreAccount"], "externalAuthorizations");
+    const deepbookCoreAccount = asRecord(externalAuthorizations.deepbookCoreAccount);
+    exactKeys(
+        deepbookCoreAccount,
+        ["authorized", "appType", "registry"],
+        "externalAuthorizations.deepbookCoreAccount",
+    );
+    if (
+        deepbookCoreAccount.authorized !== true ||
+        deepbookCoreAccount.appType !==
+            `${packages.deepbookCoreAccount}::account_data::DeepbookCoreAccountApp` ||
+        deepbookCoreAccount.registry !== objects.deepbookRegistry
+    ) {
+        throw new Error("externalAuthorizations.deepbookCoreAccount is invalid");
+    }
+
+    const indexing = asRecord(manifest.indexing);
+    exactKeys(indexing, ["startCheckpoint"], "indexing");
+    const startCheckpoint = BigInt(
+        decimalString(indexing.startCheckpoint, "indexing.startCheckpoint"),
+    );
+    const initial = asRecord(manifest.initialConfiguration);
+    exactKeys(
+        initial,
+        [
+            "verifiedAfterCheckpoint",
+            "stateAnchors",
+            "units",
+            "liveProtocol",
+            "futureMarketTemplate",
+            "cadences",
+        ],
+        "initialConfiguration",
+    );
+    const verifiedAfterCheckpoint = BigInt(
+        decimalString(
+            initial.verifiedAfterCheckpoint,
+            "initialConfiguration.verifiedAfterCheckpoint",
+        ),
+    );
+    if (startCheckpoint > verifiedAfterCheckpoint) {
+        throw new Error("indexing.startCheckpoint is after the configuration verification fence");
+    }
+    const stateAnchors = asRecord(initial.stateAnchors);
+    exactKeys(
+        stateAnchors,
+        ["protocolConfig", "registry", "oracleRegistry", "sessionsConfig", "deepbookRegistry"],
+        "initialConfiguration.stateAnchors",
+    );
+    for (const name of [
+        "protocolConfig",
+        "registry",
+        "oracleRegistry",
+        "sessionsConfig",
+        "deepbookRegistry",
+    ]) {
+        const anchor = asRecord(stateAnchors[name]);
+        exactKeys(anchor, ["objectVersion", "digest"], `initialConfiguration.stateAnchors.${name}`);
+        if (
+            BigInt(
+                decimalString(
+                    anchor.objectVersion,
+                    `initialConfiguration.stateAnchors.${name}.objectVersion`,
+                ),
+            ) === 0n
+        ) {
+            throw new Error(`initialConfiguration.stateAnchors.${name}.objectVersion is zero`);
+        }
+        requiredString(anchor.digest, `initialConfiguration.stateAnchors.${name}.digest`);
+    }
+
+    const units = asRecord(initial.units);
+    exactKeys(
+        units,
+        [
+            "fixedPointScale",
+            "quoteCoinDecimals",
+            "plpCoinDecimals",
+            "deepCoinDecimals",
+            "positionQuantityDecimals",
+            "positionLotSize",
+            "timestampUnit",
+        ],
+        "initialConfiguration.units",
+    );
+    if (
+        units.fixedPointScale !== "1000000000" ||
+        units.quoteCoinDecimals !== 6 ||
+        units.plpCoinDecimals !== 6 ||
+        units.deepCoinDecimals !== 6 ||
+        units.positionQuantityDecimals !== 6 ||
+        units.positionLotSize !== "10000" ||
+        units.timestampUnit !== "milliseconds"
+    ) {
+        throw new Error("initialConfiguration.units does not match Predict units");
+    }
+
+    const live = asRecord(initial.liveProtocol);
+    exactKeys(
+        live,
+        [
+            "pricing",
+            "ewmaPenalty",
+            "protocolReserveProfitShare",
+            "referralFeeRate",
+            "plpSupplyFeeRate",
+            "plpWithdrawFeeRate",
+            "lpRequestLimitFlushAttempts",
+            "maxLpPoolValue",
+            "maxValuationWindowMs",
+        ],
+        "initialConfiguration.liveProtocol",
+    );
+    const pricing = asRecord(live.pricing);
+    exactKeys(
+        pricing,
+        [
+            "usePythSpotForForward",
+            "pythSpotFreshnessMs",
+            "blockScholesPriceFreshnessMs",
+            "blockScholesSviFreshnessMs",
+        ],
+        "initialConfiguration.liveProtocol.pricing",
+    );
+    const ewma = asRecord(live.ewmaPenalty);
+    exactKeys(
+        ewma,
+        ["alpha", "zScoreThreshold", "penaltyRate", "enabled"],
+        "initialConfiguration.liveProtocol.ewmaPenalty",
+    );
+    const template = asRecord(initial.futureMarketTemplate);
+    exactKeys(
+        template,
+        [
+            "backingBufferLambda",
+            "inventoryImpactMaxRate",
+            "baseFee",
+            "minFee",
+            "minEntryProbability",
+            "maxEntryProbability",
+            "expiryFeeWindowMs",
+            "expiryFeeMaxMultiplier",
+        ],
+        "initialConfiguration.futureMarketTemplate",
+    );
+    const numericConfig = [
+        [pricing.pythSpotFreshnessMs, "pricing.pythSpotFreshnessMs"],
+        [pricing.blockScholesPriceFreshnessMs, "pricing.blockScholesPriceFreshnessMs"],
+        [pricing.blockScholesSviFreshnessMs, "pricing.blockScholesSviFreshnessMs"],
+        [ewma.alpha, "ewmaPenalty.alpha"],
+        [ewma.zScoreThreshold, "ewmaPenalty.zScoreThreshold"],
+        [ewma.penaltyRate, "ewmaPenalty.penaltyRate"],
+        [live.protocolReserveProfitShare, "liveProtocol.protocolReserveProfitShare"],
+        [live.referralFeeRate, "liveProtocol.referralFeeRate"],
+        [live.plpSupplyFeeRate, "liveProtocol.plpSupplyFeeRate"],
+        [live.plpWithdrawFeeRate, "liveProtocol.plpWithdrawFeeRate"],
+        [live.lpRequestLimitFlushAttempts, "liveProtocol.lpRequestLimitFlushAttempts"],
+        [live.maxLpPoolValue, "liveProtocol.maxLpPoolValue"],
+        [live.maxValuationWindowMs, "liveProtocol.maxValuationWindowMs"],
+        ...Object.entries(template).map(([name, item]) => [item, `futureMarketTemplate.${name}`]),
+    ] as Array<[unknown, string]>;
+    for (const [item, label] of numericConfig) decimalString(item, label);
+    if (typeof pricing.usePythSpotForForward !== "boolean" || typeof ewma.enabled !== "boolean") {
+        throw new Error("initialConfiguration boolean values are invalid");
+    }
+
+    const cadenceGroups = asRecord(initial.cadences);
+    exactKeys(cadenceGroups, ["BTC"], "initialConfiguration.cadences");
+    if (!Array.isArray(cadenceGroups.BTC) || cadenceGroups.BTC.length !== CADENCES.length) {
+        throw new Error("initialConfiguration.cadences.BTC must contain every cadence");
+    }
+    for (const [index, valueAtIndex] of cadenceGroups.BTC.entries()) {
+        const valueRecord = asRecord(valueAtIndex);
+        exactKeys(
+            valueRecord,
+            [
+                "id",
+                "name",
+                "periodMs",
+                "enabled",
+                "tickSize",
+                "admissionTickSize",
+                "maxExpiryAllocation",
+                "initialExpiryCash",
+                "windowSize",
+            ],
+            `initialConfiguration.cadences.BTC[${index}]`,
+        );
+        const spec = CADENCES[index];
+        if (
+            valueRecord.id !== spec.id ||
+            valueRecord.name !== spec.name ||
+            valueRecord.periodMs !== spec.periodMs.toString() ||
+            valueRecord.enabled !== spec.windowSize > 0n ||
+            valueRecord.tickSize !== spec.tickSize.toString() ||
+            valueRecord.admissionTickSize !== spec.admissionTickSize.toString() ||
+            valueRecord.maxExpiryAllocation !== spec.maxExpiryAllocation.toString() ||
+            valueRecord.initialExpiryCash !== spec.initialExpiryCash.toString() ||
+            valueRecord.windowSize !== spec.windowSize.toString()
+        ) {
+            throw new Error(`initialConfiguration.cadences.BTC[${index}] is invalid`);
+        }
+    }
+}
+
+function command(executable: string, args: string[]): string {
+    return execFileSync(executable, args, {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+        maxBuffer: 256 * 1024 * 1024,
+    }).trim();
+}
+
+function sha256(value: string | Buffer): string {
+    return createHash("sha256").update(value).digest("hex");
+}
+
+function suiBinaryIdentity(): { path: string; digest: string } {
+    const path = realpathSync(isAbsolute(SUI) ? SUI : command("which", [SUI]));
+    return { path, digest: sha256(readFileSync(path)) };
+}
+
+function git(args: string[]): string {
+    return command("git", args);
+}
+
+function sui(args: string[]): string {
+    return command(SUI, args);
+}
+
+function suiClient(snapshot: ClientSnapshot, args: string[]): string {
+    return sui([
+        "client",
+        "--client.config",
+        snapshot.configPath,
+        "--client.env",
+        NETWORK,
+        ...args,
+    ]);
+}
+
+function transactionCheckpoint(snapshot: ClientSnapshot, digest: string): string {
+    const response = JSON.parse(suiClient(snapshot, ["tx-block", digest, "--json"])) as Record<
+        string,
+        unknown
+    >;
+    return decimalString(response.checkpoint, `transaction ${digest} checkpoint`);
+}
+
+export function createDeploymentState(): DeploymentResult {
+    return {
+        schemaVersion: 4,
+        status: "pending",
+        network: NETWORK,
+        chainId: CHAIN_ID,
+        buildEnvironment: NETWORK,
+        suiVersion: null,
+        suiBinaryPath: null,
+        suiBinaryDigest: null,
+        rpcUrl: null,
+        clientConfigDigest: null,
+        sourceCommit: null,
+        deployer: DEPLOYER,
+        packageGasBudget: null,
+        transactionGasBudget: null,
+        startedAt: null,
+        completedAt: null,
+        lastError: null,
+        inFlight: null,
+        packages: {},
+        linked: { ...LINKED },
+        linkedObjects: { ...LINKED_OBJECTS },
+        sharedObjects: {},
+        ownedCaps: {},
+        publishTx: {},
+        transactions: {},
+        failedTransactions: {},
+        wiring: {
+            version: 3,
+            network: NETWORK,
+            operator: DEPLOYER,
+            updatedAt: null,
+            account: {
+                predictAppAuthorized: false,
+                authorizeTx: null,
+                deepbookCoreAppAuthorized: false,
+                deepbookCoreAuthorizeTx: null,
+                sessionsAppAuthorized: false,
+                sessionsAuthorizeTx: null,
+                accountWrapperId: null,
+                createAccountTx: null,
+            },
+            deepbook: {
+                coreAppAuthorized: false,
+                verifiedAt: null,
+            },
+            currencies: {
+                usdc: {
+                    pendingId: null,
+                    id: null,
+                    finalizeTx: null,
+                    mintedAmount: USDC_MINT_AMOUNT.toString(),
+                    mintTx: null,
+                },
+                plp: {
+                    pendingId: null,
+                    id: null,
+                    finalizeTx: null,
+                },
+            },
+            lifecycleCap: {
+                id: null,
+                recipient: PREDICT_WRITER,
+                owner: null,
+                mintTx: null,
+                transferTx: null,
+            },
+            valuationCap: {
+                id: null,
+                recipient: PREDICT_WRITER,
+                owner: null,
+                mintTx: null,
+                transferTx: null,
+            },
+            asset: {
+                name: ASSET.name,
+                propbookUnderlyingId: ASSET.propbookUnderlyingId,
+                pythLazerFeedId: ASSET.pythLazerFeedId,
+                blockScholesSourceId: ASSET.blockScholesSourceId,
+                pythFeedId: null,
+                blockScholesValueStoreId: null,
+                blockScholesSviStoreId: null,
+                pythFeedCreateTx: null,
+                pythBindTx: null,
+                blockScholesStoresCreateTx: null,
+                predictUnderlyingRegistered: false,
+                predictUnderlyingRegisteredTx: null,
+            },
+            cadences: CADENCES.map((spec) => ({
+                id: spec.id,
+                name: spec.name,
+                tickSize: spec.tickSize.toString(),
+                admissionTickSize: spec.admissionTickSize.toString(),
+                maxExpiryAllocation: spec.maxExpiryAllocation.toString(),
+                initialExpiryCash: spec.initialExpiryCash.toString(),
+                windowSize: spec.windowSize.toString(),
+                setTx: null,
+            })),
+            bootstrap: {
+                lockCapitalAmount: LOCK_CAPITAL_AMOUNT.toString(),
+                supplyAmount: BOOTSTRAP_SUPPLY_AMOUNT.toString(),
+                accountId: null,
+                requestIndex: null,
+                sharesMinted: null,
+                accountPlpBalance: null,
+                lockCapitalTx: null,
+                supplyRequestTx: null,
+                flushTx: null,
+            },
+            markets: [],
+            marketWindowChecks: [],
+        },
+        verification: null,
+    };
+}
+
+function loadState(): DeploymentResult {
+    if (!existsSync(STATE)) return createDeploymentState();
+    return JSON.parse(readFileSync(STATE, "utf8")) as DeploymentResult;
+}
+
+function writeState(result: DeploymentResult): void {
+    result.wiring.updatedAt = new Date().toISOString();
+    writeFileSync(STATE_TEMP, `${JSON.stringify(result, null, 4)}\n`, { mode: 0o600 });
+    renameSync(STATE_TEMP, STATE);
+}
+
+function writeIntegrationManifest(manifest: IntegrationManifest): void {
+    assertIntegrationManifest(manifest);
+    writeFileSync(MANIFEST_TEMP, `${JSON.stringify(manifest, null, 4)}\n`, { mode: 0o644 });
+    chmodSync(MANIFEST_TEMP, 0o644);
+    renameSync(MANIFEST_TEMP, MANIFEST);
+}
+
+export function publishedMetadataText(packageId: string, upgradeCapability: string): string {
+    const normalizedPackage = normalizeId(packageId);
+    const normalizedUpgradeCapability = normalizeId(upgradeCapability);
+    return `# Generated by Move
+# This file contains metadata about published versions of this package in different environments
+# This file SHOULD be committed to source control
+
+[published.testnet]
+chain-id = "${CHAIN_ID}"
+published-at = "${normalizedPackage}"
+original-id = "${normalizedPackage}"
+version = 1
+toolchain-version = "1.77.1"
+build-config = { flavor = "sui", edition = "2024" }
+upgrade-capability = "${normalizedUpgradeCapability}"
+`;
+}
+
+function normalizeId(id: string): string {
+    const hex = id.toLowerCase().replace(/^0x/, "");
+    return `0x${hex.padStart(64, "0")}`;
+}
+
+function normalizeOptionalId(value: unknown): string | null {
+    return typeof value === "string" ? normalizeId(value) : null;
+}
+
+function shortType(type: string): string {
+    const parts = type.split("::");
+    return parts.length >= 3 ? parts.slice(1).join("::") : type;
+}
+
+function isShared(owner: unknown): boolean {
+    return "Shared" in asRecord(owner);
+}
+
+function addressOwner(owner: unknown): string | null {
+    return normalizeOptionalId(asRecord(owner).AddressOwner);
+}
+
+function consensusAddressOwner(owner: unknown): string | null {
+    return normalizeOptionalId(asRecord(asRecord(owner).ConsensusAddressOwner).owner);
+}
+
+function partyOwnerLabel(owner: string): string {
+    return `party:${normalizeId(owner)}`;
+}
+
+function ownerLabel(owner: unknown): string {
+    if (isShared(owner)) return "shared";
+    const partyOwner = consensusAddressOwner(owner);
+    if (partyOwner) return partyOwnerLabel(partyOwner);
+    const address = addressOwner(owner);
+    if (address) return address;
+    const ownerRecord = asRecord(owner);
+    if (owner === "Immutable" || "Immutable" in ownerRecord) return "immutable";
+    const objectOwner = normalizeOptionalId(ownerRecord.ObjectOwner);
+    return objectOwner ? `object:${objectOwner}` : JSON.stringify(owner);
+}
+
+function expectedCaps(pkg: PackageName, packageId: string): string[] {
+    switch (pkg) {
+        case "fixed_math":
+            return ["package::UpgradeCap"];
+        case "usdc":
+            return [
+                `coin::TreasuryCap<${packageId}::usdc::USDC>`,
+                `coin_registry::MetadataCap<${packageId}::usdc::USDC>`,
+                "package::UpgradeCap",
+            ];
+        case "account":
+            return ["account_registry::AccountAdminCap", "package::UpgradeCap"];
+        case "propbook":
+            return ["package::UpgradeCap", "registry::RegistryAdminCap"];
+        case "predict":
+            return [
+                "admin::AdminCap",
+                `coin_registry::MetadataCap<${packageId}::plp::PLP>`,
+                "package::UpgradeCap",
+            ];
+        case "deepbook_core_account":
+            return ["package::UpgradeCap"];
+        case "sessions":
+            return ["package::UpgradeCap", "session_config::SessionsAdminCap"];
+    }
+}
+
+function publishedPath(pkg: PackageName): string {
+    return resolve(REPO_ROOT, "packages", pkg, "Published.toml");
+}
+
+function reconstructPublishedMetadata(result: DeploymentResult, pkg: PackageName): void {
+    const packageId = requiredObjectId(result.packages[pkg], `${pkg} package ID`);
+    const upgradeCapability = requiredObjectId(
+        result.ownedCaps[pkg]?.["package::UpgradeCap"],
+        `${pkg} upgrade capability`,
+    );
+    const path = publishedPath(pkg);
+    const temporaryPath = `${path}.recovery.tmp`;
+    try {
+        writeFileSync(temporaryPath, publishedMetadataText(packageId, upgradeCapability), {
+            mode: 0o644,
+        });
+        renameSync(temporaryPath, path);
+    } finally {
+        rmSync(temporaryPath, { force: true });
+    }
+    assertPublishedIdentity(path, packageId, pkg);
+}
+
+function publishedField(section: string, field: string, label: string): string {
+    const match = section.match(new RegExp(`^${field}\\s*=\\s*"?([^"\\n]+)"?\\s*$`, "m"));
+    if (!match) throw new Error(`${label} is missing '${field}'`);
+    return match[1].trim();
+}
+
+function assertPublishedIdentity(
+    path: string,
+    expectedId: string,
+    label: string,
+    expectedOriginalId = expectedId,
+): void {
+    if (!existsSync(path)) throw new Error(`${label} is missing ${path}`);
+    const text = readFileSync(path, "utf8");
+    const section = text.match(/\[published\.testnet\]([\s\S]*?)(?=\n\[|$)/)?.[1];
+    if (!section) throw new Error(`${label} is missing [published.testnet]`);
+    const chainId = publishedField(section, "chain-id", label);
+    const publishedAt = normalizeId(publishedField(section, "published-at", label));
+    const originalId = normalizeId(publishedField(section, "original-id", label));
+    if (chainId !== CHAIN_ID || publishedAt !== expectedId || originalId !== expectedOriginalId) {
+        throw new Error(
+            `${label} metadata is ${chainId}/${publishedAt}/${originalId}, expected ${CHAIN_ID}/${expectedId}/${expectedOriginalId}`,
+        );
+    }
+}
+
+function assertRequiredKeys(
+    values: Record<string, string> | undefined,
+    keys: readonly string[],
+    label: string,
+): void {
+    for (const key of keys) {
+        const id = values?.[key];
+        if (!id || !OBJECT_ID.test(id)) throw new Error(`${label} is missing valid '${key}'`);
+    }
+}
+
+function assertCompletedPackage(result: DeploymentResult, pkg: PackageName): void {
+    const packageId = result.packages[pkg];
+    const digest = result.publishTx[pkg];
+    if (!packageId || !OBJECT_ID.test(packageId) || !digest) {
+        throw new Error(`${pkg} checkpoint is missing its package ID or publish digest`);
+    }
+    assertPublishedIdentity(publishedPath(pkg), packageId, pkg);
+    assertRequiredKeys(result.sharedObjects[pkg], EXPECTED_SHARED[pkg], `${pkg} shared objects`);
+    assertRequiredKeys(result.ownedCaps[pkg], expectedCaps(pkg, packageId), `${pkg} owned caps`);
+    const currency =
+        pkg === "usdc"
+            ? result.wiring.currencies.usdc
+            : pkg === "predict"
+              ? result.wiring.currencies.plp
+              : null;
+    if (currency && (!currency.pendingId || !OBJECT_ID.test(currency.pendingId))) {
+        throw new Error(`${pkg} checkpoint is missing its pending Currency object`);
+    }
+}
+
+function assertPackageCheckpoints(result: DeploymentResult): void {
+    for (const pkg of PACKAGES) {
+        if (result.packages[pkg]) {
+            assertCompletedPackage(result, pkg);
+        }
+    }
+}
+
+function withFreshPackageStage<T>(pkg: PackageName, operation: (directory: string) => T): T {
+    const directory = mkdtempSync(join(tmpdir(), `${DEPLOYMENT}-${pkg}-`));
+    const stagedPackages = resolve(directory, "packages");
+    try {
+        cpSync(resolve(REPO_ROOT, "packages"), stagedPackages, {
+            recursive: true,
+            filter: (source) => !["build", "node_modules"].includes(basename(source)),
+        });
+        const stagedPackage = resolve(stagedPackages, pkg);
+        rmSync(resolve(stagedPackage, "Published.toml"), { force: true });
+        return operation(stagedPackage);
+    } finally {
+        rmSync(directory, { recursive: true, force: true });
+    }
+}
+
+function changedPaths(): string[] {
+    const output = execFileSync("git", ["status", "--porcelain=v1", "--untracked-files=all"], {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+    }).trimEnd();
+    if (!output) return [];
+    return output.split("\n").map((line) => {
+        const path = line.slice(3);
+        const rename = path.lastIndexOf(" -> ");
+        return rename >= 0 ? path.slice(rename + 4) : path;
+    });
+}
+
+export function unexpectedDeploymentPaths(
+    paths: readonly string[],
+    generatedPackages: readonly string[],
+    allowManifest = false,
+): string[] {
+    const allowed = new Set<string>([
+        STATE_RELATIVE,
+        ...generatedPackages.map((pkg) => `packages/${pkg}/Published.toml`),
+    ]);
+    if (allowManifest) allowed.add(MANIFEST_RELATIVE);
+    return paths.filter((path) => !allowed.has(path));
+}
+
+export function removeRecoveryTemporaries(paths: readonly string[]): void {
+    for (const path of paths) rmSync(path, { force: true });
+}
+
+function assertExpectedWorktree(result: DeploymentResult): void {
+    const generatedPackages = PACKAGES.filter(
+        (pkg) => result.packages[pkg] || result.inFlight?.package === pkg,
+    );
+    removeRecoveryTemporaries(generatedPackages.map((pkg) => `${publishedPath(pkg)}.recovery.tmp`));
+    const unexpected = unexpectedDeploymentPaths(
+        changedPaths(),
+        generatedPackages,
+        result.status === "complete",
+    );
+    if (unexpected.length > 0) {
+        throw new Error(
+            `deployment source is dirty outside generated artifacts: ${unexpected.join(", ")}`,
+        );
+    }
+}
+
+export function assertSourceBinding(expectedCommit: string, actualCommit: string): void {
+    if (actualCommit !== expectedCommit) {
+        throw new Error(
+            `deployment source commit changed from ${expectedCommit} to ${actualCommit}`,
+        );
+    }
+}
+
+function assertSourceCommit(expectedCommit: string): void {
+    assertSourceBinding(expectedCommit, git(["rev-parse", "HEAD"]));
+}
+
+function expectedCadenceRecord(spec: CadenceSpec, setTx: string | null): CadenceRecord {
+    return {
+        id: spec.id,
+        name: spec.name,
+        tickSize: spec.tickSize.toString(),
+        admissionTickSize: spec.admissionTickSize.toString(),
+        maxExpiryAllocation: spec.maxExpiryAllocation.toString(),
+        initialExpiryCash: spec.initialExpiryCash.toString(),
+        windowSize: spec.windowSize.toString(),
+        setTx,
+    };
+}
+
+function cadenceMatches(actual: CadenceRecord, expected: CadenceSpec): boolean {
+    return (
+        actual.id === expected.id &&
+        actual.tickSize === expected.tickSize.toString() &&
+        actual.admissionTickSize === expected.admissionTickSize.toString() &&
+        actual.maxExpiryAllocation === expected.maxExpiryAllocation.toString() &&
+        actual.initialExpiryCash === expected.initialExpiryCash.toString() &&
+        actual.windowSize === expected.windowSize.toString()
+    );
+}
+
+function assertStateFile(result: DeploymentResult): void {
+    if (
+        result.schemaVersion !== 4 ||
+        result.network !== NETWORK ||
+        result.chainId !== CHAIN_ID ||
+        result.buildEnvironment !== NETWORK ||
+        normalizeId(result.deployer) !== DEPLOYER
+    ) {
+        throw new Error(`${STATE_RELATIVE} is not the expected schema-4 Testnet deployment`);
+    }
+    if (JSON.stringify(result.linked) !== JSON.stringify(LINKED)) {
+        throw new Error(`linked package IDs in ${STATE_RELATIVE} do not match deploy.ts`);
+    }
+    if (JSON.stringify(result.linkedObjects) !== JSON.stringify(LINKED_OBJECTS)) {
+        throw new Error(`linked object IDs in ${STATE_RELATIVE} do not match deploy.ts`);
+    }
+    if (
+        result.wiring.lifecycleCap.recipient !== PREDICT_WRITER ||
+        result.wiring.valuationCap.recipient !== PREDICT_WRITER ||
+        result.wiring.currencies.usdc.mintedAmount !== USDC_MINT_AMOUNT.toString() ||
+        result.wiring.bootstrap.lockCapitalAmount !== LOCK_CAPITAL_AMOUNT.toString() ||
+        result.wiring.bootstrap.supplyAmount !== BOOTSTRAP_SUPPLY_AMOUNT.toString()
+    ) {
+        throw new Error("deployment wiring authority or bootstrap amounts do not match deploy.ts");
+    }
+    if (
+        result.wiring.cadences.length !== CADENCES.length ||
+        !result.wiring.cadences.every((record, index) => cadenceMatches(record, CADENCES[index]))
+    ) {
+        throw new Error("deployment cadence policy does not match deploy.ts");
+    }
+}
+
+function acquireLock(): LockHandle {
+    const commonDirRaw = git(["rev-parse", "--git-common-dir"]);
+    const commonDir = isAbsolute(commonDirRaw) ? commonDirRaw : resolve(REPO_ROOT, commonDirRaw);
+    const path = resolve(commonDir, "predict-testnet-deployment.lock");
+    const token = randomUUID();
+    const payload = {
+        token,
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        worktree: REPO_ROOT,
+        branch: git(["branch", "--show-current"]),
+        head: git(["rev-parse", "HEAD"]),
+    };
+    let fd: number;
+    try {
+        fd = openSync(path, "wx", 0o600);
+    } catch (error) {
+        if (existsSync(path)) {
+            const detail = readFileSync(path, "utf8").trim();
+            throw new Error(
+                `deployment lock already exists at ${path}. Fail closed: inspect ${STATE_RELATIVE} and Testnet before removing it. lock=${detail}`,
+            );
+        }
+        throw new Error(`unable to acquire deployment lock at ${path}: ${String(error)}`);
+    }
+    writeFileSync(fd, `${JSON.stringify(payload, null, 2)}\n`);
+    closeSync(fd);
+    return { path, token };
+}
+
+function releaseLock(lock: LockHandle): void {
+    if (!existsSync(lock.path)) return;
+    const current = JSON.parse(readFileSync(lock.path, "utf8")) as { token?: string };
+    if (current.token !== lock.token) {
+        throw new Error(`deployment lock token changed at ${lock.path}; refusing to remove it`);
+    }
+    rmSync(lock.path);
+}
+
+function stripYamlScalar(value: string): string {
+    const trimmed = value.trim();
+    if (
+        (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+        (trimmed.startsWith("'") && trimmed.endsWith("'"))
+    ) {
+        return trimmed.slice(1, -1);
+    }
+    return trimmed;
+}
+
+function snapshotClientConfig(): ClientSnapshot {
+    const source =
+        process.env.SUI_CLIENT_CONFIG ?? resolve(homedir(), ".sui", "sui_config", "client.yaml");
+    if (!existsSync(source)) throw new Error(`Sui client config does not exist: ${source}`);
+    const yaml = readFileSync(source, "utf8");
+    const activeEnv = yaml.match(/^active_env:\s*(.+)$/m)?.[1];
+    const activeAddress = yaml.match(/^active_address:\s*(.+)$/m)?.[1];
+    if (
+        !activeEnv ||
+        stripYamlScalar(activeEnv) !== NETWORK ||
+        !activeAddress ||
+        normalizeId(stripYamlScalar(activeAddress)) !== DEPLOYER
+    ) {
+        throw new Error(`Sui client config must be active on ${NETWORK} as ${DEPLOYER}`);
+    }
+
+    const environmentBlock = yaml.match(
+        new RegExp(
+            `^\\s*- alias:\\s*${NETWORK}\\s*$([\\s\\S]*?)(?=^\\s*- alias:|^active_env:)`,
+            "m",
+        ),
+    )?.[1];
+    const rpc = environmentBlock?.match(/^\s*rpc:\s*(.+)$/m)?.[1];
+    const configuredChain = environmentBlock?.match(/^\s*chain_id:\s*(.+)$/m)?.[1];
+    if (!rpc || !configuredChain || stripYamlScalar(configuredChain) !== CHAIN_ID) {
+        throw new Error(
+            `Sui client config is missing the pinned ${NETWORK}/${CHAIN_ID} environment`,
+        );
+    }
+
+    assertNoKeystoreOverride(process.env.SUI_KEYSTORE_PATH);
+    const configuredKeystore = yaml.match(/keystore:\s*\n\s*File:\s*(.+)$/m)?.[1];
+    const keystorePath = configuredKeystore
+        ? stripYamlScalar(configuredKeystore)
+        : resolve(homedir(), ".sui", "sui_config", "sui.keystore");
+    if (!existsSync(keystorePath)) throw new Error(`Sui keystore does not exist: ${keystorePath}`);
+
+    const directory = mkdtempSync(join(tmpdir(), "predict-testnet-deploy-"));
+    const configPath = resolve(directory, "client.yaml");
+    copyFileSync(source, configPath);
+    chmodSync(configPath, 0o600);
+    return {
+        directory,
+        configPath,
+        rpcUrl: stripYamlScalar(rpc),
+        keystorePath,
+        configDigest: sha256(yaml),
+    };
+}
+
+export function assertNoKeystoreOverride(value: string | undefined): void {
+    if (value) {
+        throw new Error(
+            "SUI_KEYSTORE_PATH is unsupported for this deployment; the CLI and SDK must use the keystore pinned by client.yaml",
+        );
+    }
+}
+
+function getSigner(keystorePath: string): Ed25519Keypair {
+    const entries = JSON.parse(readFileSync(keystorePath, "utf8")) as unknown;
+    if (!Array.isArray(entries)) throw new Error(`invalid Sui keystore: ${keystorePath}`);
+    for (const entry of entries) {
+        if (typeof entry !== "string") continue;
+        const raw = fromBase64(entry);
+        if (raw.length !== 33 || raw[0] !== 0) continue;
+        const signer = Ed25519Keypair.fromSecretKey(raw.slice(1));
+        if (normalizeId(signer.getPublicKey().toSuiAddress()) === DEPLOYER) return signer;
+    }
+    throw new Error(`Ed25519 keypair for ${DEPLOYER} was not found in the configured keystore`);
+}
+
+function debugPackageId(path: string): string {
+    const debug = JSON.parse(readFileSync(path, "utf8")) as { module_name?: unknown[] };
+    const id = debug.module_name?.[0];
+    if (typeof id !== "string") throw new Error(`missing module package ID in ${path}`);
+    return normalizeId(id);
+}
+
+function bytecodeBase64(value: unknown, label: string): string {
+    if (
+        !Array.isArray(value) ||
+        value.some((byte) => !Number.isInteger(byte) || Number(byte) < 0 || Number(byte) > 255)
+    ) {
+        throw new Error(`${label} is not bytecode`);
+    }
+    return Buffer.from(value as number[]).toString("base64");
+}
+
+export function parsePackageMetadata(raw: unknown): PublishedPackageMetadata {
+    const root = asRecord(raw);
+    const data = asRecord(root.data ?? root);
+    const contentRoot = asRecord(data.content ?? data);
+    const content = asRecord(contentRoot.Package ?? contentRoot.package ?? contentRoot);
+    const moduleMap = asRecord(content.moduleMap ?? content.module_map);
+    if (Object.keys(moduleMap).length === 0) throw new Error("package module_map is empty");
+    const modules = Object.fromEntries(
+        Object.entries(moduleMap)
+            .sort(([left], [right]) => left.localeCompare(right))
+            .map(([name, bytecode]) => [name, bytecodeBase64(bytecode, `module_map.${name}`)]),
+    );
+    const linkage = asRecord(content.linkageTable ?? content.linkage_table);
+    const linkageRecords = Object.entries(linkage)
+        .map(([originalId, value]) => {
+            const record = asRecord(value);
+            return {
+                originalId: normalizeId(originalId),
+                upgradedId: normalizeId(
+                    requiredString(
+                        record.upgradedId ?? record.upgraded_id,
+                        `${originalId}.upgraded_id`,
+                    ),
+                ),
+                upgradedVersion: decimalString(
+                    String(record.upgradedVersion ?? record.upgraded_version),
+                    `${originalId}.upgraded_version`,
+                ),
+            };
+        })
+        .sort((left, right) => left.originalId.localeCompare(right.originalId));
+    const rawOrigins = content.typeOriginTable ?? content.type_origin_table;
+    if (!Array.isArray(rawOrigins)) throw new Error("package type_origin_table is missing");
+    const typeOrigins = rawOrigins
+        .map((value, index) => {
+            const record = asRecord(value);
+            return {
+                module: requiredString(
+                    record.moduleName ?? record.module_name,
+                    `type_origin_table[${index}].module_name`,
+                ),
+                datatype: requiredString(
+                    record.datatypeName ?? record.datatype_name,
+                    `type_origin_table[${index}].datatype_name`,
+                ),
+                packageId: normalizeId(
+                    requiredString(record.package, `type_origin_table[${index}].package`),
+                ),
+            };
+        })
+        .sort((left, right) =>
+            `${left.module}::${left.datatype}`.localeCompare(`${right.module}::${right.datatype}`),
+        );
+    return {
+        packageVersion: decimalString(String(content.version), "package version"),
+        modules,
+        linkage: linkageRecords,
+        typeOrigins,
+    };
+}
+
+function packageMetadata(runtime: Runtime, id: string): ReturnType<typeof parsePackageMetadata> {
+    const packageId = normalizeId(id);
+    const cached = runtime.packageMetadataCache.get(packageId);
+    if (cached) return cached;
+    const metadata = parsePackageMetadata(
+        JSON.parse(suiClient(runtime.snapshot, ["object", id, "--json"])) as unknown,
+    );
+    runtime.packageMetadataCache.set(packageId, metadata);
+    return metadata;
+}
+
+function moveSourceTypeOrigins(directory: string): CompiledPackageMetadata["typeOrigins"] {
+    const origins: CompiledPackageMetadata["typeOrigins"] = [];
+    const visit = (path: string): void => {
+        for (const entry of readdirSync(path, { withFileTypes: true })) {
+            const child = resolve(path, entry.name);
+            if (entry.isDirectory()) visit(child);
+            else if (entry.isFile() && entry.name.endsWith(".move")) {
+                const source = readFileSync(child, "utf8");
+                const module = source.match(/\bmodule\s+[A-Za-z0-9_]+::([A-Za-z0-9_]+)\s*;/)?.[1];
+                if (!module) throw new Error(`${child} has no Move module declaration`);
+                for (const match of source.matchAll(
+                    /^\s*(?:public(?:\([^)]*\))?\s+)?(?:struct|enum)\s+([A-Za-z_][A-Za-z0-9_]*)/gm,
+                )) {
+                    origins.push({ module, datatype: match[1] });
+                }
+            }
+        }
+    };
+    visit(resolve(directory, "sources"));
+    return origins.sort((left, right) =>
+        `${left.module}::${left.datatype}`.localeCompare(`${right.module}::${right.datatype}`),
+    );
+}
+
+function compiledPackageMetadata(pkg: PackageName): CompiledPackageMetadata {
+    return withFreshPackageStage(pkg, (directory) => {
+        const raw = JSON.parse(
+            sui([
+                "move",
+                "build",
+                "--path",
+                directory,
+                "--build-env",
+                NETWORK,
+                "--warnings-are-errors",
+                "--force",
+                "--dump-bytecode-as-base64",
+            ]),
+        ) as Record<string, unknown>;
+        if (
+            !Array.isArray(raw.modules) ||
+            !raw.modules.every((value) => typeof value === "string") ||
+            !Array.isArray(raw.dependencies) ||
+            !raw.dependencies.every((value) => typeof value === "string")
+        ) {
+            throw new Error(`${pkg} build did not return exact bytecode metadata`);
+        }
+        return {
+            modules: [...raw.modules].sort(),
+            dependencies: raw.dependencies.map(normalizeId).sort(),
+            typeOrigins: moveSourceTypeOrigins(directory),
+        };
+    });
+}
+
+function expectedDependency(
+    runtime: Runtime,
+    upgradedId: string,
+): { originalId: string; upgradedVersion: string } | null {
+    const upgraded = normalizeId(upgradedId);
+    let originalId: string | null = null;
+    if (upgraded === normalizeId("0x1") || upgraded === normalizeId("0x2")) {
+        originalId = upgraded;
+    } else if (Object.values(runtime.result.packages).includes(upgraded)) {
+        originalId = upgraded;
+    } else if (upgraded === LINKED.deepbook) {
+        originalId = DEEPBOOK_ORIGINAL;
+    } else if ((Object.values(LINKED) as string[]).includes(upgraded)) {
+        originalId = upgraded;
+    }
+    return originalId
+        ? {
+              originalId,
+              upgradedVersion: packageMetadata(runtime, upgraded).packageVersion,
+          }
+        : null;
+}
+
+export function assertExactPackageGraph(
+    label: string,
+    packageId: string,
+    compiled: CompiledPackageMetadata,
+    published: PublishedPackageMetadata,
+    expectedDependencyFor: (
+        upgradedId: string,
+    ) => { originalId: string; upgradedVersion: string } | null,
+    modulesVerifiedExternally = false,
+): void {
+    const id = normalizeId(packageId);
+    if (published.packageVersion !== "1") {
+        throw new Error(`${label} package version is ${published.packageVersion}, expected 1`);
+    }
+    const compiledModules = [...compiled.modules].sort();
+    const publishedModules = Object.values(published.modules).sort();
+    if (
+        !modulesVerifiedExternally &&
+        JSON.stringify(publishedModules) !== JSON.stringify(compiledModules)
+    ) {
+        throw new Error(`${label} on-chain module bytecode does not match the reviewed build`);
+    }
+    const compiledDependencies = [...compiled.dependencies].map(normalizeId).sort();
+    const publishedDependencies = published.linkage.map((entry) => entry.upgradedId).sort();
+    if (JSON.stringify(publishedDependencies) !== JSON.stringify(compiledDependencies)) {
+        throw new Error(`${label} on-chain linkage does not match the reviewed build`);
+    }
+    if (new Set(publishedDependencies).size !== publishedDependencies.length) {
+        throw new Error(`${label} on-chain linkage contains duplicate upgraded packages`);
+    }
+    for (const link of published.linkage) {
+        const expected = expectedDependencyFor(link.upgradedId);
+        if (
+            !expected ||
+            link.originalId !== normalizeId(expected.originalId) ||
+            link.upgradedVersion !== expected.upgradedVersion
+        ) {
+            throw new Error(
+                `${label} dependency ${link.upgradedId} has original/version ${link.originalId}/${link.upgradedVersion}, expected ${expected ? `${expected.originalId}/${expected.upgradedVersion}` : "no dependency"}`,
+            );
+        }
+    }
+    const expectedOrigins = compiled.typeOrigins.map((origin) => ({ ...origin, packageId: id }));
+    if (JSON.stringify(published.typeOrigins) !== JSON.stringify(expectedOrigins)) {
+        throw new Error(`${label} on-chain type origins do not match the reviewed source`);
+    }
+}
+
+function verifyPublishedSource(runtime: Runtime, pkg: PackageName): void {
+    suiClient(runtime.snapshot, [
+        "verify-source",
+        resolve(REPO_ROOT, "packages", pkg),
+        "--build-env",
+        NETWORK,
+        "--warnings-are-errors",
+        "--force",
+        "--toolchain",
+        requiredString(runtime.result.suiBinaryPath, "recorded Sui binary path"),
+        "--json",
+    ]);
+}
+
+function assertPublishedPackageGraph(runtime: Runtime, pkg: PackageName, id: string): void {
+    verifyPublishedSource(runtime, pkg);
+    assertExactPackageGraph(
+        pkg,
+        id,
+        compiledPackageMetadata(pkg),
+        packageMetadata(runtime, id),
+        (upgradedId) => expectedDependency(runtime, upgradedId),
+        true,
+    );
+}
+
+async function verifyPublishedPackageCheckpoint(runtime: Runtime, pkg: PackageName): Promise<void> {
+    assertCompletedPackage(runtime.result, pkg);
+    const id = packageId(runtime.result, pkg);
+    const packageEvidence = await objectEvidence(runtime, id, "package", null);
+    if (packageEvidence.previousTransaction !== runtime.result.publishTx[pkg]) {
+        throw new Error(`${pkg} package was not created by ${runtime.result.publishTx[pkg]}`);
+    }
+    assertPublishedPackageGraph(runtime, pkg, id);
+    const shared = runtime.result.sharedObjects[pkg] ?? {};
+    exactKeys(asRecord(shared), EXPECTED_SHARED[pkg], `${pkg} shared objects`);
+    for (const [type, objectId] of Object.entries(shared)) {
+        await objectEvidence(runtime, objectId, `${id}::${type}`, "shared");
+    }
+    const caps = runtime.result.ownedCaps[pkg] ?? {};
+    exactKeys(asRecord(caps), expectedCaps(pkg, id), `${pkg} owned capabilities`);
+    for (const [type, objectId] of Object.entries(caps)) {
+        await objectEvidence(runtime, objectId, type, DEPLOYER);
+    }
+}
+
+export function assertPackagePlan(plan: readonly PackageName[] = PACKAGES): void {
+    if (new Set(plan).size !== PACKAGES.length || plan.some((pkg) => !PACKAGES.includes(pkg))) {
+        throw new Error("package plan must contain every fresh package exactly once");
+    }
+    const position = new Map(plan.map((pkg, index) => [pkg, index]));
+    for (const pkg of plan) {
+        const manifest = readFileSync(resolve(REPO_ROOT, "packages", pkg, "Move.toml"), "utf8");
+        const dependencies = [...manifest.matchAll(/local\s*=\s*"\.\.\/([^"]+)"/g)].map(
+            (match) => match[1] as PackageName,
+        );
+        for (const dependency of dependencies) {
+            if (!position.has(dependency)) continue;
+            if (position.get(dependency)! >= position.get(pkg)!) {
+                throw new Error(`${pkg} is planned before local dependency ${dependency}`);
+            }
+        }
+    }
+}
+
+function assertResolvedLinkedPackages(): void {
+    assertPackagePlan();
+    for (const pkg of PACKAGES) {
+        command(SUI, [
+            "move",
+            "build",
+            "--path",
+            resolve(REPO_ROOT, "packages", pkg),
+            "--build-env",
+            NETWORK,
+            "--warnings-are-errors",
+            "--force",
+        ]);
+    }
+    const debug = resolve(
+        REPO_ROOT,
+        "packages",
+        "sessions",
+        "build",
+        "deepbook_sessions",
+        "debug_info",
+        "dependencies",
+    );
+    const resolved: Record<keyof typeof LINKED, string> = {
+        deepbook: debugPackageId(resolve(debug, "deepbook", "registry.json")),
+        deep: debugPackageId(resolve(debug, "token_2", "deep.json")),
+        pyth_lazer: debugPackageId(resolve(debug, "pyth_lazer", "channel.json")),
+        wormhole: debugPackageId(resolve(debug, "wormhole", "external_address.json")),
+        bs_oracle: debugPackageId(resolve(debug, "bs_oracle", "verify.json")),
+        bs_sid: debugPackageId(resolve(debug, "bs_sid", "sid.json")),
+    };
+    for (const [name, linkedId] of Object.entries(LINKED)) {
+        const expectedId = name === "deepbook" ? DEEPBOOK_ORIGINAL : linkedId;
+        if (resolved[name as keyof typeof LINKED] !== expectedId) {
+            throw new Error(
+                `${name} resolves to ${resolved[name as keyof typeof LINKED]}, expected ${expectedId}`,
+            );
+        }
+    }
+    assertPublishedIdentity(
+        resolve(REPO_ROOT, "packages", "token", "Published.toml"),
+        LINKED.deep,
+        "DEEP",
+    );
+    assertPublishedIdentity(
+        resolve(REPO_ROOT, "packages", "deepbook", "Published.toml"),
+        LINKED.deepbook,
+        "DeepBook",
+        "0xfb28c4cbc6865bd1c897d26aecbe1f8792d1509a20ffec692c800660cbec6982",
+    );
+}
+
+async function assertSdkTarget(runtime: Runtime): Promise<void> {
+    assertSourceCommit(runtime.sourceCommit);
+    assertExpectedWorktree(runtime.result);
+    const chainId = await shortChainId(runtime.client);
+    if (chainId !== CHAIN_ID) {
+        throw new Error(`RPC ${runtime.snapshot.rpcUrl} is chain ${chainId}, expected ${CHAIN_ID}`);
+    }
+    if (normalizeId(runtime.signer.getPublicKey().toSuiAddress()) !== DEPLOYER) {
+        throw new Error("deployment signer changed during the run");
+    }
+}
+
+export function assertDeploymentTarget(
+    environment: string,
+    chainId: string,
+    address: string,
+): void {
+    const normalizedAddress = normalizeId(address);
+    if (environment !== NETWORK || chainId !== CHAIN_ID || normalizedAddress !== DEPLOYER) {
+        throw new Error(
+            `deployment target is ${environment}/${chainId}/${normalizedAddress}, expected ${NETWORK}/${CHAIN_ID}/${DEPLOYER}`,
+        );
+    }
+}
+
+export function assertSuiCliVersion(version: string): void {
+    if (version !== SUI_VERSION) {
+        throw new Error(`Sui CLI must be '${SUI_VERSION}', got '${version}'`);
+    }
+}
+
+interface ExecutionBindings {
+    suiVersion: string;
+    suiBinaryPath: string;
+    suiBinaryDigest: string;
+    rpcUrl: string;
+    clientConfigDigest: string;
+    packageGasBudget: string;
+    transactionGasBudget: string;
+}
+
+export function assertExecutionBindings(
+    result: DeploymentResult,
+    bindings: ExecutionBindings,
+): void {
+    const recorded: ExecutionBindings = {
+        suiVersion: requiredString(result.suiVersion, "recorded Sui version"),
+        suiBinaryPath: requiredString(result.suiBinaryPath, "recorded Sui binary path"),
+        suiBinaryDigest: requiredString(result.suiBinaryDigest, "recorded Sui binary digest"),
+        rpcUrl: requiredString(result.rpcUrl, "recorded RPC URL"),
+        clientConfigDigest: requiredString(
+            result.clientConfigDigest,
+            "recorded client config digest",
+        ),
+        packageGasBudget: requiredString(result.packageGasBudget, "recorded package gas budget"),
+        transactionGasBudget: requiredString(
+            result.transactionGasBudget,
+            "recorded transaction gas budget",
+        ),
+    };
+    if (JSON.stringify(recorded) !== JSON.stringify(bindings)) {
+        throw new Error(
+            `deployment execution bindings changed: recorded=${JSON.stringify(recorded)} actual=${JSON.stringify(bindings)}`,
+        );
+    }
+}
+
+function assertCliTarget(snapshot: ClientSnapshot): void {
+    const environment = suiClient(snapshot, ["active-env"]);
+    const chainId = suiClient(snapshot, ["chain-identifier", "--format", "hex"]);
+    const address = suiClient(snapshot, ["active-address"]);
+    assertDeploymentTarget(environment, chainId, address);
+}
+
+function effectsError(effects: unknown): string | null {
+    const status = asRecord(asRecord(effects).status);
+    const state = status.status;
+    if (state === "success" || status.success === true) return null;
+    return typeof status.error === "string" ? status.error : JSON.stringify(status);
+}
+
+async function shortChainId(client: SuiGrpcClient): Promise<string> {
+    const { chainIdentifier } = await client.core.getChainIdentifier();
+    return toHex(fromBase58(chainIdentifier).slice(0, 4));
+}
+
+function coreReceipt(response: unknown): Receipt {
+    const envelope = asRecord(response);
+    const transaction = asRecord(envelope.Transaction ?? envelope.FailedTransaction);
+    const effects = asRecord(transaction.effects);
+    const objectTypes = asRecord(transaction.objectTypes);
+    const changedObjects = effects.changedObjects;
+    const objectChanges: ObjectChange[] = [];
+    if (Array.isArray(changedObjects)) {
+        for (const value of changedObjects) {
+            const change = asRecord(value);
+            if (change.idOperation !== "Created" || typeof change.objectId !== "string") continue;
+            if (change.outputState === "PackageWrite") {
+                objectChanges.push({
+                    type: "published",
+                    packageId: normalizeId(change.objectId),
+                });
+            } else if (change.outputState === "ObjectWrite") {
+                const objectType = objectTypes[change.objectId];
+                objectChanges.push({
+                    type: "created",
+                    objectId: normalizeId(change.objectId),
+                    objectType: typeof objectType === "string" ? objectType : undefined,
+                    owner: change.outputOwner,
+                });
+            }
+        }
+    }
+    const rawEvents = transaction.events;
+    const events: EventRecord[] = Array.isArray(rawEvents)
+        ? rawEvents.map((value) => {
+              const event = asRecord(value);
+              return {
+                  type: typeof event.eventType === "string" ? event.eventType : undefined,
+                  parsedJson: event.json,
+              };
+          })
+        : [];
+    return {
+        digest: typeof transaction.digest === "string" ? transaction.digest : undefined,
+        effects: transaction.effects,
+        objectChanges,
+        events,
+    };
+}
+
+async function settledReceipt(
+    client: SuiGrpcClient,
+    digest: string,
+    attempts = 24,
+): Promise<Receipt> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt < attempts; attempt++) {
+        try {
+            return coreReceipt(
+                await client.getTransaction({
+                    digest,
+                    include: {
+                        effects: true,
+                        events: true,
+                        objectTypes: true,
+                    },
+                }),
+            );
+        } catch (error) {
+            lastError = error;
+            await new Promise((done) => setTimeout(done, 250));
+        }
+    }
+    throw lastError;
+}
+
+function createdObjectId(receipt: Receipt, typeSuffix: string): string {
+    const change = (receipt.objectChanges ?? []).find(
+        (candidate) =>
+            candidate.type === "created" &&
+            typeof candidate.objectType === "string" &&
+            candidate.objectType.endsWith(typeSuffix),
+    );
+    if (!change?.objectId) {
+        throw new Error(`transaction ${receipt.digest} did not create ${typeSuffix}`);
+    }
+    return normalizeId(change.objectId);
+}
+
+function eventNamed(receipt: Receipt, name: string): EventRecord | null {
+    return (
+        (receipt.events ?? []).find(
+            (event) => typeof event.type === "string" && event.type.endsWith(`::${name}`),
+        ) ?? null
+    );
+}
+
+function call(
+    tx: Transaction,
+    target: string,
+    args: TransactionArgument[],
+    typeArguments: string[] = [],
+): TransactionResult {
+    return tx.moveCall({
+        target: target as `${string}::${string}::${string}`,
+        typeArguments,
+        arguments: args,
+    });
+}
+
+async function dryRun(runtime: Runtime, label: string, bytes: Uint8Array): Promise<void> {
+    const response = await runtime.client.simulateTransaction({
+        transaction: bytes,
+        checksEnabled: true,
+        include: { effects: true },
+    });
+    const error = effectsError(coreReceipt(response).effects);
+    if (error) throw new DryRunFailure(label, error);
+}
+
+async function executeTransaction(
+    runtime: Runtime,
+    label: string,
+    tx: Transaction,
+): Promise<Receipt> {
+    const completedDigest = irreversibleStepDigest(runtime.result, "transaction", label, null);
+    if (completedDigest) {
+        const receipt = await settledReceipt(runtime.client, completedDigest);
+        const failure = effectsError(receipt.effects);
+        if (failure) {
+            throw new Error(`${label}/${completedDigest} was checkpointed but failed: ${failure}`);
+        }
+        return receipt;
+    }
+    if (runtime.result.inFlight) {
+        throw new Error(`cannot start ${label}; ${runtime.result.inFlight.label} is in flight`);
+    }
+    await assertSdkTarget(runtime);
+    tx.setSender(DEPLOYER);
+    tx.setGasBudget(TRANSACTION_GAS_BUDGET);
+    const bytes = await tx.build({ client: runtime.client });
+    await dryRun(runtime, label, bytes);
+    const digest = TransactionDataBuilder.getDigestFromBytes(bytes);
+    runtime.result.inFlight = {
+        kind: "transaction",
+        label,
+        package: null,
+        startedAt: new Date().toISOString(),
+        digest,
+    };
+    writeState(runtime.result);
+
+    let receipt: Receipt;
+    try {
+        const { signature } = await runtime.signer.signTransaction(bytes);
+        receipt = coreReceipt(
+            await runtime.client.executeTransaction({
+                transaction: bytes,
+                signatures: [signature],
+                include: {
+                    effects: true,
+                    events: true,
+                    objectTypes: true,
+                },
+            }),
+        );
+    } catch (submitError) {
+        try {
+            receipt = await settledReceipt(runtime.client, digest, 8);
+        } catch {
+            throw new Error(
+                `${label} submission is ambiguous at ${digest}: ${String(submitError)}`,
+            );
+        }
+    }
+    if (receipt.digest !== digest) {
+        throw new Error(`${label} returned digest ${receipt.digest}, expected ${digest}`);
+    }
+    const failure = effectsError(receipt.effects);
+    if (failure) {
+        recordVerifiedTransactionFailure(runtime.result, runtime.result.inFlight!, failure);
+        writeState(runtime.result);
+        throw new Error(`${label} failed at ${digest}: ${failure}; failure checkpoint cleared`);
+    }
+    receipt = await settledReceipt(runtime.client, digest);
+    runtime.result.transactions[label] = digest;
+    runtime.result.inFlight = null;
+    runtime.result.status = "wiring";
+    writeState(runtime.result);
+    await assertSdkTarget(runtime);
+    console.log(`[deploy] ${label}: ${digest}`);
+    return receipt;
+}
+
+function recordPublish(result: DeploymentResult, pkg: PackageName, receipt: Receipt): void {
+    const changes = receipt.objectChanges ?? [];
+    const packageId = normalizeOptionalId(
+        changes.find((change) => change.type === "published")?.packageId,
+    );
+    if (!packageId || !receipt.digest) throw new Error(`publish ${pkg} receipt is incomplete`);
+    result.packages[pkg] = packageId;
+    result.publishTx[pkg] = receipt.digest;
+
+    const shared: Record<string, string> = {};
+    const caps: Record<string, string> = {};
+    for (const change of changes) {
+        if (change.type !== "created" || !change.objectType || !change.objectId) continue;
+        const key = shortType(change.objectType);
+        if (
+            pkg === "usdc" &&
+            change.objectType.endsWith(`::coin_registry::Currency<${packageId}::usdc::USDC>`)
+        ) {
+            result.wiring.currencies.usdc.pendingId = normalizeId(change.objectId);
+        }
+        if (
+            pkg === "predict" &&
+            change.objectType.endsWith(`::coin_registry::Currency<${packageId}::plp::PLP>`)
+        ) {
+            result.wiring.currencies.plp.pendingId = normalizeId(change.objectId);
+        }
+        if (isShared(change.owner)) shared[key] = normalizeId(change.objectId);
+        else if (change.objectType.includes("Cap") && addressOwner(change.owner) === DEPLOYER) {
+            caps[key] = normalizeId(change.objectId);
+        }
+    }
+    if (Object.keys(shared).length > 0) result.sharedObjects[pkg] = shared;
+    result.ownedCaps[pkg] = caps;
+}
+
+async function publishPackage(runtime: Runtime, pkg: PackageName): Promise<void> {
+    if (runtime.result.inFlight) throw new Error(`${runtime.result.inFlight.label} is in flight`);
+    assertExpectedWorktree(runtime.result);
+    assertSourceCommit(runtime.sourceCommit);
+    assertCliTarget(runtime.snapshot);
+    runtime.result.inFlight = {
+        kind: "publish",
+        label: `publish_${pkg}`,
+        package: pkg,
+        startedAt: new Date().toISOString(),
+        digest: null,
+    };
+    writeState(runtime.result);
+
+    const receipt = withFreshPackageStage(pkg, (directory) => {
+        const output = suiClient(runtime.snapshot, [
+            "publish",
+            directory,
+            "--warnings-are-errors",
+            "--force",
+            "--sender",
+            DEPLOYER,
+            "--gas-budget",
+            PACKAGE_GAS_BUDGET,
+            "--json",
+        ]);
+        const receipt = JSON.parse(output) as Receipt;
+        const failure = effectsError(receipt.effects);
+        if (!receipt.digest) throw new Error(`publish ${pkg} returned no digest: ${failure}`);
+        runtime.result.inFlight!.digest = receipt.digest;
+        writeState(runtime.result);
+        if (failure) return receipt;
+        const publishedId = normalizeId(
+            (receipt.objectChanges ?? []).find((change) => change.type === "published")
+                ?.packageId ?? "",
+        );
+        const stagedPublished = resolve(directory, "Published.toml");
+        assertPublishedIdentity(stagedPublished, publishedId, pkg);
+        copyFileSync(stagedPublished, publishedPath(pkg));
+        return receipt;
+    });
+    runtime.result.inFlight!.digest = requiredString(receipt.digest, `${pkg} publish digest`);
+    const publishFailure = effectsError(receipt.effects);
+    if (publishFailure) {
+        recordVerifiedTransactionFailure(runtime.result, runtime.result.inFlight, publishFailure);
+        writeState(runtime.result);
+        throw new Error(
+            `publish ${pkg} failed at ${receipt.digest}: ${publishFailure}; failure checkpoint cleared`,
+        );
+    }
+    assertCliTarget(runtime.snapshot);
+    assertPublishedIdentity(
+        publishedPath(pkg),
+        normalizeId(
+            (receipt.objectChanges ?? []).find((change) => change.type === "published")
+                ?.packageId ?? "",
+        ),
+        pkg,
+    );
+    recordPublish(runtime.result, pkg, receipt);
+    assertCompletedPackage(runtime.result, pkg);
+    await verifyPublishedPackageCheckpoint(runtime, pkg);
+    runtime.result.inFlight = null;
+    writeState(runtime.result);
+    console.log(`[deploy] ${pkg}: ${runtime.result.packages[pkg]} (${receipt.digest})`);
+}
+
+export function assertRecoverableInFlight(inFlight: InFlight, digestVisible: boolean): void {
+    if (!inFlight.digest) {
+        throw new Error(`${inFlight.label} has no known digest; fail closed`);
+    }
+    if (!digestVisible) {
+        throw new Error(`${inFlight.label}/${inFlight.digest} is not visible; fail closed`);
+    }
+}
+
+export function checkpointRecoveredTransaction(result: DeploymentResult): void {
+    const inFlight = result.inFlight;
+    if (!inFlight) return;
+    if (inFlight.kind !== "transaction" || !inFlight.digest) {
+        throw new Error("only a transaction with a known digest can be checkpointed generically");
+    }
+    result.transactions[inFlight.label] = inFlight.digest;
+    result.inFlight = null;
+}
+
+export function recordVerifiedTransactionFailure(
+    result: DeploymentResult,
+    inFlight: InFlight,
+    error: string,
+): void {
+    if (!inFlight.digest) throw new Error("verified failure is missing its transaction digest");
+    result.failedTransactions[inFlight.label] = {
+        digest: inFlight.digest,
+        error,
+        recordedAt: new Date().toISOString(),
+    };
+    result.inFlight = null;
+}
+
+export function irreversibleStepDigest(
+    result: DeploymentResult,
+    kind: InFlight["kind"],
+    label: string,
+    pkg: PackageName | null,
+): string | null {
+    if (kind === "publish") {
+        if (!pkg) throw new Error(`${label} publish step is missing its package`);
+        return result.packages[pkg] && result.publishTx[pkg] ? result.publishTx[pkg]! : null;
+    }
+    return result.transactions[label] ?? null;
+}
+
+interface ReconcileJournaledInFlightActions {
+    loadReceipt: (digest: string) => Promise<Receipt>;
+    recoverPublish: (pkg: PackageName, receipt: Receipt) => Promise<void>;
+    persist: () => void;
+}
+
+export async function reconcileJournaledInFlight(
+    result: DeploymentResult,
+    actions: ReconcileJournaledInFlightActions,
+): Promise<InFlight | null> {
+    const inFlight = result.inFlight;
+    if (!inFlight) return null;
+    assertRecoverableInFlight(inFlight, true);
+    let receipt: Receipt;
+    try {
+        receipt = await actions.loadReceipt(inFlight.digest!);
+    } catch {
+        assertRecoverableInFlight(inFlight, false);
+        throw new Error(
+            `${inFlight.label}/${inFlight.digest} is not visible on Testnet. Fail closed; do not retry with new transaction bytes`,
+        );
+    }
+    if (receipt.digest !== inFlight.digest) {
+        throw new Error(
+            `${inFlight.label} recovery returned digest ${receipt.digest}, expected ${inFlight.digest}`,
+        );
+    }
+    const failure = effectsError(receipt.effects);
+    if (failure) {
+        recordVerifiedTransactionFailure(result, inFlight, failure);
+        actions.persist();
+        throw new Error(
+            `${inFlight.label}/${inFlight.digest} failed: ${failure}; failure checkpoint cleared`,
+        );
+    }
+    if (inFlight.kind === "publish") {
+        if (!inFlight.package) throw new Error("in-flight publish is missing its package");
+        await actions.recoverPublish(inFlight.package, receipt);
+        result.inFlight = null;
+    } else {
+        checkpointRecoveredTransaction(result);
+    }
+    actions.persist();
+    return inFlight;
+}
+
+async function reconcileInFlight(runtime: Runtime): Promise<void> {
+    const recovered = await reconcileJournaledInFlight(runtime.result, {
+        loadReceipt: (digest) => settledReceipt(runtime.client, digest, 4),
+        recoverPublish: async (pkg, receipt) => {
+            recordPublish(runtime.result, pkg, receipt);
+            reconstructPublishedMetadata(runtime.result, pkg);
+            assertCompletedPackage(runtime.result, pkg);
+            await verifyPublishedPackageCheckpoint(runtime, pkg);
+        },
+        persist: () => writeState(runtime.result),
+    });
+    if (recovered) console.log(`[deploy] reconciled ${recovered.label}: ${recovered.digest}`);
+}
+
+function packageId(result: DeploymentResult, pkg: PackageName): string {
+    const id = result.packages[pkg];
+    if (!id) throw new Error(`${pkg} has not been published`);
+    return id;
+}
+
+function sharedId(result: DeploymentResult, pkg: PackageName, type: string): string {
+    const id = result.sharedObjects[pkg]?.[type];
+    if (!id) throw new Error(`${pkg} shared object ${type} is missing`);
+    return id;
+}
+
+function capId(result: DeploymentResult, pkg: PackageName, type: string): string {
+    const id = result.ownedCaps[pkg]?.[type];
+    if (!id) throw new Error(`${pkg} capability ${type} is missing`);
+    return id;
+}
+
+function target(result: DeploymentResult, pkg: PackageName, module: string, fn: string): string {
+    return `${packageId(result, pkg)}::${module}::${fn}`;
+}
+
+function usdcType(result: DeploymentResult): string {
+    return `${packageId(result, "usdc")}::usdc::USDC`;
+}
+
+function plpType(result: DeploymentResult): string {
+    return `${packageId(result, "predict")}::plp::PLP`;
+}
+
+async function devInspect(runtime: Runtime, label: string, tx: Transaction): Promise<unknown> {
+    tx.setSender(DEPLOYER);
+    const response = await runtime.client.simulateTransaction({
+        transaction: tx,
+        checksEnabled: false,
+        include: {
+            commandResults: true,
+            effects: true,
+        },
+    });
+    const error = effectsError(coreReceipt(response).effects);
+    if (error) throw new Error(`${label} simulation failed: ${error}`);
+    return response;
+}
+
+function returnBytes(response: unknown, resultIndex = 0, returnIndex = 0): number[] {
+    const results = asRecord(response).commandResults;
+    if (!Array.isArray(results)) throw new Error("simulation response has no command results");
+    const result = asRecord(results[resultIndex]);
+    const returnValues = result.returnValues;
+    if (!Array.isArray(returnValues)) {
+        throw new Error(`simulation result ${resultIndex} has no return ${returnIndex}`);
+    }
+    const bytes = asRecord(returnValues[returnIndex]).bcs;
+    if (bytes instanceof Uint8Array) return Array.from(bytes);
+    if (Array.isArray(bytes) && bytes.every((value) => Number.isInteger(value))) {
+        return bytes as number[];
+    }
+    throw new Error("simulation return is not byte-encoded");
+}
+
+function parseBool(bytes: number[]): boolean {
+    return bytes[0] === 1;
+}
+
+function parseU64(bytes: number[]): bigint {
+    if (bytes.length < 8) throw new Error(`invalid u64 return (${bytes.length} bytes)`);
+    let value = 0n;
+    for (let index = 7; index >= 0; index--) value = (value << 8n) + BigInt(bytes[index]);
+    return value;
+}
+
+function parseU256(bytes: number[]): bigint {
+    if (bytes.length < 32) throw new Error(`invalid u256 return (${bytes.length} bytes)`);
+    let value = 0n;
+    for (let index = 31; index >= 0; index--) value = (value << 8n) + BigInt(bytes[index]);
+    return value;
+}
+
+function parseOptionU64(bytes: number[]): bigint | null {
+    if (bytes.length === 1 && bytes[0] === 0) return null;
+    if (bytes[0] !== 1 || bytes.length !== 9) {
+        throw new Error(`invalid Option<u64> return (${bytes.length} bytes)`);
+    }
+    return parseU64(bytes.slice(1));
+}
+
+function parseU32(bytes: number[]): number {
+    if (bytes.length < 4) throw new Error(`invalid u32 return (${bytes.length} bytes)`);
+    return bytes[0] + bytes[1] * 2 ** 8 + bytes[2] * 2 ** 16 + bytes[3] * 2 ** 24;
+}
+
+function parseAddress(bytes: number[]): string {
+    if (bytes.length < 32) throw new Error(`invalid address return (${bytes.length} bytes)`);
+    return normalizeId(
+        `0x${bytes
+            .slice(0, 32)
+            .map((byte) => byte.toString(16).padStart(2, "0"))
+            .join("")}`,
+    );
+}
+
+function parseOptionId(bytes: number[]): string | null {
+    if (bytes.length === 1 && bytes[0] === 0) return null;
+    if (bytes[0] !== 1 || bytes.length !== 33) {
+        throw new Error(`invalid Option<ID> return (${bytes.length} bytes)`);
+    }
+    return parseAddress(bytes.slice(1));
+}
+
+interface BlockScholesStorePair {
+    valueStoreId: string;
+    sviStoreId: string;
+    baseAsset: string;
+}
+
+export function parseOptionBlockScholesStorePair(bytes: number[]): BlockScholesStorePair | null {
+    if (bytes.length === 1 && bytes[0] === 0) return null;
+    if (bytes[0] !== 1 || bytes.length <= 65) {
+        throw new Error(`invalid Option<BlockScholesStorePair> return (${bytes.length} bytes)`);
+    }
+    return {
+        valueStoreId: parseAddress(bytes.slice(1, 33)),
+        sviStoreId: parseAddress(bytes.slice(33, 65)),
+        baseAsset: parseString(bytes.slice(65)),
+    };
+}
+
+function readUleb(bytes: number[], start: number): { value: number; next: number } {
+    let value = 0;
+    let shift = 0;
+    let index = start;
+    while (index < bytes.length) {
+        const byte = bytes[index++];
+        value |= (byte & 0x7f) << shift;
+        if ((byte & 0x80) === 0) return { value, next: index };
+        shift += 7;
+    }
+    throw new Error("truncated ULEB128");
+}
+
+function parseIdVector(bytes: number[]): string[] {
+    const length = readUleb(bytes, 0);
+    const ids: string[] = [];
+    let offset = length.next;
+    for (let index = 0; index < length.value; index++) {
+        ids.push(parseAddress(bytes.slice(offset, offset + 32)));
+        offset += 32;
+    }
+    if (offset !== bytes.length) throw new Error("unexpected bytes after vector<ID>");
+    return ids;
+}
+
+function parseString(bytes: number[]): string {
+    const length = readUleb(bytes, 0);
+    const end = length.next + length.value;
+    if (end !== bytes.length) throw new Error("invalid Move String return");
+    return new TextDecoder("utf-8", { fatal: true }).decode(
+        Uint8Array.from(bytes.slice(length.next, end)),
+    );
+}
+
+async function inspectOptionId(
+    runtime: Runtime,
+    label: string,
+    moveTarget: string,
+    args: (tx: Transaction) => TransactionArgument[],
+): Promise<string | null> {
+    const tx = new Transaction();
+    call(tx, moveTarget, args(tx));
+    return parseOptionId(returnBytes(await devInspect(runtime, label, tx)));
+}
+
+async function inspectBlockScholesStorePair(
+    runtime: Runtime,
+    label: string,
+    oracleRegistry: string,
+): Promise<BlockScholesStorePair | null> {
+    const tx = new Transaction();
+    call(
+        tx,
+        target(
+            runtime.result,
+            "propbook",
+            "registry",
+            "propbook_block_scholes_store_pair_for_underlying",
+        ),
+        [tx.object(oracleRegistry), tx.pure.u32(ASSET.propbookUnderlyingId)],
+    );
+    return parseOptionBlockScholesStorePair(returnBytes(await devInspect(runtime, label, tx)));
+}
+
+async function inspectString(
+    runtime: Runtime,
+    label: string,
+    moveTarget: string,
+    args: (tx: Transaction) => TransactionArgument[],
+    typeArguments: string[] = [],
+): Promise<string> {
+    const tx = new Transaction();
+    call(tx, moveTarget, args(tx), typeArguments);
+    return parseString(returnBytes(await devInspect(runtime, label, tx)));
+}
+
+async function assertBlockScholesStoreBaseAssets(
+    runtime: Runtime,
+    pair: BlockScholesStorePair,
+): Promise<void> {
+    const valueStoreBaseAsset = await inspectString(
+        runtime,
+        "block_scholes_value_store_base_asset",
+        target(runtime.result, "propbook", "block_scholes_store", "value_store_base_asset"),
+        (tx) => [tx.object(pair.valueStoreId)],
+    );
+    const sviStoreBaseAsset = await inspectString(
+        runtime,
+        "block_scholes_svi_store_base_asset",
+        target(runtime.result, "propbook", "block_scholes_store", "svi_store_base_asset"),
+        (tx) => [tx.object(pair.sviStoreId)],
+    );
+    if (
+        pair.baseAsset !== ASSET.blockScholesBaseAsset ||
+        valueStoreBaseAsset !== ASSET.blockScholesBaseAsset ||
+        sviStoreBaseAsset !== ASSET.blockScholesBaseAsset
+    ) {
+        throw new Error(
+            `Block Scholes binding/store base assets are ${pair.baseAsset}/${valueStoreBaseAsset}/${sviStoreBaseAsset}, expected ${ASSET.blockScholesBaseAsset}`,
+        );
+    }
+}
+
+async function inspectBool(
+    runtime: Runtime,
+    label: string,
+    moveTarget: string,
+    args: (tx: Transaction) => TransactionArgument[],
+    typeArguments: string[] = [],
+): Promise<boolean> {
+    const tx = new Transaction();
+    call(tx, moveTarget, args(tx), typeArguments);
+    return parseBool(returnBytes(await devInspect(runtime, label, tx)));
+}
+
+async function inspectU64(
+    runtime: Runtime,
+    label: string,
+    moveTarget: string,
+    args: (tx: Transaction) => TransactionArgument[],
+    typeArguments: string[] = [],
+): Promise<bigint> {
+    const tx = new Transaction();
+    call(tx, moveTarget, args(tx), typeArguments);
+    return parseU64(returnBytes(await devInspect(runtime, label, tx)));
+}
+
+async function objectEvidence(
+    runtime: Runtime,
+    id: string,
+    expectedType: string | "package",
+    expectedOwner: "shared" | string | null,
+): Promise<ObjectEvidence> {
+    const objectId = normalizeId(id);
+    const { object } = await runtime.client.getObject({
+        objectId,
+        include: {
+            previousTransaction: true,
+        },
+    });
+    const actualType = object.type;
+    if (
+        expectedType === "package" ? actualType !== "package" : !actualType.endsWith(expectedType)
+    ) {
+        throw new Error(`${objectId} has type ${actualType}, expected ${expectedType}`);
+    }
+    const actualOwner = ownerLabel(object.owner);
+    const normalizedExpectedOwner =
+        expectedOwner === "shared" || expectedOwner === null
+            ? expectedOwner
+            : expectedOwner.startsWith("party:")
+              ? partyOwnerLabel(expectedOwner.slice("party:".length))
+              : expectedOwner.startsWith("object:")
+                ? `object:${normalizeId(expectedOwner.slice("object:".length))}`
+                : normalizeId(expectedOwner);
+    if (
+        normalizedExpectedOwner &&
+        (normalizedExpectedOwner === "shared"
+            ? actualOwner !== "shared"
+            : actualOwner !== normalizedExpectedOwner)
+    ) {
+        throw new Error(
+            `${objectId} is owned by ${actualOwner}, expected ${normalizedExpectedOwner}`,
+        );
+    }
+    return {
+        objectId,
+        type: actualType,
+        owner: actualOwner,
+        version: String(object.version),
+        digest: object.digest,
+        previousTransaction: object.previousTransaction ?? null,
+    };
+}
+
+export function sameObjectReference(left: ObjectEvidence, right: ObjectEvidence): boolean {
+    return (
+        left.objectId === right.objectId &&
+        left.version === right.version &&
+        left.digest === right.digest
+    );
+}
+
+async function stableObjectSnapshot<T>(
+    runtime: Runtime,
+    id: string,
+    expectedType: string,
+    read: () => Promise<T>,
+    attempts = 3,
+): Promise<{ evidence: ObjectEvidence; value: T }> {
+    for (let attempt = 0; attempt < attempts; attempt++) {
+        const before = await objectEvidence(runtime, id, expectedType, "shared");
+        const value = await read();
+        const after = await objectEvidence(runtime, id, expectedType, "shared");
+        if (sameObjectReference(before, after)) return { evidence: after, value };
+    }
+    throw new Error(`${normalizeId(id)} changed while its configuration snapshot was read`);
+}
+
+async function moveObjectFields(runtime: Runtime, id: string): Promise<Record<string, unknown>> {
+    const { object } = await runtime.client.getObject({
+        objectId: normalizeId(id),
+        include: { json: true },
+    });
+    if (object.type === "package" || !object.json) throw new Error(`${id} is not a Move object`);
+    return object.json;
+}
+
+async function verifyExternalDependencies(runtime: Runtime): Promise<{
+    packages: Record<string, ObjectEvidence>;
+    objects: Record<string, ObjectEvidence>;
+}> {
+    const packages: Record<string, ObjectEvidence> = {};
+    for (const [name, id] of Object.entries(LINKED)) {
+        packages[name] = await objectEvidence(runtime, id, "package", null);
+    }
+    const objects: Record<string, ObjectEvidence> = {
+        clock: await objectEvidence(runtime, CLOCK_ID, "clock::Clock", "shared"),
+        accumulatorRoot: await objectEvidence(
+            runtime,
+            ACCUMULATOR_ROOT_ID,
+            "accumulator::AccumulatorRoot",
+            "shared",
+        ),
+        pythLazerState: await objectEvidence(
+            runtime,
+            LINKED_OBJECTS.pythLazerState,
+            `${LINKED.pyth_lazer}::state::State`,
+            "shared",
+        ),
+        wormholeState: await objectEvidence(
+            runtime,
+            LINKED_OBJECTS.wormholeState,
+            `${LINKED.wormhole}::state::State`,
+            "shared",
+        ),
+        blockScholesSignerRegistry: await objectEvidence(
+            runtime,
+            LINKED_OBJECTS.blockScholesSignerRegistry,
+            `${LINKED.bs_oracle}::registry::SignerRegistry`,
+            "shared",
+        ),
+        deepbookRegistry: await objectEvidence(
+            runtime,
+            DEEPBOOK_REGISTRY,
+            `${DEEPBOOK_ORIGINAL}::registry::Registry`,
+            "shared",
+        ),
+    };
+    await objectEvidence(
+        runtime,
+        DEEPBOOK_ADMIN_CAP,
+        `${DEEPBOOK_ORIGINAL}::registry::DeepbookAdminCap`,
+        partyOwnerLabel(DEEPBOOK_ADMIN_OWNER),
+    );
+    const signerRegistry = await moveObjectFields(
+        runtime,
+        LINKED_OBJECTS.blockScholesSignerRegistry,
+    );
+    const signerPubkey = signerRegistry.signer_pubkey;
+    if (
+        signerRegistry.paused !== false ||
+        typeof signerPubkey !== "string" ||
+        fromBase64(signerPubkey).length !== 33
+    ) {
+        throw new Error("Block Scholes signer registry is paused or has no valid signer");
+    }
+    const pythState = await moveObjectFields(runtime, LINKED_OBJECTS.pythLazerState);
+    const trustedSigners = pythState.trusted_signers;
+    const now = (await currentClockMs(runtime)) / 1_000n;
+    if (
+        !Array.isArray(trustedSigners) ||
+        !trustedSigners.some((value) => {
+            const expiresAt = asRecord(value).expires_at;
+            return (
+                (typeof expiresAt === "string" || typeof expiresAt === "number") &&
+                /^[0-9]+$/.test(String(expiresAt)) &&
+                BigInt(String(expiresAt)) > now
+            );
+        })
+    ) {
+        throw new Error("Pyth Lazer state has no unexpired trusted signer");
+    }
+    return { packages, objects };
+}
+
+async function accountAppAuthorized(
+    runtime: Runtime,
+    label: string,
+    appType: string,
+): Promise<boolean> {
+    const result = runtime.result;
+    const registry = sharedId(result, "account", "account_registry::AccountRegistry");
+    return inspectBool(
+        runtime,
+        `is_${label}_authorized`,
+        target(result, "account", "account_registry", "is_app_authorized"),
+        (tx) => [tx.object(registry)],
+        [appType],
+    );
+}
+
+async function ensureAccountAppAuthorized(
+    runtime: Runtime,
+    label: string,
+    appType: string,
+): Promise<string | null> {
+    const result = runtime.result;
+    const registry = sharedId(result, "account", "account_registry::AccountRegistry");
+    const transactionLabel = `authorize_${label}`;
+    const authorized = await accountAppAuthorized(runtime, label, appType);
+    if (!authorized) {
+        const tx = new Transaction();
+        call(
+            tx,
+            target(result, "account", "account_registry", "authorize_app"),
+            [
+                tx.object(registry),
+                tx.object(capId(result, "account", "account_registry::AccountAdminCap")),
+            ],
+            [appType],
+        );
+        const receipt = await executeTransaction(runtime, transactionLabel, tx);
+        if (!(await accountAppAuthorized(runtime, label, appType))) {
+            throw new Error(`${appType} authorization did not read back true`);
+        }
+        return receipt.digest ?? null;
+    }
+    return result.transactions[transactionLabel] ?? null;
+}
+
+async function ensureAccountAppsAuthorized(runtime: Runtime): Promise<void> {
+    const result = runtime.result;
+    result.wiring.account.authorizeTx = await ensureAccountAppAuthorized(
+        runtime,
+        "predict_app",
+        `${packageId(result, "predict")}::predict_account::PredictApp`,
+    );
+    result.wiring.account.predictAppAuthorized = true;
+    result.wiring.account.deepbookCoreAuthorizeTx = await ensureAccountAppAuthorized(
+        runtime,
+        "deepbook_core_app",
+        `${packageId(result, "deepbook_core_account")}::account_data::DeepbookCoreAccountApp`,
+    );
+    result.wiring.account.deepbookCoreAppAuthorized = true;
+    result.wiring.account.sessionsAuthorizeTx = await ensureAccountAppAuthorized(
+        runtime,
+        "sessions_app",
+        `${packageId(result, "sessions")}::sessions::SessionsApp`,
+    );
+    result.wiring.account.sessionsAppAuthorized = true;
+    writeState(result);
+}
+
+async function deepbookCoreAppAuthorized(runtime: Runtime): Promise<boolean> {
+    const tx = new Transaction();
+    call(
+        tx,
+        `${LINKED.deepbook}::registry::assert_app_is_authorized`,
+        [tx.object(DEEPBOOK_REGISTRY)],
+        [
+            `${packageId(runtime.result, "deepbook_core_account")}::account_data::DeepbookCoreAccountApp`,
+        ],
+    );
+    try {
+        await devInspect(runtime, "is_deepbook_core_app_authorized", tx);
+        return true;
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (message.includes("MoveAbort") && message.includes("registry")) return false;
+        throw error;
+    }
+}
+
+async function ensureDeepbookCoreAppAuthorized(runtime: Runtime): Promise<void> {
+    const authorized = await deepbookCoreAppAuthorized(runtime);
+    runtime.result.wiring.deepbook = {
+        coreAppAuthorized: authorized,
+        verifiedAt: new Date().toISOString(),
+    };
+    writeState(runtime.result);
+    if (!authorized) {
+        console.log(
+            "[deploy] DeepBook core wrapper authorization is pending external admin-cap execution",
+        );
+    }
+}
+
+type CurrencyName = keyof WiringState["currencies"];
+
+function deploymentCurrencyType(result: DeploymentResult, name: CurrencyName): string {
+    return name === "usdc" ? usdcType(result) : plpType(result);
+}
+
+function deploymentCurrencyPackage(name: CurrencyName): PackageName {
+    return name === "usdc" ? "usdc" : "predict";
+}
+
+async function ensureCurrencyRegistration(runtime: Runtime, name: CurrencyName): Promise<string> {
+    const result = runtime.result;
+    const state = result.wiring.currencies[name];
+    const type = deploymentCurrencyType(result, name);
+    const packageName = deploymentCurrencyPackage(name);
+    const label = `finalize_${name}_currency_registration`;
+    if (!state.pendingId) {
+        const receipt = await settledReceipt(
+            runtime.client,
+            requiredString(result.publishTx[packageName], `${packageName} publish digest`),
+        );
+        state.pendingId = createdObjectId(receipt, `::coin_registry::Currency<${type}>`);
+        writeState(result);
+    }
+    if (!state.id && result.transactions[label]) {
+        const receipt = await settledReceipt(runtime.client, result.transactions[label]);
+        state.id = createdObjectId(receipt, `::coin_registry::Currency<${type}>`);
+        state.finalizeTx = receipt.digest ?? null;
+        writeState(result);
+    }
+    if (!state.id) {
+        await objectEvidence(
+            runtime,
+            state.pendingId,
+            `coin_registry::Currency<${type}>`,
+            "object:0xc",
+        );
+        const tx = new Transaction();
+        call(
+            tx,
+            "0x2::coin_registry::finalize_registration",
+            [tx.object("0xc"), tx.object(state.pendingId)],
+            [type],
+        );
+        const receipt = await executeTransaction(runtime, label, tx);
+        state.id = createdObjectId(receipt, `::coin_registry::Currency<${type}>`);
+        state.finalizeTx = receipt.digest ?? null;
+        writeState(result);
+    }
+    await objectEvidence(runtime, state.id, `coin_registry::Currency<${type}>`, "shared");
+    if (name === "usdc") {
+        const symbol = await inspectString(
+            runtime,
+            "usdc_display_symbol",
+            "0x2::coin_registry::symbol",
+            (tx) => [tx.object(state.id!)],
+            [type],
+        );
+        if (symbol !== "DUSDC") {
+            throw new Error(`USDC display symbol is ${symbol}, expected DUSDC`);
+        }
+    }
+    return state.id;
+}
+
+async function usdcTotalSupply(runtime: Runtime): Promise<bigint> {
+    return inspectU64(
+        runtime,
+        "usdc_total_supply",
+        "0x2::coin::total_supply",
+        (tx) => [
+            tx.object(
+                capId(runtime.result, "usdc", `coin::TreasuryCap<${usdcType(runtime.result)}>`),
+            ),
+        ],
+        [usdcType(runtime.result)],
+    );
+}
+
+async function ensureDeployerUsdcMint(runtime: Runtime): Promise<void> {
+    const result = runtime.result;
+    let totalSupply = await usdcTotalSupply(runtime);
+    if (totalSupply === 0n) {
+        const tx = new Transaction();
+        call(
+            tx,
+            "0x2::coin::mint_and_transfer",
+            [
+                tx.object(capId(result, "usdc", `coin::TreasuryCap<${usdcType(result)}>`)),
+                tx.pure.u64(USDC_MINT_AMOUNT),
+                tx.pure.address(DEPLOYER),
+            ],
+            [usdcType(result)],
+        );
+        const receipt = await executeTransaction(runtime, "mint_deployer_usdc", tx);
+        result.wiring.currencies.usdc.mintTx = receipt.digest ?? null;
+        writeState(result);
+        totalSupply = await usdcTotalSupply(runtime);
+    }
+    if (totalSupply !== USDC_MINT_AMOUNT || !result.transactions.mint_deployer_usdc) {
+        throw new Error(
+            `fresh USDC supply is ${totalSupply}, expected one recorded ${USDC_MINT_AMOUNT} mint`,
+        );
+    }
+    result.wiring.currencies.usdc.mintTx = result.transactions.mint_deployer_usdc;
+    writeState(result);
+}
+
+async function ensureLifecycleCap(runtime: Runtime): Promise<string> {
+    const result = runtime.result;
+    if (!result.wiring.lifecycleCap.id && result.transactions.mint_lifecycle_cap) {
+        const receipt = await settledReceipt(
+            runtime.client,
+            result.transactions.mint_lifecycle_cap,
+        );
+        result.wiring.lifecycleCap.id = createdObjectId(
+            receipt,
+            "::market_lifecycle_cap::MarketLifecycleCap",
+        );
+        result.wiring.lifecycleCap.mintTx = receipt.digest ?? null;
+        writeState(result);
+    }
+    const recorded = result.wiring.lifecycleCap.id;
+    if (recorded) {
+        const evidence = await objectEvidence(
+            runtime,
+            recorded,
+            `${packageId(result, "predict")}::market_lifecycle_cap::MarketLifecycleCap`,
+            null,
+        );
+        if (evidence.owner === DEPLOYER) result.wiring.lifecycleCap.owner = "deployer";
+        else if (evidence.owner === partyOwnerLabel(PREDICT_WRITER)) {
+            result.wiring.lifecycleCap.owner = "recipient";
+        } else {
+            throw new Error(`lifecycle cap ${recorded} has unexpected owner ${evidence.owner}`);
+        }
+        result.wiring.lifecycleCap.mintTx ??= result.transactions.mint_lifecycle_cap ?? null;
+        result.wiring.lifecycleCap.transferTx ??=
+            result.transactions.transfer_operational_caps_to_keeper ?? null;
+        writeState(result);
+        return recorded;
+    }
+
+    const tx = new Transaction();
+    const cap = call(tx, target(result, "predict", "registry", "mint_lifecycle_cap"), [
+        tx.object(sharedId(result, "predict", "registry::Registry")),
+        tx.object(sharedId(result, "predict", "protocol_config::ProtocolConfig")),
+        tx.object(capId(result, "predict", "admin::AdminCap")),
+    ]);
+    tx.transferObjects([cap], tx.pure.address(DEPLOYER));
+    const receipt = await executeTransaction(runtime, "mint_lifecycle_cap", tx);
+    const id = createdObjectId(receipt, "::market_lifecycle_cap::MarketLifecycleCap");
+    result.wiring.lifecycleCap.id = id;
+    result.wiring.lifecycleCap.owner = "deployer";
+    result.wiring.lifecycleCap.mintTx = receipt.digest ?? null;
+    writeState(result);
+    return id;
+}
+
+async function ensureValuationCap(runtime: Runtime): Promise<string> {
+    const result = runtime.result;
+    if (!result.wiring.valuationCap.id && result.transactions.mint_pool_valuation_cap) {
+        const receipt = await settledReceipt(
+            runtime.client,
+            result.transactions.mint_pool_valuation_cap,
+        );
+        result.wiring.valuationCap.id = createdObjectId(
+            receipt,
+            "::pool_valuation_cap::PoolValuationCap",
+        );
+        result.wiring.valuationCap.mintTx = receipt.digest ?? null;
+        writeState(result);
+    }
+    const recorded = result.wiring.valuationCap.id;
+    if (recorded) {
+        const evidence = await objectEvidence(
+            runtime,
+            recorded,
+            `${packageId(result, "predict")}::pool_valuation_cap::PoolValuationCap`,
+            null,
+        );
+        if (evidence.owner === DEPLOYER) result.wiring.valuationCap.owner = "deployer";
+        else if (evidence.owner === partyOwnerLabel(PREDICT_WRITER)) {
+            result.wiring.valuationCap.owner = "recipient";
+        } else {
+            throw new Error(
+                `pool valuation cap ${recorded} has unexpected owner ${evidence.owner}`,
+            );
+        }
+        result.wiring.valuationCap.mintTx ??= result.transactions.mint_pool_valuation_cap ?? null;
+        result.wiring.valuationCap.transferTx ??=
+            result.transactions.transfer_operational_caps_to_keeper ?? null;
+        writeState(result);
+        return recorded;
+    }
+
+    const tx = new Transaction();
+    const cap = call(tx, target(result, "predict", "registry", "mint_pool_valuation_cap"), [
+        tx.object(sharedId(result, "predict", "registry::Registry")),
+        tx.object(capId(result, "predict", "admin::AdminCap")),
+        tx.object(sharedId(result, "predict", "protocol_config::ProtocolConfig")),
+    ]);
+    tx.transferObjects([cap], tx.pure.address(DEPLOYER));
+    const receipt = await executeTransaction(runtime, "mint_pool_valuation_cap", tx);
+    const id = createdObjectId(receipt, "::pool_valuation_cap::PoolValuationCap");
+    result.wiring.valuationCap.id = id;
+    result.wiring.valuationCap.owner = "deployer";
+    result.wiring.valuationCap.mintTx = receipt.digest ?? null;
+    writeState(result);
+    return id;
+}
+
+async function ensureOracleObjects(runtime: Runtime): Promise<void> {
+    const result = runtime.result;
+    const oracleRegistry = sharedId(result, "propbook", "registry::OracleRegistry");
+    const registryAdmin = capId(result, "propbook", "registry::RegistryAdminCap");
+
+    let pythFeedId = await inspectOptionId(
+        runtime,
+        "propbook_pyth_id_for_source",
+        target(result, "propbook", "registry", "propbook_pyth_id_for_source"),
+        (tx) => [tx.object(oracleRegistry), tx.pure.u32(ASSET.pythLazerFeedId)],
+    );
+    if (!pythFeedId) {
+        const tx = new Transaction();
+        call(tx, target(result, "propbook", "registry", "create_and_share_pyth_feed"), [
+            tx.object(oracleRegistry),
+            tx.pure.u32(ASSET.pythLazerFeedId),
+        ]);
+        const receipt = await executeTransaction(runtime, "create_pyth_feed", tx);
+        pythFeedId = createdObjectId(receipt, "::pyth_feed::PythFeed");
+        result.wiring.asset.pythFeedCreateTx = receipt.digest ?? null;
+    }
+    result.wiring.asset.pythFeedId = pythFeedId;
+    result.wiring.asset.pythFeedCreateTx ??= result.transactions.create_pyth_feed ?? null;
+
+    let storePair = await inspectBlockScholesStorePair(
+        runtime,
+        "block_scholes_store_pair_for_underlying",
+        oracleRegistry,
+    );
+    if (!storePair) {
+        const tx = new Transaction();
+        call(tx, target(result, "propbook", "registry", "create_and_share_block_scholes_stores"), [
+            tx.object(oracleRegistry),
+            tx.object(registryAdmin),
+            tx.pure.u32(ASSET.propbookUnderlyingId),
+            tx.pure.string(ASSET.blockScholesBaseAsset),
+        ]);
+        const receipt = await executeTransaction(runtime, "create_block_scholes_stores", tx);
+        const createdPair = {
+            valueStoreId: createdObjectId(receipt, "::block_scholes_store::BlockScholesValueStore"),
+            sviStoreId: createdObjectId(receipt, "::block_scholes_store::BlockScholesSVIStore"),
+        };
+        storePair = await inspectBlockScholesStorePair(
+            runtime,
+            "created_block_scholes_store_pair",
+            oracleRegistry,
+        );
+        if (
+            !storePair ||
+            storePair.valueStoreId !== createdPair.valueStoreId ||
+            storePair.sviStoreId !== createdPair.sviStoreId
+        ) {
+            throw new Error("created Block Scholes stores do not match the canonical pair");
+        }
+        result.wiring.asset.blockScholesStoresCreateTx = receipt.digest ?? null;
+    }
+    await assertBlockScholesStoreBaseAssets(runtime, storePair);
+    result.wiring.asset.blockScholesValueStoreId = storePair.valueStoreId;
+    result.wiring.asset.blockScholesSviStoreId = storePair.sviStoreId;
+    result.wiring.asset.blockScholesStoresCreateTx ??=
+        result.transactions.create_block_scholes_stores ?? null;
+
+    const boundPyth = await inspectOptionId(
+        runtime,
+        "propbook_pyth_id_for_underlying",
+        target(result, "propbook", "registry", "propbook_pyth_id_for_underlying"),
+        (tx) => [tx.object(oracleRegistry), tx.pure.u32(ASSET.propbookUnderlyingId)],
+    );
+    if (!boundPyth) {
+        const tx = new Transaction();
+        call(tx, target(result, "propbook", "registry", "bind_pyth_to_underlying"), [
+            tx.object(oracleRegistry),
+            tx.object(registryAdmin),
+            tx.object(pythFeedId),
+            tx.pure.u32(ASSET.propbookUnderlyingId),
+        ]);
+        const receipt = await executeTransaction(runtime, "bind_pyth_to_underlying", tx);
+        result.wiring.asset.pythBindTx = receipt.digest ?? null;
+    } else if (boundPyth !== pythFeedId) {
+        throw new Error(`underlying ${ASSET.propbookUnderlyingId} is bound to Pyth ${boundPyth}`);
+    }
+    result.wiring.asset.pythBindTx ??= result.transactions.bind_pyth_to_underlying ?? null;
+    writeState(result);
+}
+
+export function assertMatchingSid(label: string, onChain: bigint, subscription: bigint): void {
+    if (onChain !== subscription) {
+        throw new Error(`${label} SID is ${onChain}, subscription derives ${subscription}`);
+    }
+}
+
+async function verifyOracleReadiness(runtime: Runtime): Promise<Verification["oracleReadiness"]> {
+    const result = runtime.result;
+    const propbook = packageId(result, "propbook");
+    const valueStore = requiredObjectId(
+        result.wiring.asset.blockScholesValueStoreId,
+        "Block Scholes value store",
+    );
+    const sviStore = requiredObjectId(
+        result.wiring.asset.blockScholesSviStoreId,
+        "Block Scholes SVI store",
+    );
+    const planningClockMs = await currentClockMs(runtime);
+    const expirySet = new Set<bigint>();
+    for (const cadence of CADENCES.filter((candidate) => candidate.marketsToCreate > 0)) {
+        const firstSlot = Math.floor(Number(planningClockMs) / cadence.periodMs) + 1;
+        for (let offset = 0; offset < cadence.marketsToCreate; offset++) {
+            expirySet.add(BigInt((firstSlot + offset) * cadence.periodMs));
+        }
+    }
+    const expiries = [...expirySet].sort((left, right) => (left < right ? -1 : 1));
+    const tx = new Transaction();
+    let commandIndex = 0;
+    const clockIndex = commandIndex++;
+    call(tx, "0x2::clock::timestamp_ms", [tx.object(CLOCK_ID)]);
+    const spotSidIndex = commandIndex++;
+    call(tx, target(result, "propbook", "block_scholes_store", "spot_sid"), [
+        tx.object(valueStore),
+    ]);
+    const valueReadType = `${propbook}::block_scholes_store::BsRead<u128>`;
+    const spotRead = call(tx, target(result, "propbook", "block_scholes_store", "spot"), [
+        tx.object(valueStore),
+    ]);
+    commandIndex++;
+    const borrowedSpot = call(tx, "0x1::option::borrow", [spotRead], [valueReadType]);
+    commandIndex++;
+    const spotTimestampIndex = commandIndex++;
+    call(
+        tx,
+        target(result, "propbook", "block_scholes_store", "read_source_timestamp_ms"),
+        [borrowedSpot],
+        ["u128"],
+    );
+    const sviValueType = `${propbook}::block_scholes_store::SVIParams`;
+    const sviReadType = `${propbook}::block_scholes_store::BsRead<${sviValueType}>`;
+    const indexes: Array<{
+        expiryMs: bigint;
+        forwardSid: number;
+        sviSid: number;
+        forwardTimestamp: number;
+        sviTimestamp: number;
+    }> = [];
+    for (const expiryMs of expiries) {
+        const forwardSidIndex = commandIndex++;
+        call(tx, target(result, "propbook", "block_scholes_store", "forward_sid"), [
+            tx.object(valueStore),
+            tx.pure.u64(expiryMs),
+        ]);
+        const sviSidIndex = commandIndex++;
+        call(tx, target(result, "propbook", "block_scholes_store", "svi_sid"), [
+            tx.object(sviStore),
+            tx.pure.u64(expiryMs),
+        ]);
+        const forwardRead = call(tx, target(result, "propbook", "block_scholes_store", "forward"), [
+            tx.object(valueStore),
+            tx.pure.u64(expiryMs),
+        ]);
+        commandIndex++;
+        const borrowedForward = call(tx, "0x1::option::borrow", [forwardRead], [valueReadType]);
+        commandIndex++;
+        const forwardTimestampIndex = commandIndex++;
+        call(
+            tx,
+            target(result, "propbook", "block_scholes_store", "read_source_timestamp_ms"),
+            [borrowedForward],
+            ["u128"],
+        );
+        const sviRead = call(tx, target(result, "propbook", "block_scholes_store", "svi"), [
+            tx.object(sviStore),
+            tx.pure.u64(expiryMs),
+        ]);
+        commandIndex++;
+        const borrowedSvi = call(tx, "0x1::option::borrow", [sviRead], [sviReadType]);
+        commandIndex++;
+        const sviTimestampIndex = commandIndex++;
+        call(
+            tx,
+            target(result, "propbook", "block_scholes_store", "read_source_timestamp_ms"),
+            [borrowedSvi],
+            [sviValueType],
+        );
+        indexes.push({
+            expiryMs,
+            forwardSid: forwardSidIndex,
+            sviSid: sviSidIndex,
+            forwardTimestamp: forwardTimestampIndex,
+            sviTimestamp: sviTimestampIndex,
+        });
+    }
+    let response: unknown;
+    try {
+        response = await devInspect(runtime, "block_scholes_sid_and_source_clock_audit", tx);
+    } catch (error) {
+        throw new AwaitingOracleData(
+            `Block Scholes observations are not ready for the initial market window: ${String(error)}`,
+        );
+    }
+    const now = parseU64(returnBytes(response, clockIndex));
+    const onChainSpotSid = parseU256(returnBytes(response, spotSidIndex));
+    const subscriptionSpotSid = spotSid(LINKED.bs_oracle, ASSET.blockScholesBaseAsset);
+    assertMatchingSid("BTC spot", onChainSpotSid, subscriptionSpotSid);
+    const spotSourceTimestampMs = parseU64(returnBytes(response, spotTimestampIndex));
+    const checks: Verification["oracleReadiness"] = [];
+    for (const index of indexes) {
+        const { expiryMs } = index;
+        const onChainForwardSid = parseU256(returnBytes(response, index.forwardSid));
+        const onChainSviSid = parseU256(returnBytes(response, index.sviSid));
+        const subscriptionForwardSid = forwardSid(
+            LINKED.bs_oracle,
+            ASSET.blockScholesBaseAsset,
+            expiryMs,
+        );
+        const subscriptionSviSid = sviSid(LINKED.bs_oracle, ASSET.blockScholesBaseAsset, expiryMs);
+        assertMatchingSid(`BTC forward ${expiryMs}`, onChainForwardSid, subscriptionForwardSid);
+        assertMatchingSid(`BTC SVI ${expiryMs}`, onChainSviSid, subscriptionSviSid);
+        const forwardSourceTimestampMs = parseU64(returnBytes(response, index.forwardTimestamp));
+        const sviSourceTimestampMs = parseU64(returnBytes(response, index.sviTimestamp));
+        if (
+            spotSourceTimestampMs === 0n ||
+            forwardSourceTimestampMs === 0n ||
+            sviSourceTimestampMs === 0n ||
+            spotSourceTimestampMs > now ||
+            forwardSourceTimestampMs > now ||
+            sviSourceTimestampMs > now ||
+            now - spotSourceTimestampMs >
+                BigInt(EXPECTED_PROTOCOL_CONFIG.blockScholesPriceFreshnessMs) ||
+            now - forwardSourceTimestampMs >
+                BigInt(EXPECTED_PROTOCOL_CONFIG.blockScholesPriceFreshnessMs) ||
+            now - sviSourceTimestampMs > BigInt(EXPECTED_PROTOCOL_CONFIG.blockScholesSviFreshnessMs)
+        ) {
+            throw new AwaitingOracleData(
+                `Block Scholes source clocks are not fresh for expiry ${expiryMs}: now=${now} spot=${spotSourceTimestampMs} forward=${forwardSourceTimestampMs} svi=${sviSourceTimestampMs}`,
+            );
+        }
+        checks.push({
+            expiryMs: expiryMs.toString(),
+            spotSid: onChainSpotSid.toString(),
+            forwardSid: onChainForwardSid.toString(),
+            sviSid: onChainSviSid.toString(),
+            spotSourceTimestampMs: spotSourceTimestampMs.toString(),
+            forwardSourceTimestampMs: forwardSourceTimestampMs.toString(),
+            sviSourceTimestampMs: sviSourceTimestampMs.toString(),
+        });
+    }
+    return checks;
+}
+
+export function isUnderlyingNotRegisteredError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error);
+    const missingCode =
+        /},\s*0\)(?:\s|$)/.test(message) ||
+        /"abortCode"\s*:\s*(?:"0"|0)/.test(message) ||
+        /abort code:\s*0(?:\D|$)/.test(message);
+    return (
+        message.includes("MoveAbort") &&
+        message.includes("market_manager") &&
+        message.includes("underlying_config") &&
+        missingCode
+    );
+}
+
+async function predictUnderlyingRegistered(runtime: Runtime): Promise<boolean> {
+    const tx = new Transaction();
+    call(tx, target(runtime.result, "predict", "registry", "cadence_configs"), [
+        tx.object(sharedId(runtime.result, "predict", "registry::Registry")),
+        tx.pure.u32(ASSET.propbookUnderlyingId),
+    ]);
+    try {
+        await devInspect(runtime, "predict_underlying_registered", tx);
+        return true;
+    } catch (error) {
+        if (isUnderlyingNotRegisteredError(error)) return false;
+        throw error;
+    }
+}
+
+async function ensureUnderlyingRegistered(runtime: Runtime): Promise<void> {
+    const result = runtime.result;
+    if (!(await predictUnderlyingRegistered(runtime))) {
+        const tx = new Transaction();
+        call(tx, target(result, "predict", "registry", "register_underlying"), [
+            tx.object(sharedId(result, "predict", "registry::Registry")),
+            tx.object(sharedId(result, "predict", "protocol_config::ProtocolConfig")),
+            tx.object(capId(result, "predict", "admin::AdminCap")),
+            tx.pure.u32(ASSET.propbookUnderlyingId),
+        ]);
+        const receipt = await executeTransaction(runtime, "register_predict_underlying", tx);
+        result.wiring.asset.predictUnderlyingRegisteredTx = receipt.digest ?? null;
+        if (!(await predictUnderlyingRegistered(runtime))) {
+            throw new Error("Predict underlying registration did not persist on-chain");
+        }
+    }
+    result.wiring.asset.predictUnderlyingRegistered = true;
+    result.wiring.asset.predictUnderlyingRegisteredTx ??=
+        result.transactions.register_predict_underlying ?? null;
+    writeState(result);
+}
+
+async function readCadence(runtime: Runtime, spec: CadenceSpec): Promise<CadenceRecord> {
+    const result = runtime.result;
+    const registry = sharedId(result, "predict", "registry::Registry");
+    const tx = new Transaction();
+    const getters = [
+        "cadence_tick_size",
+        "cadence_admission_tick_size",
+        "cadence_max_expiry_allocation",
+        "cadence_initial_expiry_cash",
+        "cadence_window_size",
+    ];
+    for (const getter of getters) {
+        const config = call(tx, target(result, "predict", "registry", "cadence_config"), [
+            tx.object(registry),
+            tx.pure.u32(ASSET.propbookUnderlyingId),
+            tx.pure.u8(spec.id),
+        ]);
+        call(tx, target(result, "predict", "market_manager", getter), [config]);
+    }
+    const response = await devInspect(runtime, `read_${spec.name}_cadence`, tx);
+    const values = getters.map((_, index) => parseU64(returnBytes(response, index * 2 + 1)));
+    return {
+        id: spec.id,
+        name: spec.name,
+        tickSize: values[0].toString(),
+        admissionTickSize: values[1].toString(),
+        maxExpiryAllocation: values[2].toString(),
+        initialExpiryCash: values[3].toString(),
+        windowSize: values[4].toString(),
+        setTx: result.transactions.set_cadence_configs ?? null,
+    };
+}
+
+async function readCadences(runtime: Runtime): Promise<CadenceRecord[]> {
+    const records: CadenceRecord[] = [];
+    for (const cadence of CADENCES) records.push(await readCadence(runtime, cadence));
+    return records;
+}
+
+async function ensureCadences(runtime: Runtime): Promise<void> {
+    const result = runtime.result;
+    const current = await readCadences(runtime);
+    if (!current.every((record, index) => cadenceMatches(record, CADENCES[index]))) {
+        const tx = new Transaction();
+        for (const cadence of CADENCES) {
+            call(tx, target(result, "predict", "registry", "set_template_cadence_config"), [
+                tx.object(sharedId(result, "predict", "registry::Registry")),
+                tx.object(sharedId(result, "predict", "protocol_config::ProtocolConfig")),
+                tx.object(capId(result, "predict", "admin::AdminCap")),
+                tx.pure.u32(ASSET.propbookUnderlyingId),
+                tx.pure.u8(cadence.id),
+                tx.pure.u64(cadence.tickSize),
+                tx.pure.u64(cadence.admissionTickSize),
+                tx.pure.u64(cadence.maxExpiryAllocation),
+                tx.pure.u64(cadence.initialExpiryCash),
+                tx.pure.u64(cadence.windowSize),
+            ]);
+        }
+        const receipt = await executeTransaction(runtime, "set_cadence_configs", tx);
+        result.wiring.cadences = CADENCES.map((cadence) =>
+            expectedCadenceRecord(cadence, receipt.digest ?? null),
+        );
+        writeState(result);
+    }
+    const verified = await readCadences(runtime);
+    if (!verified.every((record, index) => cadenceMatches(record, CADENCES[index]))) {
+        throw new Error("on-chain cadence configuration does not match the deployment policy");
+    }
+    result.wiring.cadences = verified;
+    writeState(result);
+}
+
+async function ensureAccountWrapper(runtime: Runtime): Promise<string> {
+    const result = runtime.result;
+    const registry = sharedId(result, "account", "account_registry::AccountRegistry");
+    const exists = await inspectBool(
+        runtime,
+        "derived_wrapper_exists",
+        target(result, "account", "account_registry", "derived_wrapper_exists"),
+        (tx) => [tx.object(registry), tx.pure.address(DEPLOYER)],
+    );
+    let wrapperId: string;
+    if (!exists) {
+        const tx = new Transaction();
+        const wrapper = call(tx, target(result, "account", "account_registry", "new"), [
+            tx.object(registry),
+        ]);
+        call(tx, target(result, "account", "account", "share"), [wrapper]);
+        const receipt = await executeTransaction(runtime, "create_deployer_account", tx);
+        wrapperId = createdObjectId(receipt, "::account::AccountWrapper");
+        result.wiring.account.createAccountTx = receipt.digest ?? null;
+    } else {
+        const tx = new Transaction();
+        call(tx, target(result, "account", "account_registry", "derived_wrapper_address"), [
+            tx.object(registry),
+            tx.pure.address(DEPLOYER),
+        ]);
+        wrapperId = parseAddress(
+            returnBytes(await devInspect(runtime, "derived_wrapper_address", tx)),
+        );
+    }
+    if (
+        result.wiring.account.accountWrapperId &&
+        result.wiring.account.accountWrapperId !== wrapperId
+    ) {
+        throw new Error(
+            `recorded account wrapper ${result.wiring.account.accountWrapperId} != ${wrapperId}`,
+        );
+    }
+    result.wiring.account.accountWrapperId = wrapperId;
+    result.wiring.account.createAccountTx ??= result.transactions.create_deployer_account ?? null;
+    writeState(result);
+    return wrapperId;
+}
+
+function generateOwnerAuth(result: DeploymentResult, tx: Transaction): TransactionResult {
+    return call(tx, target(result, "account", "account", "generate_auth"), []);
+}
+
+async function deploymentAccountId(runtime: Runtime, accountWrapperId: string): Promise<string> {
+    const tx = new Transaction();
+    const account = call(tx, target(runtime.result, "account", "account", "load_account"), [
+        tx.object(accountWrapperId),
+    ]);
+    call(tx, target(runtime.result, "account", "account", "account_id"), [account]);
+    return parseAddress(returnBytes(await devInspect(runtime, "deployment_account_id", tx), 1));
+}
+
+async function deploymentAccountPlpBalance(
+    runtime: Runtime,
+    accountWrapperId: string,
+): Promise<bigint> {
+    const tx = new Transaction();
+    const account = call(tx, target(runtime.result, "account", "account", "load_account"), [
+        tx.object(accountWrapperId),
+    ]);
+    call(
+        tx,
+        target(runtime.result, "account", "account", "balance"),
+        [account, tx.object(ACCUMULATOR_ROOT_ID), tx.object(CLOCK_ID)],
+        [plpType(runtime.result)],
+    );
+    return parseU64(
+        returnBytes(await devInspect(runtime, "deployment_account_plp_balance", tx), 1),
+    );
+}
+
+async function poolU64(runtime: Runtime, fn: string): Promise<bigint> {
+    return inspectU64(runtime, fn, target(runtime.result, "predict", "plp", fn), (tx) => [
+        tx.object(sharedId(runtime.result, "predict", "plp::PoolVault")),
+    ]);
+}
+
+function integerEventField(fields: Record<string, unknown>, name: string): string {
+    const value = fields[name];
+    if (typeof value !== "string" && typeof value !== "number") {
+        throw new Error(`bootstrap event field ${name} is not numeric`);
+    }
+    return String(value);
+}
+
+function validateBootstrapReceipt(
+    receipt: Receipt,
+    vaultId: string,
+    accountId: string,
+    accountWrapperId: string,
+): { requestIndex: string; sharesMinted: string } {
+    const requested = asRecord(eventNamed(receipt, "SupplyRequested")?.parsedJson);
+    const filled = asRecord(eventNamed(receipt, "SupplyFilled")?.parsedJson);
+    if (Object.keys(requested).length === 0 || Object.keys(filled).length === 0) {
+        throw new Error(`bootstrap transaction ${receipt.digest} is missing supply events`);
+    }
+    const requestIndex = integerEventField(requested, "index");
+    const sharesMinted = integerEventField(filled, "shares_minted");
+    const expected = [
+        [normalizeOptionalId(requested.pool_vault_id), vaultId, "requested pool"],
+        [normalizeOptionalId(filled.pool_vault_id), vaultId, "filled pool"],
+        [normalizeOptionalId(requested.account_id), accountId, "requested account"],
+        [normalizeOptionalId(filled.account_id), accountId, "filled account"],
+        [normalizeOptionalId(requested.recipient), accountWrapperId, "requested recipient"],
+        [normalizeOptionalId(filled.recipient), accountWrapperId, "filled recipient"],
+    ] as const;
+    for (const [actual, wanted, label] of expected) {
+        if (actual !== wanted) throw new Error(`${label} is ${actual}, expected ${wanted}`);
+    }
+    if (
+        integerEventField(requested, "amount") !== BOOTSTRAP_SUPPLY_AMOUNT.toString() ||
+        integerEventField(requested, "min_plp_out") !== "0" ||
+        integerEventField(requested, "requests_pending_after") !== "1" ||
+        integerEventField(filled, "index") !== requestIndex ||
+        integerEventField(filled, "dusdc_amount") !== BOOTSTRAP_SUPPLY_AMOUNT.toString() ||
+        sharesMinted !== BOOTSTRAP_SUPPLY_AMOUNT.toString() ||
+        integerEventField(filled, "dusdc_remaining") !== "0" ||
+        integerEventField(filled, "requests_pending_after") !== "0"
+    ) {
+        throw new Error(`bootstrap transaction ${receipt.digest} has unexpected supply events`);
+    }
+    return { requestIndex, sharesMinted };
+}
+
+async function ensureBootstrap(
+    runtime: Runtime,
+    valuationCapId: string,
+    accountWrapperId: string,
+): Promise<void> {
+    const result = runtime.result;
+    const vault = sharedId(result, "predict", "plp::PoolVault");
+    const config = sharedId(result, "predict", "protocol_config::ProtocolConfig");
+    const accountId = await deploymentAccountId(runtime, accountWrapperId);
+    let totalSupply = await poolU64(runtime, "plp_total_supply");
+    let pendingSupply = await poolU64(runtime, "supply_requests_pending");
+    let pendingWithdraw = await poolU64(runtime, "withdraw_requests_pending");
+    let accountPlpBalance = await deploymentAccountPlpBalance(runtime, accountWrapperId);
+    if (totalSupply === 0n) {
+        if (pendingSupply !== 0n || pendingWithdraw !== 0n || accountPlpBalance !== 0n) {
+            throw new Error(
+                `nonempty bootstrap state supply=${pendingSupply} withdraw=${pendingWithdraw} accountPLP=${accountPlpBalance}`,
+            );
+        }
+        const tx = new Transaction();
+        const lockPayment = coinWithBalance({
+            type: usdcType(result),
+            balance: LOCK_CAPITAL_AMOUNT,
+            useGasCoin: false,
+        })(tx);
+        call(tx, target(result, "predict", "plp", "lock_capital"), [
+            tx.object(vault),
+            tx.object(config),
+            tx.object(capId(result, "predict", "admin::AdminCap")),
+            lockPayment,
+        ]);
+        const supplyPayment = coinWithBalance({
+            type: usdcType(result),
+            balance: BOOTSTRAP_SUPPLY_AMOUNT,
+            useGasCoin: false,
+        })(tx);
+        const depositAuth = generateOwnerAuth(result, tx);
+        call(
+            tx,
+            target(result, "account", "account", "deposit_funds"),
+            [
+                tx.object(accountWrapperId),
+                depositAuth,
+                supplyPayment,
+                tx.object(ACCUMULATOR_ROOT_ID),
+                tx.object(CLOCK_ID),
+            ],
+            [usdcType(result)],
+        );
+        const supplyAuth = generateOwnerAuth(result, tx);
+        call(tx, target(result, "predict", "plp", "request_supply"), [
+            tx.object(vault),
+            tx.object(accountWrapperId),
+            supplyAuth,
+            tx.object(config),
+            tx.pure.u64(BOOTSTRAP_SUPPLY_AMOUNT),
+            tx.pure.u64(0),
+            tx.object(ACCUMULATOR_ROOT_ID),
+            tx.object(CLOCK_ID),
+        ]);
+        const proof = call(
+            tx,
+            target(result, "predict", "registry", "generate_pool_valuation_proof"),
+            [
+                tx.object(sharedId(result, "predict", "registry::Registry")),
+                tx.object(valuationCapId),
+            ],
+        );
+        const snapshotStage = call(tx, target(result, "predict", "plp", "start_pool_valuation"), [
+            tx.object(config),
+            tx.object(vault),
+            proof,
+            tx.pure(bcs.option(bcs.u64()).serialize(1n)),
+            tx.pure(bcs.option(bcs.u64()).serialize(0n)),
+            tx.object(CLOCK_ID),
+        ]);
+        call(tx, target(result, "predict", "plp", "seal_valuation_snapshot"), [
+            tx.object(vault),
+            snapshotStage,
+            tx.object(config),
+        ]);
+        call(tx, target(result, "predict", "plp", "finish_flush"), [
+            tx.object(vault),
+            tx.object(config),
+            tx.object(CLOCK_ID),
+        ]);
+        const receipt = await executeTransaction(runtime, "bootstrap_pool", tx);
+        const eventState = validateBootstrapReceipt(receipt, vault, accountId, accountWrapperId);
+        result.wiring.bootstrap.accountId = accountId;
+        result.wiring.bootstrap.requestIndex = eventState.requestIndex;
+        result.wiring.bootstrap.sharesMinted = eventState.sharesMinted;
+        result.wiring.bootstrap.lockCapitalTx = receipt.digest ?? null;
+        result.wiring.bootstrap.supplyRequestTx = receipt.digest ?? null;
+        result.wiring.bootstrap.flushTx = receipt.digest ?? null;
+        writeState(result);
+    }
+    totalSupply = await poolU64(runtime, "plp_total_supply");
+    pendingSupply = await poolU64(runtime, "supply_requests_pending");
+    pendingWithdraw = await poolU64(runtime, "withdraw_requests_pending");
+    accountPlpBalance = await deploymentAccountPlpBalance(runtime, accountWrapperId);
+    const bootstrapDigest = result.transactions.bootstrap_pool;
+    if (
+        totalSupply !== LOCK_CAPITAL_AMOUNT + BOOTSTRAP_SUPPLY_AMOUNT ||
+        pendingSupply !== 0n ||
+        pendingWithdraw !== 0n ||
+        accountPlpBalance !== BOOTSTRAP_SUPPLY_AMOUNT ||
+        !bootstrapDigest
+    ) {
+        throw new Error(
+            `bootstrap incomplete: totalSupply=${totalSupply} pending=${pendingSupply}/${pendingWithdraw} accountPLP=${accountPlpBalance} tx=${bootstrapDigest}`,
+        );
+    }
+    if (
+        !result.wiring.bootstrap.requestIndex ||
+        !result.wiring.bootstrap.sharesMinted ||
+        result.wiring.bootstrap.accountId !== accountId
+    ) {
+        const receipt = await settledReceipt(runtime.client, bootstrapDigest);
+        const eventState = validateBootstrapReceipt(receipt, vault, accountId, accountWrapperId);
+        result.wiring.bootstrap.accountId = accountId;
+        result.wiring.bootstrap.requestIndex = eventState.requestIndex;
+        result.wiring.bootstrap.sharesMinted = eventState.sharesMinted;
+    }
+    result.wiring.bootstrap.accountPlpBalance = accountPlpBalance.toString();
+    result.wiring.bootstrap.lockCapitalTx = bootstrapDigest;
+    result.wiring.bootstrap.supplyRequestTx = bootstrapDigest;
+    result.wiring.bootstrap.flushTx = bootstrapDigest;
+    writeState(result);
+}
+
+async function activeMarketIds(runtime: Runtime): Promise<string[]> {
+    const tx = new Transaction();
+    call(tx, target(runtime.result, "predict", "plp", "active_expiry_markets"), [
+        tx.object(sharedId(runtime.result, "predict", "plp::PoolVault")),
+    ]);
+    return parseIdVector(returnBytes(await devInspect(runtime, "active_expiry_markets", tx)));
+}
+
+async function marketState(
+    runtime: Runtime,
+    id: string,
+): Promise<{
+    underlying: number;
+    expiryMs: bigint;
+    referenceTickSourceTimestampMs: bigint;
+    referenceTick: bigint | null;
+    cashBalance: bigint;
+}> {
+    const result = runtime.result;
+    const tx = new Transaction();
+    call(tx, target(result, "predict", "expiry_market", "propbook_underlying_id"), [tx.object(id)]);
+    call(tx, target(result, "predict", "expiry_market", "expiry"), [tx.object(id)]);
+    call(tx, target(result, "predict", "expiry_market", "reference_tick_source_timestamp_ms"), [
+        tx.object(id),
+    ]);
+    call(tx, target(result, "predict", "expiry_market", "reference_tick"), [tx.object(id)]);
+    call(tx, target(result, "predict", "expiry_market", "cash_balance"), [tx.object(id)]);
+    const response = await devInspect(runtime, `market_state_${id}`, tx);
+    return {
+        underlying: parseU32(returnBytes(response, 0)),
+        expiryMs: parseU64(returnBytes(response, 1)),
+        referenceTickSourceTimestampMs: parseU64(returnBytes(response, 2)),
+        referenceTick: parseOptionU64(returnBytes(response, 3)),
+        cashBalance: parseU64(returnBytes(response, 4)),
+    };
+}
+
+function cadenceForPeriod(periodMs: bigint): CadenceSpec {
+    const match = CADENCES.find(
+        (cadence) => cadence.windowSize > 0n && BigInt(cadence.periodMs) === periodMs,
+    );
+    if (!match) throw new Error(`cannot infer cadence for period ${periodMs}`);
+    return match;
+}
+
+function cadenceForMarketLabel(label: string): CadenceSpec {
+    const name = label.match(/^create_market_([^_]+)_[0-9]+$/)?.[1];
+    const match = CADENCES.find((cadence) => cadence.windowSize > 0n && cadence.name === name);
+    if (!match) throw new Error(`cannot infer cadence from transaction label ${label}`);
+    return match;
+}
+
+function marketFromEvent(receipt: Receipt, cadence: CadenceSpec): MarketRecord {
+    const event = eventNamed(receipt, "MarketCreated");
+    const parsed = asRecord(event?.parsedJson);
+    const id =
+        normalizeOptionalId(parsed.expiry_market_id) ??
+        createdObjectId(receipt, "::expiry_market::ExpiryMarket");
+    const expiry = parsed.expiry;
+    if (typeof expiry !== "string" && typeof expiry !== "number") {
+        throw new Error(`MarketCreated in ${receipt.digest} has no expiry`);
+    }
+    return {
+        id,
+        cadenceId: cadence.id,
+        cadence: cadence.name,
+        expiryMs: String(expiry),
+        tickSize: String(parsed.tick_size ?? cadence.tickSize),
+        admissionTickSize: String(parsed.admission_tick_size ?? cadence.admissionTickSize),
+        maxExpiryAllocation: String(parsed.max_expiry_allocation ?? cadence.maxExpiryAllocation),
+        initialExpiryCash: String(parsed.initial_expiry_cash ?? cadence.initialExpiryCash),
+        createTx: receipt.digest ?? null,
+        referenceTick: null,
+        setReferenceTickTx: null,
+        rebalanceTx: null,
+        cashBalance: "0",
+    };
+}
+
+async function rebuildMarketsFromTransactions(runtime: Runtime): Promise<void> {
+    const result = runtime.result;
+    const byId = new Map(result.wiring.markets.map((market) => [market.id, market]));
+    for (const [label, digest] of Object.entries(result.transactions)) {
+        if (!label.startsWith("create_market_")) continue;
+        if (result.wiring.markets.some((market) => market.createTx === digest)) continue;
+        const receipt = await settledReceipt(runtime.client, digest);
+        const event = eventNamed(receipt, "MarketCreated");
+        const parsed = asRecord(event?.parsedJson);
+        if (typeof parsed.expiry !== "string" && typeof parsed.expiry !== "number") {
+            throw new Error(`${label}/${digest} has no MarketCreated expiry`);
+        }
+        const cadence = cadenceForMarketLabel(label);
+        const market = marketFromEvent(receipt, cadence);
+        const existing = byId.get(market.id);
+        if (existing) {
+            existing.createTx ??= digest;
+        } else {
+            result.wiring.markets.push(market);
+            byId.set(market.id, market);
+        }
+    }
+    writeState(result);
+}
+
+async function discoverMarkets(runtime: Runtime): Promise<void> {
+    const result = runtime.result;
+    await rebuildMarketsFromTransactions(runtime);
+    const byId = new Map(result.wiring.markets.map((market) => [market.id, market]));
+    for (const id of await activeMarketIds(runtime)) {
+        const state = await marketState(runtime, id);
+        if (state.underlying !== ASSET.propbookUnderlyingId) {
+            throw new Error(`active market ${id} belongs to underlying ${state.underlying}`);
+        }
+        if (state.referenceTickSourceTimestampMs >= state.expiryMs) {
+            throw new Error(
+                `active market ${id} has invalid reference timestamp ${state.referenceTickSourceTimestampMs}`,
+            );
+        }
+        const cadence = cadenceForPeriod(state.expiryMs - state.referenceTickSourceTimestampMs);
+        const existing = byId.get(id);
+        if (existing) {
+            existing.cashBalance = state.cashBalance.toString();
+            existing.referenceTick = state.referenceTick?.toString() ?? null;
+            existing.setReferenceTickTx ??= result.transactions[`set_reference_tick_${id}`] ?? null;
+            existing.rebalanceTx ??= result.transactions[`rebalance_market_${id}`] ?? null;
+        } else {
+            const evidence = await objectEvidence(
+                runtime,
+                id,
+                `${packageId(result, "predict")}::expiry_market::ExpiryMarket`,
+                "shared",
+            );
+            const market: MarketRecord = {
+                id,
+                cadenceId: cadence.id,
+                cadence: cadence.name,
+                expiryMs: state.expiryMs.toString(),
+                tickSize: cadence.tickSize.toString(),
+                admissionTickSize: cadence.admissionTickSize.toString(),
+                maxExpiryAllocation: cadence.maxExpiryAllocation.toString(),
+                initialExpiryCash: cadence.initialExpiryCash.toString(),
+                createTx: state.cashBalance === 0n ? evidence.previousTransaction : null,
+                referenceTick: state.referenceTick?.toString() ?? null,
+                setReferenceTickTx: result.transactions[`set_reference_tick_${id}`] ?? null,
+                rebalanceTx: state.cashBalance > 0n ? evidence.previousTransaction : null,
+                cashBalance: state.cashBalance.toString(),
+            };
+            result.wiring.markets.push(market);
+            byId.set(id, market);
+        }
+    }
+    result.wiring.markets.sort((left, right) =>
+        Number(BigInt(left.expiryMs) - BigInt(right.expiryMs)),
+    );
+    writeState(result);
+}
+
+async function currentClockMs(runtime: Runtime): Promise<bigint> {
+    return inspectU64(runtime, "clock_timestamp_ms", "0x2::clock::timestamp_ms", (tx) => [
+        tx.object(CLOCK_ID),
+    ]);
+}
+
+async function waitForCadenceLead(runtime: Runtime, cadence: CadenceSpec): Promise<void> {
+    const now = Number(await currentClockMs(runtime));
+    const nextExpiry = (Math.floor(now / cadence.periodMs) + 1) * cadence.periodMs;
+    const lead = nextExpiry - now;
+    const minimumLead = Math.min(90_000, Math.floor(cadence.periodMs / 2));
+    if (lead >= minimumLead) return;
+    const wait = lead + 1_500;
+    console.log(
+        `[deploy] ${cadence.name} next slot has ${lead}ms lead; waiting ${wait}ms for a fresh slot`,
+    );
+    await new Promise((done) => setTimeout(done, wait));
+}
+
+function isCadenceWindowFull(error: unknown): boolean {
+    return (
+        error instanceof DryRunFailure &&
+        error.detail.includes("market_manager") &&
+        (/,\s*5\)?/.test(error.detail) || /"abortCode":"5"/.test(error.detail))
+    );
+}
+
+function marketCreationTransaction(
+    result: DeploymentResult,
+    lifecycleCapId: string,
+    cadence: CadenceSpec,
+): Transaction {
+    const tx = new Transaction();
+    call(tx, target(result, "predict", "registry", "create_and_share_expiry_market"), [
+        tx.object(sharedId(result, "predict", "registry::Registry")),
+        tx.object(sharedId(result, "predict", "plp::PoolVault")),
+        tx.object(sharedId(result, "predict", "protocol_config::ProtocolConfig")),
+        tx.object(sharedId(result, "propbook", "registry::OracleRegistry")),
+        tx.object(lifecycleCapId),
+        tx.pure.u32(ASSET.propbookUnderlyingId),
+        tx.pure.u8(cadence.id),
+        tx.object(CLOCK_ID),
+    ]);
+    return tx;
+}
+
+function nextMarketLabel(result: DeploymentResult, cadence: CadenceSpec): string {
+    let sequence = 0;
+    while (result.transactions[`create_market_${cadence.name}_${sequence}`]) sequence++;
+    return `create_market_${cadence.name}_${sequence}`;
+}
+
+async function liveMarketSnapshot(runtime: Runtime): Promise<{
+    clockMs: bigint;
+    markets: MarketRecord[];
+}> {
+    const [clockMs, activeIds] = await Promise.all([
+        currentClockMs(runtime),
+        activeMarketIds(runtime),
+    ]);
+    const active = new Set(activeIds);
+    return {
+        clockMs,
+        markets: runtime.result.wiring.markets.filter(
+            (market) => active.has(market.id) && BigInt(market.expiryMs) > clockMs,
+        ),
+    };
+}
+
+async function assertLiveMarketWindows(
+    runtime: Runtime,
+    lifecycleCapId: string,
+    canProbe: boolean,
+): Promise<void> {
+    await discoverMarkets(runtime);
+    const snapshot = await liveMarketSnapshot(runtime);
+    const checks: WiringState["marketWindowChecks"] = [];
+    for (const cadence of CADENCES.filter((candidate) => candidate.marketsToCreate > 0)) {
+        const recorded = snapshot.markets.filter(
+            (market) => market.cadenceId === cadence.id,
+        ).length;
+        let windowFull = false;
+        if (recorded < cadence.marketsToCreate) {
+            if (canProbe) {
+                const tx = marketCreationTransaction(runtime.result, lifecycleCapId, cadence);
+                tx.setSender(DEPLOYER);
+                tx.setGasBudget(TRANSACTION_GAS_BUDGET);
+                const bytes = await tx.build({ client: runtime.client });
+                try {
+                    await dryRun(runtime, `check_${cadence.name}_market_window`, bytes);
+                } catch (error) {
+                    if (!isCadenceWindowFull(error)) throw error;
+                    windowFull = true;
+                }
+                if (!windowFull) {
+                    throw new Error(`${cadence.name} still has a deployable market slot`);
+                }
+            } else {
+                const prior = runtime.result.wiring.marketWindowChecks.find(
+                    (check) => check.cadenceId === cadence.id,
+                );
+                if (
+                    !prior?.windowFull ||
+                    prior.recorded !== recorded ||
+                    !prior.checkedAtChainMs ||
+                    snapshot.clockMs < BigInt(prior.checkedAtChainMs) ||
+                    snapshot.clockMs / BigInt(cadence.periodMs) !==
+                        BigInt(prior.checkedAtChainMs) / BigInt(cadence.periodMs)
+                ) {
+                    throw new Error(
+                        `${cadence.name} has only ${recorded}/${cadence.marketsToCreate} future markets after lifecycle-cap handoff`,
+                    );
+                }
+                windowFull = true;
+            }
+        }
+        checks.push({
+            cadenceId: cadence.id,
+            cadence: cadence.name,
+            target: cadence.marketsToCreate,
+            recorded,
+            windowFull,
+            checkedAtChainMs: snapshot.clockMs.toString(),
+            checkedAt: new Date().toISOString(),
+        });
+    }
+    if (canProbe) {
+        runtime.result.wiring.marketWindowChecks = checks;
+        writeState(runtime.result);
+    }
+}
+
+async function ensureReferenceTick(runtime: Runtime, market: MarketRecord): Promise<void> {
+    let state = await marketState(runtime, market.id);
+    if (state.referenceTick === null) {
+        const result = runtime.result;
+        const tx = new Transaction();
+        call(tx, target(result, "predict", "expiry_market", "set_reference_tick"), [
+            tx.object(market.id),
+            tx.object(sharedId(result, "predict", "protocol_config::ProtocolConfig")),
+            tx.object(sharedId(result, "propbook", "registry::OracleRegistry")),
+            tx.object(requiredObjectId(result.wiring.asset.pythFeedId, "BTC Pyth feed")),
+            tx.object(CLOCK_ID),
+        ]);
+        let receipt: Receipt;
+        try {
+            receipt = await executeTransaction(runtime, `set_reference_tick_${market.id}`, tx);
+        } catch (error) {
+            if (error instanceof DryRunFailure) {
+                throw new AwaitingOracleData(
+                    `market ${market.id} is waiting for its exact Pyth reference observation at ${state.referenceTickSourceTimestampMs}`,
+                );
+            }
+            throw error;
+        }
+        market.setReferenceTickTx = receipt.digest ?? null;
+        state = await marketState(runtime, market.id);
+    }
+    if (state.referenceTick === null) {
+        throw new Error(`market ${market.id} has no reference tick after initialization`);
+    }
+    market.referenceTick = state.referenceTick.toString();
+    market.setReferenceTickTx ??=
+        runtime.result.transactions[`set_reference_tick_${market.id}`] ?? null;
+    writeState(runtime.result);
+}
+
+async function rebalanceMarket(runtime: Runtime, market: MarketRecord): Promise<void> {
+    if (market.cashBalance && BigInt(market.cashBalance) > 0n) return;
+    const result = runtime.result;
+    const tx = new Transaction();
+    call(tx, target(result, "predict", "plp", "rebalance_expiry_cash"), [
+        tx.object(sharedId(result, "predict", "plp::PoolVault")),
+        tx.object(market.id),
+        tx.object(sharedId(result, "predict", "protocol_config::ProtocolConfig")),
+        tx.object(CLOCK_ID),
+    ]);
+    const label = `rebalance_market_${market.id}`;
+    const receipt = await executeTransaction(runtime, label, tx);
+    market.rebalanceTx = receipt.digest ?? null;
+    market.cashBalance = (await marketState(runtime, market.id)).cashBalance.toString();
+    if (BigInt(market.cashBalance) === 0n) {
+        throw new Error(`market ${market.id} remained unfunded after rebalance`);
+    }
+    writeState(result);
+}
+
+async function ensureMarkets(runtime: Runtime, lifecycleCapId: string): Promise<void> {
+    const result = runtime.result;
+    if (result.wiring.lifecycleCap.owner === "recipient") {
+        await assertLiveMarketWindows(runtime, lifecycleCapId, false);
+        return;
+    }
+    await discoverMarkets(runtime);
+    for (const market of (await liveMarketSnapshot(runtime)).markets) {
+        await ensureReferenceTick(runtime, market);
+        await rebalanceMarket(runtime, market);
+    }
+
+    const enabledCadences = CADENCES.filter((candidate) => candidate.marketsToCreate > 0)
+        .slice()
+        .sort((left, right) => right.periodMs - left.periodMs);
+    for (const cadence of enabledCadences) {
+        while (
+            (await liveMarketSnapshot(runtime)).markets.filter(
+                (market) => market.cadenceId === cadence.id,
+            ).length < cadence.marketsToCreate
+        ) {
+            const creationLimit = cadence.marketsToCreate + MARKET_ROLLOVER_RESERVE_PER_CADENCE;
+            const creationsThisRun = runtime.marketCreationsThisRun[cadence.id] ?? 0;
+            if (creationsThisRun >= creationLimit) {
+                throw new Error(
+                    `${cadence.name} exceeded its per-run market rollover bound (${creationLimit}); preserve the journal and resume`,
+                );
+            }
+            await waitForCadenceLead(runtime, cadence);
+            const tx = marketCreationTransaction(result, lifecycleCapId, cadence);
+            const label = nextMarketLabel(result, cadence);
+            let receipt: Receipt;
+            try {
+                receipt = await executeTransaction(runtime, label, tx);
+            } catch (error) {
+                if (isCadenceWindowFull(error)) {
+                    console.log(`[deploy] ${cadence.name} cadence window is full`);
+                    break;
+                }
+                throw error;
+            }
+            runtime.marketCreationsThisRun[cadence.id] = creationsThisRun + 1;
+            const market = marketFromEvent(receipt, cadence);
+            result.wiring.markets.push(market);
+            writeState(result);
+            await ensureReferenceTick(runtime, market);
+            await rebalanceMarket(runtime, market);
+        }
+    }
+    await assertLiveMarketWindows(runtime, lifecycleCapId, true);
+}
+
+async function transferOperationalCaps(
+    runtime: Runtime,
+    lifecycleCapId: string,
+    valuationCapId: string,
+): Promise<void> {
+    const result = runtime.result;
+    const lifecycleEvidence = await objectEvidence(
+        runtime,
+        lifecycleCapId,
+        `${packageId(result, "predict")}::market_lifecycle_cap::MarketLifecycleCap`,
+        null,
+    );
+    const valuationEvidence = await objectEvidence(
+        runtime,
+        valuationCapId,
+        `${packageId(result, "predict")}::pool_valuation_cap::PoolValuationCap`,
+        null,
+    );
+    const recipientOwner = partyOwnerLabel(PREDICT_WRITER);
+    if (lifecycleEvidence.owner === recipientOwner && valuationEvidence.owner === recipientOwner) {
+        result.wiring.lifecycleCap.owner = "recipient";
+        result.wiring.valuationCap.owner = "recipient";
+        result.wiring.lifecycleCap.transferTx ??=
+            result.transactions.transfer_operational_caps_to_keeper ?? null;
+        result.wiring.valuationCap.transferTx ??=
+            result.transactions.transfer_operational_caps_to_keeper ?? null;
+        writeState(result);
+        return;
+    }
+    if (lifecycleEvidence.owner !== DEPLOYER || valuationEvidence.owner !== DEPLOYER) {
+        throw new Error(
+            `operational caps are owned by ${lifecycleEvidence.owner}/${valuationEvidence.owner}, expected both ${DEPLOYER}`,
+        );
+    }
+    const tx = new Transaction();
+    const lifecycleParty = call(tx, "0x2::party::single_owner", [tx.pure.address(PREDICT_WRITER)]);
+    call(
+        tx,
+        "0x2::transfer::public_party_transfer",
+        [tx.object(lifecycleCapId), lifecycleParty],
+        [`${packageId(result, "predict")}::market_lifecycle_cap::MarketLifecycleCap`],
+    );
+    const valuationParty = call(tx, "0x2::party::single_owner", [tx.pure.address(PREDICT_WRITER)]);
+    call(
+        tx,
+        "0x2::transfer::public_party_transfer",
+        [tx.object(valuationCapId), valuationParty],
+        [`${packageId(result, "predict")}::pool_valuation_cap::PoolValuationCap`],
+    );
+    const receipt = await executeTransaction(runtime, "transfer_operational_caps_to_keeper", tx);
+    await objectEvidence(
+        runtime,
+        lifecycleCapId,
+        `${packageId(result, "predict")}::market_lifecycle_cap::MarketLifecycleCap`,
+        recipientOwner,
+    );
+    await objectEvidence(
+        runtime,
+        valuationCapId,
+        `${packageId(result, "predict")}::pool_valuation_cap::PoolValuationCap`,
+        recipientOwner,
+    );
+    result.wiring.lifecycleCap.owner = "recipient";
+    result.wiring.valuationCap.owner = "recipient";
+    result.wiring.lifecycleCap.transferTx = receipt.digest ?? null;
+    result.wiring.valuationCap.transferTx = receipt.digest ?? null;
+    writeState(result);
+}
+
+function boolField(fields: Record<string, unknown>, name: string): boolean {
+    const value = fields[name];
+    if (typeof value !== "boolean") throw new Error(`ProtocolConfig.${name} is not a bool`);
+    return value;
+}
+
+function stringField(fields: Record<string, unknown>, name: string): string {
+    const value = fields[name];
+    if (typeof value !== "string" && typeof value !== "number") {
+        throw new Error(`ProtocolConfig.${name} is not numeric`);
+    }
+    return String(value);
+}
+
+async function readProtocolConfig(runtime: Runtime): Promise<Verification["protocolConfig"]> {
+    const fields = await moveObjectFields(
+        runtime,
+        sharedId(runtime.result, "predict", "protocol_config::ProtocolConfig"),
+    );
+    const pricing = asRecord(fields.pricing_config);
+    const ewma = asRecord(fields.ewma_config);
+    const strike = asRecord(fields.strike_exposure_template_config);
+    const config: ProtocolConfigRecord = {
+        usePythSpotForForward: boolField(pricing, "use_pyth_spot_for_forward"),
+        pythSpotFreshnessMs: stringField(pricing, "pyth_spot_freshness_ms"),
+        blockScholesPriceFreshnessMs: stringField(pricing, "block_scholes_price_freshness_ms"),
+        blockScholesSviFreshnessMs: stringField(pricing, "block_scholes_svi_freshness_ms"),
+        ewmaAlpha: stringField(ewma, "alpha"),
+        ewmaZScoreThreshold: stringField(ewma, "z_score_threshold"),
+        ewmaPenaltyRate: stringField(ewma, "penalty_rate"),
+        ewmaEnabled: boolField(ewma, "enabled"),
+        protocolReserveProfitShare: stringField(fields, "protocol_reserve_profit_share"),
+        referralFeeRate: stringField(fields, "referral_fee_rate"),
+        plpSupplyFeeRate: stringField(fields, "plp_supply_fee_rate"),
+        plpWithdrawFeeRate: stringField(fields, "plp_withdraw_fee_rate"),
+        lpRequestLimitFlushAttempts: stringField(fields, "lp_request_limit_flush_attempts"),
+        maxLpPoolValue: stringField(fields, "max_lp_pool_value"),
+        maxValuationWindowMs: stringField(fields, "max_valuation_window_ms"),
+        backingBufferLambda: stringField(strike, "backing_buffer_lambda"),
+        inventoryImpactMaxRate: stringField(strike, "inventory_impact_max_rate"),
+        baseFee: stringField(strike, "base_fee"),
+        minFee: stringField(strike, "min_fee"),
+        minEntryProbability: stringField(strike, "min_entry_probability"),
+        maxEntryProbability: stringField(strike, "max_entry_probability"),
+        expiryFeeWindowMs: stringField(strike, "expiry_fee_window_ms"),
+        expiryFeeMaxMultiplier: stringField(strike, "expiry_fee_max_multiplier"),
+        versionWatermark: stringField(fields, "version_watermark"),
+        tradingPaused: boolField(fields, "trading_paused"),
+        frozen: boolField(fields, "frozen"),
+        valuationInProgress: boolField(fields, "valuation_in_progress"),
+    };
+    if (JSON.stringify(config) !== JSON.stringify(EXPECTED_PROTOCOL_CONFIG)) {
+        throw new Error(`ProtocolConfig defaults are unexpected: ${JSON.stringify(config)}`);
+    }
+    return config;
+}
+
+async function verifyDeployment(runtime: Runtime): Promise<Verification> {
+    const result = runtime.result;
+    await assertSdkTarget(runtime);
+    const external = await verifyExternalDependencies(runtime);
+    if (!result.wiring.lifecycleCap.id) throw new Error("lifecycle cap is missing");
+    if (!result.wiring.valuationCap.id) throw new Error("pool valuation cap is missing");
+    await assertLiveMarketWindows(runtime, result.wiring.lifecycleCap.id, true);
+    const packages: Record<string, ObjectEvidence> = {};
+    const sharedObjects: Record<string, Record<string, ObjectEvidence>> = {};
+    const ownedCaps: Record<string, Record<string, ObjectEvidence>> = {};
+    for (const pkg of PACKAGES) {
+        assertCompletedPackage(result, pkg);
+        const id = packageId(result, pkg);
+        packages[pkg] = await objectEvidence(runtime, id, "package", null);
+        assertPublishedPackageGraph(runtime, pkg, id);
+        if (packages[pkg].previousTransaction !== result.publishTx[pkg]) {
+            throw new Error(`${pkg} package was not created by ${result.publishTx[pkg]}`);
+        }
+        const shared: Record<string, ObjectEvidence> = {};
+        for (const [type, objectId] of Object.entries(result.sharedObjects[pkg] ?? {})) {
+            shared[type] = await objectEvidence(runtime, objectId, `${id}::${type}`, "shared");
+        }
+        if (Object.keys(shared).length > 0) sharedObjects[pkg] = shared;
+        const caps: Record<string, ObjectEvidence> = {};
+        for (const [type, objectId] of Object.entries(result.ownedCaps[pkg] ?? {})) {
+            caps[type] = await objectEvidence(runtime, objectId, type, DEPLOYER);
+        }
+        ownedCaps[pkg] = caps;
+    }
+
+    const oracleRegistry = sharedId(result, "propbook", "registry::OracleRegistry");
+    const oracleSnapshot = await stableObjectSnapshot(
+        runtime,
+        oracleRegistry,
+        `${packageId(result, "propbook")}::registry::OracleRegistry`,
+        async () => ({
+            pythFeed: await inspectOptionId(
+                runtime,
+                "verify_pyth_binding",
+                target(result, "propbook", "registry", "propbook_pyth_id_for_underlying"),
+                (tx) => [tx.object(oracleRegistry), tx.pure.u32(ASSET.propbookUnderlyingId)],
+            ),
+            storePair: await inspectBlockScholesStorePair(
+                runtime,
+                "verify_block_scholes_store_pair",
+                oracleRegistry,
+            ),
+        }),
+    );
+    const { pythFeed, storePair } = oracleSnapshot.value;
+    sharedObjects.propbook!["registry::OracleRegistry"] = oracleSnapshot.evidence;
+    if (
+        !storePair ||
+        pythFeed !== result.wiring.asset.pythFeedId ||
+        storePair.valueStoreId !== result.wiring.asset.blockScholesValueStoreId ||
+        storePair.sviStoreId !== result.wiring.asset.blockScholesSviStoreId
+    ) {
+        throw new Error(`Propbook canonical bindings do not match ${STATE_RELATIVE}`);
+    }
+    await assertBlockScholesStoreBaseAssets(runtime, storePair);
+    const oracleObjects = {
+        pythFeed: await objectEvidence(
+            runtime,
+            pythFeed!,
+            `${packageId(result, "propbook")}::pyth_feed::PythFeed`,
+            "shared",
+        ),
+        blockScholesValueStore: await objectEvidence(
+            runtime,
+            storePair.valueStoreId,
+            `${packageId(result, "propbook")}::block_scholes_store::BlockScholesValueStore`,
+            "shared",
+        ),
+        blockScholesSviStore: await objectEvidence(
+            runtime,
+            storePair.sviStoreId,
+            `${packageId(result, "propbook")}::block_scholes_store::BlockScholesSVIStore`,
+            "shared",
+        ),
+    };
+    const oracleReadiness = await verifyOracleReadiness(runtime);
+
+    const predictAppAuthorized = await accountAppAuthorized(
+        runtime,
+        "verify_predict_app",
+        `${packageId(result, "predict")}::predict_account::PredictApp`,
+    );
+    const deepbookCoreAccountAppAuthorized = await accountAppAuthorized(
+        runtime,
+        "verify_deepbook_core_app",
+        `${packageId(result, "deepbook_core_account")}::account_data::DeepbookCoreAccountApp`,
+    );
+    const sessionsAppAuthorized = await accountAppAuthorized(
+        runtime,
+        "verify_sessions_app",
+        `${packageId(result, "sessions")}::sessions::SessionsApp`,
+    );
+    const deepbookSnapshot = await stableObjectSnapshot(
+        runtime,
+        DEEPBOOK_REGISTRY,
+        `${DEEPBOOK_ORIGINAL}::registry::Registry`,
+        () => deepbookCoreAppAuthorized(runtime),
+    );
+    const deepbookCoreAuthorized = deepbookSnapshot.value;
+    if (
+        !predictAppAuthorized ||
+        !deepbookCoreAccountAppAuthorized ||
+        !sessionsAppAuthorized ||
+        !result.wiring.account.accountWrapperId
+    ) {
+        throw new Error("application authorization or deployment account is missing");
+    }
+    result.wiring.deepbook = {
+        coreAppAuthorized: deepbookCoreAuthorized,
+        verifiedAt: new Date().toISOString(),
+    };
+    const sessionsConfigId = sharedId(result, "sessions", "session_config::SessionsConfig");
+    const sessionsSnapshot = await stableObjectSnapshot(
+        runtime,
+        sessionsConfigId,
+        `${packageId(result, "sessions")}::session_config::SessionsConfig`,
+        () => moveObjectFields(runtime, sessionsConfigId),
+    );
+    const sessionsConfigFields = sessionsSnapshot.value;
+    sharedObjects.sessions!["session_config::SessionsConfig"] = sessionsSnapshot.evidence;
+    if (stringField(sessionsConfigFields, "version_watermark") !== "1") {
+        throw new Error("SessionsConfig version watermark is not 1");
+    }
+    const accountWrapper = await objectEvidence(
+        runtime,
+        result.wiring.account.accountWrapperId,
+        `${packageId(result, "account")}::account::AccountWrapper`,
+        "shared",
+    );
+    const accountId = await deploymentAccountId(runtime, result.wiring.account.accountWrapperId);
+    const accountPlpBalance = await deploymentAccountPlpBalance(
+        runtime,
+        result.wiring.account.accountWrapperId,
+    );
+    const bootstrapDigest = result.transactions.bootstrap_pool;
+    if (
+        result.wiring.bootstrap.accountId !== accountId ||
+        !result.wiring.bootstrap.requestIndex ||
+        result.wiring.bootstrap.sharesMinted !== BOOTSTRAP_SUPPLY_AMOUNT.toString() ||
+        result.wiring.bootstrap.accountPlpBalance !== accountPlpBalance.toString() ||
+        accountPlpBalance !== BOOTSTRAP_SUPPLY_AMOUNT ||
+        !bootstrapDigest ||
+        result.wiring.bootstrap.lockCapitalTx !== bootstrapDigest ||
+        result.wiring.bootstrap.supplyRequestTx !== bootstrapDigest ||
+        result.wiring.bootstrap.flushTx !== bootstrapDigest
+    ) {
+        throw new Error("bootstrap supply is not attributed to the deployment account");
+    }
+    const lifecycleCap = await objectEvidence(
+        runtime,
+        result.wiring.lifecycleCap.id,
+        `${packageId(result, "predict")}::market_lifecycle_cap::MarketLifecycleCap`,
+        DEPLOYER,
+    );
+    const valuationCap = await objectEvidence(
+        runtime,
+        result.wiring.valuationCap.id,
+        `${packageId(result, "predict")}::pool_valuation_cap::PoolValuationCap`,
+        DEPLOYER,
+    );
+    const currencies = {
+        usdc: await objectEvidence(
+            runtime,
+            requiredObjectId(result.wiring.currencies.usdc.id, "USDC currency"),
+            `coin_registry::Currency<${usdcType(result)}>`,
+            "shared",
+        ),
+        plp: await objectEvidence(
+            runtime,
+            requiredObjectId(result.wiring.currencies.plp.id, "PLP currency"),
+            `coin_registry::Currency<${plpType(result)}>`,
+            "shared",
+        ),
+    };
+
+    const registryId = sharedId(result, "predict", "registry::Registry");
+    const cadenceSnapshot = await stableObjectSnapshot(
+        runtime,
+        registryId,
+        `${packageId(result, "predict")}::registry::Registry`,
+        () => readCadences(runtime),
+    );
+    const cadences = cadenceSnapshot.value;
+    sharedObjects.predict!["registry::Registry"] = cadenceSnapshot.evidence;
+    if (!cadences.every((record, index) => cadenceMatches(record, CADENCES[index]))) {
+        throw new Error("verified cadence policy does not match deploy.ts");
+    }
+    await discoverMarkets(runtime);
+    const activeIds = await activeMarketIds(runtime);
+    const verificationClockMs = await currentClockMs(runtime);
+    let activeMarketCash = 0n;
+    const verifiedMarkets: MarketRecord[] = [];
+    for (const id of activeIds) {
+        const state = await marketState(runtime, id);
+        const record = result.wiring.markets.find((market) => market.id === id);
+        if (!record) throw new Error(`active market ${id} is absent from ${STATE_RELATIVE}`);
+        if (state.cashBalance === 0n) throw new Error(`active market ${id} has zero cash`);
+        if (state.referenceTick === null) {
+            throw new Error(`active market ${id} has no initialized reference tick`);
+        }
+        activeMarketCash += state.cashBalance;
+        record.cashBalance = state.cashBalance.toString();
+        record.referenceTick = state.referenceTick.toString();
+        await objectEvidence(
+            runtime,
+            id,
+            `${packageId(result, "predict")}::expiry_market::ExpiryMarket`,
+            "shared",
+        );
+        verifiedMarkets.push({ ...record });
+    }
+    for (const cadence of CADENCES.filter((spec) => spec.marketsToCreate > 0)) {
+        const futureCount = verifiedMarkets.filter(
+            (market) =>
+                market.cadenceId === cadence.id && BigInt(market.expiryMs) > verificationClockMs,
+        ).length;
+        const check = result.wiring.marketWindowChecks.find(
+            (candidate) => candidate.cadenceId === cadence.id,
+        );
+        if (
+            futureCount === 0 ||
+            !check ||
+            check.recorded !== futureCount ||
+            (futureCount < cadence.marketsToCreate && !check.windowFull)
+        ) {
+            throw new Error(
+                `${cadence.name} future market window is incomplete (${futureCount}/${cadence.marketsToCreate})`,
+            );
+        }
+    }
+
+    const totalSupply = await poolU64(runtime, "plp_total_supply");
+    const idleBalance = await poolU64(runtime, "idle_balance");
+    const pendingSupply = await poolU64(runtime, "supply_requests_pending");
+    const pendingWithdraw = await poolU64(runtime, "withdraw_requests_pending");
+    if (
+        totalSupply !== LOCK_CAPITAL_AMOUNT + BOOTSTRAP_SUPPLY_AMOUNT ||
+        pendingSupply !== 0n ||
+        pendingWithdraw !== 0n ||
+        idleBalance + activeMarketCash !== totalSupply
+    ) {
+        throw new Error(
+            `pool accounting mismatch supply=${totalSupply} idle=${idleBalance} activeCash=${activeMarketCash} pending=${pendingSupply}/${pendingWithdraw}`,
+        );
+    }
+    const mintedAmount = await usdcTotalSupply(runtime);
+    const deployerUsdcBalance = BigInt(
+        (
+            await runtime.client.getBalance({
+                owner: DEPLOYER,
+                coinType: usdcType(result),
+            })
+        ).balance.balance,
+    );
+    if (
+        mintedAmount !== USDC_MINT_AMOUNT ||
+        deployerUsdcBalance + totalSupply !== USDC_MINT_AMOUNT
+    ) {
+        throw new Error(
+            `USDC accounting mismatch minted=${mintedAmount} deployer=${deployerUsdcBalance} pool=${totalSupply}`,
+        );
+    }
+    const packageCheckpoints = PACKAGES.map((pkg) =>
+        transactionCheckpoint(
+            runtime.snapshot,
+            requiredString(result.publishTx[pkg], `${pkg} publish digest`),
+        ),
+    );
+    const indexingStartCheckpoint = packageCheckpoints
+        .map((checkpoint) => BigInt(checkpoint))
+        .reduce((earliest, checkpoint) => (checkpoint < earliest ? checkpoint : earliest))
+        .toString();
+    const protocolConfigId = sharedId(result, "predict", "protocol_config::ProtocolConfig");
+    const protocolSnapshot = await stableObjectSnapshot(
+        runtime,
+        protocolConfigId,
+        `${packageId(result, "predict")}::protocol_config::ProtocolConfig`,
+        () => readProtocolConfig(runtime),
+    );
+    sharedObjects.predict!["protocol_config::ProtocolConfig"] = protocolSnapshot.evidence;
+    const linkedObjects = {
+        ...external.objects,
+        deepbookRegistry: deepbookSnapshot.evidence,
+    };
+
+    const verification: Verification = {
+        verifiedAt: new Date().toISOString(),
+        chainId: await shortChainId(runtime.client),
+        indexingStartCheckpoint,
+        verifiedAfterCheckpoint: null,
+        packages,
+        linkedPackages: external.packages,
+        linkedObjects,
+        sharedObjects,
+        ownedCaps,
+        oracleObjects,
+        account: {
+            predictAppAuthorized,
+            deepbookCoreAppAuthorized: deepbookCoreAccountAppAuthorized,
+            sessionsAppAuthorized,
+            deepbookCoreAuthorized,
+            accountWrapper,
+        },
+        currencies: {
+            ...currencies,
+            mintedAmount: mintedAmount.toString(),
+            deployerBalance: deployerUsdcBalance.toString(),
+        },
+        lifecycleCap,
+        valuationCap,
+        oracleReadiness,
+        cadences,
+        protocolConfig: protocolSnapshot.value,
+        pool: {
+            totalSupply: totalSupply.toString(),
+            idleBalance: idleBalance.toString(),
+            supplyRequestsPending: pendingSupply.toString(),
+            withdrawRequestsPending: pendingWithdraw.toString(),
+            activeMarketIds: activeIds,
+            activeMarketCash: activeMarketCash.toString(),
+            deployerAccountPlpBalance: accountPlpBalance.toString(),
+        },
+        markets: verifiedMarkets,
+    };
+    writeState(result);
+    await assertSdkTarget(runtime);
+    return verification;
+}
+
+async function finalizeOperationalCapHandoff(
+    runtime: Runtime,
+    verification: Verification,
+): Promise<Verification> {
+    await assertSdkTarget(runtime);
+    const lifecycleCap = await objectEvidence(
+        runtime,
+        requiredObjectId(runtime.result.wiring.lifecycleCap.id, "lifecycle capability"),
+        `${packageId(runtime.result, "predict")}::market_lifecycle_cap::MarketLifecycleCap`,
+        partyOwnerLabel(PREDICT_WRITER),
+    );
+    const valuationCap = await objectEvidence(
+        runtime,
+        requiredObjectId(runtime.result.wiring.valuationCap.id, "pool valuation capability"),
+        `${packageId(runtime.result, "predict")}::pool_valuation_cap::PoolValuationCap`,
+        partyOwnerLabel(PREDICT_WRITER),
+    );
+    const capTransferCheckpoint = transactionCheckpoint(
+        runtime.snapshot,
+        requiredString(
+            runtime.result.wiring.lifecycleCap.transferTx &&
+                runtime.result.wiring.valuationCap.transferTx ===
+                    runtime.result.wiring.lifecycleCap.transferTx
+                ? runtime.result.wiring.lifecycleCap.transferTx
+                : null,
+            "atomic operational capability transfer digest",
+        ),
+    );
+    const deepbookSnapshot = await stableObjectSnapshot(
+        runtime,
+        DEEPBOOK_REGISTRY,
+        `${DEEPBOOK_ORIGINAL}::registry::Registry`,
+        () => deepbookCoreAppAuthorized(runtime),
+    );
+    if (!deepbookSnapshot.value) {
+        throw new AwaitingExternalAuthorization(
+            "DeepBook core wrapper authorization is still pending external admin-cap execution",
+        );
+    }
+    const authorizationCheckpoint = transactionCheckpoint(
+        runtime.snapshot,
+        requiredString(
+            deepbookSnapshot.evidence.previousTransaction,
+            "DeepBook registry authorization transaction",
+        ),
+    );
+    const verifiedAfterCheckpoint = (
+        BigInt(capTransferCheckpoint) > BigInt(authorizationCheckpoint)
+            ? BigInt(capTransferCheckpoint)
+            : BigInt(authorizationCheckpoint)
+    ).toString();
+    if (BigInt(verifiedAfterCheckpoint) < BigInt(verification.indexingStartCheckpoint)) {
+        throw new Error("configuration verification fence precedes package publication");
+    }
+    return {
+        ...verification,
+        verifiedAt: new Date().toISOString(),
+        verifiedAfterCheckpoint,
+        linkedObjects: {
+            ...verification.linkedObjects,
+            deepbookRegistry: deepbookSnapshot.evidence,
+        },
+        account: {
+            ...verification.account,
+            deepbookCoreAuthorized: true,
+        },
+        lifecycleCap,
+        valuationCap,
+    };
+}
+
+async function assertFunding(runtime: Runtime): Promise<void> {
+    const totalSupply =
+        runtime.result.packages.predict && runtime.result.sharedObjects.predict
+            ? await poolU64(runtime, "plp_total_supply")
+            : 0n;
+    if (totalSupply === LOCK_CAPITAL_AMOUNT + BOOTSTRAP_SUPPLY_AMOUNT) return;
+    if (totalSupply !== 0n) {
+        throw new Error(`unexpected partial PLP bootstrap supply: ${totalSupply}`);
+    }
+    if (!runtime.result.packages.usdc || !runtime.result.transactions.mint_deployer_usdc) return;
+    const balance = await runtime.client.getBalance({
+        owner: DEPLOYER,
+        coinType: usdcType(runtime.result),
+    });
+    const available = BigInt(balance.balance.balance);
+    const required = LOCK_CAPITAL_AMOUNT + BOOTSTRAP_SUPPLY_AMOUNT;
+    if (available < required) {
+        throw new Error(
+            `insufficient deployer USDC: have ${available}, need ${required} (short ${required - available})`,
+        );
+    }
+}
+
+async function assertGasFunding(runtime: Runtime): Promise<void> {
+    const balance = await runtime.client.getBalance({ owner: DEPLOYER });
+    const available = BigInt(balance.balance.balance);
+    const remainingPackages = PACKAGES.filter((pkg) => !runtime.result.packages[pkg]).length;
+    const remainingFixedTransactions = FIXED_TRANSACTION_STEPS.filter(
+        (label) => !runtime.result.transactions[label],
+    ).length;
+    const remainingMarketTransactions =
+        runtime.result.wiring.lifecycleCap.owner === "recipient"
+            ? 0
+            : maximumTransactionCountPerRun() - FIXED_TRANSACTION_STEPS.length;
+    const required =
+        BigInt(PACKAGE_GAS_BUDGET) * BigInt(remainingPackages) +
+        TRANSACTION_GAS_BUDGET * BigInt(remainingFixedTransactions + remainingMarketTransactions);
+    if (available < required) {
+        throw new Error(
+            `insufficient deployer SUI gas: have ${available}, need at least ${required} for ${remainingPackages} publications, ${remainingFixedTransactions} fixed transactions, and ${remainingMarketTransactions} bounded market transactions`,
+        );
+    }
+}
+
+export async function runBroadcastBoundary(
+    execute: boolean,
+    broadcast: () => Promise<void>,
+): Promise<boolean> {
+    if (!execute) return false;
+    await broadcast();
+    return true;
+}
+
+async function executeDeployment(runtime: Runtime, bindings: ExecutionBindings): Promise<void> {
+    const result = runtime.result;
+    result.suiVersion ??= bindings.suiVersion;
+    result.suiBinaryPath ??= bindings.suiBinaryPath;
+    result.suiBinaryDigest ??= bindings.suiBinaryDigest;
+    result.rpcUrl ??= bindings.rpcUrl;
+    result.clientConfigDigest ??= bindings.clientConfigDigest;
+    result.sourceCommit ??= runtime.sourceCommit;
+    result.packageGasBudget ??= bindings.packageGasBudget;
+    result.transactionGasBudget ??= bindings.transactionGasBudget;
+    result.startedAt ??= new Date().toISOString();
+    result.completedAt = null;
+    result.lastError = null;
+    result.status = "publishing";
+    writeState(result);
+
+    try {
+        for (const pkg of PACKAGES) {
+            if (irreversibleStepDigest(result, "publish", `publish_${pkg}`, pkg)) {
+                await verifyPublishedPackageCheckpoint(runtime, pkg);
+                console.log(`[deploy] ${pkg} checkpoint verified; skipping publish`);
+            } else {
+                await publishPackage(runtime, pkg);
+            }
+        }
+        result.status = "wiring";
+        writeState(result);
+
+        await ensureCurrencyRegistration(runtime, "usdc");
+        await ensureCurrencyRegistration(runtime, "plp");
+        await ensureDeployerUsdcMint(runtime);
+        await ensureAccountAppsAuthorized(runtime);
+        await ensureDeepbookCoreAppAuthorized(runtime);
+        const lifecycleCapId = await ensureLifecycleCap(runtime);
+        const valuationCapId = await ensureValuationCap(runtime);
+        if (
+            result.wiring.lifecycleCap.owner === "recipient" ||
+            result.wiring.valuationCap.owner === "recipient"
+        ) {
+            if (
+                result.wiring.lifecycleCap.owner !== "recipient" ||
+                result.wiring.valuationCap.owner !== "recipient"
+            ) {
+                throw new Error("operational capability handoff is not atomic on-chain");
+            }
+            if (!result.verification) {
+                throw new Error(
+                    "operational capabilities were handed off without a persisted pre-handoff audit",
+                );
+            }
+            result.verification = await finalizeOperationalCapHandoff(runtime, result.verification);
+            result.status = "complete";
+            result.completedAt = new Date().toISOString();
+            result.lastError = null;
+            writeState(result);
+            writeIntegrationManifest(buildIntegrationManifest(result));
+            console.log(`[deploy] complete state: ${STATE}`);
+            console.log(`[deploy] integration manifest: ${MANIFEST}`);
+            return;
+        }
+        result.verification = null;
+        await ensureOracleObjects(runtime);
+        await ensureUnderlyingRegistered(runtime);
+        await ensureCadences(runtime);
+        await verifyOracleReadiness(runtime);
+        const accountWrapperId = await ensureAccountWrapper(runtime);
+        await ensureBootstrap(runtime, valuationCapId, accountWrapperId);
+        await ensureMarkets(runtime, lifecycleCapId);
+
+        result.status = "verifying";
+        writeState(result);
+        result.verification = await verifyDeployment(runtime);
+        result.status = "handoff";
+        writeState(result);
+        await transferOperationalCaps(runtime, lifecycleCapId, valuationCapId);
+        result.verification = await finalizeOperationalCapHandoff(runtime, result.verification);
+        result.status = "complete";
+        result.completedAt = new Date().toISOString();
+        result.lastError = null;
+        writeState(result);
+        writeIntegrationManifest(buildIntegrationManifest(result));
+        console.log(`[deploy] complete state: ${STATE}`);
+        console.log(`[deploy] integration manifest: ${MANIFEST}`);
+    } catch (error) {
+        result.status = result.inFlight
+            ? "ambiguous"
+            : error instanceof AwaitingOracleData
+              ? "awaiting_oracle_data"
+              : error instanceof AwaitingExternalAuthorization
+                ? "awaiting_external_authorization"
+                : Object.keys(result.publishTx).length > 0 ||
+                    Object.keys(result.transactions).length > 0
+                  ? "partial"
+                  : "failed";
+        result.lastError = error instanceof Error ? error.message : String(error);
+        writeState(result);
+        throw error;
+    }
+}
+
+async function run(execute: boolean): Promise<void> {
+    if (!/^[1-9][0-9]*$/.test(PACKAGE_GAS_BUDGET) || TRANSACTION_GAS_BUDGET <= 0n) {
+        throw new Error("gas budgets must be positive integers");
+    }
+    const result = loadState();
+    assertStateFile(result);
+    assertPackageCheckpoints(result);
+    assertExpectedWorktree(result);
+    const sourceCommit = git(["rev-parse", "HEAD"]);
+    if (result.sourceCommit && result.sourceCommit !== sourceCommit) {
+        throw new Error(`deployment started from ${result.sourceCommit}, HEAD is ${sourceCommit}`);
+    }
+    const binary = suiBinaryIdentity();
+    const suiVersion = sui(["--version"]);
+    assertSuiCliVersion(suiVersion);
+
+    const snapshot = snapshotClientConfig();
+    try {
+        assertCliTarget(snapshot);
+        const signer = getSigner(snapshot.keystorePath);
+        const runtime: Runtime = {
+            result,
+            snapshot,
+            client: new SuiGrpcClient({
+                baseUrl: snapshot.rpcUrl,
+                network: NETWORK,
+            }),
+            signer,
+            sourceCommit,
+            packageMetadataCache: new Map(),
+            marketCreationsThisRun: {},
+        };
+        const executionBindings: ExecutionBindings = {
+            suiVersion,
+            suiBinaryPath: binary.path,
+            suiBinaryDigest: binary.digest,
+            rpcUrl: snapshot.rpcUrl,
+            clientConfigDigest: snapshot.configDigest,
+            packageGasBudget: PACKAGE_GAS_BUDGET,
+            transactionGasBudget: TRANSACTION_GAS_BUDGET.toString(),
+        };
+        if (result.startedAt) assertExecutionBindings(result, executionBindings);
+        await assertSdkTarget(runtime);
+        if (result.inFlight) await reconcileInFlight(runtime);
+
+        console.log("[deploy] compiling Predict and proving resolved Testnet package IDs");
+        assertResolvedLinkedPackages();
+        assertExpectedWorktree(result);
+        await verifyExternalDependencies(runtime);
+        await assertGasFunding(runtime);
+        await assertFunding(runtime);
+
+        console.log(`[deploy] network: ${NETWORK} (${CHAIN_ID})`);
+        console.log(`[deploy] deployer: ${DEPLOYER}`);
+        console.log(`[deploy] source: ${sourceCommit}`);
+        console.log(`[deploy] Sui CLI: ${suiVersion}`);
+        console.log(`[deploy] package plan: ${PACKAGES.join(" -> ")}`);
+        console.log(`[deploy] Predict writer and operational-cap owner: ${PREDICT_WRITER}`);
+        console.log(`[deploy] Propbook writer: ${PROPBOOK_WRITER}`);
+        console.log(
+            `[deploy] USDC mint=${USDC_MINT_AMOUNT} (display DUSDC); PLP lock=${LOCK_CAPITAL_AMOUNT} supply=${BOOTSTRAP_SUPPLY_AMOUNT}`,
+        );
+        if (!execute) {
+            console.log("[deploy] preflight complete; no transactions submitted (pass --execute)");
+        }
+        await runBroadcastBoundary(execute, () => executeDeployment(runtime, executionBindings));
+    } finally {
+        rmSync(snapshot.directory, { recursive: true, force: true });
+    }
+}
+
+export function parseDeploymentArgs(args: readonly string[]): DeploymentMode {
+    const unknown = args.filter((arg) => arg !== "--execute");
+    if (unknown.length > 0) throw new Error(`unknown deployment arguments: ${unknown.join(", ")}`);
+    return { execute: args.includes("--execute"), sessions: false, smoke: false };
+}
+
+export async function main(args = process.argv.slice(2)): Promise<void> {
+    const mode = parseDeploymentArgs(args);
+    const lock = acquireLock();
+    try {
+        await run(mode.execute);
+    } finally {
+        releaseLock(lock);
+    }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+    main().catch((error) => {
+        console.error(error);
+        process.exitCode = 1;
+    });
+}

--- a/packages/predict/package.json
+++ b/packages/predict/package.json
@@ -6,7 +6,7 @@
   "packageManager": "npm@10.9.4",
   "scripts": {
     "build": "tsc --noEmit",
-    "test": "tsx --test harness/ts/harnessTest.ts devtools/ts/devtoolsTest.ts simulations/src/simTest.ts"
+    "test": "tsx --test harness/ts/harnessTest.ts devtools/ts/devtoolsTest.ts simulations/src/simTest.ts deployment/deploy.test.ts"
   },
   "dependencies": {
     "@mysten/sui": "^2.5.0",

--- a/packages/predict/predeploy/open-items.md
+++ b/packages/predict/predeploy/open-items.md
@@ -269,7 +269,7 @@ passes and worst-case budget usage is unchanged at 61%. The defect is that the
 tolerances are now conservative by luck rather than derived.
 
 `generate_pricing_reference.py` derives every tolerance analytically from
-`math.move`'s documented per-primitive budgets, and its `d_k` term has been
+`packages/fixed_math/sources/math.move`'s documented per-primitive budgets, and its `d_k` term has been
 corrected to the difference-of-logs form (`1e-7·(|ln strike| + |ln forward|) +
 2/F`) that RP-26 shipped. The committed `pricing_reference_data.move` was
 generated under the previous ratio model (`1/F/ratio + 1e-7·|k| + 1/F`), which
@@ -281,7 +281,7 @@ and absent from a fresh worktree, so it could not be done in the same change.
 
 **Action:** regenerate the reference data with the dataset present and confirm
 the budgets still bound the observed deviations. Until then the file's stated
-contract — "propagated from `math.move`'s documented per-primitive budgets" — is
+contract — "propagated from `packages/fixed_math/sources/math.move`'s documented per-primitive budgets" — is
 true of the generator but not of the committed data.
 
 ### P-30: The C-1 capacity model is one measurement behind the pricing path

--- a/packages/predict/tsconfig.json
+++ b/packages/predict/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es2021",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
@@ -11,6 +12,7 @@
   },
   "include": [
     "devtools/ts/**/*.ts",
+    "deployment/**/*.ts",
     "harness/ts/**/*.ts",
     "simulations/src/**/*.ts"
   ]


### PR DESCRIPTION
## Summary

- Add a resumable, non-broadcasting-by-default workflow for the official DeepBook Predict Testnet contract deployment.
- Publish a fresh seven-package graph, register fresh USDC and PLP currencies, mint 100 million Testnet USDC, bootstrap 250,000 USDC of PLP liquidity, and configure BTC 1-minute and 5-minute markets.
- Fail closed on package identity, signer, oracle freshness and subscription identity, capability custody, external DeepBook authorization, recovery ambiguity, and integration-manifest completeness.

## Why

DeepBook Predict depends on a coordinated set of Move packages, shared objects, oracle bindings, currencies, administrative capabilities, and initial market state. The repository did not contain a complete official Testnet deployment workflow for the current contract surface, so a manual publish would be difficult to audit or safely resume after a partial failure. This change makes the intended deployment and every irreversible boundary explicit before any Testnet transaction is submitted.

## Linear / Context

- https://linear.app/mysten-labs/issue/DBU-785/establish-the-official-deepbook-predict-testnet-deployment

## Key decisions

- The fresh collateral type is the repository's `usdc::usdc::USDC`; its display symbol remains `DUSDC`, and old DUSDC balances are intentionally incompatible.
- BTC is the only initial underlying. Only 1-minute and 5-minute cadences are enabled, with two markets per cadence, 2,000 USDC initial cash, and 10,000 USDC maximum allocation per market.
- The workflow retains package, root, treasury, and metadata capabilities with the deployer, but transfers the market-lifecycle and pool-valuation capabilities atomically only after the full pre-handoff audit.
- The public integration manifest is withheld until the fresh DeepBook Account app type has been externally authorized and the final on-chain audit passes.

## Scope / Descoped

- This pull request prepares the contract deployment workflow and does not submit Testnet transactions.
- It does not upgrade or mutate the existing Predict v4 deployment, launch keepers or indexers, create databases, or configure Kubernetes workloads.
- External DeepBook authorization remains a deliberate pause-and-resume boundary during execution.

## Test plan

- [x] `corepack npm run build` from `packages/predict` — TypeScript compiles without emitting files.
- [x] `corepack npm test` from `packages/predict` — all 42 TypeScript tests pass, including 17 deployment-workflow tests.
- [x] `python3 packages/predict/predeploy/check.py` — cross-references are clean with zero warnings.
- [x] `/private/tmp/deepbookv3-sui-testnet-v1.74.1/sui move test --gas-limit 100000000000 --path packages/predict` — all 564 Move tests pass.
- [x] `SUI_BINARY="$(command -v sui)" corepack npm exec -- tsx deployment/deploy.ts` from `packages/predict` — live Testnet preflight verifies the committed source and reports that no transaction was submitted.

## Risk / Rollout

The main risk is an incomplete or incorrectly resumed multi-transaction deployment. The workflow journals every irreversible boundary, binds resumes to the exact source commit, Sui binary, chain, signer, package metadata, object versions, gas budgets, and known transaction digests, and withholds operational-cap handoff and the public manifest until their respective audits pass. The execute flag remains an explicit separate action.
