### PR TITLE
scripts: add the Predict package upgrade transaction

### DIFF
--- a/.github/workflows/deepbookv3-build-tx.yml
+++ b/.github/workflows/deepbookv3-build-tx.yml
@@ -15,6 +15,7 @@ on:
           - Upgrade Protocol
           - Upgrade Margin Protocol
           - Upgrade Vault Protocol
+          - Upgrade Predict Protocol
       sui_tools_image:
         description: "image reference of sui_tools"
         default: "mysten/sui-tools:mainnet"
@@ -27,7 +28,7 @@ on:
         description: "object id to get gas from for multisig transaction"
         required: true
         type: string
-        default: "0x4850650e3566b000ea159a4ae7d13c93803ceabf1f483a7f796c7cc0b2f5ce4b"
+        default: "0x538138ff747639efd0c3b0776f802b7a7b111b3a1ccf750bacbfd8c29b6b4110"
 
 jobs:
   deepbook:
@@ -112,6 +113,17 @@ jobs:
           RPC_URL: ${{ inputs.rpc }}
         run: |
           cd scripts && pnpm install && pnpm tsx transactions/vaultPackageUpgrade.ts
+
+      - name: Upgrade Predict Protocol
+        if: ${{ inputs.transaction_type == 'Upgrade Predict Protocol' }}
+        env:
+          NODE_ENV: production
+          GAS_OBJECT: ${{ inputs.gas_object_id }}
+          NETWORK: mainnet
+          ORIGIN: gh_action
+          RPC_URL: ${{ inputs.rpc }}
+        run: |
+          cd scripts && pnpm install && pnpm tsx transactions/predictPackageUpgrade.ts
 
       - name: Show Transaction Data (To sign)
         run: |

--- a/scripts/transactions/predictPackageUpgrade.ts
+++ b/scripts/transactions/predictPackageUpgrade.ts
@@ -1,0 +1,41 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { writeFileSync } from "fs";
+import { serializeUnsignedUpgrade } from "./serializeUnsignedUpgrade.js";
+
+// Active env of sui has to be the same with the env we're publishing to.
+// if upgradeCap & gasObject is on mainnet, it has to be on mainnet.
+// Github actions are always on mainnet.
+//
+// No `--upgrade-capability` is passed: packages/predict/Published.toml records the
+// mainnet upgrade capability, so the CLI resolves it the same way margin and vault do.
+// The spot script passes one explicitly only because packages/deepbook predates that field.
+const predictPackageUpgrade = async () => {
+  const currentDir = process.cwd();
+  const predictDir = `${currentDir}/../packages/predict`;
+  const txFilePath = `${currentDir}/tx/tx-data.txt`;
+
+  try {
+    const output = serializeUnsignedUpgrade({
+      cwd: predictDir,
+    });
+
+    // Extract only the base64 transaction bytes (last non-empty line)
+    const lines = output.trim().split("\n");
+    const txBytes = lines[lines.length - 1].trim();
+
+    writeFileSync(txFilePath, txBytes);
+    console.log(
+      "Predict upgrade transaction successfully created and saved to tx-data.txt",
+    );
+  } catch (error: any) {
+    console.error("Error during predict package upgrade:", error.message);
+    console.error("stderr:", error.stderr?.toString());
+    console.error("stdout:", error.stdout?.toString());
+    console.error("Command:", error.cmd);
+    process.exit(1); // Exit with an error code
+  }
+};
+
+predictPackageUpgrade();


### PR DESCRIPTION
## Summary
- Adds `scripts/transactions/predictPackageUpgrade.ts`, the Predict equivalent of the existing spot/margin/vault upgrade builders.
- Adds `Upgrade Predict Protocol` to the Build Deepbook TX workflow.
- Repoints the workflow's default gas object, which no longer exists on chain.

## Why
`packages/predict` is live on mainnet at `0x774f9555…31afd7df` with its upgrade capability recorded in `Published.toml`, but there was no builder to produce a signable upgrade transaction for it. Spot, margin and vault each have one; Predict did not.

The gas default is a separate, pre-existing break. `0x4850650e…f5ce4b` is not on mainnet, and the CLI fails on it before building any transaction:

> `code: 'Some requested entity was not found', message: "Object 0x4850650e… not found"`

That affects **all three existing options**, not just the new one, so the new builder could not have worked out of the box without fixing it.

## Key Decisions
- **No `--upgrade-capability` flag.** `packages/predict/Published.toml` records `upgrade-capability = 0xf9fb95c8…b463c8`, so the CLI resolves it the same way margin and vault do. The spot script passes one explicitly only because `packages/deepbook`'s publication predates that field — that is a quirk of the older package, not the house pattern.
- **Follow the margin/vault output handling**, taking the last non-empty line rather than writing the CLI's whole stdout. The build log precedes the base64 on stdout; the spot script writes both, which is the older behaviour.
- **One script per package, matching the existing convention.** This covers `packages/predict` only. The Predict deployment also spans `account`, `propbook`, `sessions`, `fixed_math` and `deepbook_core_account`, each with its own capability and its own compatibility surface. Bundling them would hide which package is actually being upgraded behind one menu entry, so they are left for follow-ups if wanted.
- **Replacement gas coin is owned by the same address that owns the upgrade capabilities**, so the sender the CLI derives is the one that can actually authorize the upgrade.

## Scope / Descoped
- No Move changes. No change to what any existing option builds, beyond the gas default they were already failing on.
- Does not add builders for the sibling Predict packages.

## Test Plan
- [x] `sui move build` in `packages/predict` — exit 0, all 12 dependencies resolve.
- [x] **Script runs end to end and produces bytes:** exit 0, 109,600 characters written to `tx/tx-data.txt`.
- [x] **Decoded the serialized transaction** rather than trusting the exit code:
  - `sender` / gas owner `0x37f187e1…cf64d2` — the address holding the upgrade capabilities. The CLI derives the sender from the gas object's owner, which is why this workflow needs no imported key.
  - commands `MoveCall, Upgrade, MoveCall` — authorize → upgrade → commit.
  - owned input `0xf9fb95c8…b463c8` v947901392 — the Predict `UpgradeCap`.
  - budget 2 SUI at gas price 1000, matching `serializeUnsignedUpgrade`.
- [x] Missing-`GAS_OBJECT` guard still fires: *"No gas object supplied for a mainnet transaction"*.
- [x] Verified with the stock Homebrew `sui` (1.79.0), which is what the workflow installs — not only with a pinned binary.
- [x] Every `transaction_type` option in the workflow has a matching step.

## Risk / Rollout
The script only serializes; it never signs or executes. The output still goes through the existing multisig review and signing path, and the decode above is what a signer should re-check independently.

Note for whoever runs it: mainnet is on protocol 136, so a CLI older than that fails after a full compile with `protocol version 136 is newer than the maximum version 132 supported by this CLI`. The workflow installs `sui` from Homebrew at run time, so it picks up a current one; local runs need `sui` up to date (or `SUI_BINARY` pointed at a matching build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LB2cykaQCpPUvxkv9fZ7Q7
