### PR TITLE
predict: lower the minimum expiry cash target to 1,000 USDC

### DIFF
--- a/packages/predict/docs/concepts/liquidity-and-nav.md
+++ b/packages/predict/docs/concepts/liquidity-and-nav.md
@@ -155,10 +155,10 @@ Idle pool cash is funded into expiries to back trading, and surplus is swept bac
 
 Each expiry has a **required cash** floor of `payout_liability + inventory_impact_reserve`. The pool rebalances each active expiry toward a target derived from a **rebalance band** around that requirement:
 
-- `target_cash = max(required_cash × (1 + band), expiry_cash_floor)`
-- `sweep_threshold = max(required_cash × (1 + 2 × band), expiry_cash_floor)`
+- `target_cash = max(required_cash × (1 + band), initial_expiry_cash)`
+- `sweep_threshold = max(required_cash × (1 + 2 × band), initial_expiry_cash)`
 
-where `band` is `expiry_rebalance_pct` (a 1e9-scaled fraction) and `expiry_cash_floor` is a fixed minimum cash floor per expiry. The hysteresis between the top-up target and the higher sweep threshold prevents thrashing cash back and forth on small moves.
+where `band` is `expiry_rebalance_pct` (a 1e9-scaled fraction) and `initial_expiry_cash` is the admin-configured cadence target snapshotted when the market is created. Enabled cadences require a target of at least 1,000 USDC, enforced by the upgrade-required `constants::expiry_cash_floor`, and no more than `max_expiry_allocation`. Updating the cadence does not change existing markets' targets. The hysteresis between the top-up target and the higher sweep threshold prevents thrashing cash back and forth on small moves.
 
 - **Top up:** if `cash_balance < target_cash`, the pool sends `target_cash − cash_balance`, capped by available idle USDC and by the expiry's remaining **funding room**.
 - **Sweep:** if `cash_balance > sweep_threshold`, the pool pulls `cash_balance − target_cash` back to idle. The expiry only releases surplus above its own required backing — a sweep can never break solvency.

--- a/packages/predict/harness/ts/predictConfig.ts
+++ b/packages/predict/harness/ts/predictConfig.ts
@@ -10,7 +10,7 @@ export interface CadenceConfig {
   tickSize: bigint; // raw price unit ($0.01 = 10_000_000)
   admissionTickSize: bigint; // raw price unit ($1 = 1_000_000_000); admission/tick = 100
   maxExpiryAllocation: bigint; // USDC
-  initialExpiryCash: bigint; // USDC (>= expiry_cash_floor 10k, <= maxExpiryAllocation)
+  initialExpiryCash: bigint; // USDC (>= expiry_cash_floor 1k, <= maxExpiryAllocation)
   windowSize: bigint; // number of cadence periods in the rolling future horizon
 }
 

--- a/packages/predict/predeploy/response-policies.md
+++ b/packages/predict/predeploy/response-policies.md
@@ -1525,4 +1525,15 @@ worth-fixing.
 - **Pinning tests:** `mint_redeem_guard_tests.move` — `mint_cost_above_maximum_payout_aborts`; `quote_mint_tests.move` — `quote_at_maximum_payout_mints` and `quote_above_maximum_payout_aborts` pin exact equality as admitted and one USDC base unit above as rejected.
 - **Reopen when:** settlement can pay more than `quantity`, a mint charge becomes recoverable at settlement, or the protocol intentionally supports externally compensated loss-leading positions.
 
