### PR TITLE
predict: admit sub-precision price inversions in the NAV walk (DBU-790)

### DIFF
--- a/packages/predict/predeploy/evidence/rp15-price-inversion-2026-09-04.md
+++ b/packages/predict/predeploy/evidence/rp15-price-inversion-2026-09-04.md
@@ -1,0 +1,59 @@
+# UP price inverts on valid surfaces — Move measurement, 2026-09-04
+
+**Item:** RP-15 · **Instrument:** Move unit probe over the committed reference surfaces (`pricing_reference_data`) · **Date:** 2026-09-04
+
+Status: reproduced, deterministic, no provider defect involved. The pricer's own
+fixed point makes `up_price` rise across ascending strikes on surfaces that are valid
+and butterfly-free, which the pre-existing strict guard in `strike_payout_tree`
+treated as a surface defect and aborted on.
+
+## Where it comes from
+
+`compute_up_price` returns `floor(N(d2))` minus the floored skew correction
+`floor(phi(d2) * w' / (2 * sqrt(w)))`. Deep in the tail `N(d2)` sits on a plateau
+while the correction still steps, so the difference of the two floored terms rises by
+raw units across adjacent strikes. Nothing about the surface is inverted; only the
+evaluation is.
+
+## Measurement
+
+A probe walked ascending strike grids on each committed scenario and counted adjacent
+pairs whose UP price rises. Every inversion sits at the upper edge of the deep-ITM
+plateau, where the price is about `1 - 5e-9`.
+
+| Scenario | Grid | Window | Inverting pairs |
+| --- | --- | --- | --- |
+| 0 | $10 | $50,000-$60,000 | 24 (first $55,240 -> $55,250, 999,999,995 -> 999,999,996) |
+| 0 | $100 | $55,200-$69,000 | 1 ($55,200 -> $55,300) |
+| 0 | $1 | $55,200-$56,200 | 7 |
+| 0 | $500 | $55,200-$69,000 | 0 |
+| 1 | $10 | $62,800-$71,000 | 10 |
+| 1 | $100 | $62,800-$71,000 | 0 |
+| 2 | $10 | $66,100-$71,300 | 7 |
+| 3 | $10 / $1 | $73,100-$73,400 | 0 |
+
+Grid coarseness is the only attenuator measured: the same surface that gives 24 pairs
+on a $10 grid gives one on a $100 grid and none on a $500 grid. Scenario 3 is the
+near-degenerate low-variance surface, whose plateau edge is only ~$200 wide.
+
+## Reachability
+
+The strike whose UP price inverts is deep in the money — 11% to 27% below spot on
+these surfaces — so the ORDER that puts a boundary there is a wide range priced near
+0.5, not an exotic one. `assert_admitted_mint_ticks` constrains the boundary to the
+admission grid and nothing else, and `max_probability` bounds the range price rather
+than the boundary. Two mints of a couple of dollars each are enough.
+
+`pool_valuation_flow_tests::a_fixed_point_dust_inversion_does_not_stall_the_flush`
+carries the end-to-end path: two grid-admitted mints quoted between 0.4 and 0.6 on
+scenario 0, then `start_pool_valuation` -> snapshot -> seal -> `value_expiry`. Against
+the strict guard that sequence aborts `ENonMonotonePrice`, and `current_nav` aborts on
+the same book; under `price_monotonicity_tolerance` both proceed and the walk equals
+the independent per-order sum.
+
+## What it does not measure
+
+The probe fixes each surface at the reference fixture's expiry, so it does not sweep
+time to expiry, and it says nothing about how the plateau edge moves as a market ages.
+It also does not measure the external half of RP-15: no sampled Block Scholes surface
+has violated butterfly freedom, and that half remains unobserved.

--- a/packages/predict/predeploy/response-policies.md
+++ b/packages/predict/predeploy/response-policies.md
@@ -635,56 +635,73 @@ Each entry records: **Trigger state** / **Controller** / **Blast radius** /
 
 ---
 
-## RP-15: Block Scholes guarantees butterfly-free surfaces; active-book inversions fail closed (resolves P-11)
+## RP-15: Sub-precision price inversions price through; a material inversion fails closed (resolves P-11)
 
