### PR TITLE
predict: record the testnet publication of the Predict suite (DBU-776)

### DIFF
--- a/packages/fixed_math/Published.toml
+++ b/packages/fixed_math/Published.toml
@@ -4,9 +4,9 @@
 
 [published.testnet]
 chain-id = "4c78adac"
-published-at = "0x543139156cb90d1a73df33b5dca37d7c8bdce62506c7874ebc854afd319b98f1"
-original-id = "0x543139156cb90d1a73df33b5dca37d7c8bdce62506c7874ebc854afd319b98f1"
+published-at = "0x5d3b5af5cb48685e7641d4b0b0293f7af709151ac76367a1e791d545d422134a"
+original-id = "0x5d3b5af5cb48685e7641d4b0b0293f7af709151ac76367a1e791d545d422134a"
 version = 1
 toolchain-version = "1.77.1"
 build-config = { flavor = "sui", edition = "2024" }
-upgrade-capability = "0x9db5e33620ead76ebfe733e6a2a98375ff738c259fbc77cfb6972a8779109d1d"
+upgrade-capability = "0x6443949e0dab0be06e8480945b67cc29bd3f6e9ae399e1fac095cd188a8e0c87"

--- a/packages/predict/Published.toml
+++ b/packages/predict/Published.toml
@@ -4,9 +4,9 @@
 
 [published.testnet]
 chain-id = "4c78adac"
-published-at = "0x543139156cb90d1a73df33b5dca37d7c8bdce62506c7874ebc854afd319b98f1"
-original-id = "0x543139156cb90d1a73df33b5dca37d7c8bdce62506c7874ebc854afd319b98f1"
+published-at = "0x25d075d2de915feda7ab9b8f855afe59cbcd4b2ce96f75324940c810f84da018"
+original-id = "0x25d075d2de915feda7ab9b8f855afe59cbcd4b2ce96f75324940c810f84da018"
 version = 1
 toolchain-version = "1.77.1"
 build-config = { flavor = "sui", edition = "2024" }
-upgrade-capability = "0x9db5e33620ead76ebfe733e6a2a98375ff738c259fbc77cfb6972a8779109d1d"
+upgrade-capability = "0x8fea3e1ad8a15f844d7455469c26c85fc48f7996731fe88c631e435755f60574"

--- a/packages/propbook/Published.toml
+++ b/packages/propbook/Published.toml
@@ -4,9 +4,9 @@
 
 [published.testnet]
 chain-id = "4c78adac"
-published-at = "0x543139156cb90d1a73df33b5dca37d7c8bdce62506c7874ebc854afd319b98f1"
-original-id = "0x543139156cb90d1a73df33b5dca37d7c8bdce62506c7874ebc854afd319b98f1"
+published-at = "0xa04a43dbbfb123feec96691a22809d8a87e9ac37ae9356079c439750145aa92b"
+original-id = "0xa04a43dbbfb123feec96691a22809d8a87e9ac37ae9356079c439750145aa92b"
 version = 1
 toolchain-version = "1.77.1"
 build-config = { flavor = "sui", edition = "2024" }
-upgrade-capability = "0x9db5e33620ead76ebfe733e6a2a98375ff738c259fbc77cfb6972a8779109d1d"
+upgrade-capability = "0xe881130bad958ff8f913039b3705cea06a80afe2ea39133b59a1b2342723d8ef"

--- a/packages/sessions/Published.toml
+++ b/packages/sessions/Published.toml
@@ -4,9 +4,9 @@
 
 [published.testnet]
 chain-id = "4c78adac"
-published-at = "0x543139156cb90d1a73df33b5dca37d7c8bdce62506c7874ebc854afd319b98f1"
-original-id = "0x543139156cb90d1a73df33b5dca37d7c8bdce62506c7874ebc854afd319b98f1"
+published-at = "0x10c91d168dc4a04357f9d23795a204092ca46e5b97f8b9ef26fea95664d5bb38"
+original-id = "0x10c91d168dc4a04357f9d23795a204092ca46e5b97f8b9ef26fea95664d5bb38"
 version = 1
 toolchain-version = "1.77.1"
 build-config = { flavor = "sui", edition = "2024" }