+## RP-34: Enabled cadences admit cash targets starting at 1,000 USDC
+
+- **Trigger state:** an administrator configures an enabled cadence's `initial_expiry_cash` below 1,000 USDC.
+- **Controller:** protocol administrator through `registry::set_template_cadence_config`.
+- **Blast radius:** the configuration transaction; existing markets retain their creation-time cash targets.
+- **Response:** reject with `EInvalidCadenceConfig`; admit targets at or above 1,000 USDC and no greater than `max_expiry_allocation`. A fully zeroed cadence remains disabled. The minimum stays upgrade-required, with no new admin setter or network-specific exception.
+- **Duty inventory:** the relaxed 10,000-USDC guard set the minimum initial cash target and, through `initial_expiry_cash <= max_expiry_allocation`, the minimum allocation cap and inventory-impact scale. Both minima become 1,000 USDC and remain strictly positive. The constant has no other production consumer. Runtime rebalancing uses each market's snapshotted target; payout backing, impact reserves, net-allocation limits, and active-market/node bounds are unchanged. No arithmetic upper bound or denominator positivity check is removed.
+- **Risk profile:** smaller targets and allocation caps allow less prefunded trading capacity and a smaller inventory-impact scale; they do not authorize underbacked trades or force capital out of existing markets. This is a configuration-envelope decision, not a throughput or liquidity measurement.
+- **Pinning tests:** `registry_create_tests.move` — `set_cadence_config_accepts_1000_and_2000_usdc_targets`, `set_cadence_config_initial_cash_below_floor_aborts`, `set_cadence_config_initial_cash_above_allocation_aborts`, `cadence_configs_disable_round_trip`; `pool_valuation_flow_tests.move` — `minimum_cash_target_rebalances_without_changing_pool_capital`, `above_minimum_cash_target_rebalances_without_changing_pool_capital`.
+- **Reopen when:** the floor gains a runtime consumer, allocation-cap scaling changes, or existing market targets become mutable.
+
 ---

--- a/packages/predict/sources/constants.move
+++ b/packages/predict/sources/constants.move
@@ -30,8 +30,8 @@ public macro fun min_premium(): u64 { 1_000_000 }
 
 // === Pool Funding ===
 
-/// USDC cash floor targeted by pool rebalancing, in 6-decimal quote units.
-public(package) macro fun expiry_cash_floor(): u64 { 10_000_000_000 }
+/// Minimum configurable per-expiry cash target, in 6-decimal USDC units.
+public(package) macro fun expiry_cash_floor(): u64 { 1_000_000_000 }
 
 /// Rebalancing band and target buffer fraction, in FLOAT_SCALING.
 public(package) macro fun expiry_rebalance_pct(): u64 { 100_000_000 }