-- **Trigger state:** despite the provider's guarantee that every published SVI
-  surface is monotone and butterfly-arbitrage-free, a fresh Block Scholes
-  surface makes a higher-strike UP price exceed a lower-strike UP price. During
-  `current_nav`, the active payout tree exposes that inversion at two increasing
-  boundary ticks.
-- **Controller:** external — the BS surface publisher controls the shape inside
-  Predict's pricing-safe envelope; traders cannot choose SVI parameters.
-- **Blast radius:** single-order pricing trusts the provider's surface and
-  floors an inverted range to zero. NAV adds a defense-in-depth active-book
-  check: one exposed inversion aborts that market's NAV read, and because the
-  pool flush uses one frozen mark for all LP supply and withdraw fills, it can
-  block LP fills pool-wide until the surface is corrected.
-- **Response:** accept the provider guarantee for surface admission; do not add
-  an on-chain `g(k) >= 0` or tighter synthetic-parameter envelope. If an active
-  book nevertheless exposes an inversion, abort valuation and retry after the
-  provider publishes a corrected surface. This converts the known aggregate-NAV
-  overstatement into fail-closed liveness.
-- **Reasoning:** `strike_payout_tree::walk_linear` relies on active boundary
-  prices being monotone. Skipping the market or carrying a partial mark would
-  poison the single LP mark used for both supply and withdraw, while allowing
-  the inverted segment through can overstate pool NAV. Surface quality is part
-  of the trusted Block Scholes provider contract rather than an invariant the
-  signature or Predict Move code proves; the active-book check stays as a
-  narrow accounting backstop rather than duplicating the provider's global
-  surface validation on chain.
-- **Risk profile:** `BEST-GUESS` — no sampled Block Scholes surface violated
-  butterfly freedom, and reachability requires the trusted publisher to violate
-  its guarantee with a surface whose inversion intersects the active book. The
-  guarantee is not enforced by Predict on chain.
-- **Pinning tests:** `current_nav_flow_tests.move` —
-  `current_nav_rejects_non_monotone_active_book_surface`; and
-  `payout_tree_walk_tests.move` —
-  `inversion_on_a_cancelling_last_boundary_still_aborts`. The guard moved from
+- **Trigger state:** the in-order walk over the payout tree (`walk_linear`, and
+  `walk_linear_frozen` under the flush) reads a higher UP price at a higher
+  boundary tick than at a lower one.
+- **Controller:** internal AND external. `compute_up_price` floors `N(d2)` and
+  the skew correction independently, so where `N(d2)` sits on a tail plateau the
+  difference steps UP by raw units on a surface that is valid and butterfly-free
+  — the committed real scenario 0 inverts at 24 adjacent pairs on a $10 grid
+  between $50k and $60k (first $55,240 -> $55,250, 999,999,995 -> 999,999,996),
+  at one pair on a $100 grid, and three of the four committed surfaces invert on
+  the $1 and $10 grids. Boundary ticks are chosen by whoever mints, and a range
+  whose lower boundary sits in that plateau is an ordinary wide bet priced near
+  0.5, so this source is reachable by two admitted mints. Surface shape itself
+  stays with the provider.
+- **Blast radius:** a hard abort here lands in the pool flush's mandatory leg
+  (`plp::value_expiry` -> `expiry_market::snapshot_nav`) and in the public
+  `current_nav` read. `finish_flush` proves completeness over the snapshotted set
+  and has no per-market skip, so one aborting market stops every LP supply and
+  withdraw fill; the valuation flag that flush holds also gates request cancels
+  and the flush-gated `ProtocolConfig` setters, and a restart re-snapshots the
+  same book. A market leaves the expected set only at settlement, so the stall
+  would last its remaining life. Per-order value is unaffected: `range_price`
+  floors an inverted pair to zero, so `redeem_live` and settlement stay open.
+- **Response:** price the boundary at its quote and continue while the rise is
+  within `pricing::price_monotonicity_tolerance`; abort `ENonMonotonePrice`
+  above it. Surface admission still rests on the provider guarantee — no on-chain
+  `g(k) >= 0` or tighter synthetic-parameter envelope.
+- **Reasoning:** what the netted aggregate loses to a rise is bounded by the rise
+  itself (the aggregate lets an inverted segment cancel where the per-order sum
+  floors it at zero), so bounding the rise bounds the understatement, and keeping
+  the quoted price leaves the aggregate the same per-order sum a monotone book
+  produces. Below the pricer's own absolute precision a rise carries no
+  information about the surface, so aborting on it is a false positive in a
+  mandatory path over a variable the book positions — the blast-radius ladder in
+  `.claude/rules/move.md` puts that at skip/carry, not a hard assert. Above the
+  bound the rise is a real surface defect, the overstatement it would put into
+  the single LP mark is material, and "retry once the provider publishes a
+  corrected surface" is a recovery path that actually exists in that regime.
+  The comparison is against the running minimum rather than the previous
+  boundary, so dust accumulated across many boundaries trips the same bound
+  instead of ratcheting underneath it.
+- **Risk profile:** `MEASURED` — the internal source is counted over every
+  committed reference surface and reproduced end to end through the flush;
+  `evidence/rp15-price-inversion-2026-09-04.md`. The external source remains
+  unobserved, no sampled Block Scholes surface having violated butterfly
+  freedom.
+- **Pinning tests:** `payout_tree_walk_tests.move` —
+  `a_fixed_point_dust_inversion_on_a_real_surface_is_walked_not_aborted`,
+  `the_synthetic_inversion_exceeds_the_monotonicity_tolerance`,
+  `inversion_on_a_cancelling_last_boundary_still_aborts`;
+  `current_nav_flow_tests.move` —
+  `current_nav_rejects_non_monotone_active_book_surface`;
+  `pool_valuation_flow_tests.move` —
+  `a_fixed_point_dust_inversion_does_not_stall_the_flush`. The guard moved from
   the price memo to `strike_payout_tree::ENonMonotonePrice` when leverage was
