### PR TITLE
predict: point deepbook_core_account's testnet publication at the live wrapper

### DIFF
--- a/packages/deepbook_core_account/Published.toml
+++ b/packages/deepbook_core_account/Published.toml
@@ -4,12 +4,12 @@
 
 [published.testnet]
 chain-id = "4c78adac"
-published-at = "0x7ea715df00320b9460cd17531ecb507d8cc28925dce5be5de40af448c1d34239"
-original-id = "0x7ea715df00320b9460cd17531ecb507d8cc28925dce5be5de40af448c1d34239"
+published-at = "0x2dbb8e6a5b9a8ac6201c7aeff6de0c7e7bca5dcd8d6c16538cb1a7447a298071"
+original-id = "0x2dbb8e6a5b9a8ac6201c7aeff6de0c7e7bca5dcd8d6c16538cb1a7447a298071"
 version = 1
-toolchain-version = "1.76.0"
+toolchain-version = "1.77.1"
 build-config = { flavor = "sui", edition = "2024" }
-upgrade-capability = "0x87a4c0db084dc75892597c5e8d8bf74e11fc29eac9448db7d5d754c7d3b45b9d"
+upgrade-capability = "0xa846133c86346c64dd0b974f26877d800e81cad8570b9067256a1cda1ef048c4"
 
 [published.mainnet]
 chain-id = "35834a8a"


### PR DESCRIPTION
## Summary

- Points `packages/deepbook_core_account/Published.toml` `[published.testnet]` at `0x2dbb8e6a…a298071`, the wrapper the current Testnet deployment actually uses, instead of `0x7ea715df…c1d34239`.
- Moves `toolchain-version` (1.76.0 → 1.77.1) and `upgrade-capability` with it, so the whole section describes one publication.
- Restores `sui client verify-source --build-env testnet` for this package: it fails today and succeeds after.

## Why

`Published.toml` is how the Move toolchain resolves *which on-chain package* a local source tree corresponds to, so `verify-source`, MVR registration and any consumer resolving Testnet addresses all read it. The `deepbook_core_account` Testnet entry still names a wrapper published 2026-08-06, two Predict deployments ago. The Testnet deployment manifest `deployment.testnet.json` records the current wrapper correctly, and the other six packages' Testnet entries already agree with it — this one file drifted and was not updated when the suite was republished.

The practical effect is that source verification against Testnet cannot pass for this package: it compares the current sources against the old wrapper's bytecode and reports a mismatch. Anything else that trusts this id addresses a superseded package.

## Linear / Context

- N/A — exempt. Correcting a stale publication record; no ticket bar met.
- Current Testnet deployment: branch `deepbook-predict-testnet`, tagged `predict-testnet-v1.0.0` (`46df39bb`), manifest `sourceCommit` `a928bd2d`.

## Key decisions

- Took the values from the deployment branch's own `Published.toml` rather than hand-assembling them, so the section matches the record written at publish time.
- Confirmed the replacement `upgrade-capability` `0xa846133c…1ef048c4` on chain before copying it: it is a `0x2::package::UpgradeCap` whose `package` field is `0x2dbb8e6a…a298071`, version 1. A wrong UpgradeCap here would be invisible until someone tried to upgrade.
- Left `packages/usdc` with no `[published.mainnet]` section. That is correct rather than an omission — Mainnet USDC is Circle's package, linked through `[dep-replacements.mainnet]`, not something this repo publishes.

## Scope / Descoped

- One file, Testnet section only. The `[published.mainnet]` section of the same file is already correct and is untouched.
- I compared **every** package's `published-at` and `original-id` for both networks against `deployment.testnet.json` and `deployment.mainnet.json`; `deepbook_core_account` Testnet was the only disagreement. No other file needed changing.
- No source, no Move code, no behavior change.

## Test plan

- [x] `sui client --client.env testnet verify-source --build-env testnet` in `packages/deepbook_core_account` — **before**: `Multiple source verification errors found: Module account_data bytecode does not match its on-chain version; Module deepbook_core_account bytecode does not match its on-chain version`. **After**: `Source verification succeeded!` with `original ID` = `published at` = `0x2dbb8e6a…a298071`, toolchain 1.77.1.
- [x] Every `published-at` / `original-id` across all seven packages × both networks diffed against the two deployment manifests — only this entry mismatched.
- [x] Replacement `upgrade-capability` read on chain and confirmed to govern `0x2dbb8e6a…a298071`.

## Risk / Rollout

None — metadata only, no runtime impact. The file describes existing on-chain publications; nothing is published or upgraded by this change. Worst case is the id being wrong again, which `verify-source` now detects loudly rather than silently.