-upgrade-capability = "0x9db5e33620ead76ebfe733e6a2a98375ff738c259fbc77cfb6972a8779109d1d"
+upgrade-capability = "0x6f5dd9ed34bd1dc405260dcf763edb252d52ea0227d14cc3ae94bbaa0d65d371"

--- a/packages/usdc/Published.toml
+++ b/packages/usdc/Published.toml
@@ -4,9 +4,9 @@
 
 [published.testnet]
 chain-id = "4c78adac"
-published-at = "0x543139156cb90d1a73df33b5dca37d7c8bdce62506c7874ebc854afd319b98f1"
-original-id = "0x543139156cb90d1a73df33b5dca37d7c8bdce62506c7874ebc854afd319b98f1"
+published-at = "0xc028557a1ed49e42ed091e115aedefd70a442b184c18fbec5c48d5b6c0b8c184"
+original-id = "0xc028557a1ed49e42ed091e115aedefd70a442b184c18fbec5c48d5b6c0b8c184"
 version = 1
 toolchain-version = "1.77.1"
 build-config = { flavor = "sui", edition = "2024" }
-upgrade-capability = "0x9db5e33620ead76ebfe733e6a2a98375ff738c259fbc77cfb6972a8779109d1d"
+upgrade-capability = "0x56851fdb7cadb87b1d7065ea9913ac87942217333f774fed462669464b4e1248"


### PR DESCRIPTION
## Summary

- Adds `Published.toml` for `predict`, `propbook`, `sessions`, `fixed_math` and `usdc`, and updates `account`'s testnet entry, from the `deepbook-predict-testnet` deployment.
- Recording only; no source, manifest or dependency change.

## Why

The Predict suite was republished to testnet with the renamed USDC collateral, but the resulting publication records live only on the `deepbook-predict-testnet` branch. On `main` there is no `Published.toml` for `predict`, `propbook`, `sessions`, `fixed_math` or `usdc` at all, so nothing on main can resolve the deployed identities — a testnet build from main treats every one of them as unpublished. Main should be able to describe what is deployed.

## Linear / Context

- DBU-776 — the collateral rename this deployment carries.
- Deployment: `deepbook-predict-testnet`, manifest `sourceCommit` `a928bd2d`, chain-id `4c78adac`.

## Key decisions

- **`account`'s existing testnet entry is replaced, not preserved.** It was republished in this run, so its id moves from `0xbdbb60b0…` to `0x543139156…` with a new upgrade capability. `Published.toml` holds one entry per environment, so it can only name the current deployment; the previous identity remains in git history and is still what the 8/21 deployment links.
- **The whole cluster is recorded together, not just `predict`.** The six packages are one publication graph — recording `predict` alone would leave its dependencies unresolvable and the record internally inconsistent.
- **Nothing is written that was not verified against the chain first** (see Test plan) rather than copied from the branch on trust.

## Scope / Descoped

- Does not touch `Move.toml`, sources, or the deployment manifest.
- Does not add a mainnet entry for any package — none of these are published to mainnet.
- The deployment recorded `toolchain-version = "1.77.1"` while CI pins `testnet-v1.74.1`. That is a record of what published, not a build input, so it is left as written — but it is worth someone confirming the intended deploy toolchain separately.

## Test plan

- [x] Every id verified on testnet via GraphQL before recording: `predict` (29 modules), `propbook` (6), `account` (3), `sessions` (2), `fixed_math` (2), `usdc` (1) — all at package version 1.
- [x] Collateral type confirmed on chain: `0xc028557a…::usdc::USDC` exists with ability `drop`; `CoinMetadata` is symbol `DUSDC`, 6 decimals — the type rename as deployed, test-coin symbol deliberately unchanged.
- [x] `sui move build --path packages/<pkg>` for all six under the CI-pinned toolchain (`testnet-v1.74.1`) — clean, and no `Move.lock` churn.
- [x] CI's full loop, `sui move test --gas-limit 100000000000` over every package — 12/12 packages, 1757 tests, 0 failures.

## Risk / Rollout

- Adding a testnet `Published.toml` changes how a testnet-environment build resolves these packages: they link the published ids instead of being treated as unpublished. That is the intended effect and is what makes main able to describe the deployment; the test loop above passes with it in place.
- Reverting is a file deletion — no on-chain consequence either way, since this only records what already happened.