-  removed and the memo was deleted. It is enforced at EVERY payout-tree boundary,
-  exactly as it was before the move. An intermediate revision of that change
-  enforced it only over the boundaries whose start and end quantities do not
-  cancel; that was wrong — the netted aggregate is unaffected by a cancelling
-  boundary, but live redeem prices each order individually, so an inversion
-  sitting on a cancelling tick let NAV understate liability while the flush
-  succeeded. The second pinning test above is the regression for it.
-- **Reopen when:** Block Scholes changes or violates the surface guarantee,
-  Predict accepts another SVI publisher without the same guarantee, the
-  active-book guard is removed, NAV valuation gains a safe per-market
-  skip/carry design, or the LP flush no longer uses one shared mark for both
-  queues.
-
----
+  removed and the memo was deleted. It is evaluated at EVERY payout-tree
+  boundary. An intermediate revision of that change enforced it only over the
+  boundaries whose start and end quantities do not cancel; that was wrong — the
+  netted aggregate is unaffected by a cancelling boundary, but live redeem prices
+  each order individually, so an inversion sitting on a cancelling tick let NAV
+  understate liability while the flush succeeded. The third test above is the
+  regression for it.
+- **Reopen when:** `compute_up_price` changes its rounding or its primitives'
+  error budgets (the tolerance is derived from them), Block Scholes changes or
+  violates the surface guarantee, Predict accepts another SVI publisher without
+  the same guarantee, or NAV valuation gains a safe per-market skip/carry design.
 
 ## RP-16: Protocol reserve is accrue-only; the cut is taken on booked terminal profit — accept + disclose (resolves P-8)
 

--- a/packages/predict/sources/pricing/pricing.move
+++ b/packages/predict/sources/pricing/pricing.move
@@ -137,6 +137,16 @@ macro fun min_svi_sigma(): u64 { 1_000_000 }
 
 macro fun max_svi_input(): u64 { 100 * math::float_scaling!() }
 
+/// Largest rise in UP price across ascending strikes that says nothing about the
+/// surface. `compute_up_price` floors `N(d2)` and the skew correction
+/// independently, so where `N(d2)` sits on a tail plateau the difference steps up
+/// by raw units on a valid, butterfly-free surface. The bound is the pricer's own
+/// absolute precision, not a risk appetite: `pricing_reference_data` derives 3,304
+/// units per endpoint from `math.move`'s per-primitive budgets, two endpoints can
+/// disagree by twice that, and this rounds it up. It stays two orders of magnitude
+/// inside the 0.1% relative accuracy the reference tolerances hold pricing to.
+public(package) macro fun price_monotonicity_tolerance(): u64 { 10_000 }
+
 // === Public Functions ===
 
 /// Return the current UP digital probability for a typed strike. Public PTB and

--- a/packages/predict/sources/strike_exposure/index/strike_payout_tree.move
+++ b/packages/predict/sources/strike_exposure/index/strike_payout_tree.move
@@ -37,7 +37,7 @@
 /// stood at the snapshot instant through the same walk the live read uses.
 module deepbook_predict::strike_payout_tree;
 
-use deepbook_predict::{constants, pricing::Pricer, range_codec};
+use deepbook_predict::{constants, pricing::{Self, Pricer}, range_codec};
 use fixed_math::math;
 use sui::table::{Self, Table};
 
