### PR TITLE
ci: restore the testnet deploy dispatch and make its failure visible

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,11 +27,47 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
 
+      # SUI_OPS_DISPATCH_TOKEN needs read and write access to Contents on
+      # MystenLabs/sui-operations; a classic token also needs MystenLabs SSO
+      # authorization. The same secret carries the dispatch in
+      # crates-to-dockerhub.yml, so one rotation covers both workflows.
+      - name: Check the sui-operations dispatch credential
+        env:
+          DISPATCH_TOKEN: ${{ secrets.SUI_OPS_DISPATCH_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$DISPATCH_TOKEN" ]]; then
+            echo "::error::SUI_OPS_DISPATCH_TOKEN is not configured; the deployment cannot be triggered"
+            exit 1
+          fi
+          status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
+            --header "Authorization: Bearer $DISPATCH_TOKEN" \
+            --header 'Accept: application/vnd.github+json' \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            https://api.github.com/repos/MystenLabs/sui-operations)"
+          case "$status" in
+            200)
+              echo "SUI_OPS_DISPATCH_TOKEN can reach MystenLabs/sui-operations."
+              ;;
+            401)
+              echo "::error::SUI_OPS_DISPATCH_TOKEN is expired or invalid (HTTP 401); issue a replacement and update the repository secret"
+              exit 1
+              ;;
+            403 | 404)
+              echo "::error::SUI_OPS_DISPATCH_TOKEN authenticates but cannot reach MystenLabs/sui-operations (HTTP $status); it needs read and write access to Contents there, plus MystenLabs SSO authorization if it is a classic token"
+              exit 1
+              ;;
+            *)
+              echo "::error::Unexpected HTTP $status from api.github.com while checking SUI_OPS_DISPATCH_TOKEN"
+              exit 1
+              ;;
+          esac
+
       - name: Trigger Pulumi Deployment
         uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # pin@v3.0.0
         with:
           repository: MystenLabs/sui-operations
-          token: ${{ secrets.DEPLOY_PULUMI_DISPATCH_TOKEN }}
+          token: ${{ secrets.SUI_OPS_DISPATCH_TOKEN }}
           event-type: pulumi-up
           client-payload: |-
             {
@@ -42,4 +78,23 @@ jobs:
       - name: View deployment status
         run: |
           echo "🚀 View the status of the deployment here: https://github.com/MystenLabs/sui-operations/actions/workflows/pulumi-up.yaml"
-    
+
+      - name: Report an untriggered deployment to Slack
+        if: failure()
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$SLACK_WEBHOOK_URL" ]]; then
+            echo "::warning::SLACK_WEBHOOK_URL is not configured; skipping the failure notification"
+            exit 0
+          fi
+          text="$(printf '🚨 DeepBook testnet was not deployed for deepbookv3 %s: the sui-operations deployment was never triggered. %s' \
+            "${COMMIT_SHA:0:8}" "$RUN_URL")"
+          jq --null-input --arg text "$text" '{text: $text}' \
+            | curl --silent --show-error --fail \
+              --header 'Content-Type: application/json; charset=utf-8' \
+              --data @- "$SLACK_WEBHOOK_URL" \
+              --output /dev/null


### PR DESCRIPTION
## Summary

- `deploy.yml` dispatches to `MystenLabs/sui-operations` with `SUI_OPS_DISPATCH_TOKEN`, the secret `crates-to-dockerhub.yml` already uses for the same destination repository, instead of a second secret that does the same job.
- A preflight step checks that credential against the GitHub API and fails with the HTTP status, so an expired token (401) is distinguishable from one that cannot reach the repository (403/404).
- A failed deployment trigger posts to Slack through the repository's existing `SLACK_WEBHOOK_URL`.

## Why

This workflow is the only automatic path from a merge to `main` to a DeepBook testnet deployment: it sends a `pulumi-up` repository dispatch and the deployment itself runs in `sui-operations`. Since 2026-08-04 that dispatch has returned HTTP 404, so the two most recent merges touching `crates/**`, `docker/**`, or `Cargo.*` never triggered a deployment. The dispatch action reports 404 as "Repository not found, OR token has insufficient permissions", which does not say whether the credential expired or lost access, and the failure appeared nowhere except the Actions tab — it went unnoticed for five weeks. The receiving workflow is healthy: it still accepts the `pulumi-up` event and still allowlists this project and stack.

## Linear / Context

- N/A — exempt (CI fix).
- Failed runs: [33554124936](https://github.com/MystenLabs/deepbookv3/actions/runs/33554124936) (`f0f563a2`) and [33905431219](https://github.com/MystenLabs/deepbookv3/actions/runs/33905431219) (`011cdcb0`).

## Key decisions

- **One dispatch credential, not two.** Both secrets grant the same thing — `repository_dispatch` cannot be scoped per event type, so separate tokens buy no isolation, only a second expiry to miss. `SUI_OPS_DISPATCH_TOKEN` is named for the destination and already carries the other dispatch, so one rotation now covers both workflows. `DEPLOY_PULUMI_DISPATCH_TOKEN` becomes unused and can be deleted from the repository secrets.
- **The preflight duplicates part of what the dispatch already does**, deliberately: it costs one API call and turns a message that spans three unrelated causes into a status code that names the remediation.
- **Slack rather than an issue or an annotation**, because the repository already posts to that webhook from `auto-approve.yml` and a production deployment that never started should reach a person the same day.

## Scope / Descoped

- Does not restore the credential itself: whichever token is stored in `SUI_OPS_DISPATCH_TOKEN` must be able to reach `MystenLabs/sui-operations` with read and write access to Contents, and a classic token must be SSO-authorized for the organization. That is a repository-settings action.
- Does not replace the personal access token with a GitHub App installation token, which would remove the expiry class entirely but needs an app installed on the destination repository.
- Does not report whether the deployment itself succeeded — this workflow only triggers it, and the outcome stays in the `pulumi-up` run it links.

## Test plan

- [x] `ruby -ryaml -e 'YAML.load_file(".github/workflows/deploy.yml")'` — workflow parses, five steps in order.
- [x] `bash -n` on both new `run` blocks — no syntax errors.
- [x] Credential check with a token that can read `MystenLabs/sui-operations` — HTTP 200, step passes.
- [x] Credential check with a well-formed but unknown token — HTTP 401 branch, exits 1 with the "expired or invalid" message.
- [x] Credential check against a repository the token cannot see — HTTP 404 branch, exits 1 with the "needs read and write access to Contents" message.
- [x] Credential check with the secret unset — exits 1 with the "not configured" message.
- [x] Slack step with `SLACK_WEBHOOK_URL` unset — warns and exits 0; payload rendered with `jq` and inspected without posting.
- [ ] After merge: the next qualifying push to `main`, or one manual run, dispatches successfully and links a `pulumi-up` run.

## Risk / Rollout

Deployment behavior is unchanged when the credential is valid — the same event and payload reach the same workflow. If the credential is not valid the run now fails one step earlier with an explicit status code instead of an ambiguous dispatch error, and posts to Slack. The Slack step is skipped with a warning when the webhook secret is absent, so it cannot fail a run by itself. Rollback is reverting this commit; the previous secret keeps working if it is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZ3Lq1LYxkrY8HKHV7iZ6V
