### PR TITLE
predict: reject unpaired Block Scholes spot and forward in live pricing (DBU-818)

### DIFF
--- a/packages/predict/devtools/ts/runtime.ts
+++ b/packages/predict/devtools/ts/runtime.ts
@@ -939,6 +939,7 @@ interface MintParams extends OracleFeedIds {
     wrapperId: string;
     strike: bigint;
     isUp: boolean;
+    higherStrike?: bigint; // Optional finite upper boundary for an UP range.
     quantity: bigint;
     tickSize?: bigint; // cadence tick size; live harness default is $0.01
     maxCost?: bigint; // all-in USDC withdrawal cap; U64_MAX (uncapped) if omitted
@@ -987,6 +988,20 @@ export function binaryRangeTicks(
         lowerTick: isUp ? tick : 0n,
         higherTick: isUp ? POS_INF_TICK : tick,
     };
+}
+
+export function mintRangeTicks(
+    strike: bigint,
+    isUp: boolean,
+    tickSize = ORACLE_TICK_SIZE,
+    higherStrike?: bigint,
+): { lowerTick: bigint; higherTick: bigint } {
+    const range = binaryRangeTicks(strike, isUp, tickSize);
+    if (higherStrike === undefined) return range;
+    if (!isUp) throw new Error("higher_strike requires is_up=true");
+    const higherTick = binaryRangeTicks(higherStrike, true, tickSize).lowerTick;
+    if (range.lowerTick >= higherTick) throw new Error("higher_strike must exceed strike");
+    return { lowerTick: range.lowerTick, higherTick };
 }
 
 async function addOracleRefresh(tx: Transaction, params: OracleRefreshParams): Promise<void> {
@@ -1449,10 +1464,11 @@ function finishFlushTx(params: { poolVaultId: string; protocolConfigId: string }
 }
 
 function addMint(tx: Transaction, params: MintParams): void {
-    const { lowerTick, higherTick } = binaryRangeTicks(
+    const { lowerTick, higherTick } = mintRangeTicks(
         params.strike,
         params.isUp,
         params.tickSize,
+        params.higherStrike,
     );
     const pricer = loadLivePricer(tx, params);
     const auth = generateAuth(tx);

--- a/packages/predict/docs/concepts/fees-and-rebates.md
+++ b/packages/predict/docs/concepts/fees-and-rebates.md
@@ -15,9 +15,10 @@ Predict prices a range contract at its range probability `p` — the model's est
 The fee is computed in `StrikeExposureConfig`, which each expiry snapshots at creation so that later admin changes do not reprice contracts already trading. The composition, in the order the protocol applies it, is:
 
 ```text
-base_fee_rate   = max( base_fee * sqrt(p * (1 - p)) , min_fee )
-ramped_rate     = base_fee_rate * expiry_fee_multiplier(time_to_expiry)   (>= base_fee_rate)
-trading_fee     = ramped_rate * quantity
+leg_base_rate   = max( base_fee * sqrt(p_leg * (1 - p_leg)) , min_fee )
+leg_ramped_rate = leg_base_rate * expiry_fee_multiplier(time_to_expiry)
+leg_fee        = leg_ramped_rate * quantity
+trading_fee    = sum(leg_fee for each finite boundary)
 
 builder_fee     = min( trading_fee * builder_fee_multiplier , quantity * max_builder_fee_rate )
 congestion_fee  = penalty_rate * quantity                    (only when gas is a high outlier)
@@ -28,7 +29,7 @@ The base trading fee and the expiry ramp together set the **fee rate** a trader 
 
 ## 1. Base trading fee — a variance (Bernoulli) fee
 
-A range contract settling inside or outside its range is a Bernoulli outcome with success probability `p`. The variance of that outcome is `p · (1 − p)`, and its standard deviation is `sqrt(p · (1 − p))`. The base fee is proportional to that standard deviation:
+Each finite boundary defines a Bernoulli leg with probability `p`. Its fee is proportional to `sqrt(p · (1 − p))`. A bounded range pays the sum of its two leg fees, each with its own minimum and rounding; above/below contracts pay one leg fee. Infinite boundaries contribute no fee, while finite strikes priced at zero or one still pay the minimum. The range probability continues to determine premium and live value.
 
 ```text
 raw_fee_rate = base_fee * sqrt(p * (1 - p))
@@ -44,7 +45,7 @@ base_fee_rate = max( raw_fee_rate , min_fee )
 
 As `p → 0` or `p → 1`, the base fee rate approaches `min_fee`; in the interior it rises with the variance term. `min_fee` is a per-unit rate, so a contract pays at least `min_fee · quantity` (the floor is applied before the expiry ramp, so inside the ramp window the effective minimum is higher).
 
-Mint admission gates the raw entry probability `p` against the configured `[min_entry_probability, max_entry_probability]` band before fees are applied. The fee is still charged on top of the net premium, but it no longer rescues otherwise too-small or too-large probabilities into the admission range.
+Mint admission requires both the combined range probability and every finite leg's probability to lie in the configured `[min_entry_probability, max_entry_probability]` band. The lower leg uses ABOVE probability; the upper leg uses BELOW probability. Infinite boundaries are exempt. Minimum premium and the maximum-payout cost limit apply to the actual range purchase. These entry bounds do not restrict live closes: the summed leg fee is capped at the range's redemption value. The upgraded fee calculation also applies to positions opened before activation.
 
 After every fee component and inventory-impact charge is assembled, mint admission requires `all_in_cost <= quantity`. Because `quantity` is the position's maximum settlement payout, a trader cannot mint a position whose total debit exceeds what the position can ever pay at settlement; the check uses the trader-paid fee after any sponsor subsidy.
 

--- a/packages/predict/docs/concepts/pricing-and-oracles.md
+++ b/packages/predict/docs/concepts/pricing-and-oracles.md
@@ -149,7 +149,7 @@ A timestamp is fresh only if it is positive, not in the future, and within its m
 
 **No writes during pool valuation.** The full-pool flush computes NAV against a frozen snapshot, so Predict's valuation lock blocks Predict trading and admin changes mid-valuation; see [liquidity and NAV](./liquidity-and-nav.md). The propbook feeds are independent objects and are not part of that lock — but the flush is privileged and the flush operator is trusted not to push the oracle mid-flush, which is the model that makes the single frozen mark sound (see the audit-L8 note in [liquidity and NAV](./liquidity-and-nav.md)).
 
-**Min/max entry probability bounds.** A raw probability near `0` or `1` must not become an admitted mint just because the fee moves the all-in cash outlay away from the edge. These bounds live in `StrikeExposureConfig` (snapshotted per expiry from a global template), not in the pricing config: pricing produces the probability, and the mint-admission flow enforces the raw-probability envelope. At mint, `entry_probability` must lie within `[min_entry_probability, max_entry_probability]`. See [configuration](../design/configuration.md) for the bound values.
+**Min/max entry probability bounds.** Mint admission requires the range probability and each finite leg's probability to lie within `[min_entry_probability, max_entry_probability]`. The lower leg uses ABOVE probability and the upper leg uses BELOW probability; infinite sentinels are exempt. `StrikeExposureConfig` owns these snapshotted bounds. Pricing still produces probabilities for valuation and live closes outside the entry band. Fees do not move a probability into eligibility. See [configuration](../design/configuration.md) for the bound values.
 
 ## Settlement
 

--- a/packages/predict/docs/design/invariants.md
+++ b/packages/predict/docs/design/invariants.md
@@ -100,7 +100,7 @@ and contributors. For *how* each mechanism works, follow the links into
 
 ## Mint admission
 
-- Raw `entry_probability` must lie in `[min_entry_probability, max_entry_probability]`; fees are not included in this admission bound.
+- Raw `entry_probability` and every finite leg's probability (lower ABOVE, upper BELOW) must lie in `[min_entry_probability, max_entry_probability]`; fees are not included in these mint-only bounds, and infinite sentinels are exempt.
 - `premium = entry_probability × quantity ≥ min_premium`; the holder pays this in full — there is no financed remainder.
 - `all_in_cost ≤ quantity`; the complete trader debit cannot exceed the position's maximum settlement payout.
 

--- a/packages/predict/docs/design/invariants.md
+++ b/packages/predict/docs/design/invariants.md
@@ -126,8 +126,7 @@ and contributors. For *how* each mechanism works, follow the links into
 
 ## Fees
 
-- Trade fee = `fee_rate × quantity`, where `fee_rate = max(base_fee × √(p·(1−p)),
-  min_fee) × expiry_fee_multiplier`; the Bernoulli term is 0 at `p ∈ {0, 1}`.
+- Trade fee sums the independently rounded amount for each finite boundary, whose per-unit rate is `max(base_fee × √(p·(1−p)), min_fee) × expiry_fee_multiplier`. Infinite boundaries contribute zero; finite boundaries at `p ∈ {0, 1}` still pay the floor. Live-close collection is capped at redemption value.
 - On a referred mint, `referral_fee = floor(referral_fee_rate × ((trading_fee − fee_incentive_subsidy) + penalty_fee))`. It is split from protocol proceeds, never added to `all_in_cost`; builder fees and inventory-impact charges are excluded. The USDC destination is the stored referrer receive address, while `OrderMinted.referrer_account_id` preserves the canonical attribution even when the calculated amount is zero.
 - PLP supply and withdraw carry independent flat rates (`plp_supply_fee_rate`,
   `plp_withdraw_fee_rate`; shipped 0 and 20 bps), charged on the USDC leg

--- a/packages/predict/docs/glossary.md
+++ b/packages/predict/docs/glossary.md
@@ -113,10 +113,7 @@ Predict reads it but does not own it.
 
 ## Fees
 
-- **Trading fee** — the variance-based per-trade fee,
-  `max(base_fee × sqrt(p(1−p)), min_fee)` times an expiry ramp multiplier; a
-  transaction cost, never part of the contract's terms. See
-  [fees and rebates](./concepts/fees-and-rebates.md).
+- **Trading fee** — the sum of independently floored, expiry-ramped, and rounded fees for each finite boundary; a transaction cost, never part of the contract's terms. Infinite boundaries contribute zero. See [fees and rebates](./concepts/fees-and-rebates.md).
 - **Congestion surcharge** — a flat per-unit penalty added when the gas-price
   EWMA flags abnormal congestion. Code keeps DeepBook core's penalty
   vocabulary: the charged amount is `penalty_fee` (event field), the tunable

--- a/packages/predict/simulations/README.md
+++ b/packages/predict/simulations/README.md
@@ -62,6 +62,8 @@ The Block Scholes local fixture derives series identities through the published 
 
 The generator writes fixed-point integers as decimal text and emits explicit mint, live redeem, LP request, flush, rebalance, settlement, owner-settled-redeem, and permissionless-settled-redeem actions. The TypeScript executor records emitted transitions plus direct chain-state snapshots after every action; the Python replay independently models the same economics.
 
+Mint rows use `strike` and `is_up` for above/below. An `is_up=true` row may also supply `higher_strike` to bound its upper side; both finite strikes must align to the configured tick grid and the upper strike must exceed the lower. The generated round trip at steps 8–9 mints and closes a finite range, exercising separate boundary fees. The replay applies individual-leg and combined-probability admission only to mint, and caps summed live-close fees at redemption value.
+
 ## Verification
 
 ```bash

--- a/packages/predict/simulations/generate_scenario.py
+++ b/packages/predict/simulations/generate_scenario.py
@@ -27,6 +27,7 @@ SCENARIO_COLUMNS = [
     "risk_free_rate",
     "strike",
     "is_up",
+    "higher_strike",
     "quantity",
     "order_ref",
     "close_quantity",
@@ -136,6 +137,7 @@ class Generator:
         is_up: bool,
         *,
         strike: int | None = None,
+        higher_strike: int | None = None,
     ) -> dict[str, str]:
         snapshot = self.snapshot(step)
         forward = replay.live_forward(snapshot["spot"], snapshot["forward"])
@@ -157,6 +159,8 @@ class Generator:
         else:
             strike = replay.align_strike_to_tick(strike)
             lower, higher = replay.binary_range_bounds(strike, is_up)
+            if higher_strike is not None:
+                higher = replay.align_strike_to_tick(higher_strike)
             probability = replay.compute_range_price(
                 svi_for_replay(snapshot), forward, lower, higher
             )
@@ -193,9 +197,30 @@ class Generator:
             **oracle_fields(snapshot),
             strike=strike,
             is_up=is_up,
+            higher_strike=higher_strike,
             quantity=quantity,
             order_ref=order_ref,
         )
+
+    def finite_range_mint_row(self, step: int, order_ref: str) -> dict[str, str]:
+        snapshot = self.snapshot(step)
+        forward = replay.live_forward(snapshot["spot"], snapshot["forward"])
+        svi = svi_for_replay(snapshot)
+        for width_bps in (5, 10, 20, 50, 100, 200, 500, 1_000):
+            lower = replay.align_strike_to_tick(forward * (10_000 - width_bps) // 10_000)
+            higher = replay.align_strike_to_tick(forward * (10_000 + width_bps) // 10_000)
+            if lower >= higher:
+                continue
+            prices = (
+                replay.compute_up_price(svi, forward, lower),
+                replay.compute_up_price(svi, forward, higher),
+            )
+            try:
+                replay.assert_range_entry_bounds(prices)
+            except ValueError:
+                continue
+            return self.mint_row(step, order_ref, True, strike=lower, higher_strike=higher)
+        raise GenerationError(f"could not find an admissible finite range for step {step}")
 
     def settlement_mint_row(
         self,
@@ -272,7 +297,7 @@ class Generator:
                     lp_ref="lp_withdraw_1",
                 ),
                 scenario_row(7, "flush", **oracle_fields(self.snapshot(7))),
-                self.mint_row(8, "o_round_trip", bool(self.rng.randrange(2))),
+                self.finite_range_mint_row(8, "o_round_trip"),
                 scenario_row(
                     9,
                     "redeem_live",

--- a/packages/predict/simulations/python_replay.py
+++ b/packages/predict/simulations/python_replay.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+from copy import deepcopy
 import csv
 import json
 from functools import lru_cache
@@ -420,7 +421,12 @@ def mint_range_ticks(row: dict[str, Any]) -> tuple[int, int]:
     if row.get("higherStrike") is not None:
         if not row["isUp"]:
             raise ValueError("higher_strike requires is_up=true")
-        higher, _ = binary_range_ticks(align_strike_to_tick(row["higherStrike"]), True)
+        higher_strike = row["higherStrike"]
+        if higher_strike % ORACLE_TICK_SIZE != 0:
+            raise ValueError("higher_strike must be a whole tick multiple")
+        higher = higher_strike // ORACLE_TICK_SIZE
+        if higher >= POS_INF_TICK:
+            raise ValueError("higher_strike must be finite")
         if lower >= higher:
             raise ValueError("higher_strike must exceed strike")
     return lower, higher
@@ -1423,13 +1429,17 @@ def mint_order(
     fee = range_trading_fee(prices, quantity, model_fee_time_to_expiry_ms(model, timestamp_ms))
     lower_tick, higher_tick = mint_range_ticks(row)
     before = live_payout_liability(model)
-    model["tree"].insert_range(lower_tick, higher_tick, quantity)
-    after = live_payout_liability(model)
+    quoted_model = {**model, "tree": deepcopy(model["tree"])}
+    quoted_model["tree"].insert_range(lower_tick, higher_tick, quantity)
+    after = live_payout_liability(quoted_model)
     impact_charge = inventory_impact_potential(after) - inventory_impact_potential(before)
     total_cost = premium + fee + impact_charge
+    if total_cost > quantity:
+        raise ValueError("mint cost above maximum payout")
     if total_cost > state["account_usdc_balance"]:
         raise ValueError("insufficient account balance for mint")
 
+    model["tree"] = quoted_model["tree"]
     sequence = model["next_order_sequence"]
     model["next_order_sequence"] += 1
     model["orders"][row["orderRef"]] = {

--- a/packages/predict/simulations/python_replay.py
+++ b/packages/predict/simulations/python_replay.py
@@ -107,6 +107,7 @@ SCENARIO_COLUMNS = (
     "risk_free_rate",
     "strike",
     "is_up",
+    "higher_strike",
     "quantity",
     "order_ref",
     "close_quantity",
@@ -414,6 +415,17 @@ def binary_range_ticks(strike: int, is_up: bool) -> tuple[int, int]:
     return 0, tick
 
 
+def mint_range_ticks(row: dict[str, Any]) -> tuple[int, int]:
+    lower, higher = binary_range_ticks(align_strike_to_tick(row["strike"]), row["isUp"])
+    if row.get("higherStrike") is not None:
+        if not row["isUp"]:
+            raise ValueError("higher_strike requires is_up=true")
+        higher, _ = binary_range_ticks(align_strike_to_tick(row["higherStrike"]), True)
+        if lower >= higher:
+            raise ValueError("higher_strike must exceed strike")
+    return lower, higher
+
+
 def strikes_from_ticks(lower_tick: int, higher_tick: int) -> tuple[int, int]:
     # Tick -> raw strike with open-ended sentinels (mirrors range_codec::strike_from_tick per boundary):
     # lower_tick 0 -> NEG_INF_STRIKE; higher_tick POS_INF_TICK -> POS_INF_STRIKE.
@@ -543,6 +555,7 @@ def parse_scenario_text(text: str) -> list[dict[str, Any]]:
                     **_oracle_values(row, index),
                     "strike": _uint(row, "strike", index),
                     "isUp": _bool(row, "is_up", index),
+                    "higherStrike": _uint(row, "higher_strike", index) if row.get("higher_strike") else None,
                     "quantity": parse_mint_quantity(_uint(row, "quantity", index), index),
                     "orderRef": _ref(row, "order_ref", index),
                 }
@@ -1158,7 +1171,7 @@ def row_input(row: dict[str, Any]) -> dict[str, Any]:
         else {}
     )
     if action == "mint":
-        lower_tick, higher_tick = binary_range_ticks(align_strike_to_tick(row["strike"]), row["isUp"])
+        lower_tick, higher_tick = mint_range_ticks(row)
         return {
             **oracle_input,
             "order_ref": row["orderRef"],
@@ -1355,21 +1368,40 @@ def pricing_svi(oracle: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def price_range(row_or_order: dict[str, Any], oracle: dict[str, Any]) -> int:
-    if "lower_tick" in row_or_order:
-        lower, higher = strikes_from_ticks(
-            row_or_order["lower_tick"],
-            row_or_order["higher_tick"],
-        )
-    else:
-        strike = align_strike_to_tick(row_or_order["strike"])
-        lower, higher = binary_range_bounds(strike, row_or_order["isUp"])
-    return compute_range_price(
-        pricing_svi(oracle),
-        live_forward(oracle["spot"], oracle["forward"]),
-        lower,
-        higher,
+def range_prices(row_or_order: dict[str, Any], oracle: dict[str, Any]) -> tuple[int | None, int | None]:
+    ticks = (
+        (row_or_order["lower_tick"], row_or_order["higher_tick"])
+        if "lower_tick" in row_or_order else mint_range_ticks(row_or_order)
     )
+    lower, higher = strikes_from_ticks(*ticks)
+    svi = pricing_svi(oracle)
+    forward = live_forward(oracle["spot"], oracle["forward"])
+    return (
+        None if lower == NEG_INF_STRIKE else compute_up_price(svi, forward, lower),
+        None if higher == POS_INF_STRIKE else compute_up_price(svi, forward, higher),
+    )
+
+
+def range_probability(prices: tuple[int | None, int | None]) -> int:
+    lower, higher = prices
+    return max(0, (FLOAT_SCALING if lower is None else lower) - (0 if higher is None else higher))
+
+
+def range_trading_fee(prices: tuple[int | None, int | None], quantity: int, time_to_expiry_ms: int | None) -> int:
+    return sum(deepbook_mul(fee_rate(p, time_to_expiry_ms), quantity) for p in prices if p is not None)
+
+
+def assert_range_entry_bounds(prices: tuple[int | None, int | None]) -> None:
+    lower, higher = prices
+    if lower is not None:
+        assert_entry_probability_bounds(lower)
+    if higher is not None:
+        assert_entry_probability_bounds(FLOAT_SCALING - higher)
+    assert_entry_probability_bounds(range_probability(prices))
+
+
+def price_range(row_or_order: dict[str, Any], oracle: dict[str, Any]) -> int:
+    return range_probability(range_prices(row_or_order, oracle))
 
 
 def mint_order(
@@ -1381,17 +1413,15 @@ def mint_order(
     oracle = model["last_oracle"]
     if oracle is None:
         raise ValueError("mint requires an oracle snapshot")
-    probability = price_range(row, oracle)
-    assert_entry_probability_bounds(probability)
+    prices = range_prices(row, oracle)
+    assert_range_entry_bounds(prices)
+    probability = range_probability(prices)
     quantity = row["quantity"]
     premium = deepbook_mul(probability, quantity)
     if premium < MIN_PREMIUM:
         raise ValueError("premium below minimum")
-    fee = deepbook_mul(
-        fee_rate(probability, model_fee_time_to_expiry_ms(model, timestamp_ms)),
-        quantity,
-    )
-    lower_tick, higher_tick = binary_range_ticks(align_strike_to_tick(row["strike"]), row["isUp"])
+    fee = range_trading_fee(prices, quantity, model_fee_time_to_expiry_ms(model, timestamp_ms))
+    lower_tick, higher_tick = mint_range_ticks(row)
     before = live_payout_liability(model)
     model["tree"].insert_range(lower_tick, higher_tick, quantity)
     after = live_payout_liability(model)
@@ -1453,14 +1483,12 @@ def redeem_live(
     oracle = model["last_oracle"]
     if oracle is None:
         raise ValueError("live redeem requires an oracle snapshot")
-    probability = price_range(order, oracle)
+    prices = range_prices(order, oracle)
+    probability = range_probability(prices)
     redeem_amount = deepbook_mul(probability, close_quantity)
     fee = min(
         redeem_amount,
-        deepbook_mul(
-            fee_rate(probability, model_fee_time_to_expiry_ms(model, timestamp_ms)),
-            close_quantity,
-        ),
+        range_trading_fee(prices, close_quantity, model_fee_time_to_expiry_ms(model, timestamp_ms)),
     )
     before = live_payout_liability(model)
     model["tree"].remove_range(order["lower_tick"], order["higher_tick"], close_quantity)

--- a/packages/predict/simulations/src/shared.ts
+++ b/packages/predict/simulations/src/shared.ts
@@ -83,6 +83,7 @@ export type ScenarioRow =
               action: "mint";
               strike: bigint;
               isUp: boolean;
+              higherStrike?: bigint;
               quantity: bigint;
               orderRef: string;
           })
@@ -192,6 +193,7 @@ export const SCENARIO_COLUMNS = [
     "risk_free_rate",
     "strike",
     "is_up",
+    "higher_strike",
     "quantity",
     "order_ref",
     "close_quantity",
@@ -320,6 +322,7 @@ function parseRow(row: RawScenarioRow, lineNumber: number): ScenarioRow {
             ...parseOracleRefresh(row, lineNumber),
             strike: parseUnsignedInteger(row, "strike", lineNumber),
             isUp: parseBoolean(row, "is_up", lineNumber),
+            higherStrike: row.higher_strike ? parseUnsignedInteger(row, "higher_strike", lineNumber) : undefined,
             quantity: parseQuantity(row, "quantity", lineNumber),
             orderRef: parseRef(row, "order_ref", lineNumber),
         };

--- a/packages/predict/simulations/src/sim.ts
+++ b/packages/predict/simulations/src/sim.ts
@@ -12,7 +12,7 @@ import {
     writeJson,
 } from "./shared.js";
 import {
-    POOL_VAULT_ID, PROTOCOL_CONFIG_ID, address, bareFlushTx, binaryRangeTicks,
+    POOL_VAULT_ID, PROTOCOL_CONFIG_ID, address, bareFlushTx, mintRangeTicks,
     bindFeedsToUnderlyingTx, clockTimestampMs, createAccountTx, createExpiryMarketTx,
     depositToAccountTx, deriveAccountWrapperId, execute, executeAndWait,
     finalizeUsdcCurrencyRegistrationTx, keeperSettleTx, lockCapitalTx,
@@ -104,7 +104,7 @@ function oracleInput(value: OracleRefreshData | null): Record<string, unknown> {
 function rowInput(row: ScenarioRow, tickSize: bigint): Record<string, unknown> {
     const oracle = oracleInput(oracleFor(row));
     if (row.action === "mint") {
-        const { lowerTick, higherTick } = binaryRangeTicks(row.strike, row.isUp, tickSize);
+        const { lowerTick, higherTick } = mintRangeTicks(row.strike, row.isUp, tickSize, row.higherStrike);
         return { ...oracle, order_ref: row.orderRef, lower_tick: lowerTick.toString(), higher_tick: higherTick.toString(), quantity: row.quantity.toString() };
     }
     if (row.action === "redeem_live") return { ...oracle, order_ref: row.orderRef, close_quantity: row.closeQuantity.toString(), replacement_order_ref: row.replacementOrderRef };
@@ -221,7 +221,7 @@ function oracleParams(value: OracleRefreshData) {
 
 async function executeRow(row: ScenarioRow, state: SimState, aliases: Aliases): Promise<ExecutionReceipt> {
     const common = { expiryMarketId: state.expiryMarketId, protocolConfigId: state.protocolConfigId, wrapperId: state.accountWrapperId, pythFeedId: state.pythFeedId, bsValueStoreId: state.bsValueStoreId, bsSviStoreId: state.bsSviStoreId };
-    if (row.action === "mint") return execute(() => refreshOracleAndMintTxs({ ...common, expiry: BigInt(state.expiryMs), ...oracleParams(row), strike: row.strike, isUp: row.isUp, quantity: row.quantity, tickSize: BigInt(state.tickSize) }), `scenario_${row.step}_mint`);
+    if (row.action === "mint") return execute(() => refreshOracleAndMintTxs({ ...common, expiry: BigInt(state.expiryMs), ...oracleParams(row), strike: row.strike, isUp: row.isUp, higherStrike: row.higherStrike, quantity: row.quantity, tickSize: BigInt(state.tickSize) }), `scenario_${row.step}_mint`);
     if (row.action === "redeem_live") {
         const orderId = aliases.orderIds.get(row.orderRef);
         if (!orderId) throw new Error(`unknown order_ref ${row.orderRef}`);

--- a/packages/predict/simulations/src/simTest.ts
+++ b/packages/predict/simulations/src/simTest.ts
@@ -34,6 +34,17 @@ function csvRow(tx: number, action: string, values: Record<string, string> = {})
     return SCENARIO_COLUMNS.map((column) => row[column]).join(",");
 }
 
+test("scenario parser retains both finite boundaries", () => {
+    const rows = parseScenarioText([
+        SCENARIO_COLUMNS.join(","),
+        csvRow(1, "mint", { ...oracle, strike: "75000000000000", is_up: "true", higher_strike: "76000000000000", quantity: "20000", order_ref: "range" }),
+    ].join("\n"));
+    assert.equal(rows[0].action, "mint");
+    if (rows[0].action !== "mint") throw new Error("expected mint");
+    assert.equal(rows[0].strike, 75000000000000n);
+    assert.equal(rows[0].higherStrike, 76000000000000n);
+});
+
 test("scenario parser accepts every current explicit action", () => {
     const text = [
         SCENARIO_COLUMNS.join(","),

--- a/packages/predict/simulations/tests/test_python_model.py
+++ b/packages/predict/simulations/tests/test_python_model.py
@@ -118,6 +118,34 @@ class RangeFeeTests(unittest.TestCase):
             replay.mint_range_ticks({**row, "isUp": False})
         with self.assertRaisesRegex(ValueError, "must exceed"):
             replay.mint_range_ticks({**row, "higherStrike": row["strike"]})
+        with self.assertRaisesRegex(ValueError, "whole tick"):
+            replay.mint_range_ticks({**row, "higherStrike": row["higherStrike"] + 1})
+        with self.assertRaisesRegex(ValueError, "must be finite"):
+            replay.mint_range_ticks({**row, "higherStrike": replay.POS_INF_TICK * replay.ORACLE_TICK_SIZE})
+
+    def test_eligible_range_above_maximum_payout_does_not_mutate_model(self) -> None:
+        replay.INVENTORY_IMPACT_MAX_RATE = 0
+        model = replay.initial_model(200_000_000)
+        state = replay.initial_state()
+        before = dict(state)
+        model["last_oracle"] = {
+            "spot": 90_000_000_000, "forward": 90_000_000_000,
+            "a": 40_000_000, "aNegative": False, "b": 0,
+            "rho": 0, "rhoNegative": False, "m": 0, "mNegative": False,
+            "sigma": 100_000_000, "riskFreeRate": 0,
+            "expiryMs": 200_000_000, "pricingTimestampMs": 120_000,
+            "sviSourceTimestampMs": 120_000,
+        }
+        row = {"strike": 60_000_000_000, "higherStrike": 140_000_000_000,
+               "isUp": True, "quantity": 1_000_000_000, "orderRef": "wide"}
+        # Flat variance 0.04 gives ~96.26% range probability; two 2.2% floors
+        # exceed the remaining payout even though both legs pass admission.
+        with self.assertRaisesRegex(ValueError, "mint cost above maximum payout"):
+            replay.mint_order(model, state, row, 120_000)
+        self.assertEqual(state, before)
+        self.assertEqual(model["orders"], {})
+        self.assertEqual(model["next_order_sequence"], 0)
+        self.assertEqual(model["tree"].payout_reserve_terms(), (0, 0))
 
 
 if __name__ == "__main__":

--- a/packages/predict/simulations/tests/test_python_model.py
+++ b/packages/predict/simulations/tests/test_python_model.py
@@ -77,5 +77,48 @@ class ScenarioParserTests(unittest.TestCase):
             replay.parse_scenario_text(text)
 
 
+class RangeFeeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        config = replay.load_scenario_config()
+        config["protocol"].update(base_fee="100000000", min_fee="22000000")
+        replay.apply_scenario_config(config)
+
+    def tearDown(self) -> None:
+        replay.apply_scenario_config(replay.load_scenario_config())
+
+    def test_finite_legs_and_sentinels_have_independent_fees(self) -> None:
+        # At p=1/2 the rate is 0.05; finite endpoints pay the 0.022 floor.
+        for prices, expected in [
+            ((500_000_000, None), 50_000_000),
+            ((None, 500_000_000), 50_000_000),
+            ((None, None), 0),
+            ((1_000_000_000, 0), 44_000_000),
+            ((500_000_000, 0), 72_000_000),
+        ]:
+            with self.subTest(prices=prices):
+                self.assertEqual(replay.range_trading_fee(prices, 1_000_000_000, None), expected)
+
+    def test_floor_amounts_round_before_summing_and_after_ramp(self) -> None:
+        # Each 0.022 * 75 floors to 1. At 1.5x, each 0.033 * 75 floors to 2.
+        self.assertEqual(replay.range_trading_fee((1_000_000_000, 0), 75, None), 2)
+        self.assertEqual(replay.range_trading_fee((1_000_000_000, 0), 75, replay.EXPIRY_FEE_WINDOW_MS // 2), 4)
+
+    def test_individual_legs_and_upper_below_must_be_eligible(self) -> None:
+        for prices in [(1_000_000_000, 500_000_000), (500_000_000, 0)]:
+            with self.subTest(prices=prices), self.assertRaisesRegex(ValueError, "entry probability"):
+                replay.assert_range_entry_bounds(prices)
+        replay.MAX_ENTRY_PROBABILITY = 600_000_000
+        with self.assertRaisesRegex(ValueError, "entry probability"):
+            replay.assert_range_entry_bounds((550_000_000, 200_000_000))
+
+    def test_finite_range_decodes_both_ticks_and_rejects_inverted_bounds(self) -> None:
+        row = {"strike": 100_000_000_000, "isUp": True, "higherStrike": 110_000_000_000}
+        self.assertEqual(replay.mint_range_ticks(row), (100, 110))
+        with self.assertRaisesRegex(ValueError, "requires is_up"):
+            replay.mint_range_ticks({**row, "isUp": False})
+        with self.assertRaisesRegex(ValueError, "must exceed"):
+            replay.mint_range_ticks({**row, "higherStrike": row["strike"]})
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/packages/predict/simulations/tests/test_scenario_generation.py
+++ b/packages/predict/simulations/tests/test_scenario_generation.py
@@ -73,6 +73,13 @@ class ScenarioGenerationTests(unittest.TestCase):
 
             self.assertEqual(first.read_bytes(), second.read_bytes())
             self.assertNotEqual(first.read_bytes(), other.read_bytes())
+            with first.open() as source_file:
+                rows = list(csv.DictReader(source_file))
+            finite_mint, finite_close = rows[7:9]
+            self.assertEqual(finite_mint["action"], "mint")
+            self.assertLess(int(finite_mint["strike"]), int(finite_mint["higher_strike"]))
+            self.assertEqual(finite_close["action"], "redeem_live")
+            self.assertEqual(finite_close["order_ref"], finite_mint["order_ref"])
 
     def test_config_rejects_missing_and_unknown_fields(self) -> None:
         with tempfile.TemporaryDirectory() as raw_tmp:

--- a/packages/predict/sources/config/strike_exposure_config.move
+++ b/packages/predict/sources/config/strike_exposure_config.move
@@ -9,7 +9,7 @@
 /// themselves contract probability.
 module deepbook_predict::strike_exposure_config;
 
-use deepbook_predict::{config_constants, constants};
+use deepbook_predict::{config_constants, constants, pricing::RangePrice};
 use fixed_math::math;
 
 const EEntryProbabilityOutOfBounds: u64 = 0;
@@ -87,6 +87,37 @@ public(package) fun trading_fee(
     timestamp_ms: u64,
 ): u64 {
     math::mul_down(config.fee_rate(expiry_ms, probability, timestamp_ms), quantity)
+}
+
+/// Charge each finite boundary independently, including its floor and rounding.
+/// Infinite boundaries contribute no fee; a finite tail still pays the floor.
+public(package) fun range_trading_fee(
+    config: &StrikeExposureConfig,
+    expiry_ms: u64,
+    price: &RangePrice,
+    quantity: u64,
+    timestamp_ms: u64,
+): u64 {
+    let lower_fee = price
+        .lower_up()
+        .map!(|p| config.trading_fee(expiry_ms, p, quantity, timestamp_ms))
+        .get_with_default(0);
+    let higher_fee = price
+        .higher_up()
+        .map!(|p| config.trading_fee(expiry_ms, p, quantity, timestamp_ms))
+        .get_with_default(0);
+    lower_fee + higher_fee
+}
+
+/// Apply entry policy to the actual lower-ABOVE and upper-BELOW legs and to
+/// their combined range. This is mint-only; tail positions remain closable.
+public(package) fun assert_range_mint_probability_policy(
+    config: &StrikeExposureConfig,
+    price: &RangePrice,
+) {
+    price.lower_up().do!(|p| config.assert_mint_probability_policy(p));
+    price.higher_up().do!(|p| config.assert_mint_probability_policy(math::float_scaling!() - p));
+    config.assert_mint_probability_policy(price.probability());
 }
 
 /// Assert entry-probability policy without deriving quantity-dependent mint

--- a/packages/predict/sources/constants.move
+++ b/packages/predict/sources/constants.move
@@ -8,7 +8,7 @@ module deepbook_predict::constants;
 // === Package Versioning ===
 
 /// Returns the package version compared against `ProtocolConfig.version_watermark` by version-gated entrypoints.
-public macro fun current_version(): u64 { 1 }
+public macro fun current_version(): u64 { 2 }
 
 // === Scaling ===
 

--- a/packages/predict/sources/expiry_market.move
+++ b/packages/predict/sources/expiry_market.move
@@ -25,7 +25,7 @@ use deepbook_predict::{
     pricing::{Self, Pricer, FrozenPricer},
     protocol_config::ProtocolConfig,
     range_codec,
-    strike_exposure::{Self, MintTerms, StrikeExposure},
+    strike_exposure::{Self, PricedMintTerms, StrikeExposure},
     strike_exposure_config
 };
 use fixed_math::math;
@@ -995,7 +995,7 @@ fun mint_prepared(
 /// Assemble the cost decomposition shared by mint quotes and execution.
 fun compute_mint_quote(
     market: &ExpiryMarket,
-    terms: &MintTerms,
+    terms: &PricedMintTerms,
     builder_code_id: &Option<ID>,
     penalty_fee: u64,
     clock: &Clock,
@@ -1004,7 +1004,7 @@ fun compute_mint_quote(
     let quantity = terms.quantity();
     let trading_fee = market
         .strike_exposure
-        .trading_fee(market.expiry, entry_probability, quantity, clock);
+        .trading_fee(market.expiry, terms.mint_price(), quantity, clock);
     let fee_incentive_subsidy = market.fee_incentive_subsidy_amount(trading_fee);
     let builder_fee = builder_fee_amount(builder_code_id, trading_fee, quantity);
     let premium = terms.premium();
@@ -1127,7 +1127,7 @@ fun redeem_live_with_auth(
         .strike_exposure
         .trading_fee(
             market.expiry,
-            range_probability,
+            terms.close_price(),
             close_quantity,
             clock,
         )

--- a/packages/predict/sources/pricing/pricing.move
+++ b/packages/predict/sources/pricing/pricing.move
@@ -148,7 +148,38 @@ public fun up_price(pricer: &Pricer, strike: Strike): u64 {
 /// Return the current probability for `(lower, higher]`, floored at zero if the
 /// two approximated boundary probabilities invert.
 public fun range_price(pricer: &Pricer, lower: Strike, higher: Strike): u64 {
-    compute_range_price(&pricer.svi, pricer.forward, lower, higher)
+    pricer.range_prices(lower, higher).probability()
+}
+
+/// Boundary probabilities from one pricing snapshot. Absent boundaries are the
+/// negative/positive infinity sentinels, not finite strikes priced at zero or one.
+public struct RangePrice has copy, drop {
+    lower_up: Option<u64>,
+    higher_up: Option<u64>,
+}
+
+public(package) fun lower_up(price: &RangePrice): Option<u64> {
+    price.lower_up
+}
+
+public(package) fun higher_up(price: &RangePrice): Option<u64> {
+    price.higher_up
+}
+
+public(package) fun probability(price: &RangePrice): u64 {
+    let lower = price.lower_up.get_with_default(math::float_scaling!());
+    let higher = price.higher_up.get_with_default(0);
+    lower.saturating_sub(higher)
+}
+
+/// Retain both finite boundary prices for trade fees and mint admission.
+public(package) fun range_prices(pricer: &Pricer, lower: Strike, higher: Strike): RangePrice {
+    assert!(lower.value() < higher.value(), EInvalidRange);
+    RangePrice {
+        lower_up: if (lower.is_neg_inf()) option::none() else option::some(pricer.up_price(lower)),
+        higher_up: if (higher.is_pos_inf()) option::none()
+        else option::some(pricer.up_price(higher)),
+    }
 }
 
 // === Public-Package Functions ===
@@ -588,17 +619,6 @@ fun min_svi_variance_increment(svi: &RawSVI): u64 {
     let one_minus_rho_squared = math::float_scaling!() - math::mul_down(rho_mag, rho_mag);
     let sqrt_one_minus_rho_squared = math::sqrt_down(one_minus_rho_squared);
     math::mul_down(svi.b(), math::mul_down(svi.sigma(), sqrt_one_minus_rho_squared))
-}
-
-/// Compute the approximated probability for `(lower, higher]`.
-fun compute_range_price(svi: &PricingSVI, forward: u64, lower: Strike, higher: Strike): u64 {
-    assert!(lower.value() < higher.value(), EInvalidRange);
-
-    let lower_up_price = compute_up_price(svi, forward, lower);
-    let higher_up_price = compute_up_price(svi, forward, higher);
-    // Fixed-point approximation or a non-monotone SVI surface can invert the
-    // boundary prices; the range probability is floored at zero.
-    lower_up_price.saturating_sub(higher_up_price)
 }
 
 /// Compute the adjusted UP digital probability for `strike`.

--- a/packages/predict/sources/pricing/pricing.move
+++ b/packages/predict/sources/pricing/pricing.move
@@ -128,6 +128,9 @@ const EBlockScholesMinVarianceInvalid: u64 = 14;
 /// write is prohibited (Pyth is checked only on the re-anchor branch).
 const EOracleWrittenInThisTransaction: u64 = 15;
 const EBlockScholesInputTooWide: u64 = 16;
+/// The Block Scholes spot and forward reads carry different source timestamps, so their ratio
+/// would fold the spot move between the two provider ticks into the basis.
+const EBlockScholesSpotForwardUnpaired: u64 = 17;
 
 /// Predict's private pricing envelope for raw propbook BS inputs. These are not
 /// oracle-source validity rules; they only bound the forward/basis and SVI inputs
@@ -446,6 +449,14 @@ fun resolve_live_pricer(
             clock,
         ),
         EBlockScholesPriceStale,
+    );
+    // Both legs of the `bs_forward / bs_spot` basis must come from the same provider tick. The
+    // writer lands spot and forwards in separate transactions, so a spot that has advanced past
+    // the forward (or the reverse) is rejected here instead of pricing a basis that carries the
+    // spot move between the two ticks.
+    assert!(
+        block_scholes_forward_source_timestamp_ms == block_scholes_spot_source_timestamp_ms,
+        EBlockScholesSpotForwardUnpaired,
     );
     let bs_forward = narrow_price(bs_forward_read.read_value());
 

--- a/packages/predict/sources/pricing/pricing.move
+++ b/packages/predict/sources/pricing/pricing.move
@@ -49,6 +49,13 @@ public struct Pricer has copy, drop {
     block_scholes_svi_source_timestamp_ms: u64,
 }
 
+/// Boundary probabilities from one pricing snapshot. Absent boundaries are the
+/// negative/positive infinity sentinels, not finite strikes priced at zero or one.
+public struct RangePrice has copy, drop {
+    lower_up: Option<u64>,
+    higher_up: Option<u64>,
+}
+
 /// The flush's storable form of a `Pricer`. `seal_valuation_snapshot` freezes one
 /// per market inside `plp::PoolValuation` so every market is marked at one instant
 /// even though valuation spans transactions; `snapshot_nav` thaws it back to a
@@ -151,12 +158,7 @@ public fun range_price(pricer: &Pricer, lower: Strike, higher: Strike): u64 {
     pricer.range_prices(lower, higher).probability()
 }
 
-/// Boundary probabilities from one pricing snapshot. Absent boundaries are the
-/// negative/positive infinity sentinels, not finite strikes priced at zero or one.
-public struct RangePrice has copy, drop {
-    lower_up: Option<u64>,
-    higher_up: Option<u64>,
-}
+// === Public-Package Functions ===
 
 public(package) fun lower_up(price: &RangePrice): Option<u64> {
     price.lower_up
@@ -166,6 +168,7 @@ public(package) fun higher_up(price: &RangePrice): Option<u64> {
     price.higher_up
 }
 
+/// Preserve the existing zero floor if approximated boundary prices invert.
 public(package) fun probability(price: &RangePrice): u64 {
     let lower = price.lower_up.get_with_default(math::float_scaling!());
     let higher = price.higher_up.get_with_default(0);
@@ -181,8 +184,6 @@ public(package) fun range_prices(pricer: &Pricer, lower: Strike, higher: Strike)
         else option::some(pricer.up_price(higher)),
     }
 }
-
-// === Public-Package Functions ===
 
 /// Return the expiry market this pricer was loaded for.
 public(package) fun expiry_market_id(pricer: &Pricer): ID {

--- a/packages/predict/sources/strike_exposure/strike_exposure.move
+++ b/packages/predict/sources/strike_exposure/strike_exposure.move
@@ -351,7 +351,6 @@ public(package) fun quote_mint_terms(
     let quantity = if (exact_quantity) {
         min_quantity
     } else {
-        exposure.config.assert_mint_probability_policy(entry_probability);
         let lot = constants::position_lot_size!();
         let mut lo = 0;
         let mut hi = order::max_quantity_lots();

--- a/packages/predict/sources/strike_exposure/strike_exposure.move
+++ b/packages/predict/sources/strike_exposure/strike_exposure.move
@@ -14,7 +14,7 @@ module deepbook_predict::strike_exposure;
 use deepbook_predict::{
     constants,
     order::{Self, Order},
-    pricing::Pricer,
+    pricing::{Pricer, RangePrice},
     range_codec,
     strike_exposure_config::StrikeExposureConfig,
     strike_payout_tree::{Self, StrikePayoutTree}
@@ -88,32 +88,52 @@ public struct LiveCloseTerms has drop {
     inventory_impact_rebate: u64,
 }
 
-public(package) fun entry_probability(terms: &MintTerms): u64 {
-    terms.entry_probability
+/// Carries boundary prices without changing the deployed MintTerms layout.
+public struct PricedMintTerms has drop {
+    terms: MintTerms,
+    price: RangePrice,
 }
 
-public(package) fun premium(terms: &MintTerms): u64 {
-    terms.premium
+/// Carries boundary prices without changing the deployed LiveCloseTerms layout.
+public struct PricedLiveCloseTerms has drop {
+    terms: LiveCloseTerms,
+    price: RangePrice,
 }
 
-public(package) fun quantity(terms: &MintTerms): u64 {
-    terms.quantity
+public(package) fun entry_probability(terms: &PricedMintTerms): u64 {
+    terms.terms.entry_probability
 }
 
-public(package) fun inventory_impact_charge(terms: &MintTerms): u64 {
-    terms.inventory_impact_charge
+public(package) fun premium(terms: &PricedMintTerms): u64 {
+    terms.terms.premium
 }
 
-public(package) fun redeem_amount(terms: &LiveCloseTerms): u64 {
-    terms.redeem_amount
+public(package) fun quantity(terms: &PricedMintTerms): u64 {
+    terms.terms.quantity
 }
 
-public(package) fun range_probability(terms: &LiveCloseTerms): u64 {
-    terms.range_probability
+public(package) fun inventory_impact_charge(terms: &PricedMintTerms): u64 {
+    terms.terms.inventory_impact_charge
 }
 
-public(package) fun inventory_impact_rebate(terms: &LiveCloseTerms): u64 {
-    terms.inventory_impact_rebate
+public(package) fun mint_price(terms: &PricedMintTerms): &RangePrice {
+    &terms.price
+}
+
+public(package) fun redeem_amount(terms: &PricedLiveCloseTerms): u64 {
+    terms.terms.redeem_amount
+}
+
+public(package) fun range_probability(terms: &PricedLiveCloseTerms): u64 {
+    terms.terms.range_probability
+}
+
+public(package) fun inventory_impact_rebate(terms: &PricedLiveCloseTerms): u64 {
+    terms.terms.inventory_impact_rebate
+}
+
+public(package) fun close_price(terms: &PricedLiveCloseTerms): &RangePrice {
+    &terms.price
 }
 
 /// Return the recorded settlement price. Aborts while the exposure is live.
@@ -243,22 +263,22 @@ public(package) fun reference_tick(exposure: &StrikeExposure): Option<u64> {
     exposure.reference_tick
 }
 
-/// Return the raw per-trade fee for a live price and quantity.
+/// Return the sum of finite-boundary fees for a live range and quantity.
 ///
 /// Fee collection is expiry-market payment accounting; exposure only owns the
 /// snapshotted config needed to price it.
 public(package) fun trading_fee(
     exposure: &StrikeExposure,
     expiry_ms: u64,
-    probability: u64,
+    price: &RangePrice,
     quantity: u64,
     clock: &Clock,
 ): u64 {
     exposure
         .config
-        .trading_fee(
+        .range_trading_fee(
             expiry_ms,
-            probability,
+            price,
             quantity,
             clock.timestamp_ms(),
         )
@@ -323,8 +343,10 @@ public(package) fun quote_mint_terms(
     max_premium: u64,
     min_quantity: u64,
     exact_quantity: bool,
-): MintTerms {
-    let entry_probability = exposure.admitted_entry_probability(pricer, lower_tick, higher_tick);
+): PricedMintTerms {
+    let price = exposure.admitted_range_price(pricer, lower_tick, higher_tick);
+    exposure.config.assert_range_mint_probability_policy(&price);
+    let entry_probability = price.probability();
 
     let quantity = if (exact_quantity) {
         min_quantity
@@ -348,7 +370,7 @@ public(package) fun quote_mint_terms(
     let premium = exposure.config.assert_mint_admission(entry_probability, quantity);
     // Preserve the mutation path's validation order.
     order::assert_valid_quantity(quantity);
-    MintTerms {
+    let terms = MintTerms {
         expiry_market_id: exposure.expiry_market_id,
         lower_tick,
         higher_tick,
@@ -361,7 +383,8 @@ public(package) fun quote_mint_terms(
             quantity,
             true,
         ),
-    }
+    };
+    PricedMintTerms { terms, price }
 }
 
 /// Allocate a live mint order from priced terms: consume the expiry-local
@@ -369,7 +392,11 @@ public(package) fun quote_mint_terms(
 /// ties each allocation to exactly one admission result, so the order's contract
 /// fields are always the ones that were priced, and the market-identity assert
 /// rejects terms priced on another exposure.
-public(package) fun allocate_mint_order(exposure: &mut StrikeExposure, terms: MintTerms): Order {
+public(package) fun allocate_mint_order(
+    exposure: &mut StrikeExposure,
+    priced: PricedMintTerms,
+): Order {
+    let PricedMintTerms { terms, price: _ } = priced;
     let MintTerms { expiry_market_id, lower_tick, higher_tick, quantity, .. } = terms;
     assert!(expiry_market_id == exposure.expiry_market_id, ETermsExposureMismatch);
 
@@ -383,19 +410,23 @@ public(package) fun allocate_mint_order(exposure: &mut StrikeExposure, terms: Mi
 }
 
 /// Quote one prospective live close as pure terms, touching neither the book nor
-/// the oracle after the supplied `Pricer` snapshot. The trade fee is recovered
-/// from the returned range probability.
+/// the oracle after the supplied `Pricer` snapshot. Boundary prices feed fees;
+/// mint probability eligibility is deliberately not applied to exits.
 public(package) fun quote_live_close(
     exposure: &StrikeExposure,
     pricer: &Pricer,
     order: &Order,
     close_quantity: u64,
-): LiveCloseTerms {
+): PricedLiveCloseTerms {
     order::assert_valid_quantity(close_quantity);
     assert!(close_quantity <= order.quantity(), EInvalidCloseQuantity);
 
-    let range_probability = exposure.order_range_price(pricer, order);
-    LiveCloseTerms {
+    let price = pricer.range_prices(
+        range_codec::strike_from_tick(order.lower_tick(), exposure.tick_size),
+        range_codec::strike_from_tick(order.higher_tick(), exposure.tick_size),
+    );
+    let range_probability = price.probability();
+    let terms = LiveCloseTerms {
         expiry_market_id: exposure.expiry_market_id,
         order: *order,
         close_quantity,
@@ -407,15 +438,17 @@ public(package) fun quote_live_close(
             close_quantity,
             false,
         ),
-    }
+    };
+    PricedLiveCloseTerms { terms, price }
 }
 
 /// Apply one quoted live close to the book and return the replacement order a
 /// partial close leaves behind.
 public(package) fun process_live_close(
     exposure: &mut StrikeExposure,
-    terms: LiveCloseTerms,
+    priced: PricedLiveCloseTerms,
 ): Option<Order> {
+    let PricedLiveCloseTerms { terms, price: _ } = priced;
     let LiveCloseTerms { expiry_market_id, order, close_quantity, .. } = terms;
     assert!(expiry_market_id == exposure.expiry_market_id, ETermsExposureMismatch);
 
@@ -496,16 +529,16 @@ public(package) fun new(
 /// Price the mint tick range `(lower_tick, higher_tick]` after admission-grid
 /// validation. The single pricing-prefix orchestration shared by every mint
 /// quote/terms path.
-fun admitted_entry_probability(
+fun admitted_range_price(
     exposure: &StrikeExposure,
     pricer: &Pricer,
     lower_tick: u64,
     higher_tick: u64,
-): u64 {
+): RangePrice {
     exposure.assert_admitted_mint_ticks(lower_tick, higher_tick);
     let lower = range_codec::strike_from_tick(lower_tick, exposure.tick_size);
     let higher = range_codec::strike_from_tick(higher_tick, exposure.tick_size);
-    pricer.range_price(lower, higher)
+    pricer.range_prices(lower, higher)
 }
 
 fun inventory_impact_potential_for_liability(exposure: &StrikeExposure, liability: u64): u64 {

--- a/packages/predict/sources/strike_exposure/strike_exposure.move
+++ b/packages/predict/sources/strike_exposure/strike_exposure.move
@@ -206,7 +206,7 @@ public(package) fun live_order_value(
     pricer: &Pricer,
     order: &Order,
 ): u64 {
-    math::mul_down(exposure.order_range_price(pricer, order), order.quantity())
+    math::mul_down(exposure.order_range_price(pricer, order).probability(), order.quantity())
 }
 
 /// Return one settled order's full terminal payout.
@@ -420,10 +420,7 @@ public(package) fun quote_live_close(
     order::assert_valid_quantity(close_quantity);
     assert!(close_quantity <= order.quantity(), EInvalidCloseQuantity);
 
-    let price = pricer.range_prices(
-        range_codec::strike_from_tick(order.lower_tick(), exposure.tick_size),
-        range_codec::strike_from_tick(order.higher_tick(), exposure.tick_size),
-    );
+    let price = exposure.order_range_price(pricer, order);
     let range_probability = price.probability();
     let terms = LiveCloseTerms {
         expiry_market_id: exposure.expiry_market_id,
@@ -615,8 +612,8 @@ fun assert_admitted_mint_ticks(exposure: &StrikeExposure, lower_tick: u64, highe
     );
 }
 
-fun order_range_price(exposure: &StrikeExposure, pricer: &Pricer, order: &Order): u64 {
-    pricer.range_price(
+fun order_range_price(exposure: &StrikeExposure, pricer: &Pricer, order: &Order): RangePrice {
+    pricer.range_prices(
         range_codec::strike_from_tick(order.lower_tick(), exposure.tick_size),
         range_codec::strike_from_tick(order.higher_tick(), exposure.tick_size),
     )

--- a/packages/predict/tests/flows/current_nav_flow_tests.move
+++ b/packages/predict/tests/flows/current_nav_flow_tests.move
@@ -141,6 +141,8 @@ fun current_nav_rejects_non_monotone_active_book_surface() {
     let mut market = fx.take_market_bundle(expiry_id);
     let mut account = fx.take_account_bundle(&trader);
 
+    deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
+
     // First create a normal order with live boundaries at ticks 90 and 100. Then
     // replace the oracle surface with a synthetic bad surface where the higher
     // strike has a higher UP price than the lower strike. NAV should reject that
@@ -156,7 +158,7 @@ fun current_nav_rejects_non_monotone_active_book_surface() {
     // min `sigma`, and `rho = -1`. Together they make the model report a higher
     // chance of finishing above tick 100 than above tick 90, which is impossible
     // for a valid UP price curve.
-    fx.set_clock_for_testing(test_constants::now_ms() + 1);
+    fx.set_clock_for_testing(test_constants::now_ms() + 2);
     fx.seed_bs_surface_with_svi_bundle(
         &mut market,
         test_constants::default_live_price(),
@@ -169,7 +171,7 @@ fun current_nav_rejects_non_monotone_active_book_surface() {
         true,
         0,
         false,
-        test_constants::now_ms() + 1,
+        test_constants::now_ms() + 2,
     );
 
     fx.current_nav_bundle(&market);

--- a/packages/predict/tests/flows/live_solvency_boundary_tests.move
+++ b/packages/predict/tests/flows/live_solvency_boundary_tests.move
@@ -27,9 +27,7 @@ fun finite_range_partial_close_preserves_live_solvency() {
     fx.scenario_mut().next_tx(test_constants::alice());
     let mut market = fx.take_market_bundle(expiry_id);
     let mut account = fx.take_account_bundle(&trader);
-    if (fx.clock().timestamp_ms() < test_constants::short_expiry_ms()) {
-        deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
-    };
+    deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
 
     // --- Baseline: the fixture seeded the fresh expiry with cash while pool
     // funding is absent; nothing owed, nothing spent.

--- a/packages/predict/tests/flows/live_solvency_boundary_tests.move
+++ b/packages/predict/tests/flows/live_solvency_boundary_tests.move
@@ -1,8 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Live-solvency boundary for a thin finite-range order minted exactly at the
-/// money and then partially closed. Pins the closed-slice liability change,
+/// Live-solvency boundary for a finite-range order with two eligible legs,
+/// then partially closed. Pins the closed-slice liability change,
 /// account replacement, and market-cash conservation with backing intact.
 #[test_only]
 module deepbook_predict::live_solvency_boundary_tests;
@@ -11,16 +11,10 @@ use deepbook_predict::{flow_test_helpers as helpers, order, test_constants};
 use std::unit_test::assert_eq;
 use usdc::usdc::USDC;
 
-/// Per-trade fee floors at `min_fee`: the fixture floors base_fee to 1, so the
+/// Two per-leg fee floors at `min_fee`: the fixture floors base_fee to 1, so the
 /// raw Bernoulli fee mul(1, sqrt(0.5 * 0.5)) rounds to 0 and the floor binds.
 /// The default expiry-fee ramp multiplier is exactly 1.0 (ramp disabled).
-const MINT_MIN_FEE: u64 = 5_000_000;
-/// The order is the first admitted finite range above min_strike and the live
-/// forward == min_strike, so it is exactly at the money and the upper tail clamps
-/// to 0 (|d2| ≈ 315σ, far past the Φ clamp at 8σ). The premium is read from the
-/// quote; the close payout is measured from the manager's
-/// balance and cross-checked against the market's cash, which is what solvency
-/// preservation actually asserts. `pricing_exact_tests` owns the price itself.
+const MINT_MIN_FEE: u64 = 10_000_000;
 /// Half the minted quantity (a whole number of 10_000-unit lots).
 const HALF_CLOSE: u64 = 500_000_000;
 
@@ -33,6 +27,9 @@ fun finite_range_partial_close_preserves_live_solvency() {
     fx.scenario_mut().next_tx(test_constants::alice());
     let mut market = fx.take_market_bundle(expiry_id);
     let mut account = fx.take_account_bundle(&trader);
+    if (fx.clock().timestamp_ms() < test_constants::short_expiry_ms()) {
+        deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
+    };
 
     // --- Baseline: the fixture seeded the fresh expiry with cash while pool
     // funding is absent; nothing owed, nothing spent.
@@ -51,7 +48,7 @@ fun finite_range_partial_close_preserves_live_solvency() {
         helpers::strike_tick() + 10,
         test_constants::mint_quantity(),
     );
-    helpers::assert_atm_entry_probability_short_expiry(quote.entry_probability());
+    assert_eq!(quote.trading_fee(), MINT_MIN_FEE);
     let premium = quote.premium();
     let order_id = fx.mint_bundle(
         &mut market,
@@ -73,10 +70,10 @@ fun finite_range_partial_close_preserves_live_solvency() {
     );
     assert!(helpers::has_position_bundle(&account, expiry_id, order_id));
 
-    // --- Partial live close of exactly half at the unchanged ATM mark. The
+    // --- Partial live close of exactly half on the same flat surface. The
     // close removes the closed slice from payout backing and replaces the
     // account position with the surviving half.
-    fx.advance_live_oracle_bundle(&mut market, test_constants::default_live_price());
+    deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
     let balance_before_close = fx.account_balance_bundle<USDC>(&account);
     let cash_before_close = helpers::market(&market).cash_balance();
     let replacement = fx.redeem_live_bundle(

--- a/packages/predict/tests/flows/range_leg_fee_tests.move
+++ b/packages/predict/tests/flows/range_leg_fee_tests.move
@@ -1,0 +1,406 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Range fees and mint eligibility over production-valid oracle observations.
+#[test_only]
+module deepbook_predict::range_leg_fee_tests;
+
+use deepbook_predict::{
+    constants,
+    flow_test_helpers as helpers,
+    pricing::RangePrice,
+    range_codec::strike_for_testing as strike,
+    range_test_helpers,
+    strike_exposure_config,
+    test_constants
+};
+use std::unit_test::{assert_eq, destroy};
+use usdc::usdc::USDC;
+
+const LOWER_TICK: u64 = 100;
+const HIGHER_TICK: u64 = 110;
+const FAR_LOWER_TICK: u64 = 1;
+const FAR_HIGHER_TICK: u64 = 1000;
+const DUST_QUANTITY: u64 = 75;
+const TWO_DEFAULT_FLOORS: u64 = 44_000;
+const ONE_DEFAULT_FLOOR: u64 = 22_000;
+const TWO_FLOW_FLOORS: u64 = 10_000_000;
+const HALF_QUANTITY: u64 = 500_000_000;
+const HALF_CLOSE_FEE: u64 = 5_000_000;
+const RAMP_WINDOW_MS: u64 = 60_000;
+const HALF_WINDOW_MS: u64 = 30_000;
+const DOUBLE_MULTIPLIER: u64 = 2_000_000_000;
+const NARROW_MIN_PROBABILITY: u64 = 200_000_000;
+const ASYMMETRIC_MAX_PROBABILITY: u64 = 600_000_000;
+const CAPPED_LEG_FEE: u64 = 300_000_000;
+
+fun range(lower: u64, higher: u64): RangePrice {
+    let mut fx = helpers::setup_market_default();
+    let expiry_id = fx.create_expiry(test_constants::default_expiry_ms());
+    let mut market = fx.take_market_bundle(expiry_id);
+    fx.prepare_live_oracle_bundle(&mut market, test_constants::default_live_price());
+    range_test_helpers::prepare_range(&mut fx, &mut market);
+    let pricer = fx.load_pricer_bundle(&market);
+    let price = pricer.range_prices(strike(lower), strike(higher));
+    helpers::return_market_bundle(market);
+    fx.finish();
+    price
+}
+
+fun bounded_range(): RangePrice {
+    range(
+        LOWER_TICK * test_constants::default_tick_size(),
+        HIGHER_TICK * test_constants::default_tick_size(),
+    )
+}
+
+#[test]
+fun finite_boundaries_each_pay_the_floor() {
+    let mut config = strike_exposure_config::new();
+    config.set_base_fee(1);
+    let price = bounded_range();
+    assert_eq!(
+        config.range_trading_fee(
+            test_constants::default_expiry_ms(),
+            &price,
+            test_constants::usdc_unit(),
+            test_constants::now_ms(),
+        ),
+        TWO_DEFAULT_FLOORS,
+    );
+    destroy(config);
+}
+
+#[test]
+fun above_and_below_pay_one_floor_and_whole_line_pays_none() {
+    let mut config = strike_exposure_config::new();
+    config.set_base_fee(1);
+    let mut fx = helpers::setup_market_default();
+    let expiry_id = fx.create_expiry(test_constants::default_expiry_ms());
+    let mut market = fx.take_market_bundle(expiry_id);
+    fx.prepare_live_oracle_bundle(&mut market, test_constants::default_live_price());
+    range_test_helpers::prepare_range(&mut fx, &mut market);
+    let pricer = fx.load_pricer_bundle(&market);
+    let above = pricer.range_prices(
+        strike(LOWER_TICK * test_constants::default_tick_size()),
+        strike(constants::pos_inf!()),
+    );
+    let below = pricer.range_prices(
+        strike(constants::neg_inf!()),
+        strike(HIGHER_TICK * test_constants::default_tick_size()),
+    );
+    let whole = pricer.range_prices(strike(constants::neg_inf!()), strike(constants::pos_inf!()));
+    assert_eq!(above.higher_up(), option::none());
+    assert_eq!(below.lower_up(), option::none());
+    assert_eq!(whole.probability(), 1_000_000_000);
+    config.assert_range_mint_probability_policy(&above);
+    config.assert_range_mint_probability_policy(&below);
+    assert_eq!(
+        config.range_trading_fee(
+            test_constants::default_expiry_ms(),
+            &above,
+            test_constants::usdc_unit(),
+            test_constants::now_ms(),
+        ),
+        ONE_DEFAULT_FLOOR,
+    );
+    assert_eq!(
+        config.range_trading_fee(
+            test_constants::default_expiry_ms(),
+            &below,
+            test_constants::usdc_unit(),
+            test_constants::now_ms(),
+        ),
+        ONE_DEFAULT_FLOOR,
+    );
+    assert_eq!(
+        config.range_trading_fee(
+            test_constants::default_expiry_ms(),
+            &whole,
+            test_constants::usdc_unit(),
+            test_constants::now_ms(),
+        ),
+        0,
+    );
+    destroy(config);
+    helpers::return_market_bundle(market);
+    fx.finish();
+}
+
+#[test]
+fun finite_zero_and_one_probabilities_still_pay_two_floors() {
+    let config = strike_exposure_config::new();
+    let price = range(
+        FAR_LOWER_TICK * test_constants::default_tick_size(),
+        FAR_HIGHER_TICK * test_constants::default_tick_size(),
+    );
+    assert_eq!(price.lower_up(), option::some(1_000_000_000));
+    assert_eq!(price.higher_up(), option::some(0));
+    assert_eq!(
+        config.range_trading_fee(
+            test_constants::default_expiry_ms(),
+            &price,
+            test_constants::usdc_unit(),
+            test_constants::now_ms(),
+        ),
+        TWO_DEFAULT_FLOORS,
+    );
+    destroy(config);
+}
+
+#[test]
+fun leg_amounts_round_separately_before_summing() {
+    let mut config = strike_exposure_config::new();
+    config.set_base_fee(1);
+    let price = bounded_range();
+    // Each 0.022 * 75 = 1.65 rounds to 1, giving 2 rather than floor(3.3).
+    assert_eq!(
+        config.range_trading_fee(
+            test_constants::default_expiry_ms(),
+            &price,
+            DUST_QUANTITY,
+            test_constants::now_ms(),
+        ),
+        2,
+    );
+    config.set_expiry_fee_window_ms(RAMP_WINDOW_MS);
+    config.set_expiry_fee_max_multiplier(DOUBLE_MULTIPLIER);
+    // Halfway through a 1x -> 2x ramp: each 0.033 * 75 floors to 2.
+    assert_eq!(
+        config.range_trading_fee(
+            test_constants::now_ms() + HALF_WINDOW_MS,
+            &price,
+            DUST_QUANTITY,
+            test_constants::now_ms(),
+        ),
+        4,
+    );
+    destroy(config);
+}
+
+#[test]
+fun bernoulli_range_fee_equals_two_standalone_boundary_fees() {
+    let config = strike_exposure_config::new();
+    let price = bounded_range();
+    let expiry = test_constants::default_expiry_ms();
+    let now = test_constants::now_ms();
+    let quantity = test_constants::usdc_unit();
+    // Metamorphic contract: composing a range charges exactly the two existing
+    // standalone fees, including rounding. Absolute fee math is tested in config tests.
+    let lower_fee = config.trading_fee(expiry, price.lower_up().destroy_some(), quantity, now);
+    let upper_fee = config.trading_fee(expiry, price.higher_up().destroy_some(), quantity, now);
+    assert_eq!(config.range_trading_fee(expiry, &price, quantity, now), lower_fee + upper_fee);
+    assert!(
+        config.range_trading_fee(expiry, &price, quantity, now) > 2 * config.trading_fee(expiry, price.probability(), quantity, now),
+    );
+    destroy(config);
+}
+
+#[test, expected_failure(abort_code = strike_exposure_config::EEntryProbabilityOutOfBounds)]
+fun lower_tail_invalidates_an_otherwise_admissible_range() {
+    let config = strike_exposure_config::new();
+    let price = range(
+        FAR_LOWER_TICK * test_constants::default_tick_size(),
+        LOWER_TICK * test_constants::default_tick_size(),
+    );
+    config.assert_mint_probability_policy(price.probability());
+    config.assert_range_mint_probability_policy(&price);
+    abort 999
+}
+
+#[test, expected_failure(abort_code = strike_exposure_config::EEntryProbabilityOutOfBounds)]
+fun upper_tail_invalidates_an_otherwise_admissible_range() {
+    let config = strike_exposure_config::new();
+    let price = range(
+        LOWER_TICK * test_constants::default_tick_size(),
+        FAR_HIGHER_TICK * test_constants::default_tick_size(),
+    );
+    config.assert_mint_probability_policy(price.probability());
+    config.assert_range_mint_probability_policy(&price);
+    abort 999
+}
+
+#[test, expected_failure(abort_code = strike_exposure_config::EEntryProbabilityOutOfBounds)]
+fun admissible_legs_do_not_rescue_a_too_narrow_range() {
+    let mut config = strike_exposure_config::new();
+    config.set_min_entry_probability(NARROW_MIN_PROBABILITY);
+    let price = bounded_range();
+    config.assert_mint_probability_policy(price.lower_up().destroy_some());
+    config.assert_mint_probability_policy(1_000_000_000 - price.higher_up().destroy_some());
+    config.assert_range_mint_probability_policy(&price);
+    abort 999
+}
+
+#[test, expected_failure(abort_code = strike_exposure_config::EEntryProbabilityOutOfBounds)]
+fun upper_leg_eligibility_uses_below_probability_under_asymmetric_bounds() {
+    let mut config = strike_exposure_config::new();
+    config.set_max_entry_probability(ASYMMETRIC_MAX_PROBABILITY);
+    let price = bounded_range();
+    config.assert_mint_probability_policy(price.lower_up().destroy_some());
+    config.assert_mint_probability_policy(price.higher_up().destroy_some());
+    config.assert_mint_probability_policy(price.probability());
+    config.assert_range_mint_probability_policy(&price);
+    abort 999
+}
+
+#[test]
+fun range_quote_mint_and_partial_close_conserve_cash_with_two_fees() {
+    let (mut fx, expiry_id, trader) = helpers::setup_live_market(
+        test_constants::short_expiry_ms(),
+        test_constants::default_live_price(),
+    );
+    fx.scenario_mut().next_tx(test_constants::alice());
+    let mut market = fx.take_market_bundle(expiry_id);
+    let mut account = fx.take_account_bundle(&trader);
+    range_test_helpers::prepare_range(&mut fx, &mut market);
+    let quote = fx.quote_mint_bundle(
+        &market,
+        LOWER_TICK,
+        HIGHER_TICK,
+        test_constants::mint_quantity(),
+    );
+    assert_eq!(quote.trading_fee(), TWO_FLOW_FLOORS);
+    let balance_before = fx.account_balance_bundle<USDC>(&account);
+    let order = fx.mint_exact_quantity_bundle(
+        &mut market,
+        &mut account,
+        LOWER_TICK,
+        HIGHER_TICK,
+        test_constants::mint_quantity(),
+        quote.all_in_cost(),
+        std::u64::max_value!(),
+    );
+    assert_eq!(fx.account_balance_bundle<USDC>(&account), balance_before - quote.all_in_cost());
+    helpers::assert_market_backed_bundle(&market);
+    range_test_helpers::prepare_range(&mut fx, &mut market);
+    let gross = helpers::market(&market).live_order_value(&fx.load_pricer_bundle(&market), order);
+    let before_close = fx.account_balance_bundle<USDC>(&account);
+    let cash_before = helpers::market(&market).cash_balance();
+    let survivor = fx
+        .redeem_live_bundle(&mut market, &mut account, order, HALF_QUANTITY)
+        .destroy_some();
+    let proceeds = gross / 2 - HALF_CLOSE_FEE;
+    assert_eq!(fx.account_balance_bundle<USDC>(&account), before_close + proceeds);
+    assert_eq!(helpers::market(&market).cash_balance(), cash_before - proceeds);
+    assert!(helpers::has_position_bundle(&account, expiry_id, survivor));
+    helpers::assert_market_backed_bundle(&market);
+    helpers::return_account_bundle(account);
+    helpers::return_market_bundle(market);
+    fx.finish();
+}
+
+#[test, expected_failure(abort_code = strike_exposure_config::EEntryProbabilityOutOfBounds)]
+fun public_quote_rejects_a_range_with_an_ineligible_upper_leg() {
+    let (mut fx, expiry_id, _trader) = helpers::setup_live_market(
+        test_constants::short_expiry_ms(),
+        test_constants::default_live_price(),
+    );
+    let market = fx.take_market_bundle(expiry_id);
+    // The default tiny variance prices the upper finite boundary at zero.
+    fx.quote_mint_bundle(&market, LOWER_TICK, HIGHER_TICK, test_constants::mint_quantity());
+    abort 999
+}
+
+#[test, expected_failure(abort_code = strike_exposure_config::EEntryProbabilityOutOfBounds)]
+fun public_mint_rejects_a_range_with_an_ineligible_lower_leg() {
+    let (mut fx, expiry_id, trader) = helpers::setup_live_market(
+        test_constants::short_expiry_ms(),
+        test_constants::default_live_price(),
+    );
+    fx.scenario_mut().next_tx(test_constants::alice());
+    let mut market = fx.take_market_bundle(expiry_id);
+    let mut account = fx.take_account_bundle(&trader);
+    fx.mint_bundle(
+        &mut market,
+        &mut account,
+        LOWER_TICK - 10,
+        LOWER_TICK,
+        test_constants::mint_quantity(),
+    );
+    abort 999
+}
+
+#[test]
+fun existing_range_closes_after_a_finite_leg_moves_outside_entry_bounds() {
+    let (mut fx, expiry_id, trader) = helpers::setup_live_market(
+        test_constants::short_expiry_ms(),
+        test_constants::default_live_price(),
+    );
+    fx.scenario_mut().next_tx(test_constants::alice());
+    let mut market = fx.take_market_bundle(expiry_id);
+    let mut account = fx.take_account_bundle(&trader);
+    range_test_helpers::prepare_range(&mut fx, &mut market);
+    let order = fx.mint_bundle(
+        &mut market,
+        &mut account,
+        LOWER_TICK,
+        HIGHER_TICK,
+        test_constants::mint_quantity(),
+    );
+    fx.advance_live_oracle_bundle(&mut market, test_constants::default_live_price());
+    let pricer = fx.load_pricer_bundle(&market);
+    let price = pricer.range_prices(
+        strike(LOWER_TICK * test_constants::default_tick_size()),
+        strike(HIGHER_TICK * test_constants::default_tick_size()),
+    );
+    assert_eq!(price.higher_up(), option::some(0));
+    let gross = helpers::market(&market).live_order_value(&pricer, order);
+    let before = fx.account_balance_bundle<USDC>(&account);
+    assert_eq!(
+        fx.redeem_live_bundle(&mut market, &mut account, order, test_constants::mint_quantity()),
+        option::none(),
+    );
+    assert_eq!(fx.account_balance_bundle<USDC>(&account), before + gross - TWO_FLOW_FLOORS);
+    assert!(!helpers::has_position_bundle(&account, expiry_id, order));
+    helpers::assert_market_backed_bundle(&market);
+    helpers::return_account_bundle(account);
+    helpers::return_market_bundle(market);
+    fx.finish();
+}
+
+#[test]
+fun range_close_caps_the_sum_at_redemption_value() {
+    let mut fx = helpers::setup_market_default();
+    fx.set_template_min_fee(CAPPED_LEG_FEE);
+    let expiry_id = fx.create_expiry(test_constants::short_expiry_ms());
+    let trader = fx.create_funded_manager(test_constants::mint_deposit());
+    let mut market = fx.take_market_bundle(expiry_id);
+    fx.prepare_live_oracle_bundle(&mut market, test_constants::default_live_price());
+    fx.seed_market_cash(
+        helpers::market_mut(&mut market),
+        test_constants::default_seeded_expiry_cash(),
+    );
+    fx.scenario_mut().next_tx(test_constants::alice());
+    let mut account = fx.take_account_bundle(&trader);
+    range_test_helpers::prepare_range(&mut fx, &mut market);
+    let quote = fx.quote_mint_bundle(
+        &market,
+        LOWER_TICK,
+        HIGHER_TICK,
+        test_constants::mint_quantity(),
+    );
+    assert_eq!(quote.trading_fee(), 2 * CAPPED_LEG_FEE);
+    assert!(quote.premium() < quote.trading_fee());
+    let order = fx.mint_bundle(
+        &mut market,
+        &mut account,
+        LOWER_TICK,
+        HIGHER_TICK,
+        test_constants::mint_quantity(),
+    );
+    range_test_helpers::prepare_range(&mut fx, &mut market);
+    let balance = fx.account_balance_bundle<USDC>(&account);
+    let cash = helpers::market(&market).cash_balance();
+    assert_eq!(
+        fx.redeem_live_bundle(&mut market, &mut account, order, test_constants::mint_quantity()),
+        option::none(),
+    );
+    assert_eq!(fx.account_balance_bundle<USDC>(&account), balance);
+    assert_eq!(helpers::market(&market).cash_balance(), cash);
+    assert!(!helpers::has_position_bundle(&account, expiry_id, order));
+    assert_eq!(helpers::market(&market).payout_liability(), 0);
+    helpers::assert_market_backed_bundle(&market);
+    helpers::return_account_bundle(account);
+    helpers::return_market_bundle(market);
+    fx.finish();
+}

--- a/packages/predict/tests/flows/range_leg_fee_tests.move
+++ b/packages/predict/tests/flows/range_leg_fee_tests.move
@@ -11,7 +11,7 @@ use deepbook_predict::{
     pricing::RangePrice,
     range_codec::strike_for_testing as strike,
     range_test_helpers,
-    strike_exposure_config,
+    strike_exposure_config::{Self, StrikeExposureConfig},
     test_constants
 };
 use std::unit_test::{assert_eq, destroy};
@@ -52,6 +52,12 @@ fun bounded_range(): RangePrice {
         LOWER_TICK * test_constants::default_tick_size(),
         HIGHER_TICK * test_constants::default_tick_size(),
     )
+}
+
+// Fixture prerequisites must not throw the policy abort expected from the target call.
+fun assert_admissible_probability(config: &StrikeExposureConfig, probability: u64) {
+    assert!(probability >= config.min_entry_probability());
+    assert!(probability <= config.max_entry_probability());
 }
 
 #[test]
@@ -203,7 +209,7 @@ fun lower_tail_invalidates_an_otherwise_admissible_range() {
         FAR_LOWER_TICK * test_constants::default_tick_size(),
         LOWER_TICK * test_constants::default_tick_size(),
     );
-    config.assert_mint_probability_policy(price.probability());
+    assert_admissible_probability(&config, price.probability());
     config.assert_range_mint_probability_policy(&price);
     abort 999
 }
@@ -215,7 +221,7 @@ fun upper_tail_invalidates_an_otherwise_admissible_range() {
         LOWER_TICK * test_constants::default_tick_size(),
         FAR_HIGHER_TICK * test_constants::default_tick_size(),
     );
-    config.assert_mint_probability_policy(price.probability());
+    assert_admissible_probability(&config, price.probability());
     config.assert_range_mint_probability_policy(&price);
     abort 999
 }
@@ -225,8 +231,8 @@ fun admissible_legs_do_not_rescue_a_too_narrow_range() {
     let mut config = strike_exposure_config::new();
     config.set_min_entry_probability(NARROW_MIN_PROBABILITY);
     let price = bounded_range();
-    config.assert_mint_probability_policy(price.lower_up().destroy_some());
-    config.assert_mint_probability_policy(1_000_000_000 - price.higher_up().destroy_some());
+    assert_admissible_probability(&config, price.lower_up().destroy_some());
+    assert_admissible_probability(&config, 1_000_000_000 - price.higher_up().destroy_some());
     config.assert_range_mint_probability_policy(&price);
     abort 999
 }
@@ -236,9 +242,9 @@ fun upper_leg_eligibility_uses_below_probability_under_asymmetric_bounds() {
     let mut config = strike_exposure_config::new();
     config.set_max_entry_probability(ASYMMETRIC_MAX_PROBABILITY);
     let price = bounded_range();
-    config.assert_mint_probability_policy(price.lower_up().destroy_some());
-    config.assert_mint_probability_policy(price.higher_up().destroy_some());
-    config.assert_mint_probability_policy(price.probability());
+    assert_admissible_probability(&config, price.lower_up().destroy_some());
+    assert_admissible_probability(&config, price.higher_up().destroy_some());
+    assert_admissible_probability(&config, price.probability());
     config.assert_range_mint_probability_policy(&price);
     abort 999
 }

--- a/packages/predict/tests/flows/range_leg_fee_tests.move
+++ b/packages/predict/tests/flows/range_leg_fee_tests.move
@@ -7,6 +7,7 @@ module deepbook_predict::range_leg_fee_tests;
 
 use deepbook_predict::{
     constants,
+    expiry_market,
     flow_test_helpers as helpers,
     pricing::RangePrice,
     range_codec::strike_for_testing as strike,
@@ -33,6 +34,113 @@ const DOUBLE_MULTIPLIER: u64 = 2_000_000_000;
 const NARROW_MIN_PROBABILITY: u64 = 200_000_000;
 const ASYMMETRIC_MAX_PROBABILITY: u64 = 600_000_000;
 const CAPPED_LEG_FEE: u64 = 300_000_000;
+const SHIPPED_BASE_FEE: u64 = 100_000_000;
+const SHIPPED_MIN_FEE: u64 = 22_000_000;
+const WIDE_LOWER_TICK: u64 = 60;
+const QUOTABLE_WIDE_HIGHER_TICK: u64 = 130;
+const TOO_WIDE_HIGHER_TICK: u64 = 140;
+const WIDE_RANGE_SPOT: u64 = 90_000_000_000;
+const WIDE_RANGE_VARIANCE: u64 = 40_000_000;
+
+fun prepare_wide_range(fx: &mut helpers::Fixture, market: &mut helpers::MarketBundle) {
+    let timestamp_ms = fx.clock().timestamp_ms() + 1;
+    fx.set_clock_for_testing(timestamp_ms);
+    fx.seed_bs_surface_with_svi_bundle(
+        market,
+        WIDE_RANGE_SPOT,
+        WIDE_RANGE_SPOT,
+        WIDE_RANGE_VARIANCE,
+        false,
+        0,
+        test_constants::default_svi_sigma(),
+        0,
+        false,
+        0,
+        false,
+        timestamp_ms,
+    );
+}
+
+#[test]
+fun wide_range_mints_below_the_two_floor_cost_limit() {
+    let mut fx = helpers::setup_market_default();
+    fx.set_template_base_fee(SHIPPED_BASE_FEE);
+    fx.set_template_min_fee(SHIPPED_MIN_FEE);
+    let expiry_id = fx.create_expiry(test_constants::default_expiry_ms());
+    let trader = fx.create_funded_manager(test_constants::mint_deposit());
+    let mut market = fx.take_market_bundle(expiry_id);
+    fx.prepare_live_oracle_bundle(&mut market, WIDE_RANGE_SPOT);
+    prepare_wide_range(&mut fx, &mut market);
+    fx.seed_market_cash(
+        helpers::market_mut(&mut market),
+        test_constants::default_seeded_expiry_cash(),
+    );
+    fx.scenario_mut().next_tx(test_constants::alice());
+    let mut account = fx.take_account_bundle(&trader);
+    let quote = fx.quote_mint_bundle(
+        &market,
+        WIDE_LOWER_TICK,
+        QUOTABLE_WIDE_HIGHER_TICK,
+        test_constants::mint_quantity(),
+    );
+    // At forward 90 and total variance 0.04, (60,130] is below 95.6%; both fees bind at 2.2%.
+    assert_eq!(quote.trading_fee(), 2 * SHIPPED_MIN_FEE);
+    assert!(quote.all_in_cost() <= quote.quantity());
+    let before = fx.account_balance_bundle<USDC>(&account);
+    let order = fx.mint_bundle(
+        &mut market,
+        &mut account,
+        WIDE_LOWER_TICK,
+        QUOTABLE_WIDE_HIGHER_TICK,
+        test_constants::mint_quantity(),
+    );
+    assert_eq!(fx.account_balance_bundle<USDC>(&account), before - quote.all_in_cost());
+    assert!(helpers::has_position_bundle(&account, expiry_id, order));
+    helpers::assert_market_backed_bundle(&market);
+    helpers::return_account_bundle(account);
+    helpers::return_market_bundle(market);
+    fx.finish();
+}
+
+#[test, expected_failure(abort_code = expiry_market::EMintCostAboveMaxPayout)]
+fun eligible_wide_range_aborts_above_the_two_floor_cost_limit() {
+    let mut fx = helpers::setup_market_default();
+    fx.set_template_base_fee(SHIPPED_BASE_FEE);
+    fx.set_template_min_fee(SHIPPED_MIN_FEE);
+    let expiry_id = fx.create_expiry(test_constants::default_expiry_ms());
+    let trader = fx.create_funded_manager(test_constants::mint_deposit());
+    let mut market = fx.take_market_bundle(expiry_id);
+    fx.prepare_live_oracle_bundle(&mut market, WIDE_RANGE_SPOT);
+    prepare_wide_range(&mut fx, &mut market);
+    fx.seed_market_cash(
+        helpers::market_mut(&mut market),
+        test_constants::default_seeded_expiry_cash(),
+    );
+    fx.scenario_mut().next_tx(test_constants::alice());
+    let mut account = fx.take_account_bundle(&trader);
+    let pricer = fx.load_pricer_bundle(&market);
+    let price = pricer.range_prices(
+        strike(WIDE_LOWER_TICK * test_constants::default_tick_size()),
+        strike(TOO_WIDE_HIGHER_TICK * test_constants::default_tick_size()),
+    );
+    let config = strike_exposure_config::new();
+    assert_admissible_probability(&config, price.lower_up().destroy_some());
+    assert_admissible_probability(&config, 1_000_000_000 - price.higher_up().destroy_some());
+    assert_admissible_probability(&config, price.probability());
+    // Extending the upper boundary to 140 pushes the combined probability above 95.6%.
+    assert!(price.probability() > 1_000_000_000 - 2 * SHIPPED_MIN_FEE);
+    destroy(config);
+    fx.mint_exact_quantity_bundle(
+        &mut market,
+        &mut account,
+        WIDE_LOWER_TICK,
+        TOO_WIDE_HIGHER_TICK,
+        test_constants::mint_quantity(),
+        std::u64::max_value!(),
+        std::u64::max_value!(),
+    );
+    abort 999
+}
 
 fun range(lower: u64, higher: u64): RangePrice {
     let mut fx = helpers::setup_market_default();

--- a/packages/predict/tests/flows/settlement_flow_tests.move
+++ b/packages/predict/tests/flows/settlement_flow_tests.move
@@ -31,8 +31,8 @@ const ONE_MS: u64 = 1;
 const ZERO_SPOT: u128 = 0;
 const ONE_U128: u128 = 1;
 
-/// Per-trade fee floor for the default flow fixture.
-const MINT_MIN_FEE: u64 = 5_000_000;
+/// Two per-leg fee floors for the finite-range flow fixture.
+const MINT_MIN_FEE: u64 = 10_000_000;
 const MARKET_SETTLED_EVENT_COUNT: u64 = 1;
 const ACTIVE_MARKET_COUNT: u64 = 1;
 
@@ -47,6 +47,9 @@ fun settled_redeem_requires_explicit_settlement() {
     fx.scenario_mut().next_tx(test_constants::alice());
     let mut market = fx.take_market_bundle(expiry_id);
     let mut account = fx.take_account_bundle(&trader);
+    if (fx.clock().timestamp_ms() < test_constants::short_expiry_ms()) {
+        deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
+    };
 
     let order_id = fx.mint_bundle(
         &mut market,
@@ -318,6 +321,9 @@ fun try_settle_materializes_exact_terminal_liability() {
     fx.scenario_mut().next_tx(test_constants::alice());
     let mut market = fx.take_market_bundle(expiry_id);
     let mut account = fx.take_account_bundle(&trader);
+    if (fx.clock().timestamp_ms() < test_constants::short_expiry_ms()) {
+        deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
+    };
 
     fx.mint_bundle(
         &mut market,
@@ -351,6 +357,9 @@ fun settled_order_payout_reads_loser_as_zero() {
     fx.scenario_mut().next_tx(test_constants::alice());
     let mut market = fx.take_market_bundle(expiry_id);
     let mut account = fx.take_account_bundle(&trader);
+    if (fx.clock().timestamp_ms() < test_constants::short_expiry_ms()) {
+        deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
+    };
 
     let order_id = fx.mint_bundle(
         &mut market,
@@ -381,6 +390,9 @@ fun settled_order_payout_of_live_market_aborts() {
     fx.scenario_mut().next_tx(test_constants::alice());
     let mut market = fx.take_market_bundle(expiry_id);
     let mut account = fx.take_account_bundle(&trader);
+    if (fx.clock().timestamp_ms() < test_constants::short_expiry_ms()) {
+        deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
+    };
 
     let order_id = fx.mint_bundle(
         &mut market,
@@ -409,6 +421,9 @@ fun settled_redeem_twice_aborts() {
     fx.scenario_mut().next_tx(test_constants::alice());
     let mut market = fx.take_market_bundle(expiry_id);
     let mut account = fx.take_account_bundle(&trader);
+    if (fx.clock().timestamp_ms() < test_constants::short_expiry_ms()) {
+        deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
+    };
 
     let order_id = fx.mint_bundle(
         &mut market,
@@ -445,6 +460,9 @@ fun explicitly_settled_redeem_pays_terminal_payout() {
     fx.scenario_mut().next_tx(test_constants::alice());
     let mut market = fx.take_market_bundle(expiry_id);
     let mut account = fx.take_account_bundle(&trader);
+    if (fx.clock().timestamp_ms() < test_constants::short_expiry_ms()) {
+        deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
+    };
 
     let premium = finite_range_premium(&mut fx, &market);
     let order_id = fx.mint_bundle(
@@ -489,6 +507,9 @@ fun deauthorized_predict_app_blocks_permissionless_settled_redeem() {
     fx.scenario_mut().next_tx(test_constants::alice());
     let mut market = fx.take_market_bundle(expiry_id);
     let mut account = fx.take_account_bundle(&trader);
+    if (fx.clock().timestamp_ms() < test_constants::short_expiry_ms()) {
+        deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
+    };
 
     let order_id = fx.mint_bundle(
         &mut market,
@@ -505,6 +526,9 @@ fun deauthorized_predict_app_blocks_permissionless_settled_redeem() {
     fx.scenario_mut().next_tx(test_constants::alice());
     let mut market = fx.take_market_bundle(expiry_id);
     let mut account = fx.take_account_bundle(&trader);
+    if (fx.clock().timestamp_ms() < test_constants::short_expiry_ms()) {
+        deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
+    };
     fx.insert_exact_settlement_spot_bundle(&mut market, settlement_price);
     assert_eq!(fx.try_settle_bundle(&mut market), true);
 
@@ -527,6 +551,9 @@ fun owner_auth_settled_redeem_survives_predict_app_deauth() {
     fx.scenario_mut().next_tx(test_constants::alice());
     let mut market = fx.take_market_bundle(expiry_id);
     let mut account = fx.take_account_bundle(&trader);
+    if (fx.clock().timestamp_ms() < test_constants::short_expiry_ms()) {
+        deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
+    };
 
     let premium = finite_range_premium(&mut fx, &market);
     let order_id = fx.mint_bundle(
@@ -544,6 +571,9 @@ fun owner_auth_settled_redeem_survives_predict_app_deauth() {
     fx.scenario_mut().next_tx(test_constants::alice());
     let mut market = fx.take_market_bundle(expiry_id);
     let mut account = fx.take_account_bundle(&trader);
+    if (fx.clock().timestamp_ms() < test_constants::short_expiry_ms()) {
+        deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
+    };
     fx.insert_exact_settlement_spot_bundle(&mut market, settlement_price);
     assert_eq!(fx.try_settle_bundle(&mut market), true);
 
@@ -586,6 +616,9 @@ fun try_settle_is_idempotent_and_keeps_settlement_price() {
     fx.scenario_mut().next_tx(test_constants::alice());
     let mut market = fx.take_market_bundle(expiry_id);
     let mut account = fx.take_account_bundle(&trader);
+    if (fx.clock().timestamp_ms() < test_constants::short_expiry_ms()) {
+        deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
+    };
     let wrong_pyth = fx.scenario_mut().take_shared_by_id<PythFeed>(wrong_pyth_id);
 
     let premium = finite_range_premium(&mut fx, &market);
@@ -742,9 +775,7 @@ fun finite_range_premium(fx: &mut helpers::Fixture, market: &helpers::MarketBund
         helpers::strike_tick() + 10,
         test_constants::mint_quantity(),
     );
-    // The upper boundary is ~315 sigma out and clamps to zero, so this finite
-    // range prices as the at-the-money digital itself.
-    helpers::assert_atm_entry_probability_short_expiry(quote.entry_probability());
+    assert_eq!(quote.trading_fee(), MINT_MIN_FEE);
     quote.premium()
 }
 
@@ -779,6 +810,9 @@ fun settled_order_payout_reads_winner_terminal_payout() {
     fx.scenario_mut().next_tx(test_constants::alice());
     let mut market = fx.take_market_bundle(expiry_id);
     let mut account = fx.take_account_bundle(&trader);
+    if (fx.clock().timestamp_ms() < test_constants::short_expiry_ms()) {
+        deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
+    };
 
     let order_id = fx.mint_bundle(
         &mut market,

--- a/packages/predict/tests/flows/settlement_flow_tests.move
+++ b/packages/predict/tests/flows/settlement_flow_tests.move
@@ -47,9 +47,7 @@ fun settled_redeem_requires_explicit_settlement() {
     fx.scenario_mut().next_tx(test_constants::alice());
     let mut market = fx.take_market_bundle(expiry_id);
     let mut account = fx.take_account_bundle(&trader);
-    if (fx.clock().timestamp_ms() < test_constants::short_expiry_ms()) {
-        deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
-    };
+    deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
 
     let order_id = fx.mint_bundle(
         &mut market,
@@ -321,9 +319,7 @@ fun try_settle_materializes_exact_terminal_liability() {
     fx.scenario_mut().next_tx(test_constants::alice());
     let mut market = fx.take_market_bundle(expiry_id);
     let mut account = fx.take_account_bundle(&trader);
-    if (fx.clock().timestamp_ms() < test_constants::short_expiry_ms()) {
-        deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
-    };
+    deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
 
     fx.mint_bundle(
         &mut market,
@@ -357,9 +353,7 @@ fun settled_order_payout_reads_loser_as_zero() {
     fx.scenario_mut().next_tx(test_constants::alice());
     let mut market = fx.take_market_bundle(expiry_id);
     let mut account = fx.take_account_bundle(&trader);
-    if (fx.clock().timestamp_ms() < test_constants::short_expiry_ms()) {
-        deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
-    };
+    deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
 
     let order_id = fx.mint_bundle(
         &mut market,
@@ -390,9 +384,7 @@ fun settled_order_payout_of_live_market_aborts() {
     fx.scenario_mut().next_tx(test_constants::alice());
     let mut market = fx.take_market_bundle(expiry_id);
     let mut account = fx.take_account_bundle(&trader);
-    if (fx.clock().timestamp_ms() < test_constants::short_expiry_ms()) {
-        deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
-    };
+    deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
 
     let order_id = fx.mint_bundle(
         &mut market,
@@ -421,9 +413,7 @@ fun settled_redeem_twice_aborts() {
     fx.scenario_mut().next_tx(test_constants::alice());
     let mut market = fx.take_market_bundle(expiry_id);
     let mut account = fx.take_account_bundle(&trader);
-    if (fx.clock().timestamp_ms() < test_constants::short_expiry_ms()) {
-        deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
-    };
+    deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
 
     let order_id = fx.mint_bundle(
         &mut market,
@@ -460,9 +450,7 @@ fun explicitly_settled_redeem_pays_terminal_payout() {
     fx.scenario_mut().next_tx(test_constants::alice());
     let mut market = fx.take_market_bundle(expiry_id);
     let mut account = fx.take_account_bundle(&trader);
-    if (fx.clock().timestamp_ms() < test_constants::short_expiry_ms()) {
-        deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
-    };
+    deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
 
     let premium = finite_range_premium(&mut fx, &market);
     let order_id = fx.mint_bundle(
@@ -507,9 +495,7 @@ fun deauthorized_predict_app_blocks_permissionless_settled_redeem() {
     fx.scenario_mut().next_tx(test_constants::alice());
     let mut market = fx.take_market_bundle(expiry_id);
     let mut account = fx.take_account_bundle(&trader);
-    if (fx.clock().timestamp_ms() < test_constants::short_expiry_ms()) {
-        deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
-    };
+    deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
 
     let order_id = fx.mint_bundle(
         &mut market,
@@ -526,9 +512,6 @@ fun deauthorized_predict_app_blocks_permissionless_settled_redeem() {
     fx.scenario_mut().next_tx(test_constants::alice());
     let mut market = fx.take_market_bundle(expiry_id);
     let mut account = fx.take_account_bundle(&trader);
-    if (fx.clock().timestamp_ms() < test_constants::short_expiry_ms()) {
-        deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
-    };
     fx.insert_exact_settlement_spot_bundle(&mut market, settlement_price);
     assert_eq!(fx.try_settle_bundle(&mut market), true);
 
@@ -551,9 +534,7 @@ fun owner_auth_settled_redeem_survives_predict_app_deauth() {
     fx.scenario_mut().next_tx(test_constants::alice());
     let mut market = fx.take_market_bundle(expiry_id);
     let mut account = fx.take_account_bundle(&trader);
-    if (fx.clock().timestamp_ms() < test_constants::short_expiry_ms()) {
-        deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
-    };
+    deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
 
     let premium = finite_range_premium(&mut fx, &market);
     let order_id = fx.mint_bundle(
@@ -571,9 +552,6 @@ fun owner_auth_settled_redeem_survives_predict_app_deauth() {
     fx.scenario_mut().next_tx(test_constants::alice());
     let mut market = fx.take_market_bundle(expiry_id);
     let mut account = fx.take_account_bundle(&trader);
-    if (fx.clock().timestamp_ms() < test_constants::short_expiry_ms()) {
-        deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
-    };
     fx.insert_exact_settlement_spot_bundle(&mut market, settlement_price);
     assert_eq!(fx.try_settle_bundle(&mut market), true);
 
@@ -616,9 +594,7 @@ fun try_settle_is_idempotent_and_keeps_settlement_price() {
     fx.scenario_mut().next_tx(test_constants::alice());
     let mut market = fx.take_market_bundle(expiry_id);
     let mut account = fx.take_account_bundle(&trader);
-    if (fx.clock().timestamp_ms() < test_constants::short_expiry_ms()) {
-        deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
-    };
+    deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
     let wrong_pyth = fx.scenario_mut().take_shared_by_id<PythFeed>(wrong_pyth_id);
 
     let premium = finite_range_premium(&mut fx, &market);
@@ -810,9 +786,7 @@ fun settled_order_payout_reads_winner_terminal_payout() {
     fx.scenario_mut().next_tx(test_constants::alice());
     let mut market = fx.take_market_bundle(expiry_id);
     let mut account = fx.take_account_bundle(&trader);
-    if (fx.clock().timestamp_ms() < test_constants::short_expiry_ms()) {
-        deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
-    };
+    deepbook_predict::range_test_helpers::prepare_range(&mut fx, &mut market);
 
     let order_id = fx.mint_bundle(
         &mut market,

--- a/packages/predict/tests/helper/flow_test_helpers.move
+++ b/packages/predict/tests/helper/flow_test_helpers.move
@@ -573,6 +573,14 @@ public fun set_expiry_mint_paused_bundle(self: &Fixture, market: &mut MarketBund
     self.set_expiry_mint_paused(&mut market.market, &market.config, paused);
 }
 
+public fun set_template_base_fee(self: &mut Fixture, value: u64) {
+    self.scenario.next_tx(test_constants::admin());
+    let mut config = self.scenario.take_shared<ProtocolConfig>();
+    config.set_template_base_fee(&self.admin_cap, value, &self.clock);
+    return_shared(config);
+    self.scenario.next_tx(test_constants::admin());
+}
+
 public fun set_template_min_fee(self: &mut Fixture, value: u64) {
     self.scenario.next_tx(test_constants::admin());
     let mut config = self.scenario.take_shared<ProtocolConfig>();

--- a/packages/predict/tests/helper/range_test_helpers.move
+++ b/packages/predict/tests/helper/range_test_helpers.move
@@ -1,0 +1,31 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Production-valid flat-variance feed for finite-range trade tests. Both
+/// boundaries at ticks 90, 100 and 110 remain inside mint probability bounds.
+#[test_only]
+module deepbook_predict::range_test_helpers;
+
+use deepbook_predict::{flow_test_helpers::{Fixture, MarketBundle}, test_constants};
+
+const RANGE_VARIANCE: u64 = 40_000_000;
+const ONE_MS: u64 = 1;
+
+public fun prepare_range(fx: &mut Fixture, market: &mut MarketBundle) {
+    let timestamp_ms = fx.clock().timestamp_ms() + ONE_MS;
+    fx.set_clock_for_testing(timestamp_ms);
+    fx.seed_bs_surface_with_svi_bundle(
+        market,
+        test_constants::default_live_price(),
+        test_constants::default_live_price(),
+        RANGE_VARIANCE,
+        false,
+        0,
+        test_constants::default_svi_sigma(),
+        0,
+        false,
+        0,
+        false,
+        timestamp_ms,
+    );
+}

--- a/packages/predict/tests/strike_exposure/inventory_impact_tests.move
+++ b/packages/predict/tests/strike_exposure/inventory_impact_tests.move
@@ -239,7 +239,7 @@ fun quote_mint(
     pricer: &deepbook_predict::pricing::Pricer,
     quantity: u64,
     clock: &Clock,
-): deepbook_predict::strike_exposure::MintTerms {
+): deepbook_predict::strike_exposure::PricedMintTerms {
     quote_range_mint(
         exposure,
         pricer,
@@ -257,7 +257,7 @@ fun quote_range_mint(
     higher_tick: u64,
     quantity: u64,
     _clock: &Clock,
-): deepbook_predict::strike_exposure::MintTerms {
+): deepbook_predict::strike_exposure::PricedMintTerms {
     exposure.quote_mint_terms(
         pricer,
         lower_tick,

--- a/packages/sessions/tests/sessions_tests.move
+++ b/packages/sessions/tests/sessions_tests.move
@@ -15,6 +15,7 @@ use deepbook_predict::{
     predict_account,
     pricing::Pricer,
     protocol_config::ProtocolConfig,
+    range_test_helpers,
     test_constants
 };
 use deepbook_sessions::{
@@ -931,6 +932,12 @@ fun session_redeems_settled_order() {
     let mut fixture = setup_flow_fixture(expiry_ms);
     authorize_flow_session(&mut fixture, SETTLEMENT_SESSION_DURATION_MS);
     let market_id = fixture.market_id;
+    // Keep both finite boundaries quotable before exercising session settlement.
+    let mut market_bundle = fixture.predict.take_market_bundle(market_id);
+    range_test_helpers::prepare_range(&mut fixture.predict, &mut market_bundle);
+    let timestamp_ms = fixture.predict.clock().timestamp_ms();
+    fixture.clock.set_for_testing(timestamp_ms);
+    predict_helpers::return_market_bundle(market_bundle);
     let lower_tick = predict_helpers::strike_tick();
     let higher_tick = lower_tick + SETTLEMENT_HIGHER_TICK_OFFSET;
     let LiveInputs {


### PR DESCRIPTION
## Summary

- `pricing::resolve_live_pricer` now aborts with `EBlockScholesSpotForwardUnpaired` (code 17) when the Block Scholes forward read for the expiry carries a different source timestamp from the spot read.
- No propbook change, no new storage; the pair is enforced at the read that divides them.

## Why

Live pricing re-anchors the Pyth spot through `bs_forward / bs_spot`, reading the latest spot and the latest forward independently. The propbook keeper lands spot and forwards in separate transactions, so a spot tick that lands before its forward tick prices a basis that carries the spot move between the two provider ticks. Both series publish on the same 500 ms grid, so a paired read is the normal case; this makes the unpaired case fail closed instead of mispricing.

## Linear / Context

- [DBU-818](https://linear.app/mysten-labs/issue/DBU-818)
- Stacked on #1304 (DBU-811); base is `at/predict-range-leg-fees`.
- Companion keeper change (deepbook-services `keeper/propbook`): submit the spot batch and all forward batches for one provider tick in a single PTB and drop an unpaired tick, so this assert holds in normal operation.

## Key decisions

- Compares source timestamps, not writer digests, so a pair written by two transactions still prices.
- Exact equality, no tolerance: the two series share one 500 ms grid, and a tolerance would readmit exactly the case being rejected.
- Chosen over a per-SID history in propbook: no upgrade of propbook, no extra dynamic-field access on every keeper write and every pricer read. The trade-off is that an unpaired write by any Block Scholes signed-feed holder becomes a liveness failure for that market (and for the flush snapshot) rather than a mispricing.

## Scope / Descoped

- Code change only. Still needed before merge:
  - 13 existing tests fail because the fixtures stamp the forward strictly after the spot (`flow_test_helpers.move` forward writes use `source_timestamp_ms.max(latest + 1)`; `pricing_tests.move` uses distinct `BLOCK_SCHOLES_SPOT_SOURCE_MS` / `BLOCK_SCHOLES_FORWARD_SOURCE_MS`). The fixtures need to write spot and forward at one source timestamp, and `pricer_snapshots_all_oracle_source_timestamps` needs its expectation updated.
  - A pinning test for the new abort and its `predeploy/response-policies.md` entry: the abort is reachable in the flush snapshot over an oracle-controlled variable.
- The keeper batching change lands separately in deepbook-services.

## Test plan

- [x] `sui move build --path packages/predict --warnings-are-errors` on Sui 1.78.1: exit 0, no warnings.
- [x] `python3 packages/predict/predeploy/check.py`: 0 warnings.
- [ ] `sui move test --path packages/predict --gas-limit 100000000000`: 587/600, the 13 failures listed above are fixture timestamp staggering, not pricing regressions.
- [ ] Register and pin the new abort.

## Risk / Rollout

Rides the Predict v2 compatible upgrade with #1304: private function change plus a new error constant, no layout or public-signature change. Until the keeper batches spot and forwards, roughly 4% of ticks on mainnet (measured 2026-09-11) would fail to price for one 500 ms tick.