@@ -186,14 +186,14 @@ public(package) fun settled_payout_liability(
 /// anchor for `(-inf, h]` ranges (its quantity enters at face value); `+inf` ends
 /// are never stored (`P = 0`).
 public(package) fun walk_linear(tree: &StrikePayoutTree, pricer: &Pricer, tick_size: u64): u64 {
-    let mut previous_price = option::none();
+    let mut price_envelope = option::none();
     let (start_total, end_total) = walk_linear_subtree(
         &tree.nodes,
         tree.root,
         pricer,
         tick_size,
         0,
-        &mut previous_price,
+        &mut price_envelope,
     );
     // Boundary products are rounded per node and the signed aggregate is floored
     // once. This can differ from pricing and flooring each order independently.
@@ -215,14 +215,14 @@ public(package) fun walk_linear_frozen(
         tree.snapshot_active && tree.snapshot_seq == snapshot_seq && snapshot_seq != 0,
         EStaleValuationSnapshot,
     );
-    let mut previous_price = option::none();
+    let mut price_envelope = option::none();
     let (start_total, end_total) = walk_linear_subtree(
         &tree.nodes,
         tree.root,
         pricer,
         tick_size,
         snapshot_seq,
-        &mut previous_price,
+        &mut price_envelope,
     );
     (tree.snapshot_base + start_total).saturating_sub(end_total)
 }
@@ -604,7 +604,7 @@ fun walk_linear_subtree(
     pricer: &Pricer,
     tick_size: u64,
     frozen_seq: u64,
-    previous_price: &mut Option<u64>,
+    price_envelope: &mut Option<u64>,
 ): (u64, u64) {
     if (root.is_none()) return (0, 0);
     let tick = *root.borrow();
@@ -616,7 +616,7 @@ fun walk_linear_subtree(
         pricer,
         tick_size,
         frozen_seq,
-        previous_price,
+        price_envelope,
     );
 
     let (local_start, local_end) = if (frozen_seq != 0 && node.snapshot_seq == frozen_seq) {
@@ -630,13 +630,32 @@ fun walk_linear_subtree(
     if (local_start != 0 || local_end != 0) {
         let price = pricer.up_price(range_codec::strike_from_tick(tick, tick_size));
         // UP price is non-increasing in strike and the in-order walk visits
-        // ascending ticks, so a rising price is a non-monotone surface: the netted
-        // aggregate below would understate the per-order liability the protocol
-        // actually honors.
-        if (previous_price.is_some()) {
-            assert!(price <= *previous_price.borrow(), ENonMonotonePrice);
+        // ascending ticks, so a rise is either the pricer's own fixed-point dust
+        // or a genuinely inverted surface. What the netted aggregate below loses
+        // to a rise is bounded by the rise itself — `range_price` floors an
+        // inverted pair to zero for a single order while the aggregate lets it
+        // cancel — so bounding the rise bounds the understatement, and the
+        // boundary keeps its quoted price either way, leaving the aggregate the
+        // same per-order sum a monotone book produces. A rise within
+        // `price_monotonicity_tolerance` therefore proceeds: this walk is the
+        // pool-wide flush's mandatory leg, and the ticks it prices are positioned
+        // by whoever mints, so a price cannot carry a hard assert here (move.md's
+        // blast-radius ladder). A rise past that bound is a real inversion and
+        // still fails closed for the provider to correct (RP-15).
+        //
+        // The comparison is against the running minimum rather than the last
+        // boundary, so dust accumulated over many boundaries trips the same bound
+        // instead of ratcheting underneath it.
+        if (price_envelope.is_some()) {
+            let envelope = *price_envelope.borrow();
+            assert!(
+                price <= envelope + pricing::price_monotonicity_tolerance!(),
+                ENonMonotonePrice,
+            );
+            *price_envelope = option::some(envelope.min(price));
+        } else {
+            *price_envelope = option::some(price);
         };
-        *previous_price = option::some(price);
 
         if (local_start != local_end) {
             start_total = math::mul_down(price, local_start);
@@ -650,7 +669,7 @@ fun walk_linear_subtree(
         pricer,
         tick_size,
         frozen_seq,
-        previous_price,
+        price_envelope,
     );
     (start_total + left_start + right_start, end_total + left_end + right_end)
 }

--- a/packages/predict/tests/flows/pool_valuation_flow_tests.move
+++ b/packages/predict/tests/flows/pool_valuation_flow_tests.move
@@ -27,7 +27,9 @@ use deepbook_predict::{
     flow_test_helpers as helpers,
     plp::{Self, PoolVault},
     pricing,
+    pricing_reference_data as ref_data,
     protocol_config::{Self, ProtocolConfig},
+    range_codec,
     test_constants,
     vault_events
 };
@@ -78,6 +80,12 @@ const REPRICE_SOURCE_TS: u64 = 119_500;
 /// the 11e9 active+returned credit basis, the frozen LP mark is 9.91e9.
 const ABOVE_MAX_PRICE_MARKET_CASH: u64 = 11_000_000_000;
 const ABOVE_MAX_PRICE_POOL_NAV: u64 = 9_910_000_000;
+/// Adjacent $10-grid ticks whose committed scenario-0 UP prices rise by one raw
+/// unit, and a shared upper boundary near that surface's forward.
+const DUST_LOWER_TICK: u64 = 55_240;
+const DUST_HIGHER_TICK: u64 = 55_250;
+const DUST_SHARED_TICK: u64 = 75_800;
+const DUST_QUANTITY: u64 = 2_000_000_000;
 /// The first provider-native magnitude that cannot be represented by Predict's u64 pricing domain.
 const FIRST_UNREPRESENTABLE_U64: u128 = 18_446_744_073_709_551_616;
 
@@ -362,6 +370,74 @@ fun newer_representable_block_scholes_spot_restores_pool_valuation_flush() {
     fx.value_expiry_bundle(&mut market);
     let pool_nav = fx.finish_flush_bundle(&mut market);
     assert_eq!(pool_nav, IDLE_SEED);
+
+    helpers::return_market_bundle(market);
+    fx.finish();
+}
+
+/// A book carrying the pricer's own fixed-point dust must not stall the flush.
+///
+/// Regression for the reachable-abort class: two ordinary wide ranges, admitted on
+/// the market's own $10 grid and quoted near a coin flip, put adjacent boundaries
+/// either side of a one-unit UP-price rise on committed real scenario 0 — a valid,
+/// butterfly-free provider surface. Before `price_monotonicity_tolerance` this
+/// aborted `value_expiry`, and because `finish_flush` proves completeness over the
+/// snapshotted set with no skip, the pool-wide flush stalled until the market
+/// expired. The live NAV read the SDK composes aborted with it.
+#[test]
+fun a_fixed_point_dust_inversion_does_not_stall_the_flush() {
+    let mut fx = helpers::setup_market_default();
+    fx.bootstrap_lock(IDLE_SEED);
+    let e = fx.create_expiry(test_constants::default_expiry_ms());
+    let trader = fx.create_funded_manager(test_constants::default_manager_deposit());
+
+    fx.scenario_mut().next_tx(test_constants::alice());
+    let mut market = fx.take_market_bundle(e);
+    let mut account = fx.take_account_bundle(&trader);
+    fx.prepare_live_oracle_bundle(&mut market, test_constants::default_live_price());
+    fx.rebalance_expiry_cash_bundle(&mut market);
+    seed_real_scenario_surface(&mut fx, &mut market);
+
+    // Both ranges are ordinary: on the admission grid, and priced near 0.5.
+    let quote = fx.quote_mint_bundle(&market, DUST_LOWER_TICK, DUST_SHARED_TICK, DUST_QUANTITY);
+    assert!(quote.entry_probability() > 400_000_000);
+    assert!(quote.entry_probability() < 600_000_000);
+    let id_low = fx.mint_bundle(
+        &mut market,
+        &mut account,
+        DUST_LOWER_TICK,
+        DUST_SHARED_TICK,
+        DUST_QUANTITY,
+    );
+    let id_high = fx.mint_bundle(
+        &mut market,
+        &mut account,
+        DUST_HIGHER_TICK,
+        DUST_SHARED_TICK,
+        DUST_QUANTITY,
+    );
+    helpers::return_account_bundle(account);
+
+    // The two lower boundaries invert, so this book drives the guard.
+    let pricer = fx.load_pricer_bundle(&market);
+    assert!(
+        pricer.up_price(range_codec::strike_from_tick(DUST_HIGHER_TICK, test_constants::default_tick_size()))
+            > pricer.up_price(range_codec::strike_from_tick(DUST_LOWER_TICK, test_constants::default_tick_size())),
+    );
+
+    // Live NAV is free cash less the independent per-order sum (`live_order_value`
+    // prices each order through `range_price`, not the walk's `up_price`).
+    let per_order_liability =
+        fx.live_order_value_bundle(&market, id_low) + fx.live_order_value_bundle(&market, id_high);
+    let free_cash =
+        helpers::market(&market).cash_balance() - helpers::market(&market).inventory_impact_reserve();
+    assert_eq!(fx.current_nav_bundle(&market), free_cash - per_order_liability);
+
+    // ... and the flush runs to completion over that same book.
+    fx.start_flush_bundle(&mut market);
+    fx.value_expiry_bundle(&mut market);
+    let pool_nav = fx.finish_flush_bundle(&mut market);
+    assert!(pool_nav > 0);
 
     helpers::return_market_bundle(market);
     fx.finish();
@@ -991,6 +1067,26 @@ fun set_protocol_reserve_profit_share_above_max_aborts() {
 /// Bootstrap pool idle via the genesis `lock_capital` so nonzero NAV has matching PLP
 /// supply (`idle == total_supply == amount` at a 1.0 mark). The lock is
 /// operator-gated and needs no trader account.
+/// Install committed real scenario 0 over a prepared market.
+fun seed_real_scenario_surface(fx: &mut helpers::Fixture, market: &mut helpers::MarketBundle) {
+    let ts = test_constants::live_source_timestamp_ms() + 1;
+    fx.set_pyth_price_for_testing_bundle(market, ref_data::spot(0), ts);
+    fx.seed_bs_surface_with_svi_bundle(
+        market,
+        ref_data::spot(0),
+        ref_data::forward(0),
+        ref_data::svi_a(0),
+        false,
+        ref_data::svi_b(0),
+        ref_data::svi_sigma(0),
+        ref_data::svi_rho_magnitude(0),
+        ref_data::svi_rho_is_negative(0),
+        ref_data::svi_m_magnitude(0),
+        ref_data::svi_m_is_negative(0),
+        ts,
+    );
+}
+
 fun bootstrap_pool(fx: &mut helpers::Fixture, amount: u64) {
     fx.bootstrap_lock(amount);
 }

--- a/packages/predict/tests/flows/pool_valuation_flow_tests.move
+++ b/packages/predict/tests/flows/pool_valuation_flow_tests.move
@@ -30,6 +30,7 @@ use deepbook_predict::{
     pricing_reference_data as ref_data,
     protocol_config::{Self, ProtocolConfig},
     range_codec,
+    strike_exposure_config,
     test_constants,
     vault_events
 };
@@ -387,18 +388,11 @@ fun newer_representable_block_scholes_spot_restores_pool_valuation_flush() {
 #[test]
 fun a_fixed_point_dust_inversion_does_not_stall_the_flush() {
     let mut fx = helpers::setup_market_default();
-    fx.bootstrap_lock(IDLE_SEED);
-    let e = fx.create_expiry(test_constants::default_expiry_ms());
-    let trader = fx.create_funded_manager(test_constants::default_manager_deposit());
+    let (mut market, mut account) = real_scenario_market(&mut fx);
 
-    fx.scenario_mut().next_tx(test_constants::alice());
-    let mut market = fx.take_market_bundle(e);
-    let mut account = fx.take_account_bundle(&trader);
-    fx.prepare_live_oracle_bundle(&mut market, test_constants::default_live_price());
-    fx.rebalance_expiry_cash_bundle(&mut market);
-    seed_real_scenario_surface(&mut fx, &mut market);
-
-    // Both ranges are ordinary: on the admission grid, and priced near 0.5.
+    // Both ranges are ordinary: on the admission grid, and priced near 0.5. The
+    // entry band sees the RANGE price (~0.476), never the inverting boundary's
+    // own ~0.999999995.
     let quote = fx.quote_mint_bundle(&market, DUST_LOWER_TICK, DUST_SHARED_TICK, DUST_QUANTITY);
     assert!(quote.entry_probability() > 400_000_000);
     assert!(quote.entry_probability() < 600_000_000);
@@ -441,6 +435,30 @@ fun a_fixed_point_dust_inversion_does_not_stall_the_flush() {
 
     helpers::return_market_bundle(market);
     fx.finish();
+}
+
+/// The entry band is the reason this looks unreachable and is not: it bounds the
+/// RANGE price, so it rejects the open-topped order at the same lower boundary
+/// (that one really is a ~0.999999995 contract) while admitting the two-sided
+/// range over it at ~0.476. The inverting boundary's own price never faces the
+/// band — only the admission grid applies to a boundary tick.
+#[test, expected_failure(abort_code = strike_exposure_config::EEntryProbabilityOutOfBounds)]
+fun the_entry_band_bounds_the_range_not_the_boundary() {
+    let mut fx = helpers::setup_market_default();
+    let (mut market, mut account) = real_scenario_market(&mut fx);
+
+    let admitted = fx.quote_mint_bundle(&market, DUST_LOWER_TICK, DUST_SHARED_TICK, DUST_QUANTITY);
+    assert!(admitted.entry_probability() > 400_000_000);
+    assert!(admitted.entry_probability() < 600_000_000);
+
+    fx.mint_bundle(
+        &mut market,
+        &mut account,
+        DUST_LOWER_TICK,
+        constants::pos_inf_tick!(),
+        DUST_QUANTITY,
+    );
+    abort 999
 }
 
 // === Completeness proof ===
@@ -1067,6 +1085,23 @@ fun set_protocol_reserve_profit_share_above_max_aborts() {
 /// Bootstrap pool idle via the genesis `lock_capital` so nonzero NAV has matching PLP
 /// supply (`idle == total_supply == amount` at a 1.0 mark). The lock is
 /// operator-gated and needs no trader account.
+/// A funded market carrying committed real scenario 0, with the trader's account
+/// bundle taken, ready to mint into.
+fun real_scenario_market(
+    fx: &mut helpers::Fixture,
+): (helpers::MarketBundle, helpers::AccountBundle) {
+    fx.bootstrap_lock(IDLE_SEED);
+    let e = fx.create_expiry(test_constants::default_expiry_ms());
+    let trader = fx.create_funded_manager(test_constants::default_manager_deposit());
+    fx.scenario_mut().next_tx(test_constants::alice());
+    let mut market = fx.take_market_bundle(e);
+    let account = fx.take_account_bundle(&trader);
+    fx.prepare_live_oracle_bundle(&mut market, test_constants::default_live_price());
+    fx.rebalance_expiry_cash_bundle(&mut market);
+    seed_real_scenario_surface(fx, &mut market);
+    (market, account)
+}
+
 /// Install committed real scenario 0 over a prepared market.
 fun seed_real_scenario_surface(fx: &mut helpers::Fixture, market: &mut helpers::MarketBundle) {
     let ts = test_constants::live_source_timestamp_ms() + 1;

--- a/packages/predict/tests/strike_exposure/index/payout_tree_walk_tests.move
+++ b/packages/predict/tests/strike_exposure/index/payout_tree_walk_tests.move
@@ -21,6 +21,7 @@ use deepbook_predict::{
     constants,
     oracle_fixture::{Self, OracleBundle, OracleFixture},
     pricing::{Self, Pricer},
+    pricing_reference_data as ref_data,
     range_codec::{Self, Strike},
     strike_payout_tree::{Self, StrikePayoutTree},
     test_constants
@@ -61,6 +62,15 @@ const GC_SETTLEMENT_C_ONLY_TICK: u64 = 106;
 const CANCEL_LOWER_TICK: u64 = 90;
 const CANCEL_SHARED_TICK: u64 = 100;
 const CANCEL_QUANTITY: u64 = 3_000_000;
+/// Adjacent $10-grid ticks on committed real scenario 0 whose UP prices RISE by one
+/// raw unit: `N(d2)` sits on the deep-ITM plateau while the floored skew term steps.
+/// The surface itself is valid and butterfly-free — the rise is the pricer's own
+/// fixed point, which is why it must not abort a mandatory walk.
+const DUST_INVERSION_LOWER_TICK: u64 = 55_240;
+const DUST_INVERSION_HIGHER_TICK: u64 = 55_250;
+/// Shared upper boundary near scenario 0's forward, so both ranges price near 0.5.
+const DUST_INVERSION_SHARED_TICK: u64 = 75_800;
+const DUST_INVERSION_QUANTITY: u64 = 2_000_000_000;
 
 /// A cancelling boundary must still be PRICED, not just skipped in the arithmetic.
 ///
@@ -220,6 +230,63 @@ fun tick_size(): u64 { test_constants::default_tick_size() }
 
 /// Strike for a tick under the default `tick_size` (tick 0 and `pos_inf_tick`
 /// map to the open-ended sentinels).
+/// Two ordinary ranges whose lower boundaries straddle a one-unit fixed-point
+/// inversion on a REAL committed surface walk to the per-order figure instead of
+/// aborting. The prices are asserted to invert first, so the test drives the guard
+/// rather than merely passing beside it; the rise is dust by the pricer's own
+/// precision, which is what `price_monotonicity_tolerance` admits.
+#[test]
+fun a_fixed_point_dust_inversion_on_a_real_surface_is_walked_not_aborted() {
+    let (mut fixture, oracle, pricer) = real_scenario_pricer();
+    let mut tree = strike_payout_tree::new(fixture.scenario_mut().ctx());
+
+    let lower_price = pricer.up_price(raw(DUST_INVERSION_LOWER_TICK));
+    let higher_price = pricer.up_price(raw(DUST_INVERSION_HIGHER_TICK));
+    assert!(higher_price > lower_price);
+    assert!(higher_price - lower_price <= pricing::price_monotonicity_tolerance!());
+
+    tree.insert_range(
+        DUST_INVERSION_LOWER_TICK,
+        DUST_INVERSION_SHARED_TICK,
+        DUST_INVERSION_QUANTITY,
+    );
+    tree.insert_range(
+        DUST_INVERSION_HIGHER_TICK,
+        DUST_INVERSION_SHARED_TICK,
+        DUST_INVERSION_QUANTITY,
+    );
+
+    // The netted aggregate still equals the independent per-order sum: the walk
+    // prices the inverted boundary at its quote, so admitting the dust costs the
+    // mark nothing.
+    assert_eq!(
+        walk_linear(&tree, &pricer),
+        range_reference(
+            &pricer,
+            vector[DUST_INVERSION_LOWER_TICK, DUST_INVERSION_HIGHER_TICK],
+            vector[DUST_INVERSION_SHARED_TICK, DUST_INVERSION_SHARED_TICK],
+            vector[DUST_INVERSION_QUANTITY, DUST_INVERSION_QUANTITY],
+        ),
+    );
+
+    destroy(tree);
+    cleanup(fixture, oracle);
+}
+
+/// The synthetic surface the abort tests use inverts by far more than the
+/// tolerance, so their aborts are attributable to a real inversion rather than to
+/// any rise at all.
+#[test]
+fun the_synthetic_inversion_exceeds_the_monotonicity_tolerance() {
+    let (fixture, oracle, pricer) = non_monotone_pricer();
+
+    let lower_price = pricer.up_price(raw(CANCEL_LOWER_TICK));
+    let higher_price = pricer.up_price(raw(CANCEL_SHARED_TICK));
+    assert!(higher_price - lower_price > pricing::price_monotonicity_tolerance!());
+
+    cleanup(fixture, oracle);
+}
+
 fun raw(tick: u64): Strike { range_codec::strike_from_tick(tick, tick_size()) }
 
 /// Run the exact linear walk.
@@ -317,6 +384,32 @@ fun non_monotone_pricer(): (OracleFixture, OracleBundle, Pricer) {
         true,
         0,
         false,
+    );
+    let pricer = fixture.load_pricer_bundle(&oracle);
+    (fixture, oracle, pricer)
+}
+
+/// A pricer carrying committed real scenario 0 — a provider-valid, butterfly-free
+/// surface, unlike `non_monotone_pricer`'s synthetic one.
+fun real_scenario_pricer(): (OracleFixture, OracleBundle, Pricer) {
+    let mut fixture = oracle_fixture::setup_oracle(
+        ref_data::creation_spot(0),
+        ref_data::tick_size(0),
+        test_constants::default_expiry_ms(),
+    );
+    let mut oracle = fixture.take_oracle_bundle();
+    fixture.prepare_real_oracle_bundle(
+        &mut oracle,
+        ref_data::spot(0),
+        ref_data::forward(0),
+        ref_data::svi_a(0),
+        false,
+        ref_data::svi_b(0),
+        ref_data::svi_sigma(0),
+        ref_data::svi_rho_magnitude(0),
+        ref_data::svi_rho_is_negative(0),
+        ref_data::svi_m_magnitude(0),
+        ref_data::svi_m_is_negative(0),
     );
     let pricer = fixture.load_pricer_bundle(&oracle);
     (fixture, oracle, pricer)


### PR DESCRIPTION
## Summary

- `strike_payout_tree`'s NAV walk now prices a boundary at its quote while the UP price rise over the walk's running minimum stays within `pricing::price_monotonicity_tolerance`, and still aborts `ENonMonotonePrice` above it. Both the live walk and the flush's frozen walk behave identically.
- RP-15 is re-derived: the inversion has an internal source as well as the provider one, the response is the bounded tolerance, and the risk profile is `MEASURED` against a new evidence record.
- Three tests added: a walk-level dust inversion on a committed real surface, an attribution check that the synthetic inverted surface exceeds the tolerance, and an end-to-end flush regression.

## Why

`strike_payout_tree::walk_linear` values the payout book for `current_nav` and, through `snapshot_nav`, for every market in a pool-wide flush. It required the UP price to be non-increasing across ascending boundary ticks and read any rise as an inverted surface. But `compute_up_price` floors `N(d2)` and the skew correction independently, so where `N(d2)` sits on the deep-ITM plateau the difference between the two floored terms rises by raw units on a surface that is valid and butterfly-free — the committed scenario 0 does this at 24 adjacent pairs on a $10 grid, and three of the four committed surfaces invert on the $1 and $10 grids. Boundary ticks are chosen by whoever mints, and the strike whose price inverts is deep enough in the money that a range with a boundary there is an ordinary wide bet priced near 0.5, so two admitted mints put the pair in the tree. Because `plp::finish_flush` proves completeness over the snapshotted set with no per-market skip, that abort stopped every LP supply and withdraw fill until the market settled, and it took the public `current_nav` read with it.

## Linear / Context

- DBU-790
- Register entry: `packages/predict/predeploy/response-policies.md` § RP-15. Evidence: `packages/predict/predeploy/evidence/rp15-price-inversion-2026-09-04.md`.

## Key decisions

- **Keep the quoted price rather than clamping to the running minimum.** Clamping would make the netted aggregate diverge from what `redeem_live` pays per order. Keeping the quote leaves the aggregate exactly the per-order sum, so no book that values today changes value — the only behavioral difference is where the walk previously aborted. What the aggregate loses to a rise is bounded by the rise itself, so bounding the rise is what bounds the understatement.
- **Compare against the running minimum, not the previous boundary.** Otherwise a staircase of individually-tolerable rises could ratchet arbitrarily far without ever tripping the bound.
- **Tolerance is 10,000 units at 1e9, derived, not chosen for appetite.** `pricing_reference_data` derives a 3,304-unit worst-case absolute error per endpoint from `math.move`'s per-primitive budgets; two endpoints can disagree by twice that. The bound sits just above it and two orders of magnitude inside the 0.1% relative accuracy the reference tolerances hold pricing to.
- **A material inversion still fails closed.** Above the bound the rise is a real surface defect, the overstatement it would put into the single LP mark is material, and "retry once the provider publishes a corrected surface" is a recovery path that exists in that regime.

## Scope / Descoped

- Surface admission is unchanged: no on-chain butterfly or `g(k) >= 0` check, no tighter synthetic-parameter envelope.
- No event or other indexer surface for an absorbed inversion. A per-boundary emit would run into the per-transaction event ceiling, and a per-market summary event is a separate decision.
- No change to `range_price`, which already floors an inverted pair to zero for a single order.

## Test plan

- [x] `sui move test` in `packages/predict` — 567/567 pass (three new).
- [x] Negative control: restoring the strict `assert!(price <= envelope)` fails `payout_tree_walk_tests::a_fixed_point_dust_inversion_on_a_real_surface_is_walked_not_aborted` and `pool_valuation_flow_tests::a_fixed_point_dust_inversion_does_not_stall_the_flush`, both with abort code 2. Neither test passes against the old behavior.
- [x] `sui move build --warnings-are-errors` — exit 0.
- [x] `python3 packages/predict/predeploy/check.py` — clean, 0 warnings.
- [x] `checks/format-move.sh` applied to every touched Move file.

## Risk / Rollout

Pre-deploy; no struct, event, or id-layout change, so nothing to migrate. The walk returns the same value for every book that values today — the aggregate is unchanged because each boundary keeps its quoted price — so the only behavior that changes is the abort. Residual: an inversion smaller than the bound is now absorbed silently, capped at 10,000 units at 1e9 times the affected quantity, with no telemetry until a summary event is added.