--- a/packages/predict/tests/flows/inventory_impact_flow_tests.move
+++ b/packages/predict/tests/flows/inventory_impact_flow_tests.move
@@ -160,7 +160,7 @@ fun setup_enabled_market(): (helpers::Fixture, ID, helpers::Trader) {
     let mut fx = helpers::setup_market_default();
     fx.set_template_backing_buffer_lambda(BACKING_BUFFER_LAMBDA);
     fx.set_template_inventory_impact_max_rate(IMPACT_MAX_RATE);
-    fx.set_default_cadence_allocation(IMPACT_SCALE, constants::expiry_cash_floor!());
+    fx.set_default_cadence_allocation(IMPACT_SCALE, test_constants::default_initial_expiry_cash());
     let expiry_id = fx.create_expiry(test_constants::short_expiry_ms());
     let trader = fx.create_funded_manager(test_constants::mint_deposit());
     (fx, expiry_id, trader)
@@ -170,7 +170,7 @@ fun setup_enabled_referred_market(): (helpers::Fixture, ID, helpers::Trader) {
     let mut fx = helpers::setup_market_default();
     fx.set_template_backing_buffer_lambda(BACKING_BUFFER_LAMBDA);
     fx.set_template_inventory_impact_max_rate(IMPACT_MAX_RATE);
-    fx.set_default_cadence_allocation(IMPACT_SCALE, constants::expiry_cash_floor!());
+    fx.set_default_cadence_allocation(IMPACT_SCALE, test_constants::default_initial_expiry_cash());
     let expiry_id = fx.create_expiry(test_constants::short_expiry_ms());
     let referrer = fx.create_funded_manager_as(test_constants::bob(), 0);
     let trader = fx.create_funded_manager_with_referrer_as(

--- a/packages/predict/tests/flows/pool_valuation_flow_tests.move
+++ b/packages/predict/tests/flows/pool_valuation_flow_tests.move
@@ -51,6 +51,8 @@ const MID_FLUSH_EXPIRY_MS: u64 = 360_000;
 /// pinned against the ledger fields — none of it restates the digital, which is
 /// checked independently at each mint.
 const MARKET_CASH_TARGET: u64 = 10_000_000_000;
+const MINIMUM_CASH_TARGET: u64 = 1_000_000_000;
+const SMALL_CASH_TARGET: u64 = 2_000_000_000;
 const MINT_MIN_FEE: u64 = 10_000_000;
 /// Leave exactly 1e9 idle after funding a 250e9 expiry. With 251e9 PLP supply,
 /// that mark is a very low but executable fair PLP price.
@@ -82,6 +84,38 @@ const ABOVE_MAX_PRICE_POOL_NAV: u64 = 9_910_000_000;
 const FIRST_UNREPRESENTABLE_U64: u128 = 18_446_744_073_709_551_616;
 
 // === Happy path: aggregation ===
+
+#[test]
+fun minimum_cash_target_rebalances_without_changing_pool_capital() {
+    assert_small_cash_target_rebalance(MINIMUM_CASH_TARGET);
+}
+
+#[test]
+fun above_minimum_cash_target_rebalances_without_changing_pool_capital() {
+    assert_small_cash_target_rebalance(SMALL_CASH_TARGET);
+}
+
+fun assert_small_cash_target_rebalance(target: u64) {
+    let mut fx = helpers::setup_market_default();
+    fx.set_default_cadence_allocation(target, target);
+    bootstrap_pool(&mut fx, IDLE_SEED);
+    let expiry = fx.create_expiry(test_constants::default_expiry_ms());
+    fx.scenario_mut().next_tx(test_constants::admin());
+    let mut bundle = fx.take_market_bundle(expiry);
+    assert_eq!(helpers::market(&bundle).cash_balance(), 0);
+    fx.rebalance_expiry_cash_bundle(&mut bundle);
+    assert_eq!(helpers::market(&bundle).cash_balance(), target);
+    assert_eq!(helpers::market(&bundle).payout_liability(), 0);
+    assert_eq!(helpers::vault(&bundle).idle_balance(), IDLE_SEED - target);
+    assert_eq!(helpers::vault(&bundle).profit_basis_debits(), target);
+    // A repeated rebalance must not fund the same target twice.
+    fx.rebalance_expiry_cash_bundle(&mut bundle);
+    assert_eq!(helpers::market(&bundle).cash_balance(), target);
+    assert_eq!(helpers::vault(&bundle).idle_balance(), IDLE_SEED - target);
+    assert_eq!(helpers::vault(&bundle).profit_basis_debits(), target);
+    helpers::return_market_bundle(bundle);
+    fx.finish();
+}
 
 #[test]
 fun multi_market_pool_nav_is_idle_plus_sum_of_navs() {
@@ -267,15 +301,9 @@ fun empty_funded_markets_pool_nav_equals_total_idle() {
 
     // Each funded empty market holds exactly the cash floor as NAV (no liability),
     // so the entire pool NAV is the total idle originally seeded (cash conserved).
-    assert_eq!(
-        fx.current_nav(&m1, &config, &oracle_registry, &pyth, &bs),
-        constants::expiry_cash_floor!(),
-    );
-    assert_eq!(
-        fx.current_nav(&m2, &config, &oracle_registry, &pyth, &bs),
-        constants::expiry_cash_floor!(),
-    );
-    assert_eq!(vault.profit_basis_debits(), 2 * constants::expiry_cash_floor!());
+    assert_eq!(fx.current_nav(&m1, &config, &oracle_registry, &pyth, &bs), MARKET_CASH_TARGET);
+    assert_eq!(fx.current_nav(&m2, &config, &oracle_registry, &pyth, &bs), MARKET_CASH_TARGET);
+    assert_eq!(vault.profit_basis_debits(), 2 * MARKET_CASH_TARGET);
     assert_eq!(vault.profit_basis_credits(), 0);
     assert_eq!(pool_nav, IDLE_SEED);
 
@@ -825,10 +853,7 @@ fun finish_flush_releases_the_valuation_flag_and_a_mint_succeeds() {
     assert!(helpers::valuation_in_progress_bundle(&market));
     fx.value_expiry_bundle(&mut market);
     let pool_nav = fx.finish_flush_bundle(&mut market);
-    assert_eq!(
-        pool_nav,
-        constants::expiry_cash_floor!() + (IDLE_SEED - constants::expiry_cash_floor!()),
-    );
+    assert_eq!(pool_nav, IDLE_SEED);
 
     // Finish releases the flag — asserted on the flag itself, because trading is
     // not blocked by a flush and cannot witness the release. The flag is what

--- a/packages/predict/tests/flows/protocol_profit_deferral_tests.move
+++ b/packages/predict/tests/flows/protocol_profit_deferral_tests.move
@@ -33,11 +33,13 @@ use propbook::{pyth_feed::PythFeed, registry::OracleRegistry};
 use std::unit_test::{assert_eq, destroy};
 use sui::test_scenario::return_shared;
 
+const FIXTURE_CASH_TARGET: u64 = 10_000_000_000;
+
 #[test]
 /// Permissionless settled sweep when idle < the protocol cut: the cut is realized up
 /// to idle, the remainder carried, and a later live sweep drains the carried cut.
 fun settled_sweep_defers_protocol_cut_then_drains_on_later_sweep() {
-    let f = constants::expiry_cash_floor!();
+    let f = FIXTURE_CASH_TARGET;
     let mut fx = helpers::setup_market_default();
     // 0.9 of profit to the protocol: high but sub-100%, so a small idle redeploy makes
     // the cut exceed available idle at materialization.
@@ -81,7 +83,7 @@ fun settled_sweep_defers_protocol_cut_then_drains_on_later_sweep() {
 /// pool genesis-locked, the carried protocol cut is excluded from LP value separately, so
 /// pricing nets idle (f) minus the pending cut (f-l) to exactly the locked liquidity (l).
 fun flush_completes_when_settled_cut_exceeds_idle() {
-    let f = constants::expiry_cash_floor!();
+    let f = FIXTURE_CASH_TARGET;
     let l = constants::min_bootstrap_liquidity!();
     let mut fx = helpers::setup_market_default();
     fx.bootstrap_lock(l); // genesis lock so the flush is reachable (total_supply > 0)

--- a/packages/predict/tests/registry_create_tests.move
+++ b/packages/predict/tests/registry_create_tests.move
@@ -27,7 +27,9 @@ const INVALID_TICK_SIZE: u64 = BTC_TICK_SIZE + 1;
 const INVALID_ADMISSION_TICK_SIZE: u64 = BTC_ADMISSION_TICK_SIZE + 1;
 const BELOW_TICK_SIZE_ADMISSION_TICK_SIZE: u64 = BTC_TICK_SIZE / 10;
 const NON_MULTIPLE_ADMISSION_TICK_SIZE: u64 = BTC_TICK_SIZE + BTC_TICK_SIZE / 2;
-const BELOW_EXPIRY_CASH_FLOOR: u64 = 9_999_999_999;
+const BELOW_EXPIRY_CASH_FLOOR: u64 = 999_999_999;
+const MINIMUM_EXPIRY_CASH: u64 = 1_000_000_000;
+const SMALL_EXPIRY_CASH: u64 = 2_000_000_000;
 const BELOW_INITIAL_EXPIRY_CASH: u64 = BTC_INITIAL_EXPIRY_CASH - 1;
 
 const EUnexpectedSuccess: u64 = 999;
@@ -44,6 +46,30 @@ fun register_underlying_duplicate_aborts() {
 }
 
 // === set_template_cadence_config ===
+
+#[test]
+fun set_cadence_config_accepts_1000_and_2000_usdc_targets() {
+    let (scenario, mut reg, config, admin_cap) = test_helpers::begin_registry_test();
+    reg.register_underlying(&config, &admin_cap, UNDERLYING_BTC);
+    vector[MINIMUM_EXPIRY_CASH, SMALL_EXPIRY_CASH].do!(|target| {
+        reg.set_template_cadence_config(
+            &config,
+            &admin_cap,
+            UNDERLYING_BTC,
+            market_manager::cadence_one_minute!(),
+            BTC_TICK_SIZE,
+            BTC_ADMISSION_TICK_SIZE,
+            target,
+            target,
+            WINDOW_SIZE_TWO,
+        );
+        let cadence = reg.cadence_config(UNDERLYING_BTC, market_manager::cadence_one_minute!());
+        assert!(cadence.cadence_enabled());
+        assert_eq!(cadence.cadence_initial_expiry_cash(), target);
+        assert_eq!(cadence.cadence_max_expiry_allocation(), target);
+    });
+    test_helpers::finish_registry_test(scenario, reg, config, admin_cap);
+}
 
 #[test, expected_failure(abort_code = market_manager::EInvalidCadence)]
 fun set_cadence_config_invalid_cadence_id_aborts() {

--- a/packages/predict/tests/test_constants.move
+++ b/packages/predict/tests/test_constants.move
@@ -86,8 +86,8 @@ public fun default_cadence_window_size(): u64 { 1 }
 /// Default per-expiry allocation cap used by test market cadence configs.
 public fun default_max_expiry_allocation(): u64 { 250_000_000_000 }
 
-/// Default minimum USDC cash target used by test market cadence configs.
-public fun default_initial_expiry_cash(): u64 { constants::expiry_cash_floor!() }
+/// Fixed 10,000-USDC target for existing economic scenarios, independent of the admission minimum.
+public fun default_initial_expiry_cash(): u64 { 10_000_000_000 }
 
 /// The canonical finite strike tick the flow tests mint against. With the default
 /// 1e9 tick size it maps to the raw strike `100e9` (`default_strike_tick *


### PR DESCRIPTION
## Summary

- Lower the minimum configurable expiry cash target from 10,000 to 1,000 USDC.
- Cover admission boundaries and funding at 1,000 and 2,000 USDC while preserving existing economic fixtures' 10,000-USDC target.
- Document the configuration guard and the per-market target used by rebalancing.

## Why

Predict's pool funds each expiry market toward a cash target configured by an administrator and recorded when the market is created. The 10,000-USDC minimum prevents smaller capital configurations, including a 2,000-USDC target. A 1,000-USDC minimum permits those configurations through the same contract source on both networks, without a Testnet-only exception.

## Linear / Context

- N/A — exempt by explicit user instruction.

## Key decisions

- The floor remains a hardcoded, upgrade-required value; there is no new admin setter.
- The target must remain no greater than the allocation cap. Lowering the target minimum also permits smaller allocation caps and therefore smaller inventory-impact scales. Payout backing and net-allocation enforcement are unchanged.
- Existing market targets remain fixed at creation. The policy and guard duty inventory are recorded in RP-34.

## Scope / Descoped

- Contract constant, focused tests, fixture preservation, documentation, and one comment-only harness correction.
- No deployment scripts, publication records, reference-price changes, fee changes, new APIs, or object-layout changes. Fresh publication is separate follow-up work after merge.

## Test plan

- [x] CI-pinned `sui move test --path packages/predict --gas-limit 100000000000 registry_create_tests` — 18 pass, including exact minimum, below-minimum rejection, allocation constraint, and disabled cadences.
- [x] CI-pinned `sui move test --path packages/predict --gas-limit 100000000000 cash_target_rebalance` — both 1,000- and 2,000-USDC funding cases pass, including repeated rebalance and cash conservation.
- [x] CI-pinned `sui move build --path packages/predict --warnings-are-errors`.
- [x] Repo-pinned Move formatting and `python3 packages/predict/predeploy/check.py` — zero cross-reference warnings.
- [x] Full Predict suite (584 passing) and downstream Sessions suite (30 passing) on `testnet-v1.74.1`.
- [x] `corepack npm run build && corepack npm test`; Python compilation plus harness and simulation unit suites (80 and 21 passing).
- [x] Independent review: one fresh-context GPT-6 reviewer, no fan-out, covering Move guards, funding/impact-scale constraints, public surface, fixture preservation, and register consistency. The sole finding was a stale comment, corrected and re-reviewed at `017484de`.
- [x] GitHub CI on `017484de` — Linux/macOS Move suites, Move formatting, upgraded-twin parity, Predict development checks, and localnet parity/benchmark all pass.

## Risk / Rollout

Administrators can configure smaller prefunded trading capacity and allocation caps. Existing backing checks still reject underfunded trades, and this change does not move capital or alter existing market snapshots. Merge the same source change into the deployment branch before a fresh deployment; this PR does not upgrade or publish any package.
